### PR TITLE
Add InputDeviceOrder parameter to Preferences.ini

### DIFF
--- a/src/RageInput.cpp
+++ b/src/RageInput.cpp
@@ -12,6 +12,7 @@
 RageInput* INPUTMAN = nullptr; // global and accessible from anywhere in our program
 
 Preference<RString> g_sInputDrivers( "InputDrivers", "" ); // "" == DEFAULT_INPUT_DRIVER_LIST
+Preference<RString> g_sInputLinuxJoysticks( "InputLinuxJoysticks", "" ); // "" == DEFAULT_LINUX_INPUT_JOYSTICK_LIST
 
 namespace
 {

--- a/src/RageInput.cpp
+++ b/src/RageInput.cpp
@@ -12,7 +12,7 @@
 RageInput* INPUTMAN = nullptr; // global and accessible from anywhere in our program
 
 Preference<RString> g_sInputDrivers( "InputDrivers", "" ); // "" == DEFAULT_INPUT_DRIVER_LIST
-Preference<RString> g_sInputLinuxJoysticks( "InputLinuxJoysticks", "" ); // "" == DEFAULT_LINUX_INPUT_JOYSTICK_LIST
+Preference<RString> g_sInputDeviceOrder( "InputDeviceOrder", "" ); // "" == DEFAULT_LINUX_INPUT_DEVICE_ORDER_LIST
 
 namespace
 {

--- a/src/RageInput.h
+++ b/src/RageInput.h
@@ -36,6 +36,7 @@ public:
 };
 
 extern Preference<RString> g_sInputDrivers;
+extern Preference<RString> g_sInputLinuxJoysticks;
 
 extern RageInput*			INPUTMAN;	// global and accessible from anywhere in our program
 

--- a/src/RageInput.h
+++ b/src/RageInput.h
@@ -36,7 +36,7 @@ public:
 };
 
 extern Preference<RString> g_sInputDrivers;
-extern Preference<RString> g_sInputLinuxJoysticks;
+extern Preference<RString> g_sInputDeviceOrder;
 
 extern RageInput*			INPUTMAN;	// global and accessible from anywhere in our program
 

--- a/src/arch/InputHandler/LinuxInputManager.cpp
+++ b/src/arch/InputHandler/LinuxInputManager.cpp
@@ -3,10 +3,11 @@
 #include "InputHandler_Linux_Event.h"
 #include "InputHandler_Linux_Joystick.h"
 
-#include "RageInput.h" // g_sInputDrivers
+#include "RageInput.h" // g_sInputDrivers g_sInputLinuxJoysticks
 #include "RageLog.h"
 
 #include <string> // std::string::npos
+#include <vector>
 
 #if defined(HAVE_DIRENT_H)
 #include <dirent.h>
@@ -104,6 +105,11 @@ void LinuxInputManager::InitDriver(InputHandler_Linux_Event* driver)
 void LinuxInputManager::InitDriver(InputHandler_Linux_Joystick* driver)
 {
 	m_JoystickDriver = driver;
+	// Discard all the joystick devices if they were assigned manually via 
+	// 	LinuxInputJoysticks
+	if( g_sInputLinuxJoysticks.Get() != "" ) {
+		m_vsPendingJoystickDevices.clear();
+	}
 
 	for (RString &dev : m_vsPendingJoystickDevices)
 	{
@@ -112,8 +118,15 @@ void LinuxInputManager::InitDriver(InputHandler_Linux_Joystick* driver)
 		
 		driver->TryDevice(devFile);
 	}
-	
-	m_vsPendingJoystickDevices.clear();
+
+	// If any, add the manually specified devices via LinuxInputJoysticks
+	std::vector<RString> fixedDevices;
+	split( g_sInputLinuxJoysticks, ",", fixedDevices, true );
+
+	for (RString dev : fixedDevices) {
+		RString devFile = dev;
+		driver->TryDevice(devFile);
+	}
 }
 
 LinuxInputManager* LINUXINPUT = nullptr; // global and accessible anywhere in our program

--- a/src/arch/InputHandler/LinuxInputManager.cpp
+++ b/src/arch/InputHandler/LinuxInputManager.cpp
@@ -3,7 +3,7 @@
 #include "InputHandler_Linux_Event.h"
 #include "InputHandler_Linux_Joystick.h"
 
-#include "RageInput.h" // g_sInputDrivers g_sInputLinuxJoysticks
+#include "RageInput.h" // g_sInputDrivers g_sInputDeviceOrder
 #include "RageLog.h"
 
 #include <string> // std::string::npos
@@ -106,8 +106,8 @@ void LinuxInputManager::InitDriver(InputHandler_Linux_Joystick* driver)
 {
 	m_JoystickDriver = driver;
 	// Discard all the joystick devices if they were assigned manually via 
-	// 	LinuxInputJoysticks
-	if( g_sInputLinuxJoysticks.Get() != "" ) {
+	// 	InputDeviceOrder
+	if( g_sInputDeviceOrder.Get() != "" ) {
 		m_vsPendingJoystickDevices.clear();
 	}
 
@@ -119,9 +119,9 @@ void LinuxInputManager::InitDriver(InputHandler_Linux_Joystick* driver)
 		driver->TryDevice(devFile);
 	}
 
-	// If any, add the manually specified devices via LinuxInputJoysticks
+	// If any, add the manually specified devices via InputDeviceOrder
 	std::vector<RString> fixedDevices;
-	split( g_sInputLinuxJoysticks, ",", fixedDevices, true );
+	split( g_sInputDeviceOrder, ",", fixedDevices, true );
 
 	for (RString dev : fixedDevices) {
 		RString devFile = dev;


### PR DESCRIPTION
**Background**

I am currently helping a venue to install an ITGMania system with two independent dancepads.

These two dancepads are identical, and we led into an issue where they do not have a consistent order to be added to the game. Sometimes the left pad is P1, and some other time it's P2.

We tried by resolving it with udev rules, trying to override the device name, but that might not be possible.

**Changes**

In order to let any ITGMania user enforce an order in the joysticks, I have added some changes to the LinuxInputManager, so, _when the LinuxJoystick input driver is loaded_, and _LinuxInputJoysticks is not empty_, the other joysticks are ignored, and only the ones specified in _LinuxInputJoysticks_ are loaded.

**Testing**

0- Created an udev rule, so the left dancepad is always /dev/input/stepmania0. Same for the right dancepad on /dev/input/stepmania1

1- Set InputDrivers=X11,LinuxJoystick

2- Executed the game, so Preferences.ini is regenerated

3- Added InputLinuxJoysticks=/dev/input/stepmania0,/dev/input/stepmania1

4- Now the game always start with the controllers in the correct order


