### PR TITLE
README - Point workflow status badge to release branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ITGmania
 
 ITGmania is a fork of [StepMania 5.1](https://github.com/stepmania/stepmania/tree/5_1-new), an advanced cross-platform rhythm game for home and arcade use.
 
-[![Continuous integration](https://github.com/itgmania/itgmania/workflows/Continuous%20integration/badge.svg?branch=beta)](https://github.com/itgmania/itgmania/actions?query=workflow%3A%22Continuous+integration%22+branch%3Abeta)
+[![Continuous integration](https://github.com/itgmania/itgmania/workflows/Continuous%20integration/badge.svg?branch=release)](https://github.com/itgmania/itgmania/actions?query=workflow%3A%22Continuous+integration%22+branch%3Arelease)
 
 ## Changes to StepMania 5.1
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@ ITGmania
 
 ITGmania is a fork of [StepMania 5.1](https://github.com/stepmania/stepmania/tree/5_1-new), an advanced cross-platform rhythm game for home and arcade use.
 
+Release branch
+
 [![Release branch](https://github.com/itgmania/itgmania/workflows/Continuous%20integration/badge.svg?branch=release)](https://github.com/itgmania/itgmania/actions?query=workflow%3A%22Continuous+integration%22+branch%3Arelease)
+
+Beta branch
+
 [![Beta branch](https://github.com/itgmania/itgmania/workflows/Continuous%20integration/badge.svg?branch=beta)](https://github.com/itgmania/itgmania/actions?query=workflow%3A%22Continuous+integration%22+branch%3Abeta)
 
 ## Changes to StepMania 5.1

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ ITGmania
 
 ITGmania is a fork of [StepMania 5.1](https://github.com/stepmania/stepmania/tree/5_1-new), an advanced cross-platform rhythm game for home and arcade use.
 
-[![Continuous integration](https://github.com/itgmania/itgmania/workflows/Continuous%20integration/badge.svg?branch=release)](https://github.com/itgmania/itgmania/actions?query=workflow%3A%22Continuous+integration%22+branch%3Arelease)
+[![Release branch](https://github.com/itgmania/itgmania/workflows/Continuous%20integration/badge.svg?branch=release)](https://github.com/itgmania/itgmania/actions?query=workflow%3A%22Continuous+integration%22+branch%3Arelease)
+[![Beta branch](https://github.com/itgmania/itgmania/workflows/Continuous%20integration/badge.svg?branch=beta)](https://github.com/itgmania/itgmania/actions?query=workflow%3A%22Continuous+integration%22+branch%3Abeta)
 
 ## Changes to StepMania 5.1
 


### PR DESCRIPTION
On the "`release`" branch at least, proposing pointing this workflow status badge to the "`release`" branch - https://github.com/itgmania/itgmania/actions?query=workflow%3A%22Continuous+integration%22+branch%3Arelease - reference https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge#using-the-branch-parameter

(re-do of https://github.com/itgmania/itgmania/pull/47)