### PR TITLE
Modify runner for macOS (Intel) build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
   macos-build-x86_64:
     name: macOS (Intel)
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
       - name: Checkout submodules


### PR DESCRIPTION
From https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories, `macos-latest` runners use the M1 processor - this PR proposes modifying the runner in the Intel build step to (an older) one that does not.