### PR TITLE
pref to bass simplify lighting

### DIFF
--- a/src/NoteDataUtil.cpp
+++ b/src/NoteDataUtil.cpp
@@ -752,6 +752,24 @@ void LightTransformHelper( const NoteData &in, NoteData &out, const std::vector<
 // For every track enabled in "in", enable all tracks in "out".
 void NoteDataUtil::LoadTransformedLights( const NoteData &in, NoteData &out, int iNewNumTracks )
 {
+	// make a new NoteData that is a copy of the input.
+	NoteData bass;
+	bass.Init();
+	bass.CopyAll( in );
+
+	// if the user desires,
+	// copy from the marquee data, but slim down the notes.
+	// this makes it look more bass-ish and less like the original chart.
+	if(PREFSMAN->m_bLightsSimplifyBass)
+	{
+		RemoveHoldNotes( bass );
+		Little( bass );
+	}
+
+	LoadTransformedLightsFromTwo( in, bass, out );
+
+	// old code which will make all lights blink on every note.
+	/*
 	// reset all notes
 	out.Init();
 
@@ -762,6 +780,7 @@ void NoteDataUtil::LoadTransformedLights( const NoteData &in, NoteData &out, int
 		aiTracks.push_back( i );
 
 	LightTransformHelper( in, out, aiTracks );
+	*/
 }
 
 // This transform is specific to StepsType_lights_cabinet.

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -287,6 +287,7 @@ PrefsManager::PrefsManager() :
 	m_iRageSoundSampleCountClamp	("RageSoundSampleCountClamp", 0), //some sound drivers mask the sample location number, the most popular number for this is 2^27, this causes lockup after ~50 minutes at 44.1khz sample rate
 	m_iSoundPreferredSampleRate	( "SoundPreferredSampleRate",		0 ),
 	m_sLightsStepsDifficulty	( "LightsStepsDifficulty",		"hard,medium" ),
+	m_bLightsSimplifyBass		( "LightsSimplifyBass",		false),
 	m_bAllowUnacceleratedRenderer	( "AllowUnacceleratedRenderer",		false ),
 	m_bThreadedInput		( "ThreadedInput",			true ),
 	m_bThreadedMovieDecode		( "ThreadedMovieDecode",		true ),

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -313,6 +313,7 @@ public:
 	Preference<int> m_iRageSoundSampleCountClamp;
 	Preference<int>	m_iSoundPreferredSampleRate;
 	Preference<RString>	m_sLightsStepsDifficulty;
+	Preference<bool>	m_bLightsSimplifyBass;
 	Preference<bool>	m_bAllowUnacceleratedRenderer;
 	Preference<bool>	m_bThreadedInput;
 	Preference<bool>	m_bThreadedMovieDecode;

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1419,6 +1419,7 @@ void ScreenGameplay::LoadLights()
 	pSteps->GetNoteData( TapNoteData1 );
 
 	//taken from oitg, restores arrow -> marquee/bass light mapping.
+	//if the user has a pref for more than one difficulty to make the lighting chart...
 	if( asDifficulties.size() > 1 )
 	{
 		Difficulty d2 = StringToDifficulty( asDifficulties[1] );
@@ -1427,7 +1428,10 @@ void ScreenGameplay::LoadLights()
 
 		pSteps2 = SongUtil::GetClosestNotes( GAMESTATE->m_pCurSong, st, d2 );
 
-		if(pSteps2 != nullptr)
+		//if the difficulities are actually different
+		//then we can use them to generate a lighting chart.
+		//as the user defined.
+		if(pSteps != pSteps2)
 		{
 			NoteData TapNoteData2;
 			pSteps2->GetNoteData( TapNoteData2 );


### PR DESCRIPTION
As mentioned by @GRIM657 in a discord message, oITG takes an additional step during the generation of lighting charts.

In the event there is only one difficultly to make a lighting chart, oITG will map the four arrows to the marquee lights, and actually simplify down the bass lighting. It does this by taking out all of the holds, then leaving only the quarter notes.

This commit adds back this feature as a user preference `LightsSimplifyBass`. By setting true, you will use this feature to reduce the bass lighting, and false it will use the original code path.

Automatic lighting for charts with multiple difficulties defined using `LightsStepsDifficulty` are unaffected by this commit. Lights for the marquee are also unaffected by this commit, it is only modifying the frequency of the bass lighting.

Examples with a chart that only has an 11:
`LightsSimplifyBass` true: https://streamable.com/wsouh1
`LightsSimplifyBass` false: https://streamable.com/dfw70b

The preference will default to `false` as this is a "new" feature for mainline stepmania.