### PR TITLE
validate LuaDoc XML as GitHub Workflow CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,16 @@ jobs:
         run: cmake -B build
       - name: Build
         run: cmake --build build
+
+  validate-xml-docs:
+    name: Validate Lua.xml, LuaDocumentation.xml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y
+          libxml2-utils
+      - name: Validate Lua.xml
+        run: xmllint --noout Docs/Luadoc/Lua.xml
+      - name: Validate LuaDocumentation.xml
+        run: xmllint --noout Docs/Luadoc/LuaDocumentation.xml


### PR DESCRIPTION
This adds simple XML validation for

- Docs/Luadocs/Lua.xml
- Docs/Luadocs/LuaDocumentation.xml

I'm new to GitHub Workflows, but I skimmed [this guide](https://docs.github.com/en/actions/using-workflows/about-workflows#understanding-the-workflow-file) and followed the existing format of this project's ci.yml, and this seems to catch malformed XML like that seen in https://github.com/itgmania/itgmania/pull/188

---

Here's a **failing** workflow on my fork that's correctly catching the `</Functions>` typo:
https://github.com/quietly-turning/itgmania/actions/runs/8363663297/job/22897165431

And here's a **passing** workflow on my fork with the changes from [https://github.com/itgmania/itgmania/pull/188](PR#188) present:
https://github.com/quietly-turning/itgmania/actions/runs/8363711733/job/22897343443

---

`xmllint` has more options (e.g. validating an xml file against an xsd spec), that we can look into in the future if we wish.  This seems like a decent resource: https://www.baeldung.com/linux/xmllint