### PR TITLE
feat: allow `0` as a valid value for chart level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     name: Ubuntu
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Checkout submodules
         run: git submodule update --init
       - name: Install dependencies
@@ -35,7 +35,7 @@ jobs:
     name: macOS (M1)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Checkout submodules
         run: git submodule update --init
       - name: Install dependencies
@@ -50,7 +50,7 @@ jobs:
     name: macOS (Intel)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Checkout submodules
         run: git submodule update --init
       - name: Install dependencies

--- a/src/NoteDataUtil.cpp
+++ b/src/NoteDataUtil.cpp
@@ -752,6 +752,24 @@ void LightTransformHelper( const NoteData &in, NoteData &out, const std::vector<
 // For every track enabled in "in", enable all tracks in "out".
 void NoteDataUtil::LoadTransformedLights( const NoteData &in, NoteData &out, int iNewNumTracks )
 {
+	// make a new NoteData that is a copy of the input.
+	NoteData bass;
+	bass.Init();
+	bass.CopyAll( in );
+
+	// if the user desires,
+	// copy from the marquee data, but slim down the notes.
+	// this makes it look more bass-ish and less like the original chart.
+	if(PREFSMAN->m_bLightsSimplifyBass)
+	{
+		RemoveHoldNotes( bass );
+		Little( bass );
+	}
+
+	LoadTransformedLightsFromTwo( in, bass, out );
+
+	// old code which will make all lights blink on every note.
+	/*
 	// reset all notes
 	out.Init();
 
@@ -762,6 +780,7 @@ void NoteDataUtil::LoadTransformedLights( const NoteData &in, NoteData &out, int
 		aiTracks.push_back( i );
 
 	LightTransformHelper( in, out, aiTracks );
+	*/
 }
 
 // This transform is specific to StepsType_lights_cabinet.

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -287,6 +287,7 @@ PrefsManager::PrefsManager() :
 	m_iRageSoundSampleCountClamp	("RageSoundSampleCountClamp", 0), //some sound drivers mask the sample location number, the most popular number for this is 2^27, this causes lockup after ~50 minutes at 44.1khz sample rate
 	m_iSoundPreferredSampleRate	( "SoundPreferredSampleRate",		0 ),
 	m_sLightsStepsDifficulty	( "LightsStepsDifficulty",		"hard,medium" ),
+	m_bLightsSimplifyBass		( "LightsSimplifyBass",		false),
 	m_bAllowUnacceleratedRenderer	( "AllowUnacceleratedRenderer",		false ),
 	m_bThreadedInput		( "ThreadedInput",			true ),
 	m_bThreadedMovieDecode		( "ThreadedMovieDecode",		true ),

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -313,6 +313,7 @@ public:
 	Preference<int> m_iRageSoundSampleCountClamp;
 	Preference<int>	m_iSoundPreferredSampleRate;
 	Preference<RString>	m_sLightsStepsDifficulty;
+	Preference<bool>	m_bLightsSimplifyBass;
 	Preference<bool>	m_bAllowUnacceleratedRenderer;
 	Preference<bool>	m_bThreadedInput;
 	Preference<bool>	m_bThreadedMovieDecode;

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1419,6 +1419,7 @@ void ScreenGameplay::LoadLights()
 	pSteps->GetNoteData( TapNoteData1 );
 
 	//taken from oitg, restores arrow -> marquee/bass light mapping.
+	//if the user has a pref for more than one difficulty to make the lighting chart...
 	if( asDifficulties.size() > 1 )
 	{
 		Difficulty d2 = StringToDifficulty( asDifficulties[1] );
@@ -1427,7 +1428,10 @@ void ScreenGameplay::LoadLights()
 
 		pSteps2 = SongUtil::GetClosestNotes( GAMESTATE->m_pCurSong, st, d2 );
 
-		if(pSteps2 != nullptr)
+		//if the difficulities are actually different
+		//then we can use them to generate a lighting chart.
+		//as the user defined.
+		if(pSteps != pSteps2)
 		{
 			NoteData TapNoteData2;
 			pSteps2->GetNoteData( TapNoteData2 );

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -291,8 +291,8 @@ void Steps::TidyUpData()
 		else				SetDifficulty( Difficulty_Hard );
 	}
 
-	if( GetMeter() < 1) // meter is invalid
-		SetMeter( int(PredictMeter()) );
+	if( GetMeter() < 0) // meter is negative
+		SetMeter(1);
 }
 
 void Steps::CalculateRadarValues( float fMusicLengthSeconds )


### PR DESCRIPTION
This PR allows you to have a level of `0` in your chart.

# Why

Not everything necessarily deserves a serious rating, consider joke charts from Scrapyard Kent, things where "what level should this be" is an invalid question.

Sometimes, you just don't need to give a chart a rating.

# Stopgaps

You can deliberately make your chart level a joke at the moment, `42069`, `99999`, etc. are all obvious indications of a nonsensical un-rated chart, but they're a pain in the ass to fit nicely in a theme, and cause inelegant issues with code that seeks to do any sort of math on chart levels.

One could say that doing any sort of math on user-provided chart levels is misguided to begin with, but that's what people do, so lol.

# Backwards Compatibility

Any SM version other than itgmania will treat `0` as `1`. This is pretty much harmless in the grand scheme of things.

# Theming

Themes could treat a level of `0` with a special icon indicating that the chart has no level given.

