### PR TITLE
Only UpdateMeterSort when necessary (when sorting), Only show playable steps.

### DIFF
--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -571,6 +571,8 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 			switch( so )
 			{
 				case SORT_METER:
+					SONGMAN->UpdateMeterSort(arraySongs);
+					break;
 				case SORT_PREFERRED:
 					// obey order specified by the preferred sort list
 					break;
@@ -715,12 +717,9 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 					}
 					break;
 				case SORT_METER:
-					// If the sort order is Preferred handle it differently because we already know the sections
 					if( bUseSections )
 					{
 						int iSectionCount = 0;
-						// // Get all section names
-						std::map<int, std::vector<Song*>> meterSortSongsMap = SONGMAN->GetMeterToSongsMap();
 						for (auto const& [sectionName, songs] : SONGMAN->GetMeterToSongsMap()) {
 							RageColor colorSection = SECTION_COLORS.GetValue(iSectionColorIndex);
 							iSectionColorIndex = (iSectionColorIndex+1) % NUM_SECTION_COLORS;

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -214,7 +214,6 @@ void SongManager::Reload( bool bAllowFastLoad, LoadingWindow *ld )
 		PREFSMAN->m_bFastLoad.Set( oldVal );
 
 	UpdatePreferredSort();
-	UpdateMeterSort();
 }
 
 void SongManager::LoadAdditions( LoadingWindow *ld )
@@ -228,7 +227,6 @@ void SongManager::LoadAdditions( LoadingWindow *ld )
 	UNLOCKMAN->Reload();
 
 	UpdatePreferredSort();
-	UpdateMeterSort();
 }
 
 void SongManager::InitSongsFromDisk( LoadingWindow *ld, bool onlyAdditions )
@@ -1237,7 +1235,6 @@ void SongManager::Invalidate( const Song *pStaleSong )
 
 	UpdatePopular();
 	UpdateShuffled();
-	UpdateMeterSort();
 	RefreshCourseGroupInfo();
 }
 
@@ -1630,17 +1627,19 @@ void SongManager::UpdatePopular()
 	}
 }
 
-void SongManager::UpdateMeterSort() {
-	std::vector<Song*> apDifficultSongs = m_pSongs;
+std::map<int, std::vector<Song*>> SongManager::UpdateMeterSort( std::vector<Song*> songs) {
+	// Empty the map
+	m_mapSongsByDifficulty.clear();
+	std::vector<Song*> apDifficultSongs = songs;
 	// For each song, for each step
 	for( unsigned i = 0; i < apDifficultSongs.size(); ++i )
 	{
-		const std::vector<Steps*> &vSteps = apDifficultSongs[i]->GetAllSteps();
-		for( unsigned j = 0; j < vSteps.size(); ++j )
+		std::vector<Steps*>	vpSteps;
+		SongUtil::GetPlayableSteps( apDifficultSongs[i], vpSteps );
+		for( unsigned j = 0; j < vpSteps.size(); ++j )
 		{
-			Steps *pSteps = vSteps[j];
+			Steps *pSteps = vpSteps[j];
 			// Check if the meter is already in m_mapSongsByDifficulty
-			
 			if (std::find(m_mapSongsByDifficulty[pSteps->GetMeter()].begin(), m_mapSongsByDifficulty[pSteps->GetMeter()].end(), apDifficultSongs[i]) != m_mapSongsByDifficulty[pSteps->GetMeter()].end())
 				continue;
 			else {			
@@ -1648,12 +1647,7 @@ void SongManager::UpdateMeterSort() {
 			}
 		}
 	}
-
-	// For each meter in m_mapSongsByDifficulty, sort the songs by title
-	for( unsigned i = 0; i < m_mapSongsByDifficulty.size(); ++i )
-	{
-		SongUtil::SortSongPointerArrayByTitle( m_mapSongsByDifficulty[i] );
-	}
+	return m_mapSongsByDifficulty;
 }
 
 

--- a/src/SongManager.h
+++ b/src/SongManager.h
@@ -189,7 +189,7 @@ public:
 
 	void UpdatePopular();
 	void UpdateShuffled();	// re-shuffle songs and courses
-	void UpdateMeterSort();
+	std::map<int, std::vector<Song*>> UpdateMeterSort( std::vector<Song*> songs);
 	void SetPreferredSongs(RString sPreferredSongs, bool bIsAbsolute = false);
 	void SetPreferredCourses(RString sPreferredCourses, bool bIsAbsolute = false);
 	void UpdatePreferredSort(RString sPreferredSongs = "PreferredSongs.txt", RString sPreferredCourses = "PreferredCourses.txt");

--- a/src/SongUtil.h
+++ b/src/SongUtil.h
@@ -146,7 +146,6 @@ namespace SongUtil
 	void SortSongPointerArrayByNumPlays( std::vector<Song*> &vpSongsInOut, ProfileSlot slot, bool bDescending );
 	void SortSongPointerArrayByNumPlays( std::vector<Song*> &vpSongsInOut, const Profile* pProfile, bool bDescending );
 	void SortSongPointerArrayByStepsTypeAndMeter( std::vector<Song*> &vpSongsInOut, StepsType st, Difficulty dc );
-	void SortSongPointerArrayByStepsTypeAndLevel( std::vector<Song*> &vpSongsInOut, StepsType st, int iMeter );
 	RString GetSectionNameFromSongAndSort( const Song *pSong, SortOrder so );
 	void SortSongPointerArrayBySectionName( std::vector<Song*> &vpSongsInOut, SortOrder so );
 	void SortByMostRecentlyPlayedForMachine( std::vector<Song*> &vpSongsInOut );

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1006,7 +1006,6 @@ int sm_main(int argc, char* argv[])
 	UNLOCKMAN	= new UnlockManager;
 	SONGMAN->UpdatePopular();
 	SONGMAN->UpdatePreferredSort();
-	SONGMAN->UpdateMeterSort();
 	NETWORK		= new NetworkManager;
 	STATSMAN	= new StatsManager;
 


### PR DESCRIPTION
UpdateMeterSort only needs to be called when we're sorting by Meter (especially because there's no point doing so before we have a style selected). 
Only categorize songs based on playable steps. Example: Don't show a song in the 15 block of the sort if the 15 is not playable in the current game/style, there are not enough credits to play it, or is just straight up hidden.