### PR TITLE
Added a new #SONGSELECT course tag

### DIFF
--- a/Docs/CourseFormat.txt
+++ b/Docs/CourseFormat.txt
@@ -88,7 +88,7 @@ Complete Course Template
 
 
 
-#SONGSELECT:GROUP=Stepmania 5:BPMRANGE=120..160:Difficulty=Medium:MODS=2x;
+#SONGSELECT:GROUP=Stepmania 5:BPMRANGE=120-160:Difficulty=Medium:MODS=2x;
 -- #SONGSELECT is a new alternative to the #SONG tag, which will (hopefully)
 -- be easier to use and understand. Instead of relying on values input in a
 -- very specific and poorly-documented order, this tag is composed of 
@@ -150,7 +150,7 @@ Complete Course Template
 #SONGSELECT:DIFFICULTY=Medium,Hard;
 
 --  METER= A minimum and maximum value of a song's difficulty meter,
---  separated by EXACTLY TWO (2) periods.
+--  separated by a dash `-`.
 --  Notes:
 --  - This is independent of the DIFFICULTY parameter, which can be used
 --    along with METER to further refine a specific song hardness.
@@ -160,10 +160,10 @@ Complete Course Template
 --  - These values are inclusive, meaning that song with a meter that is exactly
 --    the value of minimum or maximum can be chosen.
 --  Example:
-#SONGSELECT:METER=8..12;
+#SONGSELECT:METER=8-12;
 
 --  BPMRANGE= A minimum and maximum value of a song's bpm, 
---  separated by EXACTLY TWO (2) periods.
+--  separated by a dash `-`.
 --  Notes:
 --  - The "bpm" values refer to the displayed bpm value/range of a song.
 --    This means that a song may be chosen if its #DISPLAYBPM matches the 
@@ -174,19 +174,19 @@ Complete Course Template
 --  - This range is inclusive, meaning that a song with a bpm that is exactly
 --    the value of the lower or upper range can also be chosen. 
 --  - This also means that if you want to choose songs of a very specific bpm,
---    like songs that are exactly 120 bpm, you can specify BPMRANGE=120..120
+--    like songs that are exactly 120 bpm, you can specify BPMRANGE=120-120
 -- Example:
-#SONGSELECT:BPMRANGE=120..150;
+#SONGSELECT:BPMRANGE=120-150;
 
 --  DURATION= A minimum and maximum value, in seconds, for the length of a song,
---            separated by EXACTLY TWO (2) periods.
+--  separated by a dash `-`.
 --  Notes:
 --  - The "duration" values refers to either the song file's actual length, or
 --    The simfile's #MUSICLENGTH value, if specified.
 --  - These values should only be whole numbers (no decimal places).
 --  - This range is inclusive.
 --  Example:
-#SONGSELECT:DURATION=90..125;
+#SONGSELECT:DURATION=90-125;
 
 --  SORT= A set of two values that specify a sort type and a number, separated
 --  by a comma. For example, SORT=MostPlays,1 selects the #1 most played song on
@@ -231,4 +231,4 @@ Finally, here's an example course:
 #SONGSELECT:GROUP=Stepmania 5:MODS=Overhead;
 #SONGSELECT:ARTIST=Kommisar:MODS=2x;
 #SONGSELECT:GROUP=In The Groove:TITLE=Mouth;
-#SONGSELECT:BPMRANGE=110..160:DIFFICULTY=Medium;
+#SONGSELECT:BPMRANGE=110-160:DIFFICULTY=Medium;

--- a/Docs/CourseFormat.txt
+++ b/Docs/CourseFormat.txt
@@ -96,8 +96,7 @@ Complete Course Template
 
 -- The following parameters are available for selecting a song:
 -- TITLE, GROUP, ARTIST, GENRE, DIFFICULTY, METER, BPMRANGE, DURATION, SORT
--- With the exception of SORT, these can be used in any combination and order.
--- (See the SORT parameter description below for a better explanation)
+-- These can be used in any combination and order.
 -- If none are specified, then a song and difficulty will be chosen completely at random.
 -- If a combination is specified that results in no possible songs to select,
 -- then that #SONGSELECT entry is skipped.
@@ -198,16 +197,18 @@ Complete Course Template
 --  by a comma. For example, SORT=MostPlays,1 selects the #1 most played song on
 --  the machine, SORT=LowestGrades,10 selects the song that you've gotten your 10th
 --  worst score on.
+--  One possible use for this would be to create a course to force you to play songs 
+--  from certain groups that you likely haven't played before, by combining this with
+--  the GROUP parameter, eg "#SONGSELECT:GROUP=In the Groove:SORT=FewestPlays,1;"
+--  
 --  Notes:
 --  - Like DIFFICULTY, there are several acceptable values that are equivalent to each other.
 --    The old style values are Best, Worst, GradeBest, or GradeWorst. 
 --    For the sake of consistency and clarity, please consider using:
 --    MostPlays, FewestPlays, TopGrades, or LowestGrades.
 --  - The number value can be between 1 and 500.
---  - As noted at the beginning of the description of #SONGSELECT, this parameter isn't
---    really intended to be used with other selection parameters.
---    It's not really accurate to say that it *can't* be used with them, but you're much
---    more likely to find yourself with an entry that can't select any songs.
+--  - As of right now, the results from using this parameter aren't exactly accurate.
+--    I can't quite work out how/why it makes the choices that it does.
 -- Example:
 #SONGSELECT:SORT=MostPlays,4;
 

--- a/Docs/CourseFormat.txt
+++ b/Docs/CourseFormat.txt
@@ -111,15 +111,18 @@ Complete Course Template
 --  - Unlike the #SONG tag, this will not take into account group names.
 --    If you want to specify a specific song from a specific group, use
 --    this along with the GROUP parameter.
---  - This does not support names that have commmas.
+--  - Commas, and other control characters (`#`,`;`, `=`, and `:`) can be used, 
+--    but they must be escaped (like `\#`, `\,`, etc).
 --  Example: 
 #SONGSELECT:TITLE=Goin' Under,Springtime;  
+#SONGSELECT:TITLE=thank u\, next;
 
 --  GROUP= A list of one or more song groups, separated by commas.
 --  Notes:
 --  - The "group" refers to the directory name of the song group.
---  - This does not support folders that have commas in their name.
 --  - Group names must be an *exact match*.
+--  - Commas, and other control characters (`#`,`;`, `=`, and `:`) can be used, 
+--    but they must be escaped (like `\#`, `\,`, etc).
 --  Example: 
 #SONGSELECT:GROUP=Stepmania 5,In The Groove;
   
@@ -127,13 +130,16 @@ Complete Course Template
 --  Notes:
 --  - The "artist" refers to either the #ARTIST or #ARTISTTRANSLIT value
 --    of the simfile.
---  - This does not support artist names that contain commas.
+--  - Commas, and other control characters (`#`,`;`, `=`, and `:`) can be used, 
+--    but they must be escaped (like `\#`, `\,`, etc).
 -- Example:
 #SONGSELECT:ARTIST=Kommisar,NegaRen;
 
 --  GENRE= A list of one or more song genres, separated by commas.
 --  Notes:
 --  - The "genre" refers to the #GENRE tag of a song.
+--  - Commas, and other control characters (`#`,`;`, `=`, and `:`) can be used, 
+--    but they must be escaped (like `\#`, `\,`, etc).
 --  - Most songs don't actually have a #GENRE defined, which unfortunately
 --    makes this parameter not terribly useful at this time.
 -- Example:

--- a/Docs/CourseFormat.txt
+++ b/Docs/CourseFormat.txt
@@ -86,13 +86,149 @@ Complete Course Template
 -- Finally, award*, where * is a number, allows you to control how many lives
 -- the player gains from successfully completing a course in Oni mode.
 
+
+
+#SONGSELECT:GROUP=Stepmania 5:BPMRANGE=120..160:Difficulty=Medium:MODS=2x;
+-- #SONGSELECT is a new alternative to the #SONG tag, which will (hopefully)
+-- be easier to use and understand. Instead of relying on values input in a
+-- very specific and poorly-documented order, this tag is composed of 
+-- a series of PARAM=VALUE statements, separated by :'s. 
+
+-- The following parameters are available for selecting a song:
+-- TITLE, GROUP, ARTIST, GENRE, DIFFICULTY, METER, BPMRANGE, DURATION, SORT
+-- With the exception of SORT, these can be used in any combination and order.
+-- (See the SORT parameter description below for a better explanation)
+-- If none are specified, then a song and difficulty will be chosen completely at random.
+-- If a combination is specified that results in no possible songs to select,
+-- then that #SONGSELECT entry is skipped.
+
+-- Parameter Desciptions:
+--  TITLE= A list of one or more song titles, separated by commas.
+--  Notes: 
+--  - The "title" here can be either the name of the song directory,
+--    the #TITLE, or the #TITLETRANSLIT.
+--  - Titles must be an *exact match*.
+--  - Unlike the #SONG tag, this will not take into account group names.
+--    If you want to specify a specific song from a specific group, use
+--    this along with the GROUP parameter.
+--  - This does not support names that have commmas.
+--  Example: 
+#SONGSELECT:TITLE=Goin' Under,Springtime;  
+
+--  GROUP= A list of one or more song groups, separated by commas.
+--  Notes:
+--  - The "group" refers to the directory name of the song group.
+--  - This does not support folders that have commas in their name.
+--  - Group names must be an *exact match*.
+--  Example: 
+#SONGSELECT:GROUP=Stepmania 5,In The Groove;
+  
+--  ARTIST= A list of one or more artist names, separated by commas.
+--  Notes:
+--  - The "artist" refers to either the #ARTIST or #ARTISTTRANSLIT value
+--    of the simfile.
+--  - This does not support artist names that contain commas.
+-- Example:
+#SONGSELECT:ARTIST=Kommisar,NegaRen;
+
+--  GENRE= A list of one or more song genres, separated by commas.
+--  Notes:
+--  - The "genre" refers to the #GENRE tag of a song.
+--  - Most songs don't actually have a #GENRE defined, which unfortunately
+--    makes this parameter not terribly useful at this time.
+-- Example:
+#SONGSELECT:GENRE=J-Pop,Black Metal;
+
+--  DIFFICULTY= A list of one or more difficulties, separated by commas.
+--  Notes:
+--  - There are a number of acceptable values for this, but for the sake
+--    of consistency, please try to use:
+--    Beginner,Easy,Medium,Hard,Challenge,Edit
+--    (if you really want to use whacky value names, you can find the rest
+--     defined in Diffiulty.cpp)
+--  Example:
+#SONGSELECT:DIFFICULTY=Medium,Hard;
+
+--  METER= A minimum and maximum value of a song's difficulty meter,
+--  separated by EXACTLY TWO (2) periods.
+--  Notes:
+--  - This is independent of the DIFFICULTY parameter, which can be used
+--    along with METER to further refine a specific song hardness.
+--  - If DIFFICULTY is not specified, then any difficulty may be picked from
+--    a song that matches the given range.
+--  - These values must be whole numbers.
+--  - These values are inclusive, meaning that song with a meter that is exactly
+--    the value of minimum or maximum can be chosen.
+--  Example:
+#SONGSELECT:METER=8..12;
+
+--  BPMRANGE= A minimum and maximum value of a song's bpm, 
+--  separated by EXACTLY TWO (2) periods.
+--  Notes:
+--  - The "bpm" values refer to the displayed bpm value/range of a song.
+--    This means that a song may be chosen if its #DISPLAYBPM matches the 
+      given range, even though it's true bpm might not.
+--  - These values should only whole numbers (no decimal places).
+--  - If a song has a displayed bpm range, both the min and max values must
+--    be within the specified range.
+--  - This range is inclusive, meaning that a song with a bpm that is exactly
+--    the value of the lower or upper range can also be chosen. 
+--  - This also means that if you want to choose songs of a very specific bpm,
+--    like songs that are exactly 120 bpm, you can specify BPMRANGE=120..120
+-- Example:
+#SONGSELECT:BPMRANGE=120..150;
+
+--  DURATION= A minimum and maximum value, in seconds, for the length of a song,
+--            separated by EXACTLY TWO (2) periods.
+--  Notes:
+--  - The "duration" values refers to either the song file's actual length, or
+--    The simfile's #MUSICLENGTH value, if specified.
+--  - These values should only be whole numbers (no decimal places).
+--  - This range is inclusive.
+--  Example:
+#SONGSELECT:DURATION=90..125;
+
+--  SORT= A set of two values that specify a sort type and a number, separated
+--  by a comma. For example, SORT=MostPlays,1 selects the #1 most played song on
+--  the machine, SORT=LowestGrades,10 selects the song that you've gotten your 10th
+--  worst score on.
+--  Notes:
+--  - Like DIFFICULTY, there are several acceptable values that are equivalent to each other.
+--    The old style values are Best, Worst, GradeBest, or GradeWorst. 
+--    For the sake of consistency and clarity, please consider using:
+--    MostPlays, FewestPlays, TopGrades, or LowestGrades.
+--  - The number value can be between 1 and 500.
+--  - As noted at the beginning of the description of #SONGSELECT, this parameter isn't
+--    really intended to be used with other selection parameters.
+--    It's not really accurate to say that it *can't* be used with them, but you're much
+--    more likely to find yourself with an entry that can't select any songs.
+-- Example:
+#SONGSELECT:SORT=MostPlays,4;
+
+-- Besides the selection parameters, there are a few more parameters added to make sure that
+-- this can be a complete replacement for the #SONG tag.
+-- These parameters are:
+-- MODS, GAINSECONDS, GAINLIVES
+
+--  MODS= A list of modifiers that are applied to the entire song.
+--  Notes:
+--  - This does *NOT* replace the #MODS tag for specifying timed mods/attacks.
+--  - At ths time, I don't actually know what all can be specified as a modifier.
+
+--  GAINSECONDS= The number of seconds gained before starting a song.
+--  This is exactly the same as if specifying the #GAINSECONDS tag.
+
+--  GAINLIVES= The number of lives gained for completing this song. 
+--  This is equivalent to the 'award*' modifier for #SONG. 
+
 Finally, here's an example course:
+
 #COURSE:My Awesome Course - The Revenge;
 #METER:Medium:8;
 
 #MODS:
 	TIME:1.00:END:50.00:MODS:C150;
-#SONG:In The Groove/Dawn:Overhead;
-#SONG:In The Groove/Mouth:;
-#SONG:In The Groove 2/Funk Factory:;
-#SONG:In The Groove 3/Disconnected Zeo:;
+#SONGSELECT:GROUP=Stepmania 5:MODS=Overhead;
+#SONGSELECT:ARTIST=Kommisar:MODS=2x;
+#SONGSELECT:GROUP=In The Groove:TITLE=Mouth;
+#SONGSELECT:BPMRANGE=110..160:DIFFICULTY=Medium;

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -638,8 +638,7 @@ bool Course::GetTrailUnsorted( StepsType st, CourseDifficulty cd, Trail &trail )
 					if( iMaxDist == iMinDist )
 						iAdd = iMaxDist;
 					else {
-						std::uniform_int_distribution<> dist( iMinDist, iMaxDist );
-						iAdd = dist( rnd );
+						iAdd = std::floor((iMinDist + iMaxDist) / 2);
 					}
 					iLowMeter += iAdd;
 					iHighMeter += iAdd;
@@ -871,8 +870,7 @@ void Course::GetTrailUnsortedEndless( const std::vector<CourseEntry> &entries, T
 				if( iMaxDist == iMinDist )
 					iAdd = iMaxDist;
 				else {
-					std::uniform_int_distribution<> dist( iMinDist, iMaxDist );
-					iAdd = dist( rnd );
+					iAdd = std::floor((iMinDist + iMaxDist) / 2);
 				}
 				iLowMeter += iAdd;
 				iHighMeter += iAdd;

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -56,7 +56,7 @@ RString CourseEntry::GetTextDescription() const
 		vsEntryDescription.push_back( pSong->GetTranslitFullTitle() );
 	else
 		vsEntryDescription.push_back( "Random" );
-	if( !songCriteria.m_vsGroupNames.size() > 0 )
+	if( songCriteria.m_vsGroupNames.size() > 0 )
 		vsEntryDescription.push_back( join(",", songCriteria.m_vsGroupNames) );
 	if( songCriteria.m_bUseSongGenreAllowedList )
 		vsEntryDescription.push_back( join(",",songCriteria.m_vsSongGenreAllowedList) );

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -34,7 +34,7 @@ static const char *SongSortNames[] = {
 };
 XToString( SongSort );
 XToLocalizedString( SongSort );
-
+StringToX( SongSort );
 
 /* Maximum lower value of ranges when difficult: */
 const int MAX_BOTTOM_RANGE = 10;

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -85,19 +85,30 @@ RString CourseEntry::GetTextDescription() const
 	else
 		vsEntryDescription.push_back( "Random" );
 	if( songCriteria.m_vsGroupNames.size() > 0 )
-		vsEntryDescription.push_back( join(",", songCriteria.m_vsGroupNames) );
+		vsEntryDescription.push_back("Groups: " + join(",", songCriteria.m_vsGroupNames));
 	if( songCriteria.m_bUseSongGenreAllowedList )
 		vsEntryDescription.push_back( join(",",songCriteria.m_vsSongGenreAllowedList) );
+	if( songCriteria.m_vsArtistNames.size() > 0 )
+		vsEntryDescription.push_back("Artists: " + join(",", songCriteria.m_vsArtistNames));
 	if( stepsCriteria.m_difficulty != Difficulty_Invalid  &&  stepsCriteria.m_difficulty != Difficulty_Medium )
 		vsEntryDescription.push_back( CourseDifficultyToLocalizedString(stepsCriteria.m_difficulty) );
 	if( stepsCriteria.m_iLowMeter != -1 )
 		vsEntryDescription.push_back( ssprintf("Low meter: %d", stepsCriteria.m_iLowMeter) );
 	if( stepsCriteria.m_iHighMeter != -1 )
 		vsEntryDescription.push_back( ssprintf("High meter: %d", stepsCriteria.m_iHighMeter) );
-	if( songSort != SongSort_Randomize )
-		vsEntryDescription.push_back( "Sort: %d" + SongSortToLocalizedString(songSort) );
-	if( songSort != SongSort_Randomize && iChooseIndex != 0 )
-		vsEntryDescription.push_back( "Choose " + FormatNumberAndSuffix(iChooseIndex) + " match" );
+	if( songCriteria.m_fMinBPM != -1 )
+		vsEntryDescription.push_back(ssprintf("Min BPM: %.3f", songCriteria.m_fMinBPM));
+	if( songCriteria.m_fMaxBPM != -1 )
+		vsEntryDescription.push_back(ssprintf("Max BPM: %.3f", songCriteria.m_fMaxBPM));
+	if( songCriteria.m_fMinDurationSeconds != -1 )
+		vsEntryDescription.push_back(ssprintf("Min Duration: %.3f seconds", songCriteria.m_fMinDurationSeconds));
+	if( songCriteria.m_fMaxDurationSeconds != -1 )
+		vsEntryDescription.push_back(ssprintf("Max Duration: %.3f seconds", songCriteria.m_fMaxDurationSeconds));
+
+	if (songSort != SongSort_Randomize)
+		vsEntryDescription.push_back("Sort: " + SongSortToLocalizedString(songSort));
+	if( songSort != SongSort_Randomize && iChooseIndex != -1 )
+		vsEntryDescription.push_back( "Choose " + FormatNumberAndSuffix(iChooseIndex+1) + " match" );
 	int iNumModChanges = GetNumModChanges();
 	if( iNumModChanges != 0 )
 		vsEntryDescription.push_back( ssprintf("%d mod changes", iNumModChanges) );
@@ -396,8 +407,6 @@ bool Course::GetTrailSorted( StepsType st, CourseDifficulty cd, Trail &trail ) c
 // TODO: Move Course initialization after PROFILEMAN is created
 static void CourseSortSongs( SongSort sort, std::vector<Song*> &vpPossibleSongs, RandomGen &rnd )
 {
-	LOG->Trace("CourseSortSongs sort= %d | %s", sort, SongSortToString(sort).c_str());
-	LOG->Flush();
 	switch (sort)
 	{
 	case SongSort_Randomize:
@@ -552,7 +561,6 @@ bool Course::GetTrailUnsorted( StepsType st, CourseDifficulty cd, Trail &trail )
 				if( v.size() == 1 )
 					vpSongs.push_back( sas->pSong );
 			}
-			LOG->Trace("Course::GetTrailUnsorted");
 			
 			CourseSortSongs(e->songSort, vpSongs, rnd);
 

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -56,8 +56,8 @@ RString CourseEntry::GetTextDescription() const
 		vsEntryDescription.push_back( pSong->GetTranslitFullTitle() );
 	else
 		vsEntryDescription.push_back( "Random" );
-	if( !songCriteria.m_sGroupName.empty() )
-		vsEntryDescription.push_back( songCriteria.m_sGroupName );
+	if( !songCriteria.m_vsGroupNames.size() > 0 )
+		vsEntryDescription.push_back( join(",", songCriteria.m_vsGroupNames) );
 	if( songCriteria.m_bUseSongGenreAllowedList )
 		vsEntryDescription.push_back( join(",",songCriteria.m_vsSongGenreAllowedList) );
 	if( stepsCriteria.m_difficulty != Difficulty_Invalid  &&  stepsCriteria.m_difficulty != Difficulty_Medium )

--- a/src/Course.h
+++ b/src/Course.h
@@ -69,7 +69,7 @@ public:
 	float fGainSeconds;	// time gained back at the beginning of the song.  LifeMeterTime only.
 	int iGainLives;			// lives gained back at the beginning of the next song
 
-	CourseEntry(): bSecret(false), songID(), songCriteria(),
+	CourseEntry(): bSecret(false), bUseSongSelect(false), songID(), songCriteria(),
 		stepsCriteria(), bNoDifficult(false),
 		songSort(SongSort_Randomize), iChooseIndex(0),
 		sModifiers(RString("")), attacks(), fGainSeconds(0),

--- a/src/Course.h
+++ b/src/Course.h
@@ -47,6 +47,7 @@ const RString& SongSortToString( SongSort ss );
 const RString& SongSortToLocalizedString( SongSort ss );
 
 SongSort StringToSongSort( const RString& ss );
+SongSort OldStyleStringToSongSort( const RString& ss );
 
 class CourseEntry
 {

--- a/src/Course.h
+++ b/src/Course.h
@@ -39,16 +39,20 @@ enum SongSort
 	SongSort_TopGrades,
 	SongSort_LowestGrades,
 	NUM_SongSort,
+	SongSort_Invalid,
 };
 /** @brief Loop through the various Song Sorts. */
 #define FOREACH_SongSort( i ) FOREACH_ENUM( SongSort, i )
 const RString& SongSortToString( SongSort ss );
 const RString& SongSortToLocalizedString( SongSort ss );
 
+SongSort StringToSongSort( const RString& ss );
+
 class CourseEntry
 {
 public:
 	bool bSecret;			// show "??????" instead of an exact song
+	bool bUseSongSelect; 	// if true, this entry was created from a #SONGSELECT entry, instead of a #SONG entry
 
 	// filter criteria, applied from top to bottom
 	SongID songID;			// don't filter if unset

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -705,8 +705,6 @@ bool CourseLoaderCRS::ParseCommaSeparatedList(const RString &sParamValue, std::v
 {
 	std::vector<RString> items;
 	//...and here is where the string unescaping gets handled
-	// Because we're dealing with a comma-separated list, we have to handle any escaped commas 
-	// as a special case. Hopefully nobody writes a song called "||escaped-comma||"
 	RString unescapedParamValue = sParamValue;
 
 	split_minding_escaped_delims(sParamValue, ",", items);

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -133,7 +133,8 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 		else if( sValueName.EqualsNoCase("SONGSELECT") )
 		{
 			CourseEntry new_entry;
-			if( CourseLoaderCRS::ParseCourseSongSelect(sParams, new_entry, sPath) == false )
+			new_entry.bUseSongSelect = true;
+			if (CourseLoaderCRS::ParseCourseSongSelect(sParams, new_entry, sPath) == false)
 			{
 				out.m_bIncomplete = true;
 				continue; // Skip this #SONGSELECT
@@ -529,7 +530,7 @@ bool CourseLoaderCRS::ParseCourseSongSelect(const MsdFile::value_t &sParams, Cou
 	// I want to be able to make courses that are really weirdly specific, so I'm going to try to put together a different
 	// format for defining the song selection criteria.
 	// The basic idea is to free up the order in which the song criteria need to be specified, and to add a bunch more options.
-	// TITLE, GROUP, ARTIST, DIFFICULTY, BPMRANGE, DURATION, METER, GENRE, SORT, MODS
+	// TITLE, GROUP, ARTIST, DIFFICULTY, BPMRANGE, DURATION, METER, GENRE, SORT, MODS, GAINSECONDS, GAINLIVES
 	// #SONGSELECT:TITLE=sometitle,some other title;
 	// #SONGSELECT:GROUP=DDR A,DDR A3;
 	// #SONGSELECT:ARTIST=TaQ,Someone else;
@@ -627,7 +628,7 @@ bool CourseLoaderCRS::ParseCourseSongSelect(const MsdFile::value_t &sParams, Cou
 			new_entry.stepsCriteria.m_iLowMeter = StringToInt(meters[0]);
 			new_entry.stepsCriteria.m_iHighMeter = StringToInt(meters[1]);
 		}
-		else if( sParamName.EqualsNoCase("LIVES") )
+		else if( sParamName.EqualsNoCase("GAINLIVES") )
 		{
 			new_entry.iGainLives = StringToInt(sParamValue);
 		}

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -421,12 +421,12 @@ bool CourseLoaderCRS::ParseCourseSong( const MsdFile::value_t &sParams, CourseEn
 	}
 	else if( sParams[1] == "*" )
 	{
-		//new_entry.bSecret = true;
+		new_entry.bSecret = true;
 	}
 	// group random
 	else if( sParams[1].Right(1) == "*" )
 	{
-		//new_entry.bSecret = true;
+		new_entry.bSecret = true;
 		RString sSong = sParams[1];
 		sSong.Replace( "\\", "/" );
 		std::vector<RString> bits;

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -356,8 +356,6 @@ bool CourseLoaderCRS::ParseCourseMods( const MsdFile::value_t &sParams, AttackAr
 
 bool CourseLoaderCRS::ParseCourseSong( const MsdFile::value_t &sParams, CourseEntry &new_entry, const RString &sPath ) 
 {
-	LOG->Trace("CourseLoaderCRS::ParseCourseSong parsing song %s", sPath.c_str());
-	LOG->Trace("CourseLoaderCRS::ParseCourseSong sParams[1] =  %s", sParams[1].c_str());
 	// infer entry::Type from the first param
 	// todo: make sure these aren't generating bogus entries due
 	// to a lack of songs. -aj
@@ -443,7 +441,7 @@ bool CourseLoaderCRS::ParseCourseSong( const MsdFile::value_t &sParams, CourseEn
 		split( sSong, "/", bits );
 		if( bits.size() == 2 )
 		{
-			new_entry.songCriteria.m_sGroupName = bits[0];
+			new_entry.songCriteria.m_vsGroupNames.push_back(bits[0]);
 		}
 		else
 		{
@@ -451,7 +449,7 @@ bool CourseLoaderCRS::ParseCourseSong( const MsdFile::value_t &sParams, CourseEn
 						"Song should be in the format \"<group>/*\".", sSong.c_str() );
 		}
 
-		if( !SONGMAN->DoesSongGroupExist(new_entry.songCriteria.m_sGroupName) )
+		if( !SONGMAN->DoesSongGroupExist(bits[0]) )
 		{
 			LOG->UserLog( "Course file", sPath, "random_within_group entry \"%s\" specifies a group that doesn't exist. "
 						"This entry will be ignored.", sSong.c_str() );
@@ -468,8 +466,8 @@ bool CourseLoaderCRS::ParseCourseSong( const MsdFile::value_t &sParams, CourseEn
 		Song *pSong = nullptr;
 		if( bits.size() == 2 )
 		{
-			new_entry.songCriteria.m_sGroupName = bits[0];
-			pSong = SONGMAN->FindSong( bits[0], bits[1] );
+			new_entry.songCriteria.m_vsGroupNames.push_back(bits[0]);
+			pSong = SONGMAN->FindSong(bits[0], bits[1]);
 		}
 		else if( bits.size() == 1 )
 		{

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -554,7 +554,9 @@ bool CourseLoaderCRS::ParseCourseSongSelect(const MsdFile::value_t &sParams, Cou
 		RString sParamName = sParamParts[0];
 		RString sParamValue = sParamParts[1];
 
-		// For params that accept multiple items, if someone were to define it twice in one #SONGSELECT, should we overwrite the first, or append?
+		// For params that accept multiple items, if someone were to define it twice in one #SONGSELECT, 
+		// should we overwrite the first, or append? Currently, it just appends it all together.
+
 		if( sParamName.EqualsNoCase("TITLE") )
 		{
 			std::vector<RString> songTitles;
@@ -630,21 +632,21 @@ bool CourseLoaderCRS::ParseCourseSongSelect(const MsdFile::value_t &sParams, Cou
 		else if( sParamName.EqualsNoCase("DURATION") )
 		{
 			std::vector<RString> durations;	
-			split(sParamValue, "..", durations);
+			split(sParamValue, "-", durations);
 			new_entry.songCriteria.m_fMinDurationSeconds = StringToFloat(durations[0]);
 			new_entry.songCriteria.m_fMaxDurationSeconds = StringToFloat(durations[1]);
 		}
 		else if( sParamName.EqualsNoCase("BPMRANGE") )
 		{
 			std::vector<RString> bpms;	
-			split(sParamValue, "..", bpms);
+			split(sParamValue, "-", bpms);
 			new_entry.songCriteria.m_fMinBPM = StringToFloat(bpms[0]);
 			new_entry.songCriteria.m_fMaxBPM = StringToFloat(bpms[1]);
 		}
 		else if( sParamName.EqualsNoCase("METER") )
 		{
 			std::vector<RString> meters;
-			split(sParamValue, "..", meters);
+			split(sParamValue, "-", meters);
 			new_entry.stepsCriteria.m_iLowMeter = StringToInt(meters[0]);
 			new_entry.stepsCriteria.m_iHighMeter = StringToInt(meters[1]);
 		}
@@ -677,57 +679,10 @@ bool CourseLoaderCRS::ParseCourseSongSelect(const MsdFile::value_t &sParams, Cou
 			}
 			new_entry.sModifiers = join( ",", mods );
 		}
-	}
-	return true;
-}
-
-bool CourseLoaderCRS::ParseCourseSongSort(RString sParam, CourseEntry &new_entry, const RString &sPath)
-{
-	int iNumSongs = SONGMAN->GetNumSongs();
-	if( sParam.Left(strlen("BEST")) == "BEST" )
-	{
-		int iChooseIndex = StringToInt( sParam.Right(sParam.size()-strlen("BEST")) ) - 1;
-		if( iChooseIndex > iNumSongs )
+		else
 		{
-			// looking up a song that doesn't exist.
-			LOG->UserLog( "Course file", sPath, "is trying to load BEST%i with only %i songs installed. "
-						"This entry will be ignored.", iChooseIndex, iNumSongs);
-			return false; // skip this #SONG
+			LOG->UserLog( "Course file", sPath, "has an unexpected parameter named '%s', ignoring.", sParamName.c_str() );
 		}
-
-		new_entry.iChooseIndex = iChooseIndex;
-		CLAMP( new_entry.iChooseIndex, 0, 500 );
-		new_entry.songSort = SongSort_MostPlays;
-	}
-	// least played
-	else if( sParam.Left(strlen("WORST")) == "WORST" )
-	{
-		int iChooseIndex = StringToInt( sParam.Right(sParam.size()-strlen("WORST")) ) - 1;
-		if( iChooseIndex > iNumSongs )
-		{
-			// looking up a song that doesn't exist.
-			LOG->UserLog( "Course file", sPath, "is trying to load WORST%i with only %i songs installed. "
-						"This entry will be ignored.", iChooseIndex, iNumSongs);
-			return false; // skip this #SONG
-		}
-
-		new_entry.iChooseIndex = iChooseIndex;
-		CLAMP( new_entry.iChooseIndex, 0, 500 );
-		new_entry.songSort = SongSort_FewestPlays;
-	}
-	// best grades
-	else if( sParam.Left(strlen("GRADEBEST")) == "GRADEBEST" )
-	{
-		new_entry.iChooseIndex = StringToInt( sParam.Right(sParam.size()-strlen("GRADEBEST")) ) - 1;
-		CLAMP( new_entry.iChooseIndex, 0, 500 );
-		new_entry.songSort = SongSort_TopGrades;
-	}
-	// worst grades
-	else if( sParam.Left(strlen("GRADEWORST")) == "GRADEWORST" )
-	{
-		new_entry.iChooseIndex = StringToInt( sParam.Right(sParam.size()-strlen("GRADEWORST")) ) - 1;
-		CLAMP( new_entry.iChooseIndex, 0, 500 );
-		new_entry.songSort = SongSort_LowestGrades;
 	}
 	return true;
 }

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -527,21 +527,7 @@ bool CourseLoaderCRS::ParseCourseSong( const MsdFile::value_t &sParams, CourseEn
 
 bool CourseLoaderCRS::ParseCourseSongSelect(const MsdFile::value_t &sParams, CourseEntry &new_entry, const RString &sPath)
 {
-	// I want to be able to make courses that are really weirdly specific, so I'm going to try to put together a different
-	// format for defining the song selection criteria.
-	// The basic idea is to free up the order in which the song criteria need to be specified, and to add a bunch more options.
-	// TITLE, GROUP, ARTIST, DIFFICULTY, BPMRANGE, DURATION, METER, GENRE, SORT, MODS, GAINSECONDS, GAINLIVES
-	// #SONGSELECT:TITLE=sometitle,some other title;
-	// #SONGSELECT:GROUP=DDR A,DDR A3;
-	// #SONGSELECT:ARTIST=TaQ,Someone else;
-	// #SONGSELECT:DURATION=69..420;
-	// #SONGSELECT:DIFFICULTY=Easy,Hard;
-	// #SONGSELECT:BPMRANGE=150..160;
-	// #SONGSELECT:METER=5..9;
-	// #SONGSELECT:GENRE=Pop,Techno,Opera;
-	// #SONGSELECT:SORT=Best,1;
-	// #SONGSELECT:SORT=Worst,10;
-
+	
 	for( unsigned i = 1; i < sParams.params.size(); ++i )
 	{
 		std::vector<RString> sParamParts;

--- a/src/CourseLoaderCRS.h
+++ b/src/CourseLoaderCRS.h
@@ -57,7 +57,6 @@ namespace CourseLoaderCRS
 	bool ParseCourseMods( const MsdFile::value_t &sParams, AttackArray &attacks, const RString &sPath );
 	bool ParseCourseSong( const MsdFile::value_t &sParams, CourseEntry &new_entry, const RString &sPath );
 	bool ParseCourseSongSelect(const MsdFile::value_t &sParams, CourseEntry &new_entry, const RString &sPath);
-	bool ParseCourseSongSort(RString sParam, CourseEntry &new_entry, const RString &sPath);
 	bool SetCourseSongSort(CourseEntry &new_entry, SongSort sort, int index, const RString &sPath);
 }
 

--- a/src/CourseLoaderCRS.h
+++ b/src/CourseLoaderCRS.h
@@ -54,6 +54,8 @@ namespace CourseLoaderCRS
 
 	bool ParseCourseMods( const MsdFile::value_t &sParams, AttackArray &attacks, const RString &sPath );
 	bool ParseCourseSong( const MsdFile::value_t &sParams, CourseEntry &new_entry, const RString &sPath );
+	bool ParseCourseSongSelect(const MsdFile::value_t &sParams, CourseEntry &new_entry, const RString &sPath);
+	bool ParseCourseSongSort(RString sParam, CourseEntry &new_entry, const RString &sPath);
 }
 
 #endif

--- a/src/CourseLoaderCRS.h
+++ b/src/CourseLoaderCRS.h
@@ -4,8 +4,10 @@
 #define COURSE_LOADER_CRS_H
 
 #include "GameConstantsAndTypes.h"
+#include "MsdFile.h"
 class Course;
-class MsdFile;
+class CourseEntry;
+struct AttackArray;
 
 /** @brief The Course Loader handles parsing the .crs files. */
 namespace CourseLoaderCRS
@@ -49,6 +51,9 @@ namespace CourseLoaderCRS
 	 * @return its success or failure.
 	 */
 	bool LoadEditFromBuffer( const RString &sBuffer, const RString &sPath, ProfileSlot slot );
+
+	bool ParseCourseMods( const MsdFile::value_t &sParams, AttackArray &attacks, const RString &sPath );
+	bool ParseCourseSong( const MsdFile::value_t &sParams, CourseEntry &new_entry, const RString &sPath );
 }
 
 #endif

--- a/src/CourseLoaderCRS.h
+++ b/src/CourseLoaderCRS.h
@@ -5,6 +5,8 @@
 
 #include "GameConstantsAndTypes.h"
 #include "MsdFile.h"
+#include "Course.h"
+
 class Course;
 class CourseEntry;
 struct AttackArray;
@@ -56,6 +58,7 @@ namespace CourseLoaderCRS
 	bool ParseCourseSong( const MsdFile::value_t &sParams, CourseEntry &new_entry, const RString &sPath );
 	bool ParseCourseSongSelect(const MsdFile::value_t &sParams, CourseEntry &new_entry, const RString &sPath);
 	bool ParseCourseSongSort(RString sParam, CourseEntry &new_entry, const RString &sPath);
+	bool SetCourseSongSort(CourseEntry &new_entry, SongSort sort, int index, const RString &sPath);
 }
 
 #endif

--- a/src/CourseLoaderCRS.h
+++ b/src/CourseLoaderCRS.h
@@ -54,9 +54,63 @@ namespace CourseLoaderCRS
 	 */
 	bool LoadEditFromBuffer( const RString &sBuffer, const RString &sPath, ProfileSlot slot );
 
+	/**
+	 * @brief Parse the list of parameters from a `#MODS` tag.
+	 * @param sParams the list of params, as retrieved from msd.GetValue()
+	 * @param attacks the destination AttackArray, where parsed attacks are added
+	 * @param sPath the course filepath (used for logging purposes)
+	 * @return its success or failure
+	*/
 	bool ParseCourseMods( const MsdFile::value_t &sParams, AttackArray &attacks, const RString &sPath );
+	
+	/**
+	 * @brief Parse the list of parameters from a `#SONG` tag.
+	 * @param sParams the list of params, as retrieved from msd.GetValue()
+	 * @param new_entry the destination CourseEntry
+	 * @param sPath the course filepath (used for logging purposes)
+	 * @return its success or failure
+	*/
 	bool ParseCourseSong( const MsdFile::value_t &sParams, CourseEntry &new_entry, const RString &sPath );
+	
+	/**
+	 * @brief Parse the list of parameters from a `#SONGSELECT` tag.
+	 * @param sParams the list of params, as retrieved from msd.GetValue()
+	 * @param new_entry the destination CourseEntry
+	 * @param sPath the course filepath (used for logging purposes)
+	 * @return its success or failure
+	*/
 	bool ParseCourseSongSelect(const MsdFile::value_t &sParams, CourseEntry &new_entry, const RString &sPath);
+
+	/**
+	 * @brief Parse a param string as a comma-separated list into a vector of strings
+	 * @param sParamValue the param to be parsed (eg `Thing1,Thing2,Thing3`)
+	 * @param dest the destination vector for the individual items
+	 * @param sParamName the parameter name (used for logging purposes)
+	 * @param sPath the course filepath (used for logging purposes)
+	 * @return its success or failure
+	*/
+	bool ParseCommaSeparatedList(const RString &sParamValue, std::vector<RString> &dest, const RString &sParamName, const RString &sPath);
+
+	/**
+	 * @brief Parses a param string as a ranged value of type T numbers. 
+	 * A valid sParamValue is either a single number, or two numbers separated by a hyphen.
+	 * @param sParamValue the param to be parsed (eg `5-10`, or just `5`)
+	 * @param minValue the destination of the first value of the range
+	 * @param maxValue the destination of the second value of the range
+	 * @param sParamName the parameter name (used for logging purposes)
+	 * @param sPath the course filepath (used for logging purposes)
+	 * @return its success or failure
+	*/
+	template <typename T>
+	bool ParseRangedValue(const RString &sParamValue, T &minValue, T &maxValue, const RString &sParamName, const RString &sPath);
+	/**
+	 * @brief Performs some basic sanity checking and sets the song sort of the new_entry
+	 * @param new_entry the destination CourseEntry
+	 * @param sort the sort type to be set
+	 * @param index of the index to choose for the given sort (if sort == SongSort_Randomize, this value is ignored)
+	 * @param sPath the course filepath (used for logging purposes)
+	 * @return its success or failure
+	 */
 	bool SetCourseSongSort(CourseEntry &new_entry, SongSort sort, int index, const RString &sPath);
 }
 

--- a/src/CourseUtil.cpp
+++ b/src/CourseUtil.cpp
@@ -255,7 +255,7 @@ void CourseUtil::AutogenEndlessFromGroup( const RString &sGroupName, Difficulty 
 	// gameplay. (We might still get a repeat at the repeat boundary,
 	// but that'd be rare.) -glenn
 	CourseEntry e;
-	e.songCriteria.m_sGroupName = sGroupName;
+	e.songCriteria.m_vsGroupNames.push_back(sGroupName);
 	e.stepsCriteria.m_difficulty = diff;
 	e.bSecret = true;
 

--- a/src/CourseWriterCRS.cpp
+++ b/src/CourseWriterCRS.cpp
@@ -142,13 +142,13 @@ bool CourseWriterCRS::Write( const Course &course, RageFileBasic &f, bool bSavin
 			const RString &sSong = Basename( pSong->GetSongDir() );
 
 			f.Write( "#SONG:" );
-			if( !entry.songCriteria.m_sGroupName.empty() )
-				f.Write( entry.songCriteria.m_sGroupName + '/' );
+			if( entry.songCriteria.m_vsGroupNames.size() > 0 )
+				f.Write( entry.songCriteria.m_vsGroupNames[0] + '/' );
 			f.Write( sSong );
 		}
-		else if( !entry.songCriteria.m_sGroupName.empty() )
+		else if( entry.songCriteria.m_vsGroupNames.size() > 0 )
 		{
-			f.Write( ssprintf( "#SONG:%s/*", entry.songCriteria.m_sGroupName.c_str() ) );
+			f.Write( ssprintf( "#SONG:%s/*", entry.songCriteria.m_vsGroupNames[0].c_str() ) );
 		}
 		else
 		{

--- a/src/CourseWriterCRS.cpp
+++ b/src/CourseWriterCRS.cpp
@@ -100,99 +100,216 @@ bool CourseWriterCRS::Write( const Course &course, RageFileBasic &f, bool bSavin
 	for( unsigned i=0; i<course.m_vEntries.size(); i++ )
 	{
 		const CourseEntry& entry = course.m_vEntries[i];
-
-		for( unsigned j = 0; j < entry.attacks.size(); ++j )
+		if( entry.bUseSongSelect )
 		{
-			if( j == 0 )
-				f.PutLine( "#MODS:" );
-
-			const Attack &a = entry.attacks[j];
-			f.Write( ssprintf( "  TIME=%.2f:LEN=%.2f:MODS=%s",
-				a.fStartSecond, a.fSecsRemaining, a.sModifiers.c_str() ) );
-
-			if( j+1 < entry.attacks.size() )
-				f.Write( ":" );
-			else
-				f.Write( ";" );
-			f.PutLine( "" );
-		}
-
-		if( entry.fGainSeconds > 0 )
-			f.PutLine( ssprintf("#GAINSECONDS:%f;", entry.fGainSeconds) );
-
-		if( entry.songSort == SongSort_MostPlays  &&  entry.iChooseIndex != -1 )
-		{
-			f.Write( ssprintf( "#SONG:BEST%d", entry.iChooseIndex+1 ) );
-		}
-		else if( entry.songSort == SongSort_FewestPlays  &&  entry.iChooseIndex != -1 )
-		{
-			f.Write( ssprintf( "#SONG:WORST%d", entry.iChooseIndex+1 ) );
-		}
-		else if( entry.songSort == SongSort_TopGrades && entry.iChooseIndex != -1 )
-		{
-			f.Write( ssprintf( "#SONG:GRADEBEST%d", entry.iChooseIndex + 1 ) );
-		}
-		else if( entry.songSort == SongSort_LowestGrades && entry.iChooseIndex != -1 )
-		{
-			f.Write( ssprintf( "#SONG:GRADEWORST%d", entry.iChooseIndex + 1 ) );
-		}
-		else if( entry.songID.ToSong() )
-		{
-			Song *pSong = entry.songID.ToSong();
-			const RString &sSong = Basename( pSong->GetSongDir() );
-
-			f.Write( "#SONG:" );
-			if( entry.songCriteria.m_vsGroupNames.size() > 0 )
-				f.Write( entry.songCriteria.m_vsGroupNames[0] + '/' );
-			f.Write( sSong );
-		}
-		else if( entry.songCriteria.m_vsGroupNames.size() > 0 )
-		{
-			f.Write( ssprintf( "#SONG:%s/*", entry.songCriteria.m_vsGroupNames[0].c_str() ) );
+			WriteSongSelectCourseEntry(entry, f);
 		}
 		else
 		{
-			f.Write( "#SONG:*" );
+			WriteCourseEntry(entry, f);
 		}
-
-		f.Write( ":" );
-		if( entry.stepsCriteria.m_difficulty != Difficulty_Invalid )
-			f.Write( DifficultyToString(entry.stepsCriteria.m_difficulty) );
-		else if( entry.stepsCriteria.m_iLowMeter != -1  &&  entry.stepsCriteria.m_iHighMeter != -1 )
-			f.Write( ssprintf( "%d..%d", entry.stepsCriteria.m_iLowMeter, entry.stepsCriteria.m_iHighMeter ) );
-		f.Write( ":" );
-
-		RString sModifiers = entry.sModifiers;
-
-		if( entry.bSecret )
-		{
-			if( sModifiers != "" )
-				sModifiers += ",";
-			sModifiers += entry.bSecret? "noshowcourse":"showcourse";
-		}
-
-		if( entry.bNoDifficult )
-		{
-			if( sModifiers != "" )
-				sModifiers += ",";
-			sModifiers += "nodifficult";
-		}
-
-		if( entry.iGainLives > -1 )
-		{
-			if( !sModifiers.empty() )
-				sModifiers += ',';
-			sModifiers += ssprintf( "award%d", entry.iGainLives );
-		}
-
-		f.Write( sModifiers );
-
-		f.PutLine( ";" );
 	}
 
 	return true;
 }
 
+bool CourseWriterCRS::WriteCourseEntry( const CourseEntry &entry, RageFileBasic &f )
+{
+
+	for( unsigned j = 0; j < entry.attacks.size(); ++j )
+	{
+		if( j == 0 )
+			f.PutLine( "#MODS:" );
+
+		const Attack &a = entry.attacks[j];
+		f.Write( ssprintf( "  TIME=%.2f:LEN=%.2f:MODS=%s",
+			a.fStartSecond, a.fSecsRemaining, a.sModifiers.c_str() ) );
+
+		if( j+1 < entry.attacks.size() )
+			f.Write( ":" );
+		else
+			f.Write( ";" );
+		f.PutLine( "" );
+	}
+
+	if( entry.fGainSeconds > 0 )
+		f.PutLine( ssprintf("#GAINSECONDS:%f;", entry.fGainSeconds) );
+
+	if( entry.songSort == SongSort_MostPlays  &&  entry.iChooseIndex != -1 )
+	{
+		f.Write( ssprintf( "#SONG:BEST%d", entry.iChooseIndex+1 ) );
+	}
+	else if( entry.songSort == SongSort_FewestPlays  &&  entry.iChooseIndex != -1 )
+	{
+		f.Write( ssprintf( "#SONG:WORST%d", entry.iChooseIndex+1 ) );
+	}
+	else if( entry.songSort == SongSort_TopGrades && entry.iChooseIndex != -1 )
+	{
+		f.Write( ssprintf( "#SONG:GRADEBEST%d", entry.iChooseIndex + 1 ) );
+	}
+	else if( entry.songSort == SongSort_LowestGrades && entry.iChooseIndex != -1 )
+	{
+		f.Write( ssprintf( "#SONG:GRADEWORST%d", entry.iChooseIndex + 1 ) );
+	}
+	else if( entry.songID.ToSong() )
+	{
+		Song *pSong = entry.songID.ToSong();
+		const RString &sSong = Basename( pSong->GetSongDir() );
+
+		f.Write( "#SONG:" );
+		if( entry.songCriteria.m_vsGroupNames.size() > 0 )
+			f.Write( entry.songCriteria.m_vsGroupNames[0] + '/' );
+		f.Write( sSong );
+	}
+	else if( entry.songCriteria.m_vsGroupNames.size() > 0 )
+	{
+		f.Write( ssprintf( "#SONG:%s/*", entry.songCriteria.m_vsGroupNames[0].c_str() ) );
+	}
+	else
+	{
+		f.Write( "#SONG:*" );
+	}
+
+	f.Write( ":" );
+	if( entry.stepsCriteria.m_difficulty != Difficulty_Invalid )
+		f.Write( DifficultyToString(entry.stepsCriteria.m_difficulty) );
+	else if( entry.stepsCriteria.m_iLowMeter != -1  &&  entry.stepsCriteria.m_iHighMeter != -1 )
+		f.Write( ssprintf( "%d..%d", entry.stepsCriteria.m_iLowMeter, entry.stepsCriteria.m_iHighMeter ) );
+	f.Write( ":" );
+
+	RString sModifiers = entry.sModifiers;
+
+	if( entry.bSecret )
+	{
+		if( sModifiers != "" )
+			sModifiers += ",";
+		sModifiers += entry.bSecret? "noshowcourse":"showcourse";
+	}
+
+	if( entry.bNoDifficult )
+	{
+		if( sModifiers != "" )
+			sModifiers += ",";
+		sModifiers += "nodifficult";
+	}
+
+	if( entry.iGainLives > -1 )
+	{
+		if( !sModifiers.empty() )
+			sModifiers += ',';
+		sModifiers += ssprintf( "award%d", entry.iGainLives );
+	}
+
+	f.Write( sModifiers );
+
+	f.PutLine( ";" );
+	return true;
+}
+
+bool CourseWriterCRS::WriteSongSelectCourseEntry( const CourseEntry &entry, RageFileBasic &f )
+{
+	for( unsigned j = 0; j < entry.attacks.size(); ++j )
+	{
+		if( j == 0 )
+			f.PutLine( "#MODS:" );
+
+		const Attack &a = entry.attacks[j];
+		f.Write( ssprintf( "  TIME=%.2f:LEN=%.2f:MODS=%s",
+			a.fStartSecond, a.fSecsRemaining, a.sModifiers.c_str() ) );
+
+		if( j+1 < entry.attacks.size() )
+			f.Write( ":" );
+		else
+			f.Write( ";" );
+		f.PutLine( "" );
+	}
+
+	std::vector<RString> songSelectParams;
+
+	if( entry.songCriteria.m_vsSongNames.size() > 0 )
+	{
+		RString songNames = join(",", entry.songCriteria.m_vsSongNames);
+		songSelectParams.push_back(ssprintf("TITLE=%s", songNames.c_str()));
+	}
+	if( entry.songCriteria.m_vsGroupNames.size() > 0)
+	{
+		RString groupNames = join(",", entry.songCriteria.m_vsGroupNames);
+		songSelectParams.push_back(ssprintf("GROUP=%s", groupNames.c_str()));
+	}
+	if( entry.songCriteria.m_vsArtistNames.size() > 0)
+	{
+		RString artistNames = join(",", entry.songCriteria.m_vsArtistNames);
+		songSelectParams.push_back(ssprintf("ARTIST=%s", artistNames.c_str()));
+	}
+	if( entry.songCriteria.m_bUseSongAllowedList &&
+		entry.songCriteria.m_vsSongGenreAllowedList.size() > 0)
+	{
+		RString genreNames = join(",", entry.songCriteria.m_vsSongGenreAllowedList);
+		songSelectParams.push_back(ssprintf("GENRE=%s", genreNames.c_str()));
+	}
+	if( entry.stepsCriteria.m_vDifficulties.size() > 0 )
+	{
+		std::vector<RString> difficulties;
+		for (unsigned d = 0; d < entry.stepsCriteria.m_vDifficulties.size(); d++)
+		{
+			Difficulty diff = entry.stepsCriteria.m_vDifficulties[d];
+			if( diff != Difficulty_Invalid)
+			{
+				difficulties.push_back(DifficultyToString(diff));
+			}
+		}
+		songSelectParams.push_back("DIFFICULTY=" + join(",", difficulties));
+	}
+	if( entry.songSort != SongSort_Randomize && entry.iChooseIndex > -1)
+	{
+		RString songSort = SongSortToString(entry.songSort);
+		songSelectParams.push_back(ssprintf("SORT=%s=%d", songSort.c_str(), entry.iChooseIndex+1));
+	}
+	if(entry.songCriteria.m_fMinDurationSeconds > 0 
+		&& entry.songCriteria.m_fMaxDurationSeconds > 0 )
+	{
+		songSelectParams.push_back(ssprintf("DURATION=%d..%d", (int)entry.songCriteria.m_fMinDurationSeconds, (int)entry.songCriteria.m_fMaxDurationSeconds));
+	}
+	if(entry.songCriteria.m_fMinBPM > 0 && entry.songCriteria.m_fMaxBPM > 0 )
+	{
+		songSelectParams.push_back(ssprintf("BPMRANGE=%f..%f", entry.songCriteria.m_fMinBPM, entry.songCriteria.m_fMaxBPM));
+	}
+	if(entry.stepsCriteria.m_iLowMeter > 0 && entry.stepsCriteria.m_iHighMeter > 0 )
+	{
+		songSelectParams.push_back(ssprintf("METER=%d..%d", entry.stepsCriteria.m_iLowMeter, entry.stepsCriteria.m_iHighMeter));
+	}
+	if( entry.iGainLives > 0 )
+	{
+		songSelectParams.push_back(ssprintf("GAINLIVES=%d", entry.iGainLives));
+	}
+	if(entry.fGainSeconds > 0 )
+	{
+		songSelectParams.push_back(ssprintf("GAINSECONDS=%f", entry.fGainSeconds));
+	}
+
+	std::vector<RString> mods;
+	split(entry.sModifiers, ",", mods);
+
+	if (entry.bSecret)
+	{
+		mods.push_back("noshowcourse");
+	}
+	else
+	{
+		mods.push_back("showcourse");
+	}
+	if( entry.bNoDifficult )
+	{
+		mods.push_back("nodifficult");
+	}
+	songSelectParams.push_back("MODS=" + join(",", mods));
+
+	RString songSelect = join(":", songSelectParams);
+	f.PutLine(ssprintf("#SONGSELECT:%s;", songSelect.c_str()));
+
+
+	return true;
+}
 
 /*
  * (c) 2001-2004 Chris Danford, Glenn Maynard

--- a/src/CourseWriterCRS.cpp
+++ b/src/CourseWriterCRS.cpp
@@ -226,25 +226,26 @@ bool CourseWriterCRS::WriteSongSelectCourseEntry( const CourseEntry &entry, Rage
 
 	std::vector<RString> songSelectParams;
 
+	//TODO: Re-escape everything
 	if( entry.songCriteria.m_vsSongNames.size() > 0 )
 	{
-		RString songNames = join(",", entry.songCriteria.m_vsSongNames);
+		RString songNames = join(",", SmEscape( entry.songCriteria.m_vsSongNames, {'\\', ':', ';', '#', ','} ));
 		songSelectParams.push_back(ssprintf("TITLE=%s", songNames.c_str()));
 	}
 	if( entry.songCriteria.m_vsGroupNames.size() > 0)
 	{
-		RString groupNames = join(",", entry.songCriteria.m_vsGroupNames);
+		RString groupNames = join(",", SmEscape( entry.songCriteria.m_vsGroupNames, {'\\', ':', ';', '#', ','} ));
 		songSelectParams.push_back(ssprintf("GROUP=%s", groupNames.c_str()));
 	}
 	if( entry.songCriteria.m_vsArtistNames.size() > 0)
 	{
-		RString artistNames = join(",", entry.songCriteria.m_vsArtistNames);
+		RString artistNames = join(",", SmEscape( entry.songCriteria.m_vsArtistNames, {'\\', ':', ';', '#', ','} ));
 		songSelectParams.push_back(ssprintf("ARTIST=%s", artistNames.c_str()));
 	}
 	if( entry.songCriteria.m_bUseSongAllowedList &&
 		entry.songCriteria.m_vsSongGenreAllowedList.size() > 0)
 	{
-		RString genreNames = join(",", entry.songCriteria.m_vsSongGenreAllowedList);
+		RString genreNames = join(",", SmEscape( entry.songCriteria.m_vsSongGenreAllowedList, {'\\', ':', ';', '#', ','} ));
 		songSelectParams.push_back(ssprintf("GENRE=%s", genreNames.c_str()));
 	}
 	if( entry.stepsCriteria.m_vDifficulties.size() > 0 )

--- a/src/CourseWriterCRS.cpp
+++ b/src/CourseWriterCRS.cpp
@@ -229,23 +229,23 @@ bool CourseWriterCRS::WriteSongSelectCourseEntry( const CourseEntry &entry, Rage
 	//TODO: Re-escape everything
 	if( entry.songCriteria.m_vsSongNames.size() > 0 )
 	{
-		RString songNames = join(",", SmEscape( entry.songCriteria.m_vsSongNames, {'\\', ':', ';', '#', ','} ));
+		RString songNames = join(",", SmEscape( entry.songCriteria.m_vsSongNames, {'\\', ':', ';', '#', ',', '='} ));
 		songSelectParams.push_back(ssprintf("TITLE=%s", songNames.c_str()));
 	}
 	if( entry.songCriteria.m_vsGroupNames.size() > 0)
 	{
-		RString groupNames = join(",", SmEscape( entry.songCriteria.m_vsGroupNames, {'\\', ':', ';', '#', ','} ));
+		RString groupNames = join(",", SmEscape( entry.songCriteria.m_vsGroupNames, {'\\', ':', ';', '#', ',', '='} ));
 		songSelectParams.push_back(ssprintf("GROUP=%s", groupNames.c_str()));
 	}
 	if( entry.songCriteria.m_vsArtistNames.size() > 0)
 	{
-		RString artistNames = join(",", SmEscape( entry.songCriteria.m_vsArtistNames, {'\\', ':', ';', '#', ','} ));
+		RString artistNames = join(",", SmEscape( entry.songCriteria.m_vsArtistNames, {'\\', ':', ';', '#', ',', '='} ));
 		songSelectParams.push_back(ssprintf("ARTIST=%s", artistNames.c_str()));
 	}
 	if( entry.songCriteria.m_bUseSongAllowedList &&
 		entry.songCriteria.m_vsSongGenreAllowedList.size() > 0)
 	{
-		RString genreNames = join(",", SmEscape( entry.songCriteria.m_vsSongGenreAllowedList, {'\\', ':', ';', '#', ','} ));
+		RString genreNames = join(",", SmEscape( entry.songCriteria.m_vsSongGenreAllowedList, {'\\', ':', ';', '#', ',', '='} ));
 		songSelectParams.push_back(ssprintf("GENRE=%s", genreNames.c_str()));
 	}
 	if( entry.stepsCriteria.m_vDifficulties.size() > 0 )

--- a/src/CourseWriterCRS.cpp
+++ b/src/CourseWriterCRS.cpp
@@ -268,15 +268,15 @@ bool CourseWriterCRS::WriteSongSelectCourseEntry( const CourseEntry &entry, Rage
 	if(entry.songCriteria.m_fMinDurationSeconds > 0 
 		&& entry.songCriteria.m_fMaxDurationSeconds > 0 )
 	{
-		songSelectParams.push_back(ssprintf("DURATION=%d..%d", (int)entry.songCriteria.m_fMinDurationSeconds, (int)entry.songCriteria.m_fMaxDurationSeconds));
+		songSelectParams.push_back(ssprintf("DURATION=%d-%d", (int)entry.songCriteria.m_fMinDurationSeconds, (int)entry.songCriteria.m_fMaxDurationSeconds));
 	}
 	if(entry.songCriteria.m_fMinBPM > 0 && entry.songCriteria.m_fMaxBPM > 0 )
 	{
-		songSelectParams.push_back(ssprintf("BPMRANGE=%f..%f", entry.songCriteria.m_fMinBPM, entry.songCriteria.m_fMaxBPM));
+		songSelectParams.push_back(ssprintf("BPMRANGE=%f-%f", entry.songCriteria.m_fMinBPM, entry.songCriteria.m_fMaxBPM));
 	}
 	if(entry.stepsCriteria.m_iLowMeter > 0 && entry.stepsCriteria.m_iHighMeter > 0 )
 	{
-		songSelectParams.push_back(ssprintf("METER=%d..%d", entry.stepsCriteria.m_iLowMeter, entry.stepsCriteria.m_iHighMeter));
+		songSelectParams.push_back(ssprintf("METER=%d-%d", entry.stepsCriteria.m_iLowMeter, entry.stepsCriteria.m_iHighMeter));
 	}
 	if( entry.iGainLives > 0 )
 	{

--- a/src/CourseWriterCRS.cpp
+++ b/src/CourseWriterCRS.cpp
@@ -263,7 +263,7 @@ bool CourseWriterCRS::WriteSongSelectCourseEntry( const CourseEntry &entry, Rage
 	if( entry.songSort != SongSort_Randomize && entry.iChooseIndex > -1)
 	{
 		RString songSort = SongSortToString(entry.songSort);
-		songSelectParams.push_back(ssprintf("SORT=%s=%d", songSort.c_str(), entry.iChooseIndex+1));
+		songSelectParams.push_back(ssprintf("SORT=%s,%d", songSort.c_str(), entry.iChooseIndex+1));
 	}
 	if(entry.songCriteria.m_fMinDurationSeconds > 0 
 		&& entry.songCriteria.m_fMaxDurationSeconds > 0 )

--- a/src/CourseWriterCRS.h
+++ b/src/CourseWriterCRS.h
@@ -4,6 +4,7 @@
 #define COURSE_WRITER_CRS_H
 
 class Course;
+class CourseEntry;
 class RageFileBasic;
 
 /** @brief The Course Writer handles writing the .crs files. */
@@ -36,6 +37,10 @@ namespace CourseWriterCRS
 	 * @param pCourse the course file.
 	 */
 	void WriteEditFileToMachine( const Course *pCourse );
+
+	bool WriteCourseEntry( const CourseEntry &entry, RageFileBasic &f );
+
+	bool WriteSongSelectCourseEntry( const CourseEntry &entry, RageFileBasic &f );
 }
 
 #endif

--- a/src/MsdFile.cpp
+++ b/src/MsdFile.cpp
@@ -127,8 +127,24 @@ void MsdFile::ReadBuf( const char *buf, int len, bool bUnescape )
 
 		/* We've gone through all the control characters.  All that is left is either an escaped character, 
 		 * ie \#, \\, \:, etc., or a regular character. */
-		if( bUnescape && i < len && buf[i] == '\\' )
-			++i;
+		if(buf[i] == '\\' && i < len)
+		{
+			// If we're escaping the next character, skip the '\\'
+			if(bUnescape)
+			{
+				++i;
+			}
+			// Otherwise, add the '\\' to cProcessed here, so that
+			// whatever character is coming next stays escaped in
+			// the resulting value/parameter string 
+			// (and most importantly, it doesn't get parsed as a control character)
+			// on the next iteration
+			else 
+			{
+				cProcessed[iProcessedLen++] = buf[i++];	
+			}
+		}
+		
 		if( i < len )
 		{
 			cProcessed[iProcessedLen++] = buf[i++];

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -422,8 +422,12 @@ RString join( const RString &sDelimitor, const std::vector<RString>& sSource );
 RString join( const RString &sDelimitor, std::vector<RString>::const_iterator begin, std::vector<RString>::const_iterator end );
 
 // These methods escapes a string for saving in a .sm or .crs file
-RString SmEscape( const RString &sUnescaped );
-RString SmEscape( const char *cUnescaped, int len );
+RString SmEscape(const RString &sUnescaped, const std::vector<char> charsToEscape = {'\\', ':', ';'});
+RString SmEscape( const char *cUnescaped, int len, const std::vector<char> charsToEscape = {'\\', ':', ';'} );
+// Escapes each element in a std::vector<RString>, returns a new vector
+std::vector<RString> SmEscape(const std::vector<RString> &vUnescaped, const std::vector<char> charsToEscape = {'\\', ':', ';'});
+
+RString SmUnescape( const RString &sEscaped );
 
 // These methods "escape" a string for .dwi by turning = into -, ] into I, etc.  That is "lossy".
 RString DwiEscape( const RString &sUnescaped );

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -295,11 +295,13 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
 
 	bool use_cache = true;
 
+	std::vector<RString> sDirectoryParts;
+	split( m_sSongDir, "/", sDirectoryParts, false );
+	m_sSongName = sDirectoryParts[sDirectoryParts.size() - 2];
+	ASSERT(m_sSongName != "");
 	// save group name
 	if(from_profile == ProfileSlot_Invalid)
 	{
-		std::vector<RString> sDirectoryParts;
-		split( m_sSongDir, "/", sDirectoryParts, false );
 		ASSERT( sDirectoryParts.size() >= 4 ); /* e.g. "/Songs/Slow/Taps/" */
 		m_sGroupName = sDirectoryParts[sDirectoryParts.size()-3];	// second from last item
 		ASSERT( m_sGroupName != "" );
@@ -1956,15 +1958,8 @@ bool Song::Matches(RString sGroup, RString sSong) const
 	if( sGroup.size() && sGroup.CompareNoCase(this->m_sGroupName) != 0)
 		return false;
 
-	RString sDir = this->GetSongDir();
-	sDir.Replace("\\","/");
-	std::vector<RString> bits;
-	split( sDir, "/", bits );
-	ASSERT(bits.size() >= 2); // should always have at least two parts
-	const RString &sLastBit = bits[bits.size()-1];
-
 	// match on song dir or title (ala DWI)
-	if( !sSong.CompareNoCase(sLastBit) )
+	if( !sSong.CompareNoCase(m_sSongName) )
 		return true;
 	if( !sSong.CompareNoCase(this->GetTranslitFullTitle()) )
 		return true;

--- a/src/Song.h
+++ b/src/Song.h
@@ -171,6 +171,9 @@ public:
 
 	/** @brief The group this Song is in. */
 	RString m_sGroupName;
+	
+	/** @brief The base directory name that this Song is in. */
+	RString m_sSongName;
 
 	/**
 	 * @brief the Profile this came from.

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -66,6 +66,16 @@ bool SongCriteria::Matches( const Song *pSong ) const
 	if( m_iMaxStagesForSong != -1  &&  GAMESTATE->GetNumStagesMultiplierForSong(pSong) > m_iMaxStagesForSong )
 		return false;
 
+	if( m_fMaxBPM != -1 && pSong->m_fSpecifiedBPMMax > m_fMaxBPM )
+	{
+		return false;
+	}
+
+	if( m_fMinBPM != -1 && pSong->m_fSpecifiedBPMMin < m_fMinBPM )
+	{
+		return false;
+	}
+	
 	switch( m_Tutorial )
 	{
 	DEFAULT_FAIL(m_Tutorial);

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -30,7 +30,20 @@ ThemeMetric<bool> SHOW_SECTIONS_IN_LENGTH_SORT ( "MusicWheel", "ShowSectionsInLe
 
 bool SongCriteria::Matches( const Song *pSong ) const
 {
-	if( !m_vsGroupNames.size() > 0 && std::find(m_vsGroupNames.begin(), m_vsGroupNames.end(), pSong->m_sGroupName) == m_vsGroupNames.end() )
+	if( m_vsGroupNames.size() > 0 && std::find(m_vsGroupNames.begin(), m_vsGroupNames.end(), pSong->m_sGroupName) == m_vsGroupNames.end() )
+	{
+		return false;
+	}
+
+	if( m_vsSongNames.size() > 0 && std::find(m_vsSongNames.begin(), m_vsSongNames.end(), pSong->m_sSongName) == m_vsSongNames.end()
+		&& std::find(m_vsSongNames.begin(), m_vsSongNames.end(), pSong->m_sMainTitle) == m_vsSongNames.end()
+		&& std::find(m_vsSongNames.begin(), m_vsSongNames.end(), pSong->m_sMainTitleTranslit) == m_vsSongNames.end() )
+	{
+		return false;
+	}
+
+	if(m_vsArtistNames.size() > 0 && std::find(m_vsArtistNames.begin(), m_vsArtistNames.end(), pSong->m_sArtist) == m_vsArtistNames.end()
+		&& std::find(m_vsArtistNames.begin(), m_vsArtistNames.end(), pSong->m_sArtistTranslit) == m_vsArtistNames.end() )
 	{
 		return false;
 	}
@@ -77,7 +90,17 @@ bool SongCriteria::Matches( const Song *pSong ) const
 	{
 		return false;
 	}
-	
+
+	if( m_fMinDurationSeconds != -1 && pSong->m_fMusicLengthSeconds < m_fMinDurationSeconds )
+	{
+		return false;
+	}
+
+	if( m_fMaxDurationSeconds != -1 && pSong->m_fMusicLengthSeconds > m_fMaxDurationSeconds )
+	{
+		return false;
+	}
+
 	switch( m_Tutorial )
 	{
 	DEFAULT_FAIL(m_Tutorial);

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -81,14 +81,18 @@ bool SongCriteria::Matches( const Song *pSong ) const
 	if( m_iMaxStagesForSong != -1  &&  GAMESTATE->GetNumStagesMultiplierForSong(pSong) > m_iMaxStagesForSong )
 		return false;
 
-	if( m_fMaxBPM != -1 && pSong->m_fSpecifiedBPMMax > m_fMaxBPM )
+	if(m_fMaxBPM != -1 && m_fMinBPM != -1)
 	{
-		return false;
-	}
-
-	if( m_fMinBPM != -1 && pSong->m_fSpecifiedBPMMin < m_fMinBPM )
-	{
-		return false;
+		DisplayBpms bpms;
+		pSong->GetDisplayBpms(bpms);
+		if(bpms.GetMax() > m_fMaxBPM)
+		{
+			return false;
+		}
+		if(bpms.GetMin() < m_fMinBPM)
+		{
+			return false;
+		}
 	}
 
 	if( m_fMinDurationSeconds != -1 && pSong->m_fMusicLengthSeconds < m_fMinDurationSeconds )

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -30,8 +30,10 @@ ThemeMetric<bool> SHOW_SECTIONS_IN_LENGTH_SORT ( "MusicWheel", "ShowSectionsInLe
 
 bool SongCriteria::Matches( const Song *pSong ) const
 {
-	if( !m_sGroupName.empty()  &&  m_sGroupName != pSong->m_sGroupName )
+	if( !m_vsGroupNames.size() > 0 && std::find(m_vsGroupNames.begin(), m_vsGroupNames.end(), pSong->m_sGroupName) == m_vsGroupNames.end() )
+	{
 		return false;
+	}
 
 	if( UNLOCKMAN->SongIsLocked(pSong) & LOCKED_DISABLED )
 		return false;

--- a/src/SongUtil.h
+++ b/src/SongUtil.h
@@ -33,8 +33,8 @@ public:
 	std::vector<Song*> m_vpSongAllowedList;
 	/** @brief How many songs does this take max? Don't use this if it's -1. */
 	int m_iMaxStagesForSong;		// don't filter if -1
-	// float m_fMinBPM;		// don't filter if -1
-	// float m_fMaxBPM;		// don't filter if -1
+	float m_fMinBPM;		// don't filter if -1
+	float m_fMaxBPM;		// don't filter if -1
 	/** @brief Is this song used for tutorial purposes? */
 	enum Tutorial
 	{
@@ -54,7 +54,7 @@ public:
 	SongCriteria(): m_sGroupName(""), m_bUseSongGenreAllowedList(false),
 		m_vsSongGenreAllowedList(), m_Selectable(Selectable_DontCare),
 		m_bUseSongAllowedList(false), m_vpSongAllowedList(),
-		m_iMaxStagesForSong(-1), m_Tutorial(Tutorial_DontCare),
+		m_iMaxStagesForSong(-1), m_fMinBPM(-1), m_fMaxBPM(-1), m_Tutorial(Tutorial_DontCare),
 		m_Locked(Locked_DontCare)
 	{
 		// m_fMinBPM = -1;
@@ -84,8 +84,8 @@ public:
 			X(m_bUseSongAllowedList) &&
 			X(m_vpSongAllowedList) &&
 			X(m_iMaxStagesForSong) &&
-			//X(m_fMinBPM) &&
-			//X(m_fMaxBPM) &&
+			X(m_fMinBPM) &&
+			X(m_fMaxBPM) &&
 			X(m_Tutorial) &&
 			X(m_Locked);
 #undef X

--- a/src/SongUtil.h
+++ b/src/SongUtil.h
@@ -26,6 +26,9 @@ public:
 	 *
 	 * If an empty string, don't bother using this for searching. */
 	std::vector<RString> m_vsGroupNames;
+	std::vector<RString> m_vsSongNames;
+	std::vector<RString> m_vsArtistNames;
+
 	bool m_bUseSongGenreAllowedList;
 	std::vector<RString> m_vsSongGenreAllowedList;
 	enum Selectable { Selectable_Yes, Selectable_No, Selectable_DontCare } m_Selectable;
@@ -35,6 +38,9 @@ public:
 	int m_iMaxStagesForSong;		// don't filter if -1
 	float m_fMinBPM;		// don't filter if -1
 	float m_fMaxBPM;		// don't filter if -1
+	float m_fMinDurationSeconds; // don't filter if -1
+	float m_fMaxDurationSeconds; // don't filter if -1
+
 	/** @brief Is this song used for tutorial purposes? */
 	enum Tutorial
 	{
@@ -51,10 +57,11 @@ public:
 	} m_Locked;
 
 	/** @brief Set up some initial song criteria. */
-	SongCriteria(): m_vsGroupNames(), m_bUseSongGenreAllowedList(false),
+	SongCriteria(): m_vsGroupNames(), m_vsSongNames(), m_vsArtistNames(), m_bUseSongGenreAllowedList(false),
 		m_vsSongGenreAllowedList(), m_Selectable(Selectable_DontCare),
 		m_bUseSongAllowedList(false), m_vpSongAllowedList(),
-		m_iMaxStagesForSong(-1), m_fMinBPM(-1), m_fMaxBPM(-1), m_Tutorial(Tutorial_DontCare),
+		m_iMaxStagesForSong(-1), m_fMinBPM(-1), m_fMaxBPM(-1), m_fMinDurationSeconds(-1), m_fMaxDurationSeconds(-1),
+		m_Tutorial(Tutorial_DontCare),
 		m_Locked(Locked_DontCare)
 	{
 		// m_fMinBPM = -1;
@@ -78,6 +85,8 @@ public:
 #define X(x) (x == other.x)
 		return
 			X(m_vsGroupNames) &&
+			X(m_vsSongNames) &&
+			X(m_vsArtistNames) &&
 			X(m_bUseSongGenreAllowedList) &&
 			X(m_vsSongGenreAllowedList) &&
 			X(m_Selectable) &&
@@ -86,6 +95,8 @@ public:
 			X(m_iMaxStagesForSong) &&
 			X(m_fMinBPM) &&
 			X(m_fMaxBPM) &&
+			X(m_fMinDurationSeconds) &&
+			X(m_fMaxDurationSeconds) &&
 			X(m_Tutorial) &&
 			X(m_Locked);
 #undef X

--- a/src/SongUtil.h
+++ b/src/SongUtil.h
@@ -25,7 +25,7 @@ public:
 	 * @brief What group name are we searching for for Songs?
 	 *
 	 * If an empty string, don't bother using this for searching. */
-	RString m_sGroupName;
+	std::vector<RString> m_vsGroupNames;
 	bool m_bUseSongGenreAllowedList;
 	std::vector<RString> m_vsSongGenreAllowedList;
 	enum Selectable { Selectable_Yes, Selectable_No, Selectable_DontCare } m_Selectable;
@@ -51,7 +51,7 @@ public:
 	} m_Locked;
 
 	/** @brief Set up some initial song criteria. */
-	SongCriteria(): m_sGroupName(""), m_bUseSongGenreAllowedList(false),
+	SongCriteria(): m_vsGroupNames(), m_bUseSongGenreAllowedList(false),
 		m_vsSongGenreAllowedList(), m_Selectable(Selectable_DontCare),
 		m_bUseSongAllowedList(false), m_vpSongAllowedList(),
 		m_iMaxStagesForSong(-1), m_fMinBPM(-1), m_fMaxBPM(-1), m_Tutorial(Tutorial_DontCare),
@@ -77,7 +77,7 @@ public:
 /** @brief A quick way to match every part of the song criterium. */
 #define X(x) (x == other.x)
 		return
-			X(m_sGroupName) &&
+			X(m_vsGroupNames) &&
 			X(m_bUseSongGenreAllowedList) &&
 			X(m_vsSongGenreAllowedList) &&
 			X(m_Selectable) &&

--- a/src/StepsUtil.cpp
+++ b/src/StepsUtil.cpp
@@ -44,8 +44,18 @@ bool StepsCriteria::Matches( const Song *pSong, const Steps *pSteps ) const
 
 void StepsUtil::GetAllMatching( const SongCriteria &soc, const StepsCriteria &stc, std::vector<SongAndSteps> &out )
 {
-	const RString &sGroupName = soc.m_sGroupName.empty()? GROUP_ALL:soc.m_sGroupName;
-	const std::vector<Song*> &songs = SONGMAN->GetSongs( sGroupName );
+	
+	std::vector<RString> groupNames = soc.m_vsGroupNames;
+	if( groupNames.size() == 0 )
+	{
+		groupNames.push_back(GROUP_ALL);
+	}
+	std::vector<Song *> songs;
+	for (unsigned i = 0; i < groupNames.size(); i++)
+	{
+		const std::vector<Song *> &groupSongs = SONGMAN->GetSongs(groupNames[i]);
+		songs.insert(songs.end(), groupSongs.begin(), groupSongs.end());
+	}
 
 	for (Song *so : songs)
 	{
@@ -103,8 +113,17 @@ void StepsUtil::GetAllMatchingEndless( Song *pSong, const StepsCriteria &stc, st
 
 bool StepsUtil::HasMatching( const SongCriteria &soc, const StepsCriteria &stc )
 {
-	const RString &sGroupName = soc.m_sGroupName.empty()? GROUP_ALL:soc.m_sGroupName;
-	const std::vector<Song*> &songs = SONGMAN->GetSongs( sGroupName );
+	std::vector<RString> groupNames = soc.m_vsGroupNames;
+	if( groupNames.size() == 0 )
+	{
+		groupNames.push_back(GROUP_ALL);
+	}
+	std::vector<Song *> songs;
+	for (unsigned i = 0; i < groupNames.size(); i++)
+	{
+		const std::vector<Song *> &groupSongs = SONGMAN->GetSongs(groupNames[i]);
+		songs.insert(songs.end(), groupSongs.begin(), groupSongs.end());
+	}
 
 	return std::any_of(songs.begin(), songs.end(), [&](Song const *so) {
 		return soc.Matches(so) && HasMatching(so, stc);

--- a/src/StepsUtil.cpp
+++ b/src/StepsUtil.cpp
@@ -18,6 +18,12 @@ bool StepsCriteria::Matches( const Song *pSong, const Steps *pSteps ) const
 {
 	if( m_difficulty != Difficulty_Invalid  &&  pSteps->GetDifficulty() != m_difficulty )
 		return false;
+	
+	if(m_vDifficulties.size() > 0 && std::find(m_vDifficulties.begin(), m_vDifficulties.end(), pSteps->GetDifficulty()) == m_vDifficulties.end() )
+	{
+		return false;
+	}
+
 	if( m_iLowMeter != -1  &&  pSteps->GetMeter() < m_iLowMeter )
 		return false;
 	if( m_iHighMeter != -1  &&  pSteps->GetMeter() > m_iHighMeter )

--- a/src/StepsUtil.h
+++ b/src/StepsUtil.h
@@ -22,6 +22,7 @@ public:
 	 *
 	 * Don't filter here if the Difficulty is Difficulty_Invalid. */
 	Difficulty m_difficulty;
+	std::vector<Difficulty> m_vDifficulties;
 	/**
 	 * @brief The lowest meter to search for.
 	 *
@@ -51,6 +52,7 @@ public:
 
 	/** @brief Set up the initial criteria. */
 	StepsCriteria(): m_difficulty(Difficulty_Invalid),
+	m_vDifficulties(),
 		m_iLowMeter(-1), m_iHighMeter(-1),
 		m_st(StepsType_Invalid), m_Locked(Locked_DontCare)
 	{


### PR DESCRIPTION
The current `#SONG` tag isn't very well documented, and it's capabilities are pretty limited. I want to introduce an alternative to it that is easier to use, and provides more flexible selection options. Because I couldn't think of a better name at the time, I've just called it `#SONGSELECT`. If anyone has a better idea, I'm very much open to changing it.

I've added a full description of the `#SONGSELECT` tag to Docs/CourseFormat.txt, but the basic idea is that you can compose a course entry by specifying one or more parameters, which follow the general format of
`#SONGSELECT:PARAM1=VALUE1:PARAM2=VALUE2:PARAM3=VALUE3;`

The available selection parameters are TITLE, GROUP, ARTIST, GENRE, DIFFICULTY, METER, BPMRANGE, DURATION, and SORT.

I also fixed a few issues that I came across while working on this, the two main ones were:
- CourseSortSongs() would cause a crash when leaving Marathon mode, but only when a course that uses SongSort_TopGrades or SongSort_LowestGrades was newly added (and it only happened on initial load because CourseWriterCRS didn't write Course caches correctly)
- Course entries that only specified a meter range would select different songs for different course difficulties.

Aside from that, and breaking out some of the course loading/writing logic into separate functions, I've avoided making any changes or optimizations that would affect how existing courses using the `#SONG` tag function. 