### PR TITLE
Add EarlyHit support to the engine

### DIFF
--- a/src/NoteTypes.h
+++ b/src/NoteTypes.h
@@ -18,6 +18,8 @@ struct TapNoteResult
 	TapNoteResult() : tns(TNS_None), fTapNoteOffset(0.f), bHidden(false), bHeld(false) { }
 	/** @brief The TapNoteScore that was achieved by the player. */
 	TapNoteScore	tns;
+	/** @brief The TapNoteScore of any early hits of this tap note. */
+	TapNoteScore	earlyTns;
 
 	/**
 	 * @brief Offset, in seconds, for a tap grade.

--- a/src/NoteTypes.h
+++ b/src/NoteTypes.h
@@ -29,6 +29,15 @@ struct TapNoteResult
 	 * (tns >= TNS_W5). */
 	float		fTapNoteOffset;
 
+	/**
+	 * @brief Offset, in seconds, for the early tap grade.
+	 *
+	 * Negative numbers mean the note was hit early; positive numbers mean
+	 * it was hit late. These values are only meaningful for graded taps
+	 * (tns >= TNS_W5). */
+	float		fEarlyTapNoteOffset;
+
+
 	/** @brief If the whole row has been judged, all taps on the row will be set to hidden. */
 	bool		bHidden;
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -2530,6 +2530,7 @@ void Player::Step( int col, int row, const RageTimer &tm, bool bHeld, bool bRele
 					Message msg( "EarlyHit" );
 					msg.SetParam( "Player", m_pPlayerState->m_PlayerNumber );
 					msg.SetParam( "TapNoteScore", score );
+					msg.SetParam( "Column", col );
 					MESSAGEMAN->Broadcast( msg );
 				}
 			} else {

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -2668,6 +2668,7 @@ void Player::UpdateTapNotesMissedOlderThan( float fMissIfOlderThanSeconds )
 		{
 			if (tn.result.earlyTns != TNS_None) {
 				tn.result.tns = tn.result.earlyTns;
+				tn.result.fTapNoteOffset = tn.result.fEarlyTapNoteOffset;
 			} else {
 				tn.result.tns = TNS_Miss;
 			}

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -1291,8 +1291,11 @@ void Player::UpdateHoldNotes( int iSongRow, float fDeltaTime, std::vector<TrackR
 		// taps was hit before activating this group of holds.
 		/* Something about the logic in this section is causing 192nd steps to
 		 * fail for some odd reason. -aj */
-		bSteppedOnHead &= (tns != TNS_Miss && tns != TNS_None);	// did they step on the start of this hold?
-		bHeadJudged &= (tns != TNS_None);	// has this hold really even started yet?
+		// NOTE(teejusb): We want early hits to count as a hit on the hold head
+		// otherwise it visually looks weird if you never have a second hit for the
+		// arrow.
+		bSteppedOnHead &= (tns != TNS_Miss && tns != TNS_None || tn.result.earlyTns != TNS_None);	// did they step on the start of this hold?
+		bHeadJudged &= (tns != TNS_None || tn.result.earlyTns != TNS_None);	// has this hold really even started yet?
 
 		/*
 		if(bSteppedOnHead)

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -2516,7 +2516,7 @@ void Player::Step( int col, int row, const RageTimer &tm, bool bHeld, bool bRele
 				// want to change the life once.
 				if (pTN->result.earlyTns == TNS_None) {
 					pTN->result.earlyTns = score;
-					pTN->result.fTapNoteOffset = -fNoteOffset;
+					pTN->result.fEarlyTapNoteOffset = -fNoteOffset;
 					ChangeLife( score );
 					// TODO: This should maybe also trigger a judgment change and a score
 					// change on hit. If a player gets an early way off, and doesn't
@@ -2531,6 +2531,7 @@ void Player::Step( int col, int row, const RageTimer &tm, bool bHeld, bool bRele
 					msg.SetParam( "Player", m_pPlayerState->m_PlayerNumber );
 					msg.SetParam( "TapNoteScore", score );
 					msg.SetParam( "Column", col );
+					msg.SetParam( "TapNoteOffset", -fNoteOffset);
 					MESSAGEMAN->Broadcast( msg );
 				}
 			} else {
@@ -3292,6 +3293,7 @@ void Player::SetJudgment( int iRow, int iTrack, const TapNote &tn, TapNoteScore 
 		msg.SetParam( "Early", fTapNoteOffset < 0.0f );
 		msg.SetParam( "TapNoteOffset", tn.result.fTapNoteOffset );
 		msg.SetParam( "EarlyTapNoteScore", tn.result.earlyTns );
+		msg.SetParam( "EarlyTapNoteOffset", tn.result.fEarlyTapNoteOffset );
 
 		if ( tns == TNS_Miss )
 			msg.SetParam( "HeldMiss", tn.result.bHeld );

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -3291,6 +3291,7 @@ void Player::SetJudgment( int iRow, int iTrack, const TapNote &tn, TapNoteScore 
 		msg.SetParam( "TapNoteScore", tns );
 		msg.SetParam( "Early", fTapNoteOffset < 0.0f );
 		msg.SetParam( "TapNoteOffset", tn.result.fTapNoteOffset );
+		msg.SetParam( "EarlyTapNoteScore", tn.result.earlyTns );
 
 		if ( tns == TNS_Miss )
 			msg.SetParam( "HeldMiss", tn.result.bHeld );
@@ -3341,6 +3342,7 @@ void Player::SetHoldJudgment( TapNote &tn, int iTrack )
 		msg.SetParam( "NumTracks", (int)m_vpHoldJudgment.size() );
 		msg.SetParam( "TapNoteScore", tn.result.tns );
 		msg.SetParam( "HoldNoteScore", tn.HoldResult.hns );
+		msg.SetParam( "EarlyTapNoteScore", tn.result.earlyTns );
 
 		Lua* L = LUA->Get();
 		tn.PushSelf(L);

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -170,7 +170,7 @@ static Preference<float> m_fTimingWindowJump	( "TimingWindowJump",		0.25 );
 static Preference<float> m_fMaxInputLatencySeconds	( "MaxInputLatencySeconds",	0.0 );
 static Preference<bool> g_bEnableAttackSoundPlayback	( "EnableAttackSounds", true );
 static Preference<bool> g_bEnableMineSoundPlayback	( "EnableMineHitSound", true );
-static Preference<int> g_iMinTnsToScoreTapNote	( "MinTnsToScoreTapNote", 3 );  // Default to great and above.
+static Preference<int> g_iMinTnsToScoreTapNote	( "MinTnsToScoreTapNote", 3 );  // Default to great and above. Use -1 to indicate None.
 
 /** @brief How much life is in a hold note when you start on it? */
 ThemeMetric<float> INITIAL_HOLD_LIFE		( "Player", "InitialHoldLife" );
@@ -2521,15 +2521,10 @@ void Player::Step( int col, int row, const RageTimer &tm, bool bHeld, bool bRele
 					pTN->result.earlyTns = score;
 					pTN->result.fEarlyTapNoteOffset = -fNoteOffset;
 					ChangeLife( score );
-					// TODO: This should maybe also trigger a judgment change and a score
-					// change on hit. If a player gets an early way off, and doesn't
-					// attempt to hit the arrow again, then they'll be met with a way off
-					// judgment instead of a miss which is weird behavior.
-					// We should give the user instant feedback when they get an EarlyHit,
-					// and then update the feedback if they manage to successfully re-hit
-					// the arrow. For now, we can just use the msg below to aid with this
-					// feedback.
-					
+					// We don't want to trigger a JudgmentMessage since we use that to
+					// indicate "finalized" judgments. We handle that elsewhere so instead
+					// we introduce a new EarlyHitMessage to control the instant feedback
+					// we want to relay to to the player.					
 					Message msg( "EarlyHit" );
 					msg.SetParam( "Player", m_pPlayerState->m_PlayerNumber );
 					msg.SetParam( "TapNoteScore", score );


### PR DESCRIPTION
This allows players to incur a life bar hit for early "bad" judgments, while allowing them to rescore the same note for a better judgment. This is similar to IIDX's early poor window. This also mitigates way off towers/error bombing which is bad player experience.

We introduce a new preference (`MinTNStoScoreNote`) which we default to `3`  to indicate that Greats or higher are considered "good" judgments. A value of `-1` would restore normal SM5 functionality.