### PR TITLE
Preferred Sort Fixes - Allow Songs in multiple sections, No screen reload required when changing preferred songs.

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -1871,6 +1871,7 @@
 			<Function name='SetPreferredSongs'/>
 			<Function name='ShortenGroupName'/>
 			<Function name='SongToPreferredSortSectionName'/>
+			<Function name='GetPreferredSortSongsBySectionName'/>
 			<Function name='WasLoadedFromAdditionalCourses'/>
 			<Function name='WasLoadedFromAdditionalSongs'/>
 		</Class>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -5901,6 +5901,9 @@ local args = {
 	<Function name='SongToPreferredSortSectionName' return='string' arguments='Song s'>
 		Returns the preferred sort section name for the specified Song.
 	</Function>
+	<Function name='GetPreferredSortSongsBySectionName' return='{Song}' arguments='string sSectionName'>
+		Returns a table containing all songs in the specified preferred sort section.
+	</Function>
 	<Function name='WasLoadedFromAdditionalCourses' return='bool' arguments='Course c'>
 		[Deprecated] Always returns <code>false</code>.
 	</Function>

--- a/Themes/_fallback/Graphics/Banner Preferred.redir
+++ b/Themes/_fallback/Graphics/Banner Preferred.redir
@@ -1,0 +1,1 @@
+Common fallback banner

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -937,8 +937,11 @@ void MusicWheel::readyWheelItemsData(SortOrder so) {
 			BuildWheelItemDatas(  aUnFilteredDatas, so );
 		}
 		FilterWheelItemDatas( aUnFilteredDatas, m__WheelItemDatas[so], so );
-		m_WheelItemDatasStatus[so]=VALID;
-
+		// The preferred sort's songs are subject to change during a session (particularly if two players have different preferred songs) 
+		// thus it's status should remain invalid so the wheel items are rebuilt each time in case of change.
+		if (so != SORT_PREFERRED) {
+			m_WheelItemDatasStatus[so]=VALID;
+		}
 		LOG->Trace( "MusicWheel sorting took: %f", timer.GetTimeSinceStart() );
 	}
 
@@ -1229,7 +1232,9 @@ void MusicWheel::ChangeMusic( int iDist )
 bool MusicWheel::ChangeSort( SortOrder new_so, bool allowSameSort )	// return true if change successful
 {
 	ASSERT( new_so < NUM_SortOrder );
-	if( GAMESTATE->m_SortOrder == new_so && !allowSameSort )
+	// Ignore allowSameSort if we're using SORT_PREFERRED
+	// Each player has their own preferred songs which sorts the songs differently -crashcringle
+	if( GAMESTATE->m_SortOrder == new_so && (!allowSameSort && new_so != SORT_PREFERRED ))
 	{
 		return false;
 	}

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -682,24 +682,19 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 			{
 				if( bUseSections )
 				{
-					// Get all section names
-					std::vector<RString> vsSectionNames = SONGMAN->GetPreferredSortSectionNames();
-					for( unsigned i=0; i<vsSectionNames.size(); i++ )
+					// Get mappping of section names to songs
+					std::map<RString, std::vector<Song*>> preferredSortSongsMap = SONGMAN->GetPreferredSortSongsMap();
+					for (auto const& [sectionName, songs] : SONGMAN->GetPreferredSortSongsMap())
 					{
-						
-						// Get all songs in this section
-						std::vector<Song*> vsSongsInSection = SONGMAN->GetPreferredSortSongsBySectionName( vsSectionNames[i] );
-						
 						// todo: preferred sort section color handling? -aj
 						RageColor colorSection = SECTION_COLORS.GetValue(iSectionColorIndex);
 						iSectionColorIndex = (iSectionColorIndex+1) % NUM_SECTION_COLORS;
-
 						// Add the section item
-						arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Section, nullptr, vsSectionNames[i], nullptr, SONGMAN->GetSongGroupColor(vsSectionNames[i]), vsSongsInSection.size()) );
+						arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Section, nullptr, sectionName, nullptr, colorSection, songs.size()) );
 						// Add all the songs in this section
-						for( unsigned j=0; j<vsSongsInSection.size(); j++ )
+						for (auto const& song : songs)
 						{
-							arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Song, vsSongsInSection[j], vsSectionNames[i], nullptr, SONGMAN->GetSongColor(vsSongsInSection[j]), 0) );
+							arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Song, song, sectionName, nullptr, SONGMAN->GetSongColor(song), 0) );
 						}
 					}
 				}
@@ -725,7 +720,6 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 							iSectionCount = j-i;
 
 							// new section, make a section item
-							// todo: preferred sort section color handling? -aj
 							RageColor colorSection = (so==SORT_GROUP) ? SONGMAN->GetSongGroupColor(pSong->m_sGroupName) : SECTION_COLORS.GetValue(iSectionColorIndex);
 							iSectionColorIndex = (iSectionColorIndex+1) % NUM_SECTION_COLORS;
 							arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Section, nullptr, sThisSection, nullptr, colorSection, iSectionCount) );

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -1232,8 +1232,8 @@ void MusicWheel::ChangeMusic( int iDist )
 bool MusicWheel::ChangeSort( SortOrder new_so, bool allowSameSort )	// return true if change successful
 {
 	ASSERT( new_so < NUM_SortOrder );
-	// Ignore allowSameSort if we're using SORT_PREFERRED
-	// Each player has their own preferred songs which sorts the songs differently -crashcringle
+	// NOTE(crashcringle): Ignore allowSameSort if we're using SORT_PREFERRED.
+	// Each player has their own preferred songs which sorts the songs differently
 	if( GAMESTATE->m_SortOrder == new_so && (!allowSameSort && new_so != SORT_PREFERRED ))
 	{
 		return false;

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -845,6 +845,43 @@ RString SongManager::SongToPreferredSortSectionName( const Song *pSong ) const
 	return RString();
 }
 
+
+void SongManager::GetPreferredSortSongsBySectionName( const RString &sSectionName, std::vector<Song*> &AddTo ) const
+{
+	for (PreferredSortSection const &v : m_vPreferredSongSort)
+	{
+		if (v.sName == sSectionName)
+		{
+			AddTo.insert( AddTo.end(), v.vpSongs.begin(), v.vpSongs.end() );
+			return;
+		}
+	}
+}
+
+std::vector<Song*> SongManager::GetPreferredSortSongsBySectionName( const RString &sSectionName ) const
+{
+	std::vector<Song*> AddTo;
+	for (PreferredSortSection const &v : m_vPreferredSongSort)
+	{
+		if (v.sName == sSectionName)
+		{
+			AddTo.insert( AddTo.end(), v.vpSongs.begin(), v.vpSongs.end() );
+			return AddTo;
+		}
+	}
+	return AddTo;
+}
+
+std::vector<RString> SongManager::GetPreferredSortSectionNames() const
+{
+	std::vector<RString> sectionNames;
+	for (PreferredSortSection const &v : m_vPreferredSongSort)
+	{
+		sectionNames.push_back(v.sName);
+	}
+	return sectionNames;
+}
+	
 void SongManager::GetPreferredSortCourses( CourseType ct, std::vector<Course*> &AddTo, bool bIncludeAutogen ) const
 {
 	if( m_vPreferredCourseSort.empty() )
@@ -1605,7 +1642,6 @@ void SongManager::SetPreferredSongs(RString sPreferredSongs, bool bIsAbsolute) {
 	ASSERT( UNLOCKMAN != nullptr );
 
 	m_vPreferredSongSort.clear();
-
 	std::vector<RString> asLines;
 	RString sFile = sPreferredSongs;
 	if (!bIsAbsolute)
@@ -2219,6 +2255,14 @@ public:
 		lua_pushstring(L, p->SongToPreferredSortSectionName(pSong));
 		return 1;
 	}
+	static int GetPreferredSortSongsBySectionName( T* p, lua_State *L )
+	{
+		std::vector<Song*> v;
+		p->GetPreferredSortSongsBySectionName(SArg(1), v);
+		LuaHelpers::CreateTableFromArray<Song*>( v, L );
+		return 1;
+	}
+
 	static int WasLoadedFromAdditionalSongs( T* p, lua_State *L )	{ lua_pushboolean(L, false); return 1; }	// deprecated
 	static int WasLoadedFromAdditionalCourses( T* p, lua_State *L )	{ lua_pushboolean(L, false); return 1; }	// deprecated
 
@@ -2261,6 +2305,7 @@ public:
 		ADD_METHOD( GetPopularSongs );
 		ADD_METHOD( GetPopularCourses );
 		ADD_METHOD( SongToPreferredSortSectionName );
+		ADD_METHOD( GetPreferredSortSongsBySectionName );
 		ADD_METHOD( WasLoadedFromAdditionalSongs );	// deprecated
 		ADD_METHOD( WasLoadedFromAdditionalCourses );	// deprecated
 	}

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -861,14 +861,7 @@ void SongManager::GetPreferredSortSongsBySectionName( const RString &sSectionNam
 std::vector<Song*> SongManager::GetPreferredSortSongsBySectionName( const RString &sSectionName ) const
 {
 	std::vector<Song*> AddTo;
-	for (PreferredSortSection const &v : m_vPreferredSongSort)
-	{
-		if (v.sName == sSectionName)
-		{
-			AddTo.insert( AddTo.end(), v.vpSongs.begin(), v.vpSongs.end() );
-			return AddTo;
-		}
-	}
+	GetPreferredSortSongsBySectionName(sSectionName, AddTo);
 	return AddTo;
 }
 

--- a/src/SongManager.h
+++ b/src/SongManager.h
@@ -144,6 +144,10 @@ public:
 
 	void GetPreferredSortSongs( std::vector<Song*> &AddTo ) const;
 	RString SongToPreferredSortSectionName( const Song *pSong ) const;
+	std::vector<RString> GetPreferredSortSectionNames() const;
+	std::vector<Song*> GetPreferredSortSongsBySectionName( const RString &sSectionName ) const;
+	void GetPreferredSortSongsBySectionName( const RString &sSectionName, std::vector<Song*> &AddTo ) const;
+
 	const std::vector<Course*> &GetPopularCourses( CourseType ct ) const { return m_pPopularCourses[ct]; }
 	Song *FindSong( RString sPath ) const;
 	Song *FindSong( RString sGroup, RString sSong ) const;

--- a/src/SongManager.h
+++ b/src/SongManager.h
@@ -143,6 +143,7 @@ public:
 	const std::vector<Song *> &GetAllSongsOfCurrentGame() const;
 
 	void GetPreferredSortSongs( std::vector<Song*> &AddTo ) const;
+	std::map<RString, std::vector<Song*>> GetPreferredSortSongsMap() const { return m_mapPreferredSectionToSongs;};
 	RString SongToPreferredSortSectionName( const Song *pSong ) const;
 	std::vector<RString> GetPreferredSortSectionNames() const;
 	std::vector<Song*> GetPreferredSortSongsBySectionName( const RString &sSectionName ) const;
@@ -229,6 +230,8 @@ protected:
 		RString sName;
 		std::vector<Song*> vpSongs;
 	};
+	/** @brief All preferred songs, keyed by section */
+	std::map<RString, std::vector<Song*>> m_mapPreferredSectionToSongs;
 	std::vector<PreferredSortSection> m_vPreferredSongSort;
 	std::vector<RString>		m_sSongGroupNames;
 	std::vector<RString>		m_sSongGroupBannerPaths; // each song group may have a banner associated with it


### PR DESCRIPTION
This PR aims to fix two issues in Preferred sorting (Favorites):
1) Songs cannot appear in more than one section
2) When two players are joined, you have to reload the screen in order for the preferred sort to update.


**1)** This commit fixes a breaking issue with the MusicWheel. SM5/ITGMania allows users to create custom groups/sections by creating a file that defines the songs and their respective sections as they should appear in the music wheel. There is a bug where if you put the same song in more than 1 section, the Music wheel will freak out. This is because the current implementation establishes the relationship between song and section as 1:1, despite allowing users and themers to define custom groups/sections where the relationship between song and section is 1:M. 

Players are now able to include a song in multiple sections. Themers are now  also able to display the Preferred Sort of two players in a single music wheel (This previously would have caused the same issue to occur). 

> Basically it has a list of every single song.  The way the songs get organized into sections is from the method GetSectionNameFromSongAndSort. Which returns the section name a song belongs to. That means the relationship between song and section is 1:1.
> I was first looking at this with Preferred sort - How can I get a song to be able to appear in multiple sections? (In early Favorites implementations, when you chose to view favorites from the sort menu, the two sections you had were P1's Favorites and P2's Favorites. This caused an issue because sometimes P1 and P2 would have the same song in both of their favorites which caused the music wheel to go nuts.)
> 
> The preferred sort as it is allows people to have custom folders set up, but the issue remains where a song can only appear in one section.
> My thought was that there must be a way to change the music wheel logic from operating Song --> Section to instead Section --> Songs.
> 
> So I created methods for GetPreferredSortSectionNames() and GetPreferredSortSongsBySectionName( const RString &sSectionName )
> There was already an existing variable m_vPreferredSongSort, of type vector<(PreferredSortSection>,  which contains every section.
> So now instead of looping through each song and matching it to a section. I now loop through each section and add all of it's respective songs to the music wheel.
> I thought about how to implement this further. But I realized that for most sorts, every song would only belong to 1 section. (A song only has 1 lengh, 1 title, 1 genre, 1 artist, 1 bpm(s)). 
> So really the only place this would be needed is Preferred Sorting because its the only place that allows for a song to be placed into multiple sections. It's the only place where a user/theme can put a song in multiple sections.

**2)** The songs included in each respective sort are not updated despite changes that might occur during the session. Currently, in order to use preferred sorting with two players, you need to reload the select music screen to allow the changes to the preferred sort's songs to be seen. 


This commit ensures that the music wheel will be rebuilt when setting the sort to PREFERRED. This is needed because the songs in this particular sort are prone to change during a session because two players can have different preferred songs. Additionally, profiles can change during a session which increases the likelihood of the PreferredSort's wheel data needing to be updated. This commit will properly rebuild the music wheel when the sort is changed to SORT_PREFERRED.

On the theme side, there is no longer a need to reload the screen.