### PR TITLE
Add Sort By Difficulty Block - New Sort Order SORT_METER

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -1871,6 +1871,7 @@
 			<Function name='SetPreferredSongs'/>
 			<Function name='ShortenGroupName'/>
 			<Function name='SongToPreferredSortSectionName'/>
+			<Function name='GetPreferredSortSongsBySectionName'/>
 			<Function name='WasLoadedFromAdditionalCourses'/>
 			<Function name='WasLoadedFromAdditionalSongs'/>
 		</Class>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -5901,6 +5901,9 @@ local args = {
 	<Function name='SongToPreferredSortSectionName' return='string' arguments='Song s'>
 		Returns the preferred sort section name for the specified Song.
 	</Function>
+	<Function name='GetPreferredSortSongsBySectionName' return='{Song}' arguments='string sSectionName'>
+		Returns a table containing all songs in the specified preferred sort section.
+	</Function>
 	<Function name='WasLoadedFromAdditionalCourses' return='bool' arguments='Course c'>
 		[Deprecated] Always returns <code>false</code>.
 	</Function>

--- a/Themes/_fallback/Graphics/Banner Meter.redir
+++ b/Themes/_fallback/Graphics/Banner Meter.redir
@@ -1,0 +1,1 @@
+Common fallback banner

--- a/Themes/_fallback/Graphics/Banner Preferred.redir
+++ b/Themes/_fallback/Graphics/Banner Preferred.redir
@@ -1,0 +1,1 @@
+Common fallback banner

--- a/src/GameConstantsAndTypes.cpp
+++ b/src/GameConstantsAndTypes.cpp
@@ -168,6 +168,7 @@ static const char *SortOrderNames[] = {
 	"TopGrades",
 	"Artist",
 	"Genre",
+	"Meter",
 	"BeginnerMeter",
 	"EasyMeter",
 	"MediumMeter",

--- a/src/GameConstantsAndTypes.h
+++ b/src/GameConstantsAndTypes.h
@@ -168,6 +168,7 @@ enum SortOrder
 	SORT_TOP_GRADES, /**< Sort by the highest grades earned on a Song. */
 	SORT_ARTIST, /**< Sort by the name of the artist of the Song. */
 	SORT_GENRE, /**< Sort by the Song's genre. */
+	SORT_METER, /**< Sort by the difficulty of all meters */
 	SORT_BEGINNER_METER, /**< Sort by the difficulty of the single beginner meter. */
 	SORT_EASY_METER, /**< Sort by the difficulty of the single easy meter. */
 	SORT_MEDIUM_METER, /**< Sort by the difficulty of the single medium meter. */

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -937,8 +937,11 @@ void MusicWheel::readyWheelItemsData(SortOrder so) {
 			BuildWheelItemDatas(  aUnFilteredDatas, so );
 		}
 		FilterWheelItemDatas( aUnFilteredDatas, m__WheelItemDatas[so], so );
-		m_WheelItemDatasStatus[so]=VALID;
-
+		// The preferred sort's songs are subject to change during a session (particularly if two players have different preferred songs) 
+		// thus it's status should remain invalid so the wheel items are rebuilt each time in case of change.
+		if (so != SORT_PREFERRED) {
+			m_WheelItemDatasStatus[so]=VALID;
+		}
 		LOG->Trace( "MusicWheel sorting took: %f", timer.GetTimeSinceStart() );
 	}
 
@@ -1229,7 +1232,9 @@ void MusicWheel::ChangeMusic( int iDist )
 bool MusicWheel::ChangeSort( SortOrder new_so, bool allowSameSort )	// return true if change successful
 {
 	ASSERT( new_so < NUM_SortOrder );
-	if( GAMESTATE->m_SortOrder == new_so && !allowSameSort )
+	// Ignore allowSameSort if we're using SORT_PREFERRED
+	// Each player has their own preferred songs which sorts the songs differently -crashcringle
+	if( GAMESTATE->m_SortOrder == new_so && (!allowSameSort && new_so != SORT_PREFERRED ))
 	{
 		return false;
 	}

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -682,24 +682,19 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 			{
 				if( bUseSections )
 				{
-					// Get all section names
-					std::vector<RString> vsSectionNames = SONGMAN->GetPreferredSortSectionNames();
-					for( unsigned i=0; i<vsSectionNames.size(); i++ )
+					// Get mappping of section names to songs
+					std::map<RString, std::vector<Song*>> preferredSortSongsMap = SONGMAN->GetPreferredSortSongsMap();
+					for (auto const& [sectionName, songs] : SONGMAN->GetPreferredSortSongsMap())
 					{
-						
-						// Get all songs in this section
-						std::vector<Song*> vsSongsInSection = SONGMAN->GetPreferredSortSongsBySectionName( vsSectionNames[i] );
-						
 						// todo: preferred sort section color handling? -aj
 						RageColor colorSection = SECTION_COLORS.GetValue(iSectionColorIndex);
 						iSectionColorIndex = (iSectionColorIndex+1) % NUM_SECTION_COLORS;
-
 						// Add the section item
-						arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Section, nullptr, vsSectionNames[i], nullptr, SONGMAN->GetSongGroupColor(vsSectionNames[i]), vsSongsInSection.size()) );
+						arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Section, nullptr, sectionName, nullptr, colorSection, songs.size()) );
 						// Add all the songs in this section
-						for( unsigned j=0; j<vsSongsInSection.size(); j++ )
+						for (auto const& song : songs)
 						{
-							arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Song, vsSongsInSection[j], vsSectionNames[i], nullptr, SONGMAN->GetSongColor(vsSongsInSection[j]), 0) );
+							arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Song, song, sectionName, nullptr, SONGMAN->GetSongColor(song), 0) );
 						}
 					}
 				}
@@ -725,7 +720,6 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 							iSectionCount = j-i;
 
 							// new section, make a section item
-							// todo: preferred sort section color handling? -aj
 							RageColor colorSection = (so==SORT_GROUP) ? SONGMAN->GetSongGroupColor(pSong->m_sGroupName) : SECTION_COLORS.GetValue(iSectionColorIndex);
 							iSectionColorIndex = (iSectionColorIndex+1) % NUM_SECTION_COLORS;
 							arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Section, nullptr, sThisSection, nullptr, colorSection, iSectionCount) );

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -1232,8 +1232,8 @@ void MusicWheel::ChangeMusic( int iDist )
 bool MusicWheel::ChangeSort( SortOrder new_so, bool allowSameSort )	// return true if change successful
 {
 	ASSERT( new_so < NUM_SortOrder );
-	// Ignore allowSameSort if we're using SORT_PREFERRED
-	// Each player has their own preferred songs which sorts the songs differently -crashcringle
+	// NOTE(crashcringle): Ignore allowSameSort if we're using SORT_PREFERRED.
+	// Each player has their own preferred songs which sorts the songs differently
 	if( GAMESTATE->m_SortOrder == new_so && (!allowSameSort && new_so != SORT_PREFERRED ))
 	{
 		return false;

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -537,6 +537,7 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 			}
 			break;
 		}
+		case SORT_METER:
 		case SORT_PREFERRED:
 		case SORT_ROULETTE:
 		case SORT_GROUP:
@@ -567,6 +568,7 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 			// sort the songs
 			switch( so )
 			{
+				case SORT_METER:
 				case SORT_PREFERRED:
 					// obey order specified by the preferred sort list
 					break;
@@ -663,6 +665,7 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 				/* We're using sections, so use the section name as the top-level sort. */
 				switch( so )
 				{
+					case SORT_METER:
 					case SORT_PREFERRED:
 					case SORT_TOP_GRADES:
 					case SORT_BPM:
@@ -676,58 +679,79 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 			// make WheelItemDatas with sections
 			RString sLastSection = "";
 			int iSectionColorIndex = 0;
-
-			// If the sort order is Preferred handle it differently because we already know the sections
-			if( so == SORT_PREFERRED )
-			{
-				if( bUseSections )
-				{
-					// Get mappping of section names to songs
-					std::map<RString, std::vector<Song*>> preferredSortSongsMap = SONGMAN->GetPreferredSortSongsMap();
-					for (auto const& [sectionName, songs] : SONGMAN->GetPreferredSortSongsMap())
-					{
-						// todo: preferred sort section color handling? -aj
-						RageColor colorSection = SECTION_COLORS.GetValue(iSectionColorIndex);
-						iSectionColorIndex = (iSectionColorIndex+1) % NUM_SECTION_COLORS;
-						// Add the section item
-						arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Section, nullptr, sectionName, nullptr, colorSection, songs.size()) );
-						// Add all the songs in this section
-						for (auto const& song : songs)
-						{
-							arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Song, song, sectionName, nullptr, SONGMAN->GetSongColor(song), 0) );
-						}
-					}
-				}
-			} else {
-
-				for( unsigned i=0; i< arraySongs.size(); i++ )
-				{
-					Song* pSong = arraySongs[i];
+			switch (so) {
+				case SORT_PREFERRED:
+					// If the sort order is Preferred handle it differently because we already know the sections
 					if( bUseSections )
 					{
-						RString sThisSection = SongUtil::GetSectionNameFromSongAndSort( pSong, so );
-
-						if( sThisSection != sLastSection )
+						// Get mappping of section names to songs
+						std::map<RString, std::vector<Song*>> preferredSortSongsMap = SONGMAN->GetPreferredSortSongsMap();
+						for (auto const& [sectionName, songs] : SONGMAN->GetPreferredSortSongsMap())
 						{
-							int iSectionCount = 0;
-							// Count songs in this section
-							unsigned j;
-							for( j=i; j < arraySongs.size(); j++ )
-							{
-								if( SongUtil::GetSectionNameFromSongAndSort( arraySongs[j], so ) != sThisSection )
-									break;
-							}
-							iSectionCount = j-i;
-
-							// new section, make a section item
-							RageColor colorSection = (so==SORT_GROUP) ? SONGMAN->GetSongGroupColor(pSong->m_sGroupName) : SECTION_COLORS.GetValue(iSectionColorIndex);
+							// todo: preferred sort section color handling? -aj
+							RageColor colorSection = SECTION_COLORS.GetValue(iSectionColorIndex);
 							iSectionColorIndex = (iSectionColorIndex+1) % NUM_SECTION_COLORS;
-							arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Section, nullptr, sThisSection, nullptr, colorSection, iSectionCount) );
-							sLastSection = sThisSection;
+							// Add the section item
+							arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Section, nullptr, sectionName, nullptr, colorSection, songs.size()) );
+							// Add all the songs in this section
+							for (auto const& song : songs)
+							{
+								arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Song, song, sectionName, nullptr, SONGMAN->GetSongColor(song), 0) );
+							}
 						}
 					}
-					arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Song, pSong, sLastSection, nullptr, SONGMAN->GetSongColor(pSong), 0) );
-				}
+					break;
+				case SORT_METER:
+					// If the sort order is Preferred handle it differently because we already know the sections
+					if( bUseSections )
+					{
+						int iSectionCount = 0;
+						// // Get all section names
+						std::map<int, std::vector<Song*>> meterSortSongsMap = SONGMAN->GetMeterToSongsMap();
+						for (auto const& [sectionName, songs] : SONGMAN->GetMeterToSongsMap()) {
+							RageColor colorSection = SECTION_COLORS.GetValue(iSectionColorIndex);
+							iSectionColorIndex = (iSectionColorIndex+1) % NUM_SECTION_COLORS;
+							// Add the section item
+							arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Section, nullptr, ssprintf("%d",sectionName), nullptr, colorSection, songs.size()) );
+							// Add all the songs in this section
+							for (auto const& song : songs)
+							{
+								arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Song, song, ssprintf("%d",sectionName), nullptr, SONGMAN->GetSongColor(song), 0) );
+							}
+						} 
+					}
+					break;
+				default:
+					for( unsigned i=0; i< arraySongs.size(); i++ )
+					{
+						Song* pSong = arraySongs[i];
+						if( bUseSections )
+						{
+							RString sThisSection = SongUtil::GetSectionNameFromSongAndSort( pSong, so );
+
+							if( sThisSection != sLastSection )
+							{
+								int iSectionCount = 0;
+								// Count songs in this section
+								unsigned j;
+								for( j=i; j < arraySongs.size(); j++ )
+								{
+									if( SongUtil::GetSectionNameFromSongAndSort( arraySongs[j], so ) != sThisSection )
+										break;
+								}
+								iSectionCount = j-i;
+
+								// new section, make a section item
+								// todo: preferred sort section color handling? -aj
+								RageColor colorSection = (so==SORT_GROUP) ? SONGMAN->GetSongGroupColor(pSong->m_sGroupName) : SECTION_COLORS.GetValue(iSectionColorIndex);
+								iSectionColorIndex = (iSectionColorIndex+1) % NUM_SECTION_COLORS;
+								arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Section, nullptr, sThisSection, nullptr, colorSection, iSectionCount) );
+								sLastSection = sThisSection;
+							}
+						}
+						arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Song, pSong, sLastSection, nullptr, SONGMAN->GetSongColor(pSong), 0) );
+					}
+					break;
 			}
 
 			if( so != SORT_ROULETTE )

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -845,6 +845,43 @@ RString SongManager::SongToPreferredSortSectionName( const Song *pSong ) const
 	return RString();
 }
 
+
+void SongManager::GetPreferredSortSongsBySectionName( const RString &sSectionName, std::vector<Song*> &AddTo ) const
+{
+	for (PreferredSortSection const &v : m_vPreferredSongSort)
+	{
+		if (v.sName == sSectionName)
+		{
+			AddTo.insert( AddTo.end(), v.vpSongs.begin(), v.vpSongs.end() );
+			return;
+		}
+	}
+}
+
+std::vector<Song*> SongManager::GetPreferredSortSongsBySectionName( const RString &sSectionName ) const
+{
+	std::vector<Song*> AddTo;
+	for (PreferredSortSection const &v : m_vPreferredSongSort)
+	{
+		if (v.sName == sSectionName)
+		{
+			AddTo.insert( AddTo.end(), v.vpSongs.begin(), v.vpSongs.end() );
+			return AddTo;
+		}
+	}
+	return AddTo;
+}
+
+std::vector<RString> SongManager::GetPreferredSortSectionNames() const
+{
+	std::vector<RString> sectionNames;
+	for (PreferredSortSection const &v : m_vPreferredSongSort)
+	{
+		sectionNames.push_back(v.sName);
+	}
+	return sectionNames;
+}
+	
 void SongManager::GetPreferredSortCourses( CourseType ct, std::vector<Course*> &AddTo, bool bIncludeAutogen ) const
 {
 	if( m_vPreferredCourseSort.empty() )
@@ -1605,7 +1642,6 @@ void SongManager::SetPreferredSongs(RString sPreferredSongs, bool bIsAbsolute) {
 	ASSERT( UNLOCKMAN != nullptr );
 
 	m_vPreferredSongSort.clear();
-
 	std::vector<RString> asLines;
 	RString sFile = sPreferredSongs;
 	if (!bIsAbsolute)
@@ -2219,6 +2255,14 @@ public:
 		lua_pushstring(L, p->SongToPreferredSortSectionName(pSong));
 		return 1;
 	}
+	static int GetPreferredSortSongsBySectionName( T* p, lua_State *L )
+	{
+		std::vector<Song*> v;
+		p->GetPreferredSortSongsBySectionName(SArg(1), v);
+		LuaHelpers::CreateTableFromArray<Song*>( v, L );
+		return 1;
+	}
+
 	static int WasLoadedFromAdditionalSongs( T* p, lua_State *L )	{ lua_pushboolean(L, false); return 1; }	// deprecated
 	static int WasLoadedFromAdditionalCourses( T* p, lua_State *L )	{ lua_pushboolean(L, false); return 1; }	// deprecated
 
@@ -2261,6 +2305,7 @@ public:
 		ADD_METHOD( GetPopularSongs );
 		ADD_METHOD( GetPopularCourses );
 		ADD_METHOD( SongToPreferredSortSectionName );
+		ADD_METHOD( GetPreferredSortSongsBySectionName );
 		ADD_METHOD( WasLoadedFromAdditionalSongs );	// deprecated
 		ADD_METHOD( WasLoadedFromAdditionalCourses );	// deprecated
 	}

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -861,14 +861,7 @@ void SongManager::GetPreferredSortSongsBySectionName( const RString &sSectionNam
 std::vector<Song*> SongManager::GetPreferredSortSongsBySectionName( const RString &sSectionName ) const
 {
 	std::vector<Song*> AddTo;
-	for (PreferredSortSection const &v : m_vPreferredSongSort)
-	{
-		if (v.sName == sSectionName)
-		{
-			AddTo.insert( AddTo.end(), v.vpSongs.begin(), v.vpSongs.end() );
-			return AddTo;
-		}
-	}
+	GetPreferredSortSongsBySectionName(sSectionName, AddTo);
 	return AddTo;
 }
 

--- a/src/SongManager.h
+++ b/src/SongManager.h
@@ -144,6 +144,10 @@ public:
 
 	void GetPreferredSortSongs( std::vector<Song*> &AddTo ) const;
 	RString SongToPreferredSortSectionName( const Song *pSong ) const;
+	std::vector<RString> GetPreferredSortSectionNames() const;
+	std::vector<Song*> GetPreferredSortSongsBySectionName( const RString &sSectionName ) const;
+	void GetPreferredSortSongsBySectionName( const RString &sSectionName, std::vector<Song*> &AddTo ) const;
+
 	const std::vector<Course*> &GetPopularCourses( CourseType ct ) const { return m_pPopularCourses[ct]; }
 	Song *FindSong( RString sPath ) const;
 	Song *FindSong( RString sGroup, RString sSong ) const;

--- a/src/SongManager.h
+++ b/src/SongManager.h
@@ -143,6 +143,7 @@ public:
 	const std::vector<Song *> &GetAllSongsOfCurrentGame() const;
 
 	void GetPreferredSortSongs( std::vector<Song*> &AddTo ) const;
+	std::map<RString, std::vector<Song*>> GetPreferredSortSongsMap() const { return m_mapPreferredSectionToSongs;};
 	RString SongToPreferredSortSectionName( const Song *pSong ) const;
 	std::vector<RString> GetPreferredSortSectionNames() const;
 	std::vector<Song*> GetPreferredSortSongsBySectionName( const RString &sSectionName ) const;
@@ -229,6 +230,8 @@ protected:
 		RString sName;
 		std::vector<Song*> vpSongs;
 	};
+	/** @brief All preferred songs, keyed by section */
+	std::map<RString, std::vector<Song*>> m_mapPreferredSectionToSongs;
 	std::vector<PreferredSortSection> m_vPreferredSongSort;
 	std::vector<RString>		m_sSongGroupNames;
 	std::vector<RString>		m_sSongGroupBannerPaths; // each song group may have a banner associated with it

--- a/src/SongManager.h
+++ b/src/SongManager.h
@@ -142,13 +142,14 @@ public:
 	 * @return the songs within the game that have at least one valid Step. */
 	const std::vector<Song *> &GetAllSongsOfCurrentGame() const;
 
+	std::map<int, std::vector<Song*>> GetMeterToSongsMap() const { return m_mapSongsByDifficulty; }
 	void GetPreferredSortSongs( std::vector<Song*> &AddTo ) const;
 	std::map<RString, std::vector<Song*>> GetPreferredSortSongsMap() const { return m_mapPreferredSectionToSongs;};
 	RString SongToPreferredSortSectionName( const Song *pSong ) const;
 	std::vector<RString> GetPreferredSortSectionNames() const;
 	std::vector<Song*> GetPreferredSortSongsBySectionName( const RString &sSectionName ) const;
 	void GetPreferredSortSongsBySectionName( const RString &sSectionName, std::vector<Song*> &AddTo ) const;
-
+	std::vector<Song*> GetSongsByMeter( int iMeter ) const;
 	const std::vector<Course*> &GetPopularCourses( CourseType ct ) const { return m_pPopularCourses[ct]; }
 	Song *FindSong( RString sPath ) const;
 	Song *FindSong( RString sGroup, RString sSong ) const;
@@ -188,6 +189,7 @@ public:
 
 	void UpdatePopular();
 	void UpdateShuffled();	// re-shuffle songs and courses
+	void UpdateMeterSort();
 	void SetPreferredSongs(RString sPreferredSongs, bool bIsAbsolute = false);
 	void SetPreferredCourses(RString sPreferredCourses, bool bIsAbsolute = false);
 	void UpdatePreferredSort(RString sPreferredSongs = "PreferredSongs.txt", RString sPreferredCourses = "PreferredCourses.txt");
@@ -225,6 +227,10 @@ protected:
 	/** @brief The most popular songs ranked by number of plays. */
 	std::vector<Song*>	m_pPopularSongs;
 	std::vector<Song*>	m_pShuffledSongs;	// used by GetRandomSong
+
+	/** @brief Meter numbers and the songs with Steps that are within.*/
+	std::map<int, std::vector<Song*>> m_mapSongsByDifficulty;
+	
 	struct PreferredSortSection
 	{
 		RString sName;

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -512,6 +512,7 @@ void SongUtil::SortSongPointerArrayByDisplayArtist( std::vector<Song*> &vpSongsI
 	stable_sort( vpSongsInOut.begin(), vpSongsInOut.end(), CompareSongPointersBySortValueAscending );
 }
 
+
 static int CompareSongPointersByGenre(const Song *pSong1, const Song *pSong2)
 {
 	return pSong1->m_sGenre < pSong2->m_sGenre;
@@ -663,6 +664,8 @@ RString SongUtil::GetSectionNameFromSongAndSort( const Song* pSong, SortOrder so
 				return ssprintf("%02d", pSteps->GetMeter() );
 			return SORT_NOT_AVAILABLE.GetValue();
 		}
+	case SORT_METER:
+		return RString();
 	case SORT_MODE_MENU:
 		return RString();
 	case SORT_ALL_COURSES:

--- a/src/SongUtil.h
+++ b/src/SongUtil.h
@@ -145,6 +145,7 @@ namespace SongUtil
 	void SortSongPointerArrayByNumPlays( std::vector<Song*> &vpSongsInOut, ProfileSlot slot, bool bDescending );
 	void SortSongPointerArrayByNumPlays( std::vector<Song*> &vpSongsInOut, const Profile* pProfile, bool bDescending );
 	void SortSongPointerArrayByStepsTypeAndMeter( std::vector<Song*> &vpSongsInOut, StepsType st, Difficulty dc );
+	void SortSongPointerArrayByStepsTypeAndLevel( std::vector<Song*> &vpSongsInOut, StepsType st, int iMeter );
 	RString GetSectionNameFromSongAndSort( const Song *pSong, SortOrder so );
 	void SortSongPointerArrayBySectionName( std::vector<Song*> &vpSongsInOut, SortOrder so );
 	void SortByMostRecentlyPlayedForMachine( std::vector<Song*> &vpSongsInOut );

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1006,6 +1006,7 @@ int sm_main(int argc, char* argv[])
 	UNLOCKMAN	= new UnlockManager;
 	SONGMAN->UpdatePopular();
 	SONGMAN->UpdatePreferredSort();
+	SONGMAN->UpdateMeterSort();
 	NETWORK		= new NetworkManager;
 	STATSMAN	= new StatsManager;
 


### PR DESCRIPTION
So this PR aims to add a new sort for sorting songs by their Meter independent of their Difficulty (Easy, Medium, Hard etc). 

![image](https://github.com/itgmania/itgmania/assets/30600688/972e58a8-e250-44d0-8389-e07dcedc207a)


The implementation of such is pretty dependent on https://github.com/itgmania/itgmania/pull/143 which aims to remove the 1:1 relationship between song and section for favorites. Will be adjusted accordingly if need be.

> what does it look like if a single song has two charts with the same difficulty?

> It'll only show up once there, it won't dupe.
> It's sorted by Title under each level.
> If a song has multiple levels it'll appear in multiple sections (i.e. If you check both 10 and 7 you'll still find Disco Pop)