### PR TITLE
Change to HIGH_PRIORITY_CLASS on Windows

### DIFF
--- a/src/arch/ArchHooks/ArchHooks_Win32.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32.cpp
@@ -150,26 +150,13 @@ void ArchHooks_Win32::SetTime( tm newtime )
 
 void ArchHooks_Win32::BoostPriority()
 {
-	/* We just want a slight boost, so we don't skip needlessly if something happens
-	 * in the background.  We don't really want to be high-priority--above normal should
-	 * be enough.  However, ABOVE_NORMAL_PRIORITY_CLASS is only supported in Win2000
-	 * and later. */
-#ifndef ABOVE_NORMAL_PRIORITY_CLASS
-#define ABOVE_NORMAL_PRIORITY_CLASS 0x00008000
-#endif
-
-	DWORD pri = HIGH_PRIORITY_CLASS;
-	if( IsWindowsVersionOrGreater(HIBYTE(_WIN32_WINNT_WIN2K), LOBYTE(_WIN32_WINNT_WIN2K), 0) )
-		pri = ABOVE_NORMAL_PRIORITY_CLASS;
-
-	/* Be sure to boost the app, not the thread, to make sure the
-	 * sound thread stays higher priority than the main thread. */
-	SetPriorityClass( GetCurrentProcess(), pri );
+	// Be sure to boost the app, not the thread, to make sure the sound thread stays higher priority than the main thread.
+	SetPriorityClass( GetCurrentProcess(), HIGH_PRIORITY_CLASS );
 }
 
 void ArchHooks_Win32::UnBoostPriority()
 {
-	SetPriorityClass( GetCurrentProcess(), NORMAL_PRIORITY_CLASS );
+	SetPriorityClass( GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS );
 }
 
 void ArchHooks_Win32::SetupConcurrentRenderingThread()


### PR DESCRIPTION
[According to Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/procthread/scheduling-priorities), `HIGH_PRIORITY_CLASS` is appropriate for time-critical threads. Also, Windows Update should not interrupt a `HIGH_PRIORITY_CLASS` thread whereas it will interrupt `ABOVE_NORMAL_PRIORITY_CLASS`. This should help prevent stutter from streaming with OBS or similar software as well.

Instead of changing to `NORMAL_PRIORITY_CLASS` when the game unboosts itself, it now changes to `ABOVE_NORMAL_PRIORITY_CLASS`.

I also removed the check to see if the OS is Windows 2000 or older.

I commented out a single line in RageBitmapTexture to prevent the annoying dialog box one usually adds `IgnoredDialogs=FRAME_DIMENSIONS_WARNING` to their `Preferences.ini` from occurring. It will still log the event to the log file.