### PR TITLE
 Change RageTimer::GetTimeSinceStart to double

### DIFF
--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -51,14 +51,18 @@ static std::uint64_t GetTime( bool /* bAccurate */ )
 #endif
 }
 
-float RageTimer::GetTimeSinceStart( bool bAccurate )
+/* In the past, this was float instead of double to maintain compatibility
+with legacy hardware that can't use the double type. That is not a concern
+with anything ITGMania will run on, and it's not going to cause noticeable
+performance issues for any ITGMania users by having this be double, and
+the precision benefits would be appreciated, so I am making this a double. */
+double RageTimer::GetTimeSinceStart(bool bAccurate)
 {
-	std::uint64_t usecs = GetTime( bAccurate );
+	std::uint64_t usecs = GetTime(bAccurate);
 	usecs -= g_iStartTime;
-	/* Avoid using doubles for hardware that doesn't support them.
-	 * This is writing usecs = high*2^32 + low and doing
+	/* This is writing usecs = high*2^32 + low and doing
 	 * usecs/10^6 = high * (2^32/10^6) + low/10^6. */
-	return std::uint32_t(usecs>>32) * 4294.967296f + std::uint32_t(usecs)/1000000.f;
+	return double(usecs >> 32) * 4294.967296 + double(usecs) / 1000000.0;
 }
 
 std::uint64_t RageTimer::GetUsecsSinceStart()

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -22,8 +22,10 @@ public:
 	/* (alias) */
 	float PeekDeltaTime() const { return Ago(); }
 
+	void ResetTimer();
+
 	/* deprecated: */
-	static double GetTimeSinceStart( bool bAccurate = true );	// seconds since the program was started
+	static long double GetTimeSinceStart( bool bAccurate = true );	// seconds since the program was started
 	static float GetTimeSinceStartFast() { return GetTimeSinceStart(false); }
 	static std::uint64_t GetUsecsSinceStart();
 

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -23,7 +23,7 @@ public:
 	float PeekDeltaTime() const { return Ago(); }
 
 	/* deprecated: */
-	static float GetTimeSinceStart( bool bAccurate = true );	// seconds since the program was started
+	static double GetTimeSinceStart( bool bAccurate = true );	// seconds since the program was started
 	static float GetTimeSinceStartFast() { return GetTimeSinceStart(false); }
 	static std::uint64_t GetUsecsSinceStart();
 


### PR DESCRIPTION
In the past (13+ years ago), this was float instead of double to maintain compatibility with legacy hardware (probably 32 bit CPU's since original SM5 was a 32 bit program).

That is not a concern with anything ITGMania will run on, since ITGMania is 64-bit only, so there is no need to keep this value within 32 bits (it's not going to cause noticeable performance issues for any ITGMania users by having this be double) 

On the other hand, the time precision benefits by having this be a double would be appreciated. 

Therefore, I have made GetTimeSinceStart a double instead of a float.

I have not noticed any unexpected behavior since implementing this in my own ITGMania builds.