### PR TITLE
Remove redundant int cast in BPMDisplay.cpp

### DIFF
--- a/src/BPMDisplay.cpp
+++ b/src/BPMDisplay.cpp
@@ -120,8 +120,8 @@ void BPMDisplay::SetBPMRange( const DisplayBpms &bpms )
 		int MaxBPM = INT_MIN;
 		for( unsigned i = 0; i < BPMS.size(); ++i )
 		{
-			MinBPM = std::min( MinBPM, static_cast<int>(std::lrint(BPMS[i])) );
-			MaxBPM = std::max( MaxBPM, static_cast<int>(std::lrint(BPMS[i])) );
+			MinBPM = std::min(MinBPM, static_cast<int>(BPMS[i] + 0.5));
+			MaxBPM = std::max(MaxBPM, static_cast<int>(BPMS[i] + 0.5));
 		}
 		if( MinBPM == MaxBPM )
 		{


### PR DESCRIPTION
This change would very slightly improve code efficiency, however this change will always round to zero, whereas the existing code will round half up, so if someone plays a chart with a BPM of `171.895`, the BPM will appear as `171` in game whereas the existing code would have the BPM appear as `172`.