### PR TITLE
Reduce rate of X11 screensave interrupt to once/minute

### DIFF
--- a/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
@@ -7,6 +7,7 @@
 #include "RageDisplay.h" // VideoModeParams
 #include "DisplaySpec.h"
 #include "LocalizedString.h"
+#include "RageTimer.h"
 
 #include "RageDisplay_OGL_Helpers.h"
 using namespace RageDisplay_Legacy_Helpers;
@@ -623,16 +624,20 @@ void LowLevelWindow_X11::SwapBuffers()
 		 * it's already active.
 		 */
 
-		XLockDisplay( Dpy );
+		auto now = RageTimer::GetTimeSinceStartFast();
+		if( (now - m_lastScreensaverInterrupt) > m_screensaverInterruptInterval ) {
+		  m_lastScreensaverInterrupt = now;
+		  XLockDisplay( Dpy );
 
-		int event_base, error_base, major, minor;
-		if( XTestQueryExtension( Dpy, &event_base, &error_base, &major, &minor ) )
-		{
-			XTestFakeRelativeMotionEvent( Dpy, 0, 0, 0 );
-			XSync( Dpy, False );
+		  int event_base, error_base, major, minor;
+		  if( XTestQueryExtension( Dpy, &event_base, &error_base, &major, &minor ) )
+		  {
+                    XTestFakeRelativeMotionEvent( Dpy, 0, 0, 0 );
+		    XSync( Dpy, False );
+		  }
+
+		  XUnlockDisplay( Dpy );
 		}
-
-		XUnlockDisplay( Dpy );
 #endif
 	}
 }

--- a/src/arch/LowLevelWindow/LowLevelWindow_X11.h
+++ b/src/arch/LowLevelWindow/LowLevelWindow_X11.h
@@ -38,6 +38,9 @@ private:
 
 	bool m_bWasWindowed;
 	ActualVideoModeParams CurrentParams;
+
+	float m_lastScreensaverInterrupt = 0.0f;
+	float m_screensaverInterruptInterval = 60.0f;
 };
 
 #ifdef ARCH_LOW_LEVEL_WINDOW


### PR DESCRIPTION
Should fix #95 

I've tested as best I can - xtest event only happens after a 60s interval now

I haven't been able to test on wayland / whether there's still mouse wheel quirks in nearby chromium based apps. Recommend merging and seeing what happens, or a few folks trying it out.