### PR TITLE
Don't skip high scores with a 0 in the Score field

### DIFF
--- a/src/HighScore.cpp
+++ b/src/HighScore.cpp
@@ -397,11 +397,7 @@ void HighScoreList::LoadFromNode( const XNode* pHighScoreList )
 			vHighScores.resize( vHighScores.size()+1 );
 			vHighScores.back().LoadFromNode( p );
 
-			// ignore all high scores that are 0
-			if( vHighScores.back().GetScore() == 0 )
-				vHighScores.pop_back();
-			else
-				HighGrade = std::min( vHighScores.back().GetGrade(), HighGrade );
+			HighGrade = std::min( vHighScores.back().GetGrade(), HighGrade );
 		}
 	}
 }


### PR DESCRIPTION
Since itgmania is storing white counts in the Score field of stats.xml instead of an actual score, ignoring these scores will eliminate quints when retrieving high scores.