### PR TITLE
[Performance improvement] Replace lrint(x) with static_cast<int>(x+0.49)

### DIFF
--- a/src/RageSoundMixBuffer.cpp
+++ b/src/RageSoundMixBuffer.cpp
@@ -82,7 +82,7 @@ void RageSoundMixBuffer::read( std::int16_t *pBuf )
 	{
 		float iOut = m_pMixbuf[iPos];
 		iOut = clamp( iOut, -1.0f, +1.0f );
-		pBuf[iPos] = std::lrint(iOut * 32767);
+		pBuf[iPos] = static_cast<int>((iOut * 32767) + 0.5);
 	}
 	m_iBufUsed = 0;
 }

--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -56,7 +56,7 @@ void RageSoundReader_Chain::AddSound( int iIndex, float fOffsetSecs, float fPan 
 
 	Sound s;
 	s.iIndex = iIndex;
-	s.iOffsetMS = std::lrint( fOffsetSecs * 1000 );
+	s.iOffsetMS = static_cast<int>((fOffsetSecs * 1000) + 0.5 );
 	s.fPan = fPan;
 	s.pSound = nullptr;
 	m_aSounds.push_back( s );

--- a/src/RageSoundReader_Extend.cpp
+++ b/src/RageSoundReader_Extend.cpp
@@ -155,7 +155,7 @@ bool RageSoundReader_Extend::SetProperty( const RString &sProperty, float fValue
 {
 	if( sProperty == "StartSecond" )
 	{
-		m_iStartFrames = std::lrint( fValue * this->GetSampleRate() );
+		m_iStartFrames = static_cast<int>((fValue * this->GetSampleRate()) + 0.5);
 		return true;
 	}
 
@@ -164,7 +164,7 @@ bool RageSoundReader_Extend::SetProperty( const RString &sProperty, float fValue
 		if( fValue == -1 )
 			m_iLengthFrames = -1;
 		else
-			m_iLengthFrames = std::lrint( fValue * this->GetSampleRate() );
+			m_iLengthFrames = static_cast<int>((fValue * this->GetSampleRate()) + 0.5);
 		return true;
 	}
 
@@ -188,13 +188,13 @@ bool RageSoundReader_Extend::SetProperty( const RString &sProperty, float fValue
 
 	if( sProperty == "FadeInSeconds" )
 	{
-		m_iFadeInFrames = std::lrint( fValue * this->GetSampleRate() );
+		m_iFadeInFrames = static_cast<int>((fValue * this->GetSampleRate()) + 0.5);
 		return true;
 	}
 
 	if( sProperty == "FadeSeconds" || sProperty == "FadeOutSeconds" )
 	{
-		m_iFadeOutFrames = std::lrint( fValue * this->GetSampleRate() );
+		m_iFadeOutFrames = static_cast<int>((fValue * this->GetSampleRate()) + 0.5);
 		return true;
 	}
 

--- a/src/RageSoundReader_Merge.cpp
+++ b/src/RageSoundReader_Merge.cpp
@@ -215,7 +215,7 @@ int RageSoundReader_Merge::Read( float *pBuffer, int iFrames )
 			/* A sound is being delayed to resync it; clamp the number of frames we
 			 * read now, so we don't advance past it. */
 			int iMaxSourceFramesToRead = aNextSourceFrames[i] - iMinPosition;
-			int iMaxStreamFramesToRead = std::lrint( iMaxSourceFramesToRead / m_fCurrentStreamToSourceRatio );
+			int iMaxStreamFramesToRead = static_cast<int>((iMaxSourceFramesToRead / m_fCurrentStreamToSourceRatio) + 0.5 );
 			iFrames = std::min( iFrames, iMaxStreamFramesToRead );
 //			LOG->Warn( "RageSoundReader_Merge: sound positions moving at different rates" );
 		}
@@ -227,7 +227,7 @@ int RageSoundReader_Merge::Read( float *pBuffer, int iFrames )
 		RageSoundReader *pSound = m_aSounds.front();
 		iFrames = pSound->Read( pBuffer, iFrames );
 		if( iFrames > 0 )
-			m_iNextSourceFrame += std::lrint( iFrames * m_fCurrentStreamToSourceRatio );
+			m_iNextSourceFrame += static_cast<int>((iFrames * m_fCurrentStreamToSourceRatio) + 0.5 );
 		aNextSourceFrames.front() = pSound->GetNextSourceFrame();
 		aRatios.front() = pSound->GetStreamToSourceRatio();
 		return iFrames;
@@ -249,9 +249,9 @@ int RageSoundReader_Merge::Read( float *pBuffer, int iFrames )
 //			if( i == 0 )
 //LOG->Trace( "*** %i", Difference(aNextSourceFrames[i], m_iNextSourceFrame + std::lrint(iFramesRead * aRatios[i])) );
 
-			if( Difference(aNextSourceFrames[i], m_iNextSourceFrame + std::lrint(iFramesRead * aRatios[i])) > ERROR_CORRECTION_THRESHOLD )
+			if( Difference(aNextSourceFrames[i], m_iNextSourceFrame + static_cast<int>((iFramesRead * aRatios[i]) + 0.5)) > ERROR_CORRECTION_THRESHOLD )
 			{
-				LOG->Trace( "*** hurk %i", Difference(aNextSourceFrames[i], m_iNextSourceFrame + std::lrint(iFramesRead * aRatios[i])) );
+				LOG->Trace( "*** hurk %i", Difference(aNextSourceFrames[i], m_iNextSourceFrame + static_cast<int>((iFramesRead * aRatios[i]) + 0.5 )) );
 				break;
 			}
 

--- a/src/RageSoundReader_Preload.cpp
+++ b/src/RageSoundReader_Preload.cpp
@@ -63,7 +63,7 @@ bool RageSoundReader_Preload::Open( RageSoundReader *pSource )
 	{
 		float fSecs = iLen / 1000.f;
 
-		int iFrames = std::lrint( fSecs * m_iSampleRate ); /* seconds -> frames */
+		int iFrames = static_cast<int>((fSecs * m_iSampleRate) + 0.5 ); /* seconds -> frames */
 		int iSamples = unsigned( iFrames * m_iChannels ); /* frames -> samples */
 		if( iSamples > iMaxSamples )
 			return false; /* Don't bother trying to preload it. */
@@ -126,7 +126,7 @@ int RageSoundReader_Preload::GetLength_Fast() const
 int RageSoundReader_Preload::SetPosition( int iFrame )
 {
 	m_iPosition = iFrame;
-	m_iPosition = std::lrint(m_iPosition / m_fRate);
+	m_iPosition = static_cast<int>((m_iPosition / m_fRate) + 0.5);
 
 	if( m_iPosition >= int(m_Buffer->size() / framesize) )
 	{
@@ -139,7 +139,7 @@ int RageSoundReader_Preload::SetPosition( int iFrame )
 
 int RageSoundReader_Preload::GetNextSourceFrame() const
 {
-	return std::lrint(m_iPosition * m_fRate);
+	return static_cast<int>((m_iPosition * m_fRate) + 0.5);
 }
 
 int RageSoundReader_Preload::Read( float *pBuffer, int iFrames )

--- a/src/RageSoundReader_Resample_Good.cpp
+++ b/src/RageSoundReader_Resample_Good.cpp
@@ -623,7 +623,7 @@ void RageSoundReader_Resample_Good::ReopenResampler()
 	}
 
 	if( m_fRate != -1 )
-		iDownFactor = std::lrint( m_fRate * iDownFactor );
+		iDownFactor = static_cast<int>((m_fRate * iDownFactor) + 0.5 );
 
 	for( std::size_t iChannel = 0; iChannel < m_apResamplers.size(); ++iChannel )
 		m_apResamplers[iChannel]->SetDownFactor( iDownFactor );
@@ -699,7 +699,7 @@ void RageSoundReader_Resample_Good::SetRate( float fRatio )
 	int iDownFactor, iUpFactor;
 	GetFactors( iDownFactor, iUpFactor );
 	if( m_fRate != -1 )
-		iDownFactor = std::lrint( m_fRate * iDownFactor );
+		iDownFactor = static_cast<int>((m_fRate * iDownFactor) + 0.5 );
 
 	/* Set m_fRate to the actual rate, after quantization by iUpFactor. */
 	m_fRate = float(iDownFactor) / iUpFactor;

--- a/src/RageSoundReader_SpeedChange.cpp
+++ b/src/RageSoundReader_SpeedChange.cpp
@@ -166,7 +166,7 @@ int RageSoundReader_SpeedChange::Step()
 		 * by 2.0 frames, and advance by 0.3 more the next time around. */
 		float fAdvanceFrames = GetWindowSizeFrames() * m_fTrailingSpeedRatio;
 		fAdvanceFrames += m_fErrorFrames;
-		int iTrailingDeltaFrames = std::lrint( fAdvanceFrames );
+		int iTrailingDeltaFrames = static_cast<int>( (fAdvanceFrames) + 0.5 );
 		m_fErrorFrames = fAdvanceFrames - iTrailingDeltaFrames;
 		m_iUncorrelatedPos += iTrailingDeltaFrames;
 
@@ -315,7 +315,7 @@ int RageSoundReader_SpeedChange::GetNextSourceFrame() const
 	float fRatio = m_fTrailingSpeedRatio;
 
 	int iSourceFrame = RageSoundReader_Filter::GetNextSourceFrame();
-	int iPos = std::lrint(m_iPos * fRatio);
+	int iPos = static_cast<int>((m_iPos * fRatio) + 0.5);
 
 	iSourceFrame -= m_iDataBufferAvailFrames;
 	iSourceFrame += m_iUncorrelatedPos + iPos;

--- a/src/RageSoundReader_ThreadedBuffer.cpp
+++ b/src/RageSoundReader_ThreadedBuffer.cpp
@@ -237,7 +237,7 @@ void RageSoundReader_ThreadedBuffer::BufferingThread()
 		else
 		{
 			m_Event.Unlock();
-			usleep( std::lrint(fTimeToSleep * 1000000) );
+			usleep( static_cast<int>((fTimeToSleep * 1000000) + 0.5) );
 			m_Event.Lock();
 		}
 	}

--- a/src/RageSoundUtil.cpp
+++ b/src/RageSoundUtil.cpp
@@ -94,7 +94,7 @@ void RageSoundUtil::ConvertFloatToNativeInt16( const float *pFrom, std::int16_t 
 {
 	for( int i = 0; i < iSamples; ++i )
 	{
-		int iOut = std::lrint( pFrom[i] * 32768.0f );
+		int iOut = static_cast<int>((pFrom[i] * 32768.0f) + 0.5);
 		pTo[i] = clamp( iOut, -32768, 32767 );
 	}
 }


### PR DESCRIPTION
Because `lrint()` / `lrintf()` performance is very bad on some compilers (notably Windows & Visual Studio), this proposes to change frequent or time-sensitive occurrences of `lrint(x)` / `lrintf(x)` to `static_cast<int>((x) + 0.49)` (or `static_cast<int64_t>` where appropriate).

This should improve performance of ITGMania on all platforms.

Please refer to the following code to verify that this code is functionally identical:
https://ideone.com/D781hJ
```
#include <iostream>
#include <cmath>
 
using namespace std;
 
float tm = 6.999;
float tmm = 6.500;
float tmr = 6.199;
 
int main() {
 
	int64_t seconds = static_cast<int64_t>(tm + 0.49);
	std::cout << "Static cast of tm (" << tm << ") is " << seconds << std::endl;
 
	int64_t secondX = std::lrint(tm);
	std::cout << "std::lrint of tm (" << tm << ") is " << secondX << std::endl;
 
	int64_t secondsm = static_cast<int64_t>(tmm + 0.49);
	std::cout << "Static cast of tmm (" << tmm << ") is " << secondsm << std::endl;
 
	int64_t secondXm = std::lrint(tmm);
	std::cout << "std::lrint of tmr (" << tmm << ") is " << secondXm << std::endl;
 
	int64_t secondsr = static_cast<int64_t>(tmr + 0.49);
	std::cout << "Static cast of tmr (" << tmr << ") is " << secondsr << std::endl;
 
	int64_t secondXr = std::lrint(tmr);
	std::cout << "std::lrint of tmr (" << tmr << ") is " << secondXr << std::endl;
 
	return 0;
}
```