### PR TITLE
Don't warn user if frame size is not a multiple of 2

### DIFF
--- a/src/RageBitmapTexture.cpp
+++ b/src/RageBitmapTexture.cpp
@@ -310,21 +310,6 @@ void RageBitmapTexture::Create()
 			float fBetterFrameHeight = std::ceil(fFrameHeight/iDimensionMultiple) * iDimensionMultiple;
 			float fBetterSourceWidth = this->GetFramesWide() * fBetterFrameWidth;
 			float fBetterSourceHeight = this->GetFramesHigh() * fBetterFrameHeight;
-			if( fFrameWidth!=fBetterFrameWidth || fFrameHeight!=fBetterFrameHeight )
-			{
-				RString sWarning = ssprintf(
-					"The graphic '%s' has frame dimensions that aren't a multiple of %d.\n"
-					"The entire image is %dx%d and frame size is %.1fx%.1f.\n"
-					"Image quality will be much improved if you resize the graphic to %.0fx%.0f, which is a frame size of %.0fx%.0f.",
-					actualID.filename.c_str(),
-					iDimensionMultiple,
-					this->GetSourceWidth(), this->GetSourceHeight(),
-					fFrameWidth, fFrameHeight,
-					fBetterSourceWidth, fBetterSourceHeight,
-					fBetterFrameWidth, fBetterFrameHeight );
-				LOG->Warn( "%s", sWarning.c_str() );
-				Dialog::OK( sWarning, "FRAME_DIMENSIONS_WARNING" );
-			}
 		}
 	}
 


### PR DESCRIPTION
Disable this common nag warning + log file warning combination. This proposed change only removes the dialog box and log file message.

Typically seen in a log file as follows:
```
/////////////////////////////////////////
11:19.586: WARNING: The graphic '/Songs/(pack)/(song)/logo.png' has frame dimensions that aren't a multiple of 2.
11:19.586: WARNING: The entire image is 150x75 and frame size is 150.0x75.0.
11:19.586: WARNING: Image quality will be much improved if you resize the graphic to 150x76, which is a frame size of 150x76.
/////////////////////////////////////////
```

and produces this dialog box:
![image](https://github.com/itgmania/itgmania/assets/163092272/391cf432-40b9-4dd8-8b40-7c6ce57269b0)
