### PR TITLE
Allow PreferredSongs/PreferredCourses to be set from absolute paths

### DIFF
--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -5888,11 +5888,15 @@ local args = {
 	<Function name='ShortenGroupName' return='string' arguments='string sGroupName'>
 		Returns the shortened group name (based on entries in Translations.xml).
 	</Function>
-	<Function name='SetPreferredCourses' return='void' arguments='string sListName'>
-		Loads preferred courses from <code>{theme}/Other/SongManager sListName.txt</code>.
+	<Function name='SetPreferredCourses' return='void' arguments='string sListName, bool bIsAbsolute'>
+		By default, loads preferred courses from <code>{theme}/Other/SongManager sListName.txt</code>.
+		(New since ITGmania 0.5.2) If the optional argument <code>bIsAbsolute</code> is set, instead treats
+		sListName as an absolute path instead of loading it from the Theme's <code>Other</code> directory.
 	</Function>
-	<Function name='SetPreferredSongs' return='void' arguments='string sListName'>
-		Loads preferred songs from <code>{theme}/Other/SongManager sListName.txt</code>.
+	<Function name='SetPreferredSongs' return='void' arguments='string sListName, bool bIsAbsolute'>
+		By default, loads preferred songs from <code>{theme}/Other/SongManager sListName.txt</code>.
+		(New since ITGmania 0.5.2) If the optional argument <code>bIsAbsolute</code> is set, instead treats
+		sListName as an absolute path instead of loading it from the Theme's <code>Other</code> directory.
 	</Function>
 	<Function name='SongToPreferredSortSectionName' return='string' arguments='Song s'>
 		Returns the preferred sort section name for the specified Song.

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -5890,12 +5890,12 @@ local args = {
 	</Function>
 	<Function name='SetPreferredCourses' return='void' arguments='string sListName, bool bIsAbsolute'>
 		By default, loads preferred courses from <code>{theme}/Other/SongManager sListName.txt</code>.
-		(New since ITGmania 0.5.2) If the optional argument <code>bIsAbsolute</code> is set, instead treats
+		(New since ITGmania 0.6.0) If the optional argument <code>bIsAbsolute</code> is set, instead treats
 		sListName as an absolute path instead of loading it from the Theme's <code>Other</code> directory.
 	</Function>
 	<Function name='SetPreferredSongs' return='void' arguments='string sListName, bool bIsAbsolute'>
 		By default, loads preferred songs from <code>{theme}/Other/SongManager sListName.txt</code>.
-		(New since ITGmania 0.5.2) If the optional argument <code>bIsAbsolute</code> is set, instead treats
+		(New since ITGmania 0.6.0) If the optional argument <code>bIsAbsolute</code> is set, instead treats
 		sListName as an absolute path instead of loading it from the Theme's <code>Other</code> directory.
 	</Function>
 	<Function name='SongToPreferredSortSectionName' return='string' arguments='Song s'>

--- a/src/SongManager.h
+++ b/src/SongManager.h
@@ -179,6 +179,8 @@ public:
 
 	void UpdatePopular();
 	void UpdateShuffled();	// re-shuffle songs and courses
+	void SetPreferredSongs(RString sPreferredSongs = "PreferredSongs.txt", bool bIsAbsolute = false);
+	void SetPreferredCourses(RString sPreferredCourses = "PreferredCourses.txt", bool bIsAbsolute = false);
 	void UpdatePreferredSort(RString sPreferredSongs = "PreferredSongs.txt", RString sPreferredCourses = "PreferredCourses.txt"); 
 	void SortSongs();		// sort m_pSongs by CompareSongPointersByTitle
 

--- a/src/SongManager.h
+++ b/src/SongManager.h
@@ -179,8 +179,8 @@ public:
 
 	void UpdatePopular();
 	void UpdateShuffled();	// re-shuffle songs and courses
-	void SetPreferredSongs(RString sPreferredSongs = "PreferredSongs.txt", bool bIsAbsolute = false);
-	void SetPreferredCourses(RString sPreferredCourses = "PreferredCourses.txt", bool bIsAbsolute = false);
+	void SetPreferredSongs(RString sPreferredSongs, bool bIsAbsolute = false);
+	void SetPreferredCourses(RString sPreferredCourses, bool bIsAbsolute = false);
 	void UpdatePreferredSort(RString sPreferredSongs = "PreferredSongs.txt", RString sPreferredCourses = "PreferredCourses.txt"); 
 	void SortSongs();		// sort m_pSongs by CompareSongPointersByTitle
 


### PR DESCRIPTION
Currently both `PreferredSongs` and `PreferredCourses` require the file to be loaded from a theme's `Other` directory (i.e. `{theme}/Other/SongManager ${sListName}.txt.` This is a bit annoying as we can't have profile specific favorites without copying the file to this location.

Additionally, calling either `PreferredSongs` or `PreferredCourses` implicitly sets the the other one (`courses` and `songs` respectively) to a default. This side effect seems unnecessary.

This PR addresses both. We can now specify an optional boolean value `bIsAbsolute` if we want to us the provided `sListName` as is, or fall back to using the Theme's other directory as per usual.