### PR TITLE
Skip build suite for changes to Markdown files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    paths-ignore:
+      - '**.md'
 
 name: Continuous integration
 


### PR DESCRIPTION
The whole build suite runs for all changes, but could be optimized to exclude changes that are not involved in the build. Following https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore this pull request proposes ignoring Markdown files, but could be expanded for other paths that can be skipped.