### PR TITLE
Prevent access to /Save/Preferences.ini from lua

### DIFF
--- a/src/RageFile.cpp
+++ b/src/RageFile.cpp
@@ -8,6 +8,7 @@
 #include "global.h"
 #include "RageFileBasic.h"
 #include "RageFile.h"
+#include "RageLog.h"
 #include "RageUtil.h"
 #include "RageFileDriver.h"
 
@@ -351,7 +352,17 @@ public:
 
 	static int Open( T* p, lua_State *L )
 	{
-		lua_pushboolean( L, p->Open( SArg(1), IArg(2) ) );
+		const RString path = SArg(1);
+		int mode = IArg(2);
+
+		if ((mode & RageFile::WRITE) && FILEMAN->IsPathProtected(path))
+		{
+			LOG->Warn("Writing to %s is not allowed", path.c_str());
+			lua_pushboolean(L, false);
+			return 1;
+		}
+
+		lua_pushboolean( L, p->Open(path, mode) );
 		return 1;
 	}
 

--- a/src/RageFileManager.h
+++ b/src/RageFileManager.h
@@ -1,5 +1,8 @@
 #ifndef RAGE_FILE_MANAGER_H
 #define RAGE_FILE_MANAGER_H
+
+#include <unordered_set>
+
 /** @brief Constants for working with the RageFileManager. */
 namespace RageFileManagerUtil
 {
@@ -74,12 +77,18 @@ public:
 
 	bool Unzip(const std::string &zipPath, std::string targetPath, int strip);
 
+	// path protection
+	void ProtectPath(const std::string& path);
+	bool IsPathProtected(const std::string& path);
+
 	// Lua
 	void PushSelf( lua_State *L );
 
 private:
 	RageFileBasic *OpenForReading( const RString &sPath, int iMode, int &iError );
 	RageFileBasic *OpenForWriting( const RString &sPath, int iMode, int &iError );
+
+	std::unordered_set<std::string> m_protectedPaths;
 };
 
 extern RageFileManager *FILEMAN;

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1002,6 +1002,9 @@ int sm_main(int argc, char* argv[])
 
 	// Almost everything uses this to read and write files.  Load this early.
 	FILEMAN = new RageFileManager( argv[0] );
+	FILEMAN->ProtectPath(SpecialFiles::DEFAULTS_INI_PATH);
+	FILEMAN->ProtectPath(SpecialFiles::STATIC_INI_PATH);
+	FILEMAN->ProtectPath(SpecialFiles::PREFERENCES_INI_PATH);
 	FILEMAN->MountInitialFilesystems();
 
 	bool bPortable = DoesFileExist("/Portable.ini");


### PR DESCRIPTION
Directly writing to the file would circumvent preference protections, compromising security.