### PR TITLE
fix: don't deadlock lua when closing a websockethandle

### DIFF
--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -328,10 +328,12 @@ int WebSocketHandle::Close(lua_State *L)
 {
 	void *udata = luaL_checkudata(L, 1, "WebSocketHandle");
 	auto handle = *static_cast<WebSocketHandlePtr*>(udata);
-	LUA->YieldLua();
+	// No need to yield lua here as we don't even have it locked.
+	// Yielding and unyielding results in Lua staying locked here forever.
+	// LUA->YieldLua(); 
 	handle->webSocket.stop();
 	handle->onClose();
-	LUA->UnyieldLua();
+	// LUA->UnyieldLua();
 	return 0;
 }
 


### PR DESCRIPTION
fixes #129 

probably, i didn't test it but i *think* its right. recommend you compile and check this.