### PR TITLE
Handle Mmod choice for per-chart #DISPLAYBPM

### DIFF
--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -436,8 +436,8 @@ void Player::Init(
 		}
 		else
 		{
-			ASSERT( GAMESTATE->m_pCurSong != nullptr );
-			GAMESTATE->m_pCurSong->GetDisplayBpms( bpms );
+			ASSERT( GAMESTATE->m_pCurSteps[pn] != nullptr );
+			GAMESTATE->m_pCurSteps[pn]->GetDisplayBpms(bpms);
 		}
 
 		float fMaxBPM = 0;


### PR DESCRIPTION
I wrote a file with split music that also required split #DISPLAYBPM and the ramifications of that reached a little...beyond...what I expected.

Test case: [Lime - "Beyond"](https://1drv.ms/u/s!AstsLKMOpXuCkI0V_-JFKmwPIiyrSw?e=8dep2j)

If #56 isn't accepted, I recommend at least making this change to maintain the expected behavior of Mmod (I think this is the only snippet that needs to change??) Otherwise, SX scrolls at 2x expected speed, and SE/SM at 0.5x expected speed.