### PR TITLE
Ensure that a time signature always exists for beat 0

### DIFF
--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -772,6 +772,7 @@ void SMLoader::ProcessDelays( TimingData &out, const RString line, const int row
 void SMLoader::ProcessTimeSignatures( TimingData &out, const RString line, const int rowsPerBeat )
 {
 	std::vector<RString> vs1;
+	std::vector<TimeSignatureSegment> segments;
 	split( line, ",", vs1 );
 
 	for (RString const &s1 : vs1)
@@ -818,8 +819,21 @@ void SMLoader::ProcessTimeSignatures( TimingData &out, const RString line, const
 				     fBeat, iDenominator );
 			continue;
 		}
+		segments.push_back( TimeSignatureSegment(BeatToNoteRow(fBeat), iNumerator, iDenominator) );
+	}
+	
+	// If there are any time signatures defined, but there isn't one
+	// for the very first beat of the song, then add one.
+	// Without it, calls to functions like TimingData::NoteRowToMeasureAndBeat
+	// can fail for charts that are otherwise valid.
+	if ( segments.size() > 0 && segments[0].GetRow() > 0 )
+	{
+		out.AddSegment( TimeSignatureSegment(0, 4, 4) );
+	}
 
-		out.AddSegment( TimeSignatureSegment(BeatToNoteRow(fBeat), iNumerator, iDenominator) );
+	for( TimeSignatureSegment segment: segments )
+	{
+		out.AddSegment( segment );
 	}
 }
 

--- a/src/NotesLoaderSMA.cpp
+++ b/src/NotesLoaderSMA.cpp
@@ -48,6 +48,7 @@ void SMALoader::ProcessMultipliers( TimingData &out, const int iRowsPerBeat, con
 void SMALoader::ProcessBeatsPerMeasure( TimingData &out, const RString sParam )
 {
 	std::vector<RString> vs1;
+	std::vector<TimeSignatureSegment> segments;
 	split( sParam, ",", vs1 );
 
 	for (RString const &s1 : vs1)
@@ -82,8 +83,21 @@ void SMALoader::ProcessBeatsPerMeasure( TimingData &out, const RString sParam )
 				     fBeat, iNumerator );
 			continue;
 		}
+		segments.push_back( TimeSignatureSegment(BeatToNoteRow(fBeat), iNumerator) );
+	}
 
-		out.AddSegment( TimeSignatureSegment(BeatToNoteRow(fBeat), iNumerator) );
+	// If there are any time signatures defined, but there isn't one
+	// for the very first beat of the song, then add one.
+	// Without it, calls to functions like TimingData::NoteRowToMeasureAndBeat
+	// can fail for charts that are otherwise valid.
+	if ( segments.size() > 0 && segments[0].GetRow() > 0 )
+	{
+		out.AddSegment( TimeSignatureSegment(0, 4, 4) );
+	}
+
+	for( TimeSignatureSegment segment: segments )
+	{
+		out.AddSegment( segment );
 	}
 }
 


### PR DESCRIPTION
If a simfile has multiple time signatures defined, but happens not to have an initial time signature defined for beat 0, `SMLoader::ProcessTimeSignatures()` should add one. Without that initial time signature, calls to `TimingData::NoteRowToMeasureAndBeat()` will fail for rows that don't have a time signature defined.

I ran into this issue while working on porting some of the SimplyLove chart parsing code. A handful of simfiles on ZiV don't have proper `#TIMESIGNATURES` defined, and it was causing a crash. And rather than try to change `TimingData::NoteRowToMeasureAndBeat()` to handle this, just adding the missing time signature seemed like the better option.