### PR TITLE
Sync drift bug patch

### DIFF
--- a/src/RageSoundPosMap.h
+++ b/src/RageSoundPosMap.h
@@ -14,8 +14,9 @@ public:
 	pos_map_queue( const pos_map_queue &cpy );
 	pos_map_queue &operator=( const pos_map_queue &rhs );
 
-	/* Insert a mapping from iSourceFrame to iDestFrame, containing iFrames. */
-	void Insert( std::int64_t iSourceFrame, int iFrames, std::int64_t iDestFrame, float fSourceToDestRatio = 1.0f );
+	/* Insert a mapping from iSourceFrame to iDestFrame, containing iFrames.
+	 * The double type is used to prevent precision loss leading to sync drift the longer the game runs. -sukibaby */
+	void Insert( std::int64_t iSourceFrame, std::int64_t iFrames, std::int64_t iDestFrame, double fSourceToDestRatio = 1.0 );
 
 	/* Return the iDestFrame for the given iSourceFrame. */
 	std::int64_t Search( std::int64_t iSourceFrame, bool *bApproximate ) const;

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -8,8 +8,9 @@
 class RageTimer
 {
 public:
+	/* Initialize the m_secs and m_us values to 0 and then fill them with the current time. */
 	RageTimer(): m_secs(0), m_us(0) { Touch(); }
-	RageTimer( int secs, int us ): m_secs(secs), m_us(us) { }
+	RageTimer( int64_t secs, int64_t us ): m_secs(secs), m_us(us) { }
 
 	/* Time ago this RageTimer represents. */
 	float Ago() const;
@@ -22,8 +23,7 @@ public:
 	/* (alias) */
 	float PeekDeltaTime() const { return Ago(); }
 
-	/* deprecated: */
-	static float GetTimeSinceStart( bool bAccurate = true );	// seconds since the program was started
+	static double GetTimeSinceStart( bool bAccurate = true );	// seconds since the program was started
 	static float GetTimeSinceStartFast() { return GetTimeSinceStart(false); }
 	static std::uint64_t GetUsecsSinceStart();
 
@@ -41,15 +41,15 @@ public:
 
 	bool operator<( const RageTimer &rhs ) const;
 
-	/* "float" is bad for a "time since start" RageTimer.  If the game is running for
-	 * several days, we'll lose a lot of resolution.  I don't want to use double
-	 * everywhere, since it's slow.  I'd rather not use double just for RageTimers, since
-	 * it's too easy to get a type wrong and end up with obscure resolution problems. */
-	unsigned m_secs, m_us;
+	/* The following is a "time since start" RageTimer. Splitting the seconds and
+	 * microseconds values into two integers and combining them later allows for
+	 * better precision. Use caution when changing data types, since resolution
+	 * mismatch errors are easy to cause when changing things in RageTimer. */
+	std::uint64_t m_secs, m_us;
 
 private:
 	static RageTimer Sum( const RageTimer &lhs, float tm );
-	static float Difference( const RageTimer &lhs, const RageTimer &rhs );
+	static double Difference( const RageTimer &lhs, const RageTimer &rhs );
 };
 
 extern const RageTimer RageZeroTimer;

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -226,53 +226,53 @@ float HHMMSSToSeconds( const RString &sHHMMSS )
 	return fSeconds;
 }
 
-RString SecondsToHHMMSS( float fSecs )
+RString SecondsToHHMMSS(float fSecs)
 {
-	const int iMinsDisplay = (int)fSecs/60;
-	const int iSecsDisplay = (int)fSecs - iMinsDisplay*60;
-	RString sReturn = ssprintf( "%02d:%02d:%02d", iMinsDisplay/60, iMinsDisplay%60, iSecsDisplay );
+	const int iMinsDisplay = static_cast<int>(fSecs / 60);
+	const int iSecsDisplay = static_cast<int>(fmod(fSecs, 60)); 
+	RString sReturn = ssprintf("%02d:%02d:%02d", iMinsDisplay / 60, iMinsDisplay % 60, iSecsDisplay);
 	return sReturn;
 }
 
-RString SecondsToMMSSMsMs( float fSecs )
+RString SecondsToMMSSMsMs(float fSecs)
 {
-	const int iMinsDisplay = (int)fSecs/60;
-	const int iSecsDisplay = (int)fSecs - iMinsDisplay*60;
-	const int iLeftoverDisplay = (int) ( (fSecs - iMinsDisplay*60 - iSecsDisplay) * 100 );
-	RString sReturn = ssprintf( "%02d:%02d.%02d", iMinsDisplay, iSecsDisplay, std::min(99,iLeftoverDisplay) );
+	const int iMinsDisplay = static_cast<int>(fSecs / 60);
+	const int iSecsDisplay = static_cast<int>(fmod(fSecs, 60)); 
+	const int iLeftoverDisplay = static_cast<int>((fSecs - iMinsDisplay * 60 - iSecsDisplay) * 100);
+	RString sReturn = ssprintf("%02d:%02d.%02d", iMinsDisplay, iSecsDisplay, std::min(99, iLeftoverDisplay));
 	return sReturn;
 }
 
 RString SecondsToMSSMsMs( float fSecs )
 {
-	const int iMinsDisplay = (int)fSecs/60;
-	const int iSecsDisplay = (int)fSecs - iMinsDisplay*60;
-	const int iLeftoverDisplay = (int) ( (fSecs - iMinsDisplay*60 - iSecsDisplay) * 100 );
+	const int iMinsDisplay = static_cast<int>(fSecs/60);
+	const int iSecsDisplay = static_cast<int>(fmod(fSecs, 60)); 
+	const int iLeftoverDisplay = static_cast<int>((fSecs - iMinsDisplay*60 - iSecsDisplay) * 100 );
 	RString sReturn = ssprintf( "%01d:%02d.%02d", iMinsDisplay, iSecsDisplay, std::min(99,iLeftoverDisplay) );
 	return sReturn;
 }
 
 RString SecondsToMMSSMsMsMs( float fSecs )
 {
-	const int iMinsDisplay = (int)fSecs/60;
-	const int iSecsDisplay = (int)fSecs - iMinsDisplay*60;
-	const int iLeftoverDisplay = (int) ( (fSecs - iMinsDisplay*60 - iSecsDisplay) * 1000 );
+	const int iMinsDisplay = static_cast<int>(fSecs/60);
+	const int iSecsDisplay = static_cast<int>(fmod(fSecs, 60)); 
+	const int iLeftoverDisplay = static_cast<int>((fSecs - iMinsDisplay*60 - iSecsDisplay) * 1000 );
 	RString sReturn = ssprintf( "%02d:%02d.%03d", iMinsDisplay, iSecsDisplay, std::min(999,iLeftoverDisplay) );
 	return sReturn;
 }
 
 RString SecondsToMSS( float fSecs )
 {
-	const int iMinsDisplay = (int)fSecs/60;
-	const int iSecsDisplay = (int)fSecs - iMinsDisplay*60;
+	const int iMinsDisplay = static_cast<int>(fSecs/60);
+	const int iSecsDisplay = static_cast<int>(fmod(fSecs, 60));
 	RString sReturn = ssprintf( "%01d:%02d", iMinsDisplay, iSecsDisplay);
 	return sReturn;
 }
 
 RString SecondsToMMSS( float fSecs )
 {
-	const int iMinsDisplay = (int)fSecs/60;
-	const int iSecsDisplay = (int)fSecs - iMinsDisplay*60;
+	const int iMinsDisplay = static_cast<int>(fSecs/60);
+	const int iSecsDisplay = static_cast<int>(fmod(fSecs, 60));
 	RString sReturn = ssprintf( "%02d:%02d", iMinsDisplay, iSecsDisplay);
 	return sReturn;
 }


### PR DESCRIPTION
## The SM5 sync drift bug

### Background

The SM5 code base suffers from a two-part bug which is responsible for causing two independent, but related, kinds of desync. The problem mainly lies between RageTimer and RageSoundPosMap, two pieces of very terse and sparsely commented code written over 20 years ago, and largely unchanged in that time. This code was extremely efficient for its time, but was written in the era of 32-bit hardware and operating systems, so code which was once very efficient has become very inaccurate.

### Explanation

One part of the problem is RageTimer using very low accuracy/low resolution data types to store time values, due to being legacy code (20+ years ago) created in a time when these values were not considered so inaccurate, and the savings on computing power and memory consumption were very significant.

The other part of the problem is RageSoundPosMap not only being smaller than necessary, but needlessly actively discarding parts of the buffer as well. The fix involves both using data types which can store larger and more precise values in RageTimer, and increasing the size of the buffer in RageSoundPosMap.

**Combined, extreme errors in time math would occur due to important time and sound buffer values being stored in the smallest data types that could store them, leading to significant precision loss. Math would then be performed on these inaccurate values, leading to an even more inaccurate result.**

The following diagram gives a very simplified visual overview of a typical scenario where a desync would occur. In this example, RageSound requests the position of the audio file currently playing, and obtains a timestamp from RageTimer via ArchHooks. RageTimer then takes the value of microseconds it got from ArchHooks and converts it to seconds, which it then passes back to RageSound. Then, RageSoundPosMap thinks it needs to get a correct time from RageTimer because it now thinks it should have been reporting a position outside of the current audio buffer, so it tries to figure out how much error there was in the time between the time it knew and the time that was reported. 

```mermaid

sequenceDiagram

RageSound-->>RageTimer: GetPositionSeconds()

RageTimer-->>ArchHooks: GetMicrosecondsSinceStart()

ArchHooks-->>RageTimer: Time in microseconds

RageTimer-->>RageSound: Timestamp

RageSoundPosMap-->>RageTimer: PeekDeltaTime()

RageSoundPosMap-->>RageTimer: Reset timer

RageTimer-->>RageSoundPosMap: Timestamp

```

(Keep in mind most modern programs will simply rely on the operating system to handle these sorts of duties, such as playing audio or keeping track of your position in the audio file, but these core elements of StepMania were designed in a time when this was a better solution than letting the operating system handle it.)

Other StepMania forks have chosen to replace RageTimer's functions with `std::chrono` functions, but have left RageSoundPosMap mostly the same. This has had the effect of solving the issue of drift over a longer period of time by not letting the time reported in-game have enough error that RageSoundPosMap has trouble finding its place in the available audio buffer. However, that kind of fix does not solve the potential for sudden desync to occur due to the audio buffer being smaller than it needs to be.

### The problem in RageTimer

The function `RageTimer::GetTimeSinceStart` calls the `GetTime()` function, which then calls `ArchHooks::GetMicrosecondsSinceStart` and stores the time value into a `uint64_t`. This value is then being stored in a `float`, the lowest precision and smallest data type capable of storing a number with decimal places. It then splits up the value into two `uint32_t`'s, does math on each section separately, and then returns the value as a sum of both `uint32_t`'s. Other functions in RageTimer, such as `RageTimer::Difference`, also do math on time as 32-bit values which needlessly lose precision and further contribute to inaccuracies.

The accuracy of the game's sync is directly reliant on RageTimer's `GetTimeSinceStart` function. Too much error due to precision loss will result in large errors when `GetTimeSinceStart` attempts to calculate the time in seconds, and this will manifest as a **sudden** change in sync. However, because precision loss is compounded over time as the value gets larger, this gradual error which grows over time causes the **long-term** sync drift.

### The problem in RageSoundPosMap

RageSoundPosMap suffered from very similar problems: not only was the sound buffer was being stored in an `int`, the smallest possible integer data type, but code was actively discarding parts of the buffer to ensure that the `int` would never overflow. This caused the **sudden** sync drift issue to occur frequently due to information being trimmed from an already too-small buffer. Additionally, math being performed to find out how far off the buffer was from the actual time was being performed and stored between an `int` and a `float`, so further precision loss was potentially occurring here as well. 

### Choice to use all 64-bit wide values

ITGMania users are all on modern hardware as it is a 64-bit program. Benchmarks of math on recent 64-bit CPU's will typically show math between 64-bit variables is faster than math between 32-bit variables, which is faster than math between a 64-bit and a 32-bit variable. Since it is critical that time math is performed quickly and accurately, there is no need to mix 32-bit and 64-bit values when there are no memory or performance concerns in modern times about using 64-bit wide values. People who looked into RageTimer in the past may have been dissuaded by a comment which states, "avoid using doubles for hardware which does not support it". This comment is seen in code at least as old as StepMania 5.0.0-alpha1, so it was written at least 13 years ago, when the game was still targeting 32-bit platforms.

Using the `double` type is costly and slow on 32-bit CPU's, but is typically very fast on 64-bit machines. A large amount of precision is gained from moving from `float` to `double`, as well. Since `GetTimeSinceStart` will return larger values the longer the game runs for, resolution begins being lost very quickly when the time is stored in a `float`. In order to fit into a 32-bit wide variable, the `float` type must begin sacrificing precision as the value gets larger, whereas `double` can store both a much larger number and a much more precise value.

Math is being performed on the number of microseconds to convert it to seconds, however this math is being done by splitting up the received time in microseconds into a series of `uint32_t`'s, performing math on each part, and then returning the sum of those two values. Unfortunately the values at all points in this process are being stored in a low-precision 32-bit value, which further loses accuracy but also is slower than it needs to be on 64-bit CPU's by keeping these values 32-bit wide.

Precision loss is compounded as the game runs longer due to the constraints of these 32-bit values. To fix these issues, all varibles storing important time data are being performed with 64-bit wide `int64_t` or `double`.

### Choice to remove all lrint()/lrintf()

A hint passed along from the OutFox team is that on Windows, the performance of `lrint()` and `lrintf()` are very poor and can run very slowly compared to other rounding functions, notably when compiled with msvc. It was assumed that replacing occurences of these with a faster method would potentially mitigate the sync drift issue, as these commands are used frequently in both sound and time related code. Sync was not notably affected by changing these `lrint`/`lrintf`'s, but testers noted builds where `lrint`/`lrintf` were replaced with `static_cast<int>` would go longer without being affected by the long term drift bug.

### Choice to change the "Approximate sound time" error in logs

This warning pushed to the log file was instrumental in tracking down the sync drift bug, but the calculations it makes are not needed besides for debug reasons. Here is what the log entry will look like in current stable ITGMania:

`Approximate sound time: driver frame 10328371, m_pImpl->m_Queue frame 0..1024 (dist 6861), closest position is 0`

In order to do the calculations shown in the log entry above, RageTimer must be called several times, and additionally RageTimer's position is reset in this process, which further exacerbates the sync drift already happening. Additionally, several RageTimer related functions in RageSoundPosMap only exist to provide the information in this log, so it can safely be removed. I have commented out all these calculations from RageSoundPosMap so they can be easily re-enabled for debugging in the future. I have changed the log entry for this event to appear like this:

`Audio frame was out of range of the data sent - possible buffer underflow? This is not always an error, but if you see it frequently there could be timing problems.`

### Change in iSecsDisplay in RageUtil

After fixing RageTimer, a new bug appeared where an in-game timer reporting the time as `HH:MM:SS` will suddenly add two hours to the time as it approaches a 3 hour duration. In RageUtil, the in-game timer is be converted to a variety of ways to display time. In this process, the amount of remaining seconds is calculated:

`const int iSecsDisplay = (int)fSecs - iMinsDisplay*60;
`

The problem here is when `fSecs` is not a multiple of 60, because `iMinsDisplay` will truncate the decimal value from `fSecs/60`. When  `iMinsDisplay*60` is subtracted from `fSecs`, `iSecsDisplay` can return a negative value. This is fixed by correcting the math of `iSecsDisplay`:

`const int iSecsDisplay = (int)fSecs%60;`

### Final thoughts

It's possible other bugs may crop up similar to the above iSecsDisplay issue, but in most cases improvements should be seen elsewhere with code that relies on RageTimer. For example, the song wheel frequently called one of RageTimer's least accurate functions, and as a result the song wheel is now much smoother.