### PR TITLE
Add Top Grades sorts per profile

### DIFF
--- a/Themes/_fallback/Graphics/Banner TopP1Grades.redir
+++ b/Themes/_fallback/Graphics/Banner TopP1Grades.redir
@@ -1,0 +1,1 @@
+Common fallback banner

--- a/Themes/_fallback/Graphics/Banner TopP2Grades.redir
+++ b/Themes/_fallback/Graphics/Banner TopP2Grades.redir
@@ -1,0 +1,1 @@
+Common fallback banner

--- a/Themes/_fallback/Languages/en.ini
+++ b/Themes/_fallback/Languages/en.ini
@@ -309,6 +309,8 @@ PreferredText=Preferred
 TitleText=Title
 RecentText=Recent
 TopGradesText=Top Grades
+TopP1GradesText=P1 Top Grades
+TopP2GradesText=P2 Top Grades
 
 CoursesText=Courses
 AllCoursesText=All Courses

--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -965,7 +965,7 @@ RecentSongsToShow=30
 
 UseEasyMarkerFlag=false
 
-ModeMenuChoiceNames="Preferred,Group,Title,Bpm,Popularity,TopGrades,Artist,EasyMeter,MediumMeter,HardMeter,ChallengeMeter,DoubleEasyMeter,DoubleMediumMeter,DoubleHardMeter,DoubleChallengeMeter,Genre,Length,Recent"
+ModeMenuChoiceNames="Preferred,Group,Title,Bpm,Popularity,TopGrades,TopP1Grades,TopP2Grades,Artist,EasyMeter,MediumMeter,HardMeter,ChallengeMeter,DoubleEasyMeter,DoubleMediumMeter,DoubleHardMeter,DoubleChallengeMeter,Genre,Length,Recent"
 # ModeMenuChoiceNames="Preferred,Group,Title,Bpm,Popularity,TopGrades,Artist,EasyMeter,MediumMeter,HardMeter,ChallengeMeter,DoubleEasyMeter,DoubleMediumMeter,DoubleHardMeter,DoubleChallengeMeter,Genre,Length,Recent,NormalMode,BattleMode"
 ChoicePreferred="sort,Preferred"
 ChoiceGroup="sort,Group"
@@ -973,6 +973,8 @@ ChoiceTitle="sort,Title"
 ChoiceBpm="sort,BPM"
 ChoicePopularity="sort,Popularity"
 ChoiceTopGrades="sort,TopGrades"
+ChoiceTopP1Grades="sort,TopP1Grades"
+ChoiceTopP2Grades="sort,TopP2Grades"
 ChoiceArtist="sort,Artist"
 ChoiceGenre="sort,Genre"
 ChoiceEasyMeter="sort,EasyMeter"

--- a/src/GameConstantsAndTypes.cpp
+++ b/src/GameConstantsAndTypes.cpp
@@ -166,6 +166,8 @@ static const char *SortOrderNames[] = {
 	"BPM",
 	"Popularity",
 	"TopGrades",
+	"TopP1Grades",
+	"TopP2Grades",
 	"Artist",
 	"Genre",
 	"BeginnerMeter",

--- a/src/GameConstantsAndTypes.h
+++ b/src/GameConstantsAndTypes.h
@@ -166,6 +166,8 @@ enum SortOrder
 	SORT_BPM, /**< Sort by the Song's BPM. */
 	SORT_POPULARITY, /**< Sort by how popular the Song is. */
 	SORT_TOP_GRADES, /**< Sort by the highest grades earned on a Song. */
+	SORT_TOP_GRADES_P1, /**< Sort by the highest grades earned on a Song for P1. */
+	SORT_TOP_GRADES_P2, /**< Sort by the highest grades earned on a Song for P2. */
 	SORT_ARTIST, /**< Sort by the name of the artist of the Song. */
 	SORT_GENRE, /**< Sort by the Song's genre. */
 	SORT_BEGINNER_METER, /**< Sort by the difficulty of the single beginner meter. */

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -544,6 +544,8 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 		case SORT_BPM:
 		case SORT_POPULARITY:
 		case SORT_TOP_GRADES:
+		case SORT_TOP_GRADES_P1:
+		case SORT_TOP_GRADES_P2:
 		case SORT_ARTIST:
 		case SORT_GENRE:
 		case SORT_BEGINNER_METER:
@@ -600,7 +602,21 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 					bUseSections = false;
 					break;
 				case SORT_TOP_GRADES:
-					SongUtil::SortSongPointerArrayByGrades( arraySongs, true );
+						SongUtil::SortSongPointerArrayByGrades( arraySongs, true );
+					break;
+				case SORT_TOP_GRADES_P1:
+					// Check if master player profile is persistent
+					if( PROFILEMAN->IsPersistentProfile(PLAYER_1) )
+						SongUtil::SortSongPointerArrayByProfileGrades( arraySongs, true, PLAYER_1);
+					else
+						SongUtil::SortSongPointerArrayByGrades( arraySongs, true );
+					break;
+				case SORT_TOP_GRADES_P2:
+					if( PROFILEMAN->IsPersistentProfile(PLAYER_2) )
+						SongUtil::SortSongPointerArrayByProfileGrades( arraySongs, true, PLAYER_2);
+					else
+						SongUtil::SortSongPointerArrayByGrades( arraySongs, true );
+
 					break;
 				case SORT_ARTIST:
 					SongUtil::SortSongPointerArrayByArtist( arraySongs );
@@ -665,6 +681,8 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 				{
 					case SORT_PREFERRED:
 					case SORT_TOP_GRADES:
+					case SORT_TOP_GRADES_P1:
+					case SORT_TOP_GRADES_P2:
 					case SORT_BPM:
 					case SORT_LENGTH:
 						break;	// don't sort by section

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -605,18 +605,13 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 						SongUtil::SortSongPointerArrayByGrades( arraySongs, true );
 					break;
 				case SORT_TOP_GRADES_P1:
-					// Check if master player profile is persistent
+					// Check if player profile is persistent
 					if( PROFILEMAN->IsPersistentProfile(PLAYER_1) )
 						SongUtil::SortSongPointerArrayByProfileGrades( arraySongs, true, PLAYER_1);
-					else
-						SongUtil::SortSongPointerArrayByGrades( arraySongs, true );
 					break;
 				case SORT_TOP_GRADES_P2:
 					if( PROFILEMAN->IsPersistentProfile(PLAYER_2) )
 						SongUtil::SortSongPointerArrayByProfileGrades( arraySongs, true, PLAYER_2);
-					else
-						SongUtil::SortSongPointerArrayByGrades( arraySongs, true );
-
 					break;
 				case SORT_ARTIST:
 					SongUtil::SortSongPointerArrayByArtist( arraySongs );

--- a/src/SongUtil.h
+++ b/src/SongUtil.h
@@ -2,7 +2,7 @@
 
 #ifndef SONG_UTIL_H
 #define SONG_UTIL_H
-
+#include "PlayerNumber.h"
 #include "GameConstantsAndTypes.h"
 #include "Difficulty.h"
 
@@ -138,6 +138,7 @@ namespace SongUtil
 	void SortSongPointerArrayByTitle( std::vector<Song*> &vpSongsInOut );
 	void SortSongPointerArrayByBPM( std::vector<Song*> &vpSongsInOut );
 	void SortSongPointerArrayByGrades( std::vector<Song*> &vpSongsInOut, bool bDescending );
+	void SortSongPointerArrayByProfileGrades( std::vector<Song*> &vpSongsInOut, bool bDescending, PlayerNumber pn );
 	void SortSongPointerArrayByArtist( std::vector<Song*> &vpSongsInOut );
 	void SortSongPointerArrayByDisplayArtist( std::vector<Song*> &vpSongsInOut );
 	void SortSongPointerArrayByGenre( std::vector<Song*> &vpSongsInOut );


### PR DESCRIPTION
Add Top Grades sort per profile. This allows each player to see their top grades based on the currently used profile.

The present implementation adds 2 new sorts for this, TOP_P1_Grades and TOP_P2_GRADES following the naming convention of TOP_GRADES which returns the machine grades.

I named the sort TopP1Grades rather than TopGradesP1 to prevent the "conflicting" banner error.

Eventually, I'd like to condense this to be 1 sort fed a playernumber or profile parameter in the future.

This commit does not change the existing functionality of sorting by grades, it only adds methods for choosing whose grades are shown. 

The "x `n`" for each grade corresponds to the number of difficulties you have that grade on. So the 4 star x 2 means that the songs in that category I have quadded on two of that song's steps. This is part of the already existing functionality which was not modified.
![image](https://github.com/itgmania/itgmania/assets/30600688/e5f2fa66-32fa-4886-9cc2-725df353f8e4)

![image](https://github.com/itgmania/itgmania/assets/30600688/60290cd1-4409-4992-8d53-402e574552a8)

