### PR TITLE
Remove duplicate names from leaderboard when merging high scores.

### DIFF
--- a/src/HighScore.cpp
+++ b/src/HighScore.cpp
@@ -442,6 +442,12 @@ void HighScoreList::MergeFromOtherHSL(HighScoreList& other, bool is_machine)
 	vHighScores.erase(unique_end, vHighScores.end());
 	// Reverse it because sort moved the lesser scores to the top.
 	std::reverse(vHighScores.begin(), vHighScores.end());
+	
+	if (!PREFSMAN->m_bAllowMultipleHighScoreWithSameName)
+	{
+		// erase all but the highest score for each name
+		RemoveAllButOneOfEachName();
+	}
 	ClampSize(is_machine);
 }
 


### PR DESCRIPTION
When merging two high score lists, the MergeFromOtherHSL() function only called ClampSize() but did not also call RemoveAllButOneOfEachName. 

This behavior was okay pre https://github.com/itgmania/itgmania/pull/83: because RemoveAllButOneOfEachName() was called on every single song on the machine multiple times every set. 

Since this is no longer behavior, we need to make sure this method calls this otherwise we may end up with a merged leaderboard that has the same person occuring more than once.

For example, if I got a 95.65% on Lotus Free MenPai/Pick pop candy/ in the present Stats.xml in the current MachineProfile...

And I want to merge a profile which has a Stats.xml in which I have a 98.65% on this same song. The merged leaderboard would show both of these scores. This PR will call RemoveAllbutOneOfEachName() (assuming the preference indicates this is desired behavior) so that these individual scores are merged into 1.