### PR TITLE
Prevent joining same player on late join

### DIFF
--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -212,6 +212,16 @@ bool ProfileManager::LoadLocalProfileFromMachine( PlayerNumber pn )
 		return false;
 	}
 
+	// Make sure the profile is currently not in use by another player
+	FOREACH_HumanPlayer( pl )
+	{
+		if( PROFILEMAN->IsPersistentProfile(pl) && PROFILEMAN->GetProfile(pl) == PROFILEMAN->GetLocalProfile(sProfileID) )
+		{
+			m_sProfileDir[pn] = "";
+			return false;
+		}
+	}
+
 	m_sProfileDir[pn] = LocalProfileIDToDir( sProfileID );
 	m_bWasLoadedFromMemoryCard[pn] = false;
 	m_bLastLoadWasFromLastGood[pn] = false;


### PR DESCRIPTION
If a player late joins on SSM, double-check whether the default profile for that side is not already joined. If so, join the player as a guest without a profile.

Sidenote: What constitutes a default profile for a side seems to be updated everytime a profile is selected for that side (see https://github.com/itgmania/itgmania/blob/beta/src/ScreenSelectProfile.cpp#L193 -- `m_sDefaultLocalProfileID` holds the default profile mapping). (Just pointing this out since I was a bit confused by it and thought it might be a bug.)

Additionally needs this change in SL: https://github.com/jenxness/Simply-Love-SM5/commit/1912a793c4b49591a3ddc78a90171ca01360cf0d (can make a PR for it too, just didn't want to alert everyone, feel free to also just commit it directly!)