### PR TITLE
PulseAudio: Report actual audio playback position

### DIFF
--- a/src/arch/Sound/RageSoundDriver_PulseAudio.h
+++ b/src/arch/Sound/RageSoundDriver_PulseAudio.h
@@ -19,11 +19,11 @@ public:
 	RString Init();
 
 	inline std::int64_t GetPosition() const;
-	inline int GetSampleRate() const { return m_SampleRate; };
+	inline int GetSampleRate() const { return m_ss.rate; };
 
 protected:
 	std::int64_t m_LastPosition;
-	int m_SampleRate;
+	pa_sample_spec m_ss;
 	char *m_Error;
 
 	void m_InitStream();


### PR DESCRIPTION
PulseAudio driver used to report position of last frame written to audio stream instead of actual playback position. This kind of worked, since on average the write position doesn't diverge too much from actual elaped time, but it can result in note stuttering and in general isn't very accurate. Change the implementation to use actual playback position from PulseAudio stream.

Remove some compatibity code with old PulseAudio, since version 0.9.10 was released in 2008.

Also, as an optimization to avoid unnecessary memory copying, use `pa_stream_begin_write()` to mix audio directly into PulseAudio memory.