### PR TITLE
Add pump shortcut for closing current song folder

### DIFF
--- a/Themes/_fallback/Scripts/03 Gameplay.lua
+++ b/Themes/_fallback/Scripts/03 Gameplay.lua
@@ -330,6 +330,8 @@ local CodeDetectorCodes = {
 	},
 	CloseCurrentFolder = {
 		default = "MenuUp-MenuDown",
+		dance = "Up-Down",
+		pump = "@UpLeft-@UpRight-Center",
 	},
 	-- OptionsList
 	PrevOptionsList = {


### PR DESCRIPTION
"Up-Down" for dance matches Simply Love.
This allows for changes to SL to use this via `CloseCurrentFolder=GetCodeForGame("CloseCurrentFolder")` in metrics.ini.