### PR TITLE
Allow high score name entry on charts with zero jumps or freezes

### DIFF
--- a/src/NoteDataWithScoring.cpp
+++ b/src/NoteDataWithScoring.cpp
@@ -401,16 +401,25 @@ void NoteDataWithScoring::GetActualRadarValues(const NoteData &in,
 		switch(rc)
 		{
 			case RadarCategory_Stream:
-				out[rc]= clamp(float(state.notes_hit_for_stream) / note_count, 0.0f, 1.0f);
+				if (note_count > 0.0f)
+					out[rc] = clamp(float(state.notes_hit_for_stream) / note_count, 0.0f, 1.0f);
+				else
+					out[rc] = 0.0f;
 				break;
 			case RadarCategory_Voltage:
 				out[rc]= GetActualVoltageRadarValue(in, hittable_steps_length, pss);
 				break;
 			case RadarCategory_Air:
-				out[rc]= clamp(float(state.jumps_hit_for_air) / jump_count, 0.0f, 1.0f);
+				if (jump_count > 0.0f)
+					out[rc] = clamp(float(state.jumps_hit_for_air) / jump_count, 0.0f, 1.0f);
+				else
+					out[rc] = 0.0f;
 				break;
 			case RadarCategory_Freeze:
-				out[rc]= clamp(float(state.holds_held) / hold_count, 0.0f, 1.0f);
+				if (hold_count > 0.0f)
+					out[rc] = clamp(float(state.holds_held) / hold_count, 0.0f, 1.0f);
+				else
+					out[rc] = 0.0f;
 				break;
 			case RadarCategory_Chaos:
 				out[rc]= GetActualChaosRadarValue(in, song_seconds, pss);


### PR DESCRIPTION
Currently, there is a bug that sometimes doesn't allow the user to enter their name when getting a high score. To reproduce with a fresh build of Stepmania:

1. Turn off Event Mode
2. Play a chart with either zero freezes or zero jumps; get a high score (requires at least 10%)
3. Do not get any other high scores in the same set

It should save your score; however, on ScreenEvaluation, you will not see "Machine Record 1" (or similar) for the score achieved in Step 2, and if you followed Step 3 then you will not be allowed to enter your name at the end of the set, leaving the score recorded by an empty name.

This happens because playing a song with no jumps or freezes can produce Air or Freeze radar values of `NaN`. Since testing equality with `NaN` always produces `false`, that means a `HighScoreImpl` object that contains a `RadarValues` object that contains a `NaN` can never equal itself (note that both `HighScoreImpl` and `RadarValues` overload the `==` operator to compare fields). This means the call to `find` fails at the end of `StageStats::FinalizeScores` will never succeed, which sets `m_iMachineHighScoreIndex` to -1, which in turn causes `EarnedMachineRecord` to be `false` in `BGAnimations\ScreenEvaluation common\PerPlayer\Upper\RecordTexts.lua`.

Checking for zero before division in `NoteDataWithScoring::GetActualRadarValues` is just a simple fix; it may be worthwhile for someone more familiar with the codebase to review both radar calculation and high score indexing as a whole