### PR TITLE
Fix 10th score erasure Bug

### DIFF
--- a/src/GameState.h
+++ b/src/GameState.h
@@ -357,6 +357,7 @@ public:
 	bool AnyPlayerHasRankingFeats() const;
 	void StoreRankingName( PlayerNumber pn, RString name );	// Called by name entry screens
 	std::vector<RString*> m_vpsNamesThatWereFilled;	// filled on StoreRankingName,
+	std::set<PlayerNumber> m_sPlayersThatWereFilled;	// filled on StoreRankingName,
 
 	// Award stuff
 	// lowest priority in front, highest priority at the back.


### PR DESCRIPTION
Addresses the issue: https://github.com/itgmania/itgmania/issues/82 and aims to make ``StoreRankingName`` more efficient. 

Copy-pasting convos from DMs

Preface: Whenever ``GAMESTATE:StoreRankingName()`` gets called, at the very end of the method it removed all duplicate names from each high score list via ``RemoveAllButOneOfEachName()`` (assuming the preference indicates that's desired behavior) and clamped each high score list to the maximum amount allowed via preference via ``ClampSize(bool)``.

 In implementation, it would loop through every single high score on the machine once for each task to achieve this per player. Meaning that if two players are enabled, we are looping through every single high score for regular songs on the machine 4 times and every single high score on courses 4 times. Our cab has over 18k songs, so this process was a noticeable one on our cab.

Solution
-------------
Instead of looping through every single high score on the entire machine twice per player per task, this implementation only loops through the songs played in the past session once*.

I loop through PlayedStageStats to get the songs that were played in the past session. After filtering out duplicates (same song played multiple times), it will call ``RemoveAllbutOneOfEachName()`` and  ``ClampSize``on the High Score List of each song that was played in the past session.

``GetRankingFeats()`` is an already existing method used in ``StoreRankingName()`` which also operates similarly in that it only loops through songs played in the past session.

- There's now a check for whether we're on the final player we need to store. If we are, then we will perform the below, otherwise it will wait until we're on the final player. This means we no longer need to loop through every song per player.

-    ``RemoveAllButOneOfEachName()`` and ``ClampSize()`` are called within the same loop with the appropriate checks. This was to reduce looping through the songs played in the last session to once* per player.

-    If we are on the final player **then** we can loop through every song and ``RemoveAllButOneOfEachName`` and ``ClampSize`` as needed. This then reduced the looping to a single* time overall.

* This is *technically* still two loops, because we have the initial loop for going through all the songs played in the session and then a loop that goes through the unique ones. But overall we will only be looping at most 2*n times, with n being the amount of songs played in a session. Which is much less than n being every song on the entire machine.

---------------------

Open to tweaks and what not to this implementation