### PR TITLE
Remove calls to dwmFlush / Prevent double-vsync with opengl renderer

### DIFF
--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -416,19 +416,6 @@ void GraphicsWindow::Initialize( bool bD3D )
 	// A few things need to be handled differently for D3D.
 	g_bD3D = bD3D;
 
-	//keeping xp on life support -- check for vista+ for dwm
-	if (IsWindowsVistaOrGreater())
-	{
-		hInstanceDwmapi = LoadLibraryA("dwmapi.dll");
-	}
-
-	//if we have dwm, get function pointers to the dll functions
-	if( hInstanceDwmapi != nullptr )
-	{
-		PFN_DwmFlush =					(HRESULT (WINAPI *)(VOID))GetProcAddress( hInstanceDwmapi, "DwmFlush" );
-		PFN_DwmIsCompositionEnabled =	(HRESULT (WINAPI *)(BOOL*))GetProcAddress( hInstanceDwmapi, "DwmIsCompositionEnabled" );
-	}
-
 	AppInstance inst;
 	do
 	{
@@ -508,20 +495,6 @@ void GraphicsWindow::Update()
 	}
 
 	HOOKS->SetHasFocus( g_bHasFocus );
-
-	if (g_CurrentParams.vsync)
-	{
-		//if we can use DWM
-		if( hInstanceDwmapi != nullptr )
-		{
-			BOOL compositeEnabled = true;
-			PFN_DwmIsCompositionEnabled(&compositeEnabled);
-			if (compositeEnabled)
-			{
-				PFN_DwmFlush();
-			}
-		}
-	}
 
 	if( g_bResolutionChanged && DISPLAY != nullptr )
 	{

--- a/src/archutils/Win32/GraphicsWindow.h
+++ b/src/archutils/Win32/GraphicsWindow.h
@@ -35,11 +35,6 @@ namespace GraphicsWindow
 	void Update();
 
 	HWND GetHwnd();
-
-	//dwm functions for vista+
-	static HINSTANCE hInstanceDwmapi = nullptr;
-	static HRESULT(WINAPI* PFN_DwmIsCompositionEnabled)(BOOL*);
-	static HRESULT (WINAPI* PFN_DwmFlush)(VOID);
 };
 
 #endif


### PR DESCRIPTION
Fixes #86 

I'm fairly sure this is the only change needed. Previously, since at_least_vista was broken, dwmFlush would never have been called.

Have checked both opengl and d3d renderers as best I can, can't see any fallout from this, and it fixes the double-vsync problem with opengl.
