### PR TITLE
(Subjective) enhancements to how MMods work internally

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -1456,6 +1456,7 @@
 			<Function name='GetPlayerOptions'/>
 			<Function name='GetPlayerOptionsArray'/>
 			<Function name='GetPlayerOptionsString'/>
+			<Function name='GetReadBpm'/>
 			<Function name='GetSongPosition'/>
 			<Function name='GetSuperMeterLevel'/>
 			<Function name='SetPlayerOptions'/>
@@ -1974,6 +1975,7 @@
 			<Function name='GetFilename'/>
 			<Function name='GetHash'/>
 			<Function name='GetMeter'/>
+			<Function name='GetMModReadBpm'/>
 			<Function name='GetRadarValues'/>
 			<Function name='GetStepsType'/>
 			<Function name='GetTimingData'/>
@@ -2099,6 +2101,7 @@
 			<Function name='GetTotalMeter'/>
 			<Function name='GetTrailEntries'/>
 			<Function name='GetTrailEntry'/>
+			<Function name='GetTrailMModReadBpm'/>
 			<Function name='IsSecret'/>
 		</Class>
 		<Class name='TrailEntry'>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -4573,6 +4573,10 @@ prev_note_name, succeeded = options:NoteSkin("cel")
 	<Function name='GetPlayerOptionsArray' return='{string}' arguments='ModsLevel ml'>
 		Returns a table of strings, containing the player options for the specified ModsLevel.
 	</Function>
+	<Function name='GetReadBpm' return='float' arguments=''>
+		Returns the current read BPM.
+		For MMods, the effective X mod is calculated by dividing the player's MMod setting by the read BPM.
+	</Function>
 	<Function name='GetSongPosition' return='SongPosition' arguments=''>
 		Returns the SongPosition for this PlayerState.
 	</Function>
@@ -6212,6 +6216,10 @@ local spr = Def.Sprite{
 	<Function name='GetMeter' return='int' arguments=''>
 		Returns the numerical difficulty of the Steps.
 	</Function>
+	<Function name='GetMModReadBpm' return='float' arguments=''>
+		Returns the MMod read BPM for the Steps.
+		See <Link class='PlayerState' function='GetReadBpm' /> for a description of read BPM.
+	</Function>
 	<Function name='HasAttacks' return='bool' arguments=''>
 		Returns <code>true</code> if the Steps has any attacks.
 	</Function>
@@ -6615,6 +6623,10 @@ local bpms_and_times = timing_data:GetBPMsAndTimes(true)
 	</Function>
 	<Function name='GetTrailEntry' return='TrailEntry' arguments='int iEntry'>
 		Returns the TrailEntry at index <code>iEntry</code>.
+	</Function>
+	<Function name='GetTrailMModReadBpm' return='float'>
+		Returns the MMod read BPM for the entire Trail taken as a whole. This is currently used as the read BPM when playing courses.
+		See <Link class='PlayerState' function='GetReadBpm' /> for a description of read BPM.
 	</Function>
 	<Function name='IsSecret' return='bool' arguments=''>
 		Returns <code>true</code> if any of the Trail entries are secret.

--- a/src/CommonMetrics.cpp
+++ b/src/CommonMetrics.cpp
@@ -21,6 +21,8 @@ ThemeMetricStepsTypesToShow	CommonMetrics::STEPS_TYPES_TO_SHOW		("Common","Steps
 ThemeMetric<bool>			CommonMetrics::AUTO_SET_STYLE			("Common","AutoSetStyle");
 ThemeMetric<int>			CommonMetrics::PERCENT_SCORE_DECIMAL_PLACES	("Common","PercentScoreDecimalPlaces");
 ThemeMetric<RString>		CommonMetrics::IMAGES_TO_CACHE	("Common","ImageCache");
+ThemeMetric<float> 			CommonMetrics::M_MOD_HIGH_CAP	("Player", "MModHighCap");
+
 
 ThemeMetricDifficultiesToShow::ThemeMetricDifficultiesToShow( const RString& sGroup, const RString& sName ) : 
 	ThemeMetric<RString>(sGroup,sName)

--- a/src/CommonMetrics.h
+++ b/src/CommonMetrics.h
@@ -77,6 +77,15 @@ namespace CommonMetrics
 	
 	extern ThemeMetric<RString>		IMAGES_TO_CACHE;
 
+	/**
+ 	* @brief What is our highest cap for mMods?
+ 	*
+ 	* If set to 0 or less, assume the actual BPM takes over. 
+	* Note that this is NOT a [Common] metric. It used to be in Player.cpp and
+	* retains that metric category for backwards compatibility. */
+	extern ThemeMetric<float>	M_MOD_HIGH_CAP;
+
+
 	RString LocalizeOptionItem( const RString &s, bool bOptional );
 };
 

--- a/src/PlayerState.cpp
+++ b/src/PlayerState.cpp
@@ -267,6 +267,7 @@ public:
 	}
 	DEFINE_METHOD( GetHealthState, m_HealthState );
 	DEFINE_METHOD( GetSuperMeterLevel, m_fSuperMeter );
+	DEFINE_METHOD( GetReadBpm, m_fReadBPM );
 
 	LunaPlayerState()
 	{
@@ -282,6 +283,7 @@ public:
 		ADD_METHOD( GetSongPosition );
 		ADD_METHOD( GetHealthState );
 		ADD_METHOD( GetSuperMeterLevel );
+		ADD_METHOD( GetReadBpm );
 	}
 };
 

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -202,6 +202,7 @@ public:
 	void SetMaxBPM(const float f)				{ this->specifiedBPMMax = f; }
 	float GetMaxBPM() const					{ return this->specifiedBPMMax; }
 	void GetDisplayBpms( DisplayBpms &addTo) const;
+	float GetMModReadBpm(const bool bPerSong = true) const;
 
 	RString GetAttackString() const
 	{

--- a/src/Trail.h
+++ b/src/Trail.h
@@ -90,6 +90,8 @@ public:
 	void GetDisplayBpms( DisplayBpms &AddTo ) const;
 	bool IsSecret() const;
 	bool ContainsSong( const Song *pSong ) const;
+	// This is the Trail's ReadBPM, not the ReadBPM of any Steps within it
+	float GetTrailMModReadBpm( const bool bPerSong = true ) const;
 
 	// Lua
 	void PushSelf( lua_State *L );


### PR DESCRIPTION
Code for calculating the read BPM for MMods moved from Player to Steps and Trail
Lua functions for getting the read BPM for a Steps and Trail and the current read BPM of a PlayerState
The possibility of MMods being calculated for each chart rather than each song (not currently enabled)