### PR TITLE
Fix groove radar value calculation

### DIFF
--- a/src/NoteDataWithScoring.cpp
+++ b/src/NoteDataWithScoring.cpp
@@ -401,16 +401,16 @@ void NoteDataWithScoring::GetActualRadarValues(const NoteData &in,
 		switch(rc)
 		{
 			case RadarCategory_Stream:
-				out[rc]= clamp(float(state.notes_hit_for_stream) / note_count, 0.0f, 1.0f);
+				out[rc]= note_count == 0 ? 0.0f : clamp(float(state.notes_hit_for_stream) / note_count, 0.0f, 1.0f);
 				break;
 			case RadarCategory_Voltage:
 				out[rc]= GetActualVoltageRadarValue(in, hittable_steps_length, pss);
 				break;
 			case RadarCategory_Air:
-				out[rc]= clamp(float(state.jumps_hit_for_air) / jump_count, 0.0f, 1.0f);
+				out[rc]= jump_count == 0 ? 0.0f : clamp(float(state.jumps_hit_for_air) / jump_count, 0.0f, 1.0f);
 				break;
 			case RadarCategory_Freeze:
-				out[rc]= clamp(float(state.holds_held) / hold_count, 0.0f, 1.0f);
+				out[rc]= hold_count == 0 ? 0.0f : clamp(float(state.holds_held) / hold_count, 0.0f, 1.0f);
 				break;
 			case RadarCategory_Chaos:
 				out[rc]= GetActualChaosRadarValue(in, song_seconds, pss);


### PR DESCRIPTION
This fixes high score comparison that compare groove radar values, which ended up being NaN for values with no freezes/jumps.