### PR TITLE
Reset input redirection on screen change

### DIFF
--- a/src/Screen.cpp
+++ b/src/Screen.cpp
@@ -106,6 +106,9 @@ void Screen::EndScreen()
 {
 	this->PlayCommand( "End" );
 	m_bRunning = false;
+
+	m_InputCallbacks.clear();
+	m_DelayedCallbackRemovals.clear();
 }
 
 void Screen::Update( float fDeltaTime )

--- a/src/ScreenManager.cpp
+++ b/src/ScreenManager.cpp
@@ -96,12 +96,20 @@ namespace ScreenManagerUtil
 		 * and was given to us for use, and it's not ours to free. */
 		bool m_bDeleteWhenDone;
 
+		// m_input_redirected exists to allow the theme to prevent input being
+		// passed to the normal Screen::Input function, on a per-player basis.
+		// Input is still passed to lua callbacks, so it's intended for the case
+		// where someone has a custom menu on a screen and needs to disable normal
+		// input for navigating the custom menu to work. -Kyz
+		bool m_input_redirected[NUM_PLAYERS];
+
 		ScreenMessage m_SendOnPop;
 
 		LoadedScreen()
 		{
 			m_pScreen = nullptr;
 			m_bDeleteWhenDone = true;
+			ZERO( m_input_redirected );
 			m_SendOnPop = SM_None;
 		}
 	};
@@ -365,20 +373,15 @@ bool ScreenManager::IsStackedScreen( const Screen *pScreen ) const
 
 bool ScreenManager::get_input_redirected(PlayerNumber pn)
 {
-	if(pn >= m_input_redirected.size())
-	{
+	if(g_ScreenStack.empty() || pn < 0 || pn >= NUM_PLAYERS)
 		return false;
-	}
-	return m_input_redirected[pn];
+	return g_ScreenStack.back().m_input_redirected[pn];
 }
 
 void ScreenManager::set_input_redirected(PlayerNumber pn, bool redir)
 {
-	while(pn >= m_input_redirected.size())
-	{
-		m_input_redirected.push_back(false);
-	}
-	m_input_redirected[pn]= redir;
+	if(!g_ScreenStack.empty() && pn >= 0 && pn < NUM_PLAYERS)
+		g_ScreenStack.back().m_input_redirected[pn]= redir;
 }
 
 /* Pop the top screen off the stack, sending SM_LoseFocus messages and
@@ -395,6 +398,7 @@ ScreenMessage ScreenManager::PopTopScreenInternal( bool bSendLoseFocus )
 	if( bSendLoseFocus )
 		ls.m_pScreen->HandleScreenMessage( SM_LoseFocus );
 	ls.m_pScreen->EndScreen();
+	ZERO( ls.m_input_redirected );
 
 	if( g_setPersistantScreens.find(ls.m_pScreen->GetName()) != g_setPersistantScreens.end() )
 	{

--- a/src/ScreenManager.h
+++ b/src/ScreenManager.h
@@ -93,13 +93,6 @@ private:
 	// It's "AfterInput" because the debug overlay carries out actions in Input.
 	bool m_bReloadOverlayScreensAfterInput;
 
-	// m_input_redirected exists to allow the theme to prevent input being
-	// passed to the normal Screen::Input function, on a per-player basis.
-	// Input is still passed to lua callbacks, so it's intended for the case
-	// where someone has a custom menu on a screen and needs to disable normal
-	// input for navigating the custom menu to work. -Kyz
-	std::vector<bool> m_input_redirected;
-
 	Screen *MakeNewScreen( const RString &sName );
 	void LoadDelayedScreen();
 	bool ActivatePreparedScreenAndBackground( const RString &sScreenName );


### PR DESCRIPTION
It's possible for LUA to redirect input and not bring it back when screen is ending (and there are existing bugs like this in Simply Love). Considering that each screen is a separate entity, it seems like this shouldn't be possible and each screen should handle redirection separately. Split redirection state per each screen in the stack and clear it once screen is ending.