### PR TITLE
Course GRADEBEST/GRADEWORST fixes

### DIFF
--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -383,11 +383,14 @@ static void CourseSortSongs( SongSort sort, std::vector<Song*> &vpPossibleSongs,
 			SongUtil::SortSongPointerArrayByNumPlays( vpPossibleSongs, PROFILEMAN->GetMachineProfile(), false );	// ascending
 		break;
 	case SongSort_TopGrades:
-		if( PROFILEMAN )
+		// SongUtil::SortSongPointerArrayByGrades() will crash if called in a state where there's no current master player 
+		// (for instance when returning to the Title Menu). 
+		// A workaround is to just not call it if we know that GAMESTATE->GetMasterPlayerNumber() == PlayerNumber_Invalid
+		if( PROFILEMAN && GAMESTATE->GetMasterPlayerNumber() != PlayerNumber_Invalid )
 			SongUtil::SortSongPointerArrayByGrades( vpPossibleSongs, true );	// descending
 		break;
 	case SongSort_LowestGrades:
-		if( PROFILEMAN )
+		if( PROFILEMAN && GAMESTATE->GetMasterPlayerNumber() != PlayerNumber_Invalid )
 			SongUtil::SortSongPointerArrayByGrades( vpPossibleSongs, false );	// ascending
 		break;
 	}

--- a/src/CourseWriterCRS.cpp
+++ b/src/CourseWriterCRS.cpp
@@ -128,6 +128,14 @@ bool CourseWriterCRS::Write( const Course &course, RageFileBasic &f, bool bSavin
 		{
 			f.Write( ssprintf( "#SONG:WORST%d", entry.iChooseIndex+1 ) );
 		}
+		else if( entry.songSort == SongSort_TopGrades && entry.iChooseIndex != -1 )
+		{
+			f.Write( ssprintf( "#SONG:GRADEBEST%d", entry.iChooseIndex + 1 ) );
+		}
+		else if( entry.songSort == SongSort_LowestGrades && entry.iChooseIndex != -1 )
+		{
+			f.Write( ssprintf( "#SONG:GRADEWORST%d", entry.iChooseIndex + 1 ) );
+		}
 		else if( entry.songID.ToSong() )
 		{
 			Song *pSong = entry.songID.ToSong();


### PR DESCRIPTION
I came across two issues while working on some additions that I'd like to make to the course file format.

- CourseWriterCRS::Write() ignored GRADEBEST and GRADEWORST, which would result in the course cache files writing incorrect course entries. Essentially, an entry of `#SONG:GRADEBEST1;` would get translated into `#SONG:*:3..6;`.

- In certain situations, when returning to the main title screen from marathon mode, the game would crash. `SongUtil::SortSongPointerArrayByGrades()` tries to access `GAMESTATE->GetCurrentStyle(GAMESTATE->GetMasterPlayerNumber())`, but the GAMESTATE's master player is `PlayerNumber_Invalid` in that state. I suspect that this issue has gone unnoticed largely because of the previous issue (this crash would only happen the very first time a course is loaded, and then only if the player navigated to it in the marathon mode), and probably because not many people make custom courses.

I'm not sure if/how `SongUtil::SortSongPointerArrayByGrades()` should handle this issue or not. It could fail gracefully and return early if master player is `PlayerNumber_Invalid`. Or, perhaps we could add an assertion so that it throws an explicit error in this case.