### PR TITLE
Fix: Windows support for fullscreen borderless window mode

### DIFF
--- a/src/arch/LowLevelWindow/LowLevelWindow_Win32.h
+++ b/src/arch/LowLevelWindow/LowLevelWindow_Win32.h
@@ -20,6 +20,8 @@ public:
 	virtual bool SupportsRenderToTexture() const { return true; }
 	virtual RenderTarget *CreateRenderTarget();
 
+	bool SupportsFullscreenBorderlessWindow() const { return true; }
+
 	const ActualVideoModeParams GetActualVideoModeParams() const;
 };
 

--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -261,12 +261,12 @@ RString GraphicsWindow::SetScreenMode( const VideoModeParams &p )
 	return RString();
 }
 
-static int GetWindowStyle( bool bWindowed )
+static int GetWindowStyle( bool bWindowed , bool bWindowIsFullscreenBorderless)
 {
-	if( bWindowed )
+	if( bWindowed && !bWindowIsFullscreenBorderless )
 		return WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
 	else
-		return WS_POPUP;
+		return WS_POPUP | WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
 }
 
 /* Set the final window size, set the window text and icon, and then unhide the
@@ -280,7 +280,7 @@ void GraphicsWindow::CreateGraphicsWindow( const VideoModeParams &p, bool bForce
 
 	if( g_hWndMain == nullptr || bForceRecreateWindow )
 	{
-		int iWindowStyle = GetWindowStyle( p.windowed );
+		int iWindowStyle = GetWindowStyle( p.windowed , p.bWindowIsFullscreenBorderless );
 
 		AppInstance inst;
 		HWND hWnd = CreateWindow( g_sClassName, "app", iWindowStyle,
@@ -331,7 +331,7 @@ void GraphicsWindow::CreateGraphicsWindow( const VideoModeParams &p, bool bForce
 
 	/* The window style may change as a result of switching to or from fullscreen;
 	 * apply it. Don't change the WS_VISIBLE bit. */
-	int iWindowStyle = GetWindowStyle( p.windowed );
+	int iWindowStyle = GetWindowStyle(p.windowed, p.bWindowIsFullscreenBorderless);
 	if( GetWindowLong( g_hWndMain, GWL_STYLE ) & WS_VISIBLE )
 		iWindowStyle |= WS_VISIBLE;
 	SetWindowLong( g_hWndMain, GWL_STYLE, iWindowStyle );


### PR DESCRIPTION
Fixes #172 

This pulls in the bare minimum from [etternagame/etterna#697](https://github.com/etternagame/etterna/pull/697) needed to add borderless fullscreen support for Windows. 

Tested a bit on my Win10 machine and it seemed to mostly follow expected behavior for borderless fullscreen from other games. The only wrinkle is that in borderless mode, any error dialogs (e.g., missing textures from a song banner) cause the game to hang until you change window focus and deal with the dialog box. In comparison, windowed mode has the dialog pop up in front of the game window like you'd expect. Exclusive fullscreen seems to just barrel through it and suppress the dialog entirely (double checked to make sure I wasn't hushing them). 

Given the existing differences between exclusive fullscreen and windowed mode, I don't think this is a deal breaker. Just wanted to note it in case someone with more experience about win32 windows interactions can figure out what's causing it.