### PR TITLE
Make tomcrypt workaround for #107 apply everywhere

### DIFF
--- a/extern/CMakeProject-tomcrypt.cmake
+++ b/extern/CMakeProject-tomcrypt.cmake
@@ -469,14 +469,13 @@ if(WITH_NO_ROLC_TOMCRYPT)
   target_compile_definitions("tomcrypt" PRIVATE LTC_NO_ROLC)
 endif()
 
+# Fixes build failures due to clang warnings
+# See itgmania/itgmania#107 for details
+# TODO(teejusb/natano): Remove these two lines once these issues have been fixed upstream.
+set_property(TARGET "tomcrypt" PROPERTY C_STANDARD 90)
+set_property(TARGET "tomcrypt" PROPERTY C_STANDARD_REQUIRED ON)
 if(APPLE)
   set_property(TARGET "tomcrypt" PROPERTY XCODE_ATTRIBUTE_GCC_NO_COMMON_BLOCKS "YES")
-
-  # Fixes build failures due to warnings on macOS >= 13.3
-  # See itgmania/itgmania#107 for details
-  # TODO(teejusb/natano): Remove these two lines once these issues have been fixed upstream.
-  set_property(TARGET "tomcrypt" PROPERTY C_STANDARD 90)
-  set_property(TARGET "tomcrypt" PROPERTY C_STANDARD_REQUIRED ON)
 endif()
 if(MSVC)
   target_compile_definitions("tomcrypt" PRIVATE _CRT_SECURE_NO_WARNINGS)


### PR DESCRIPTION
I'm seeing the same warning building with clang on Linux.