### PR TITLE
Fix macOS builds for versions >= 13.3

### DIFF
--- a/extern/CMakeProject-tomcrypt.cmake
+++ b/extern/CMakeProject-tomcrypt.cmake
@@ -471,6 +471,11 @@ endif()
 
 if(APPLE)
   set_property(TARGET "tomcrypt" PROPERTY XCODE_ATTRIBUTE_GCC_NO_COMMON_BLOCKS "YES")
+
+  # Fixes build failures due to warnings on macOS >= 13.3
+  # See itgmania/itgmania#107 for details
+  set_property(TARGET "tomcrypt" PROPERTY C_STANDARD 90)
+  set_property(TARGET "tomcrypt" PROPERTY C_STANDARD_REQUIRED ON)
 endif()
 if(MSVC)
   target_compile_definitions("tomcrypt" PRIVATE _CRT_SECURE_NO_WARNINGS)

--- a/extern/CMakeProject-tomcrypt.cmake
+++ b/extern/CMakeProject-tomcrypt.cmake
@@ -474,6 +474,7 @@ if(APPLE)
 
   # Fixes build failures due to warnings on macOS >= 13.3
   # See itgmania/itgmania#107 for details
+  # TODO(teejusb/natano): Remove these two lines once these issues have been fixed upstream.
   set_property(TARGET "tomcrypt" PROPERTY C_STANDARD 90)
   set_property(TARGET "tomcrypt" PROPERTY C_STANDARD_REQUIRED ON)
 endif()

--- a/extern/CMakeProject-zlib.cmake
+++ b/extern/CMakeProject-zlib.cmake
@@ -32,6 +32,13 @@ add_library("zlib" STATIC ${ZLIB_SRC} ${ZLIB_HPP})
 
 set_property(TARGET "zlib" PROPERTY FOLDER "External Libraries")
 
+if(APPLE)
+  # Fixes build failures due to warnings on macOS >= 13.3
+  # See itgmania/itgmania#107 for details
+  set_property(TARGET "zlib" PROPERTY C_STANDARD 90)
+  set_property(TARGET "zlib" PROPERTY C_STANDARD_REQUIRED ON)
+endif(APPLE)
+
 disable_project_warnings("zlib")
 
 if(MSVC)

--- a/extern/CMakeProject-zlib.cmake
+++ b/extern/CMakeProject-zlib.cmake
@@ -35,6 +35,7 @@ set_property(TARGET "zlib" PROPERTY FOLDER "External Libraries")
 if(APPLE)
   # Fixes build failures due to warnings on macOS >= 13.3
   # See itgmania/itgmania#107 for details
+  # TODO(teejusb/natano): Remove these two lines once these issues have been fixed upstream.
   set_property(TARGET "zlib" PROPERTY C_STANDARD 90)
   set_property(TARGET "zlib" PROPERTY C_STANDARD_REQUIRED ON)
 endif(APPLE)


### PR DESCRIPTION
Fixes itgmania/itgmania#107 with the following changes:
- Updates `mbedtls` to a newer version that doesn't have an unused variable warning.
- Specifies a C standard for `zlib` and `tomcrypt` that doesn't raise "call to undeclared function" warnings.

I'm not sure what those dependencies power and what specific features need to be tested before merging these changes, but I've tested the basic flow of playing a song through in event mode.