### PR TITLE
workflows/ci.yml - pin Continuos integration job to ubuntu-18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: Continuous integration
 jobs:
   ubuntu-build:
     name: Ubuntu
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
       - name: Checkout submodules


### PR DESCRIPTION
Noticed https://github.com/itgmania/itgmania/commit/d68cefb4fe01a57e621b79e902551862c9f607f6 upgraded the version of Ubuntu to 18.04, proposing using the same version here.

Currently uses Ubuntu 22.04, reference https://github.com/actions/runner-images#available-images