### PR TITLE
Update default Graphics settings

### DIFF
--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -479,22 +479,26 @@ struct VideoCardDefaults
 	}
 } const g_VideoCardDefaults[] =
 {
-    // We are not in 2005 anymore, rip out the Voodoos!
+	// These lines correspond to the struct defined above.
 	VideoCardDefaults(
-		"OpenGL",	// This matches all drivers in Mac and Linux. -Chris
-		"opengl",
-		1280,720,
-		32,32,32,
-		2048,
-		true
+		"OpenGL",       // Video card name (generic Mac/Linux)
+		"opengl",       // Available renderers
+		1280,720,       // Default resolution
+		32,             // Display color
+		32,             // Texture color
+		32,             // Movie color
+		2048,           // Texture size
+		true            // Smooth lines
 	),
 	VideoCardDefaults(
-		"",
-		"opengl,d3d",
-		1280,720,
-		32,32,32,
-		2048,
-		true
+		"",             // Video card name (generic Windows)
+		"opengl,d3d",   // Available renderers
+		1280,720,       // Default resolution
+		32,             // Display color
+		32,             // Texture color
+		32,             // Movie color
+		2048,           // Texture size
+		true            // Smooth lines
 	),
 };
 

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -479,157 +479,22 @@ struct VideoCardDefaults
 	}
 } const g_VideoCardDefaults[] =
 {
-	VideoCardDefaults(
-		"Voodoo *5",
-		"d3d,opengl",	// received 3 reports of opengl crashing. -Chris
-		640,480,
-		32,32,32,
-		2048,
-		true	// accelerated
-	),
-	VideoCardDefaults(
-		"Voodoo|3dfx", // all other Voodoos: some drivers don't identify which one
-		"d3d,opengl",
-		640,480,
-		16,16,16,
-		256,
-		false	// broken, causes black screen
-	),
-	VideoCardDefaults(
-		"Radeon.* 7|Wonder 7500|ArcadeVGA",	// Radeon 7xxx, RADEON Mobility 7500
-		"d3d,opengl",	// movie texture performance is terrible in OpenGL, but fine in D3D.
-		640,480,
-		16,16,16,
-		2048,
-		true	// accelerated
-	),
-	VideoCardDefaults(
-		"GeForce|Radeon|Wonder 9|Quadro",
-		"opengl,d3d",
-		640,480,
-		32,32,32,	// 32 bit textures are faster to load
-		2048,
-		true	// hardware accelerated
-	),
-	VideoCardDefaults(
-		"TNT|Vanta|M64",
-		"opengl,d3d",
-		640,480,
-		16,16,16,	// Athlon 1.2+TNT demonstration w/ movies: 70fps w/ 32bit textures, 86fps w/ 16bit textures
-		2048,
-		true	// hardware accelerated
-	),
-	VideoCardDefaults(
-		"G200|G250|G400",
-		"d3d,opengl",
-		640,480,
-		16,16,16,
-		2048,
-		false	// broken, causes black screen
-	),
-	VideoCardDefaults(
-		"Savage",
-		"d3d",
-			// OpenGL is unusable on my Savage IV with even the latest drivers.
-			// It draws 30 frames of gibberish then crashes. This happens even with
-			// simple NeHe demos. -Chris
-		640,480,
-		16,16,16,
-		2048,
-		false
-	),
-	VideoCardDefaults(
-		"XPERT@PLAY|IIC|RAGE PRO|RAGE LT PRO",	// Rage Pro chip, Rage IIC chip
-		"d3d",
-			// OpenGL is not hardware accelerated, despite the fact that the
-			// drivers come with an ICD.  Also, the WinXP driver performance
-			// is terrible and supports only 640. The ATI driver is usable.
-			// -Chris
-		320,240,	// lower resolution for 60fps. In-box WinXP driver doesn't support 400x300.
-		16,16,16,
-		256,
-		false
-	),
-	VideoCardDefaults(
-		"RAGE MOBILITY-M1",
-		"d3d,opengl",	// Vertex alpha is broken in OpenGL, but not D3D. -Chris
-		400,300,	// lower resolution for 60fps
-		16,16,16,
-		256,
-		false
-	),
-	VideoCardDefaults(
-		"Mobility M3",	// ATI Rage Mobility 128 (AKA "M3")
-		"d3d,opengl",	// bad movie texture performance in opengl
-		640,480,
-		16,16,16,
-		1024,
-		false
-	),
-	VideoCardDefaults(
-		"Intel.*82810|Intel.*82815",
-		"opengl,d3d",// OpenGL is 50%+ faster than D3D w/ latest Intel drivers.  -Chris
-		512,384,	// lower resolution for 60fps
-		16,16,16,
-		512,
-		false
-	),
-	VideoCardDefaults(
-		"Intel*Extreme Graphics",
-		"d3d",	// OpenGL blue screens w/ XP drivers from 6-21-2002
-		640,480,
-		16,16,16,	// slow at 32bpp
-		1024,
-		false
-	),
-	VideoCardDefaults(
-		"Intel.*", /* fallback: all unknown Intel cards to D3D, since Intel is notoriously bad at OpenGL */
-		"d3d,opengl",
-		640,480,
-		16,16,16,
-		2048,
-		false
-	),
-	VideoCardDefaults(
-		// Cards that have problems with OpenGL:
-		// ASSERT fail somewhere in RageDisplay_OpenGL "Trident Video Accelerator CyberBlade"
-		// bug 764499: ASSERT fail after glDeleteTextures for "SiS 650_651_740"
-		// bug 764830: ASSERT fail after glDeleteTextures for "VIA Tech VT8361/VT8601 Graphics Controller"
-		// bug 791950: AV in glsis630!DrvSwapBuffers for "SiS 630/730"
-		"Trident Video Accelerator CyberBlade|VIA.*VT|SiS 6*",
-		"d3d,opengl",
-		640,480,
-		16,16,16,
-		2048,
-		false
-	),
-	VideoCardDefaults(
-		/* Unconfirmed texture problems on this; let's try D3D, since it's
-		 * a VIA/S3 chipset. */
-		"VIA/S3G KM400/KN400",
-		"d3d,opengl",
-		640,480,
-		16,16,16,
-		2048,
-		false
-	),
+    // We are not in 2005 anymore, rip out the Voodoos!
 	VideoCardDefaults(
 		"OpenGL",	// This matches all drivers in Mac and Linux. -Chris
 		"opengl",
-		640,480,
-		16,16,16,
-		2048,
-		true // Right now, they've got to have NVidia or ATi Cards anyway..
-	),
-	VideoCardDefaults(
-		// Default graphics settings used for all cards that don't match above.
-		// This must be the very last entry!
-		"",
-		"opengl,d3d",
-		640,480,
+		1280,720,
 		32,32,32,
 		2048,
-		false  // AA is slow on some cards, so let's selectively enable HW accelerated cards.
+		true
+	),
+	VideoCardDefaults(
+		"",
+		"opengl,d3d",
+		1280,720,
+		32,32,32,
+		2048,
+		true
 	),
 };
 


### PR DESCRIPTION
This commit removes the StepMania 3.x-era graphics card checks (Voodoo, ATI Wonder, TNT etc), updates the Mac/Linux defaults to 32 bit color and enable smooth lines/AA on Windows. The default resolutions are also adjusted to 1280x720, due to Simply Love already defaulting to the 16:9 aspect ratio.