### PR TITLE
Allow ScreenSelectProfile to Finish() with guest players

### DIFF
--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -5409,7 +5409,8 @@ Details of the <code>event</code> table:
 		Sets the profile index of Player <code>pn</code> to <code>iProfileIndex</code>.<br />
 		The following values of <code>iProfileIndex</code> have special, hardcoded behavior:<br />
 		• <code>-1</code>: join the player and play the theme's start sound effect<br />
-		• <code>-2</code>: unjoin the player, unlock their MemoryCard, and unmount their MemoryCard
+		• <code>-2</code>: unjoin the player, unlock their MemoryCard, and unmount their MemoryCard<br />
+		• <code>-3</code>: allow the user to play without a local or USB profile (as a guest)
 	</Function>
 </Class>
 <Class name='ScreenTextEntry' grouping='Screen'>

--- a/src/MessageManager.cpp
+++ b/src/MessageManager.cpp
@@ -57,6 +57,7 @@ static const char *MessageIDNames[] = {
 	"MenuSelectionChanged",
 	"PlayerJoined",
 	"PlayerUnjoined",
+	"PlayerProfileSet",
 	"AutosyncChanged",
 	"PreferredSongGroupChanged",
 	"PreferredCourseGroupChanged",

--- a/src/MessageManager.h
+++ b/src/MessageManager.h
@@ -53,6 +53,7 @@ enum MessageID
 	Message_MenuSelectionChanged,
 	Message_PlayerJoined,
 	Message_PlayerUnjoined,
+	Message_PlayerProfileSet,
 	Message_AutosyncChanged,
 	Message_PreferredSongGroupChanged,
 	Message_PreferredCourseGroupChanged,

--- a/src/MusicWheelItem.cpp
+++ b/src/MusicWheelItem.cpp
@@ -118,6 +118,7 @@ MusicWheelItem::MusicWheelItem( RString sType ):
 	this->SubscribeToMessage( Message_CurrentTrailP2Changed );
 	this->SubscribeToMessage( Message_PreferredDifficultyP1Changed );
 	this->SubscribeToMessage( Message_PreferredDifficultyP2Changed );
+	this->SubscribeToMessage( Message_PlayerProfileSet );
 }
 
 MusicWheelItem::MusicWheelItem( const MusicWheelItem &cpy ):
@@ -382,7 +383,8 @@ void MusicWheelItem::HandleMessage( const Message &msg )
 	    msg == Message_CurrentTrailP1Changed ||
 	    msg == Message_CurrentTrailP2Changed ||
 	    msg == Message_PreferredDifficultyP1Changed ||
-	    msg == Message_PreferredDifficultyP2Changed )
+	    msg == Message_PreferredDifficultyP2Changed ||
+	    msg == Message_PlayerProfileSet )
 	{
 		const MusicWheelItemData *pWID = dynamic_cast<const MusicWheelItemData*>( m_pData );
 		MusicWheelItemType type = MusicWheelItemType_Invalid;

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -137,6 +137,7 @@ void ScreenSelectMusic::Init()
 	ScreenWithMenuElements::Init();
 
 	this->SubscribeToMessage( Message_PlayerJoined );
+	this->SubscribeToMessage( Message_PlayerProfileSet );
 
 	// Cache these values
 	// Marking for change -- Midiman (why? -aj)

--- a/src/ScreenSelectProfile.cpp
+++ b/src/ScreenSelectProfile.cpp
@@ -128,7 +128,7 @@ bool ScreenSelectProfile::SetProfileIndex( PlayerNumber pn, int iProfileIndex )
 		return false;
 
 	// wrong selection
-	if( iProfileIndex < -2 )
+	if( iProfileIndex < -3 )
 		return false;
 
 	// unload player
@@ -160,7 +160,7 @@ bool ScreenSelectProfile::Finish(){
 
 	FOREACH_PlayerNumber( p )
 	{
-		// not all players has made their choices
+		// not all players have made their choices
 		if( GAMESTATE->IsHumanPlayer( p ) && ( m_iSelectedProfiles[p] == -1 ) )
 			iUnselectedProfiles++;
 
@@ -209,7 +209,16 @@ bool ScreenSelectProfile::Finish(){
 				MEMCARDMAN->LockCard( p );
 			}
 		}
+
+		// If the player picked a profile (>= 0) or chose to play as a guest (-3),
+		// broadcast a message
+		if( m_iSelectedProfiles[p] >= 0 || m_iSelectedProfiles[p] == -3 ) {
+			Message msg( MessageIDToString(Message_PlayerProfileSet) );
+			msg.SetParam( "Player", p );
+			MESSAGEMAN->Broadcast( msg );
+		}
 	}
+
 	StartTransitioningScreen( SM_GoToNextScreen );
 	return true;
 }


### PR DESCRIPTION
Passing -3 as profile index to ScreenSelectProfile's SetProfileIndex will allow ScreenSelectProfile to properly finish without requiring all players to have a local or USB profile assigned.

SetProfileIndex will also broadcast a message when a player has chosen a profile (or to play as a guest).

(SL PR to make use of this change coming up soon!)