### PR TITLE
Always use CLOCK_MONOTONIC if it's available on Unix

### DIFF
--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -125,21 +125,18 @@ static void TestTLS()
 namespace
 {
 	clockid_t g_Clock = CLOCK_REALTIME;
-
 	void OpenGetTime()
 	{
 		static bool bInitialized = false;
+		
 		if( bInitialized )
 			return;
 		bInitialized = true;
 
-		/* Check whether the clock is actually supported. */
+		/* Check whether CLOCK_MONOTONIC is supported.
+		 * If it isn't available, use CLOCK_REALTIME.*/
 		timespec ts;
-		if( clock_getres(CLOCK_MONOTONIC, &ts) == -1 )
-			return;
-
-		/* If the resolution is worse than a millisecond, fall back on CLOCK_REALTIME. */
-		if( ts.tv_sec > 0 || ts.tv_nsec > 1000000 )
+		if( clock_gettime(CLOCK_MONOTONIC, &ts) == -1 )
 			return;
 
 		g_Clock = CLOCK_MONOTONIC;


### PR DESCRIPTION
This is a little more efficient than the existing code, and is much better than forcing g_Clock to return `CLOCK_MONOTONIC` (a hack to improve clock stability on Linux which started gaining traction last month).

This code also offers the use of `CLOCK_MONOTONIC_RAW`, which has the benefit of not being affected by NTP.

The original code does this:
1. Set the `static bInitialized` flag to false. If it's true, return. If not, set it to true to prevent repeated execution.
2. Get the clock from the system. If there is an error getting `CLOCK_MONOTONIC`, return without changing anything (at this point g_Clock's value is `CLOCK_REALTIME`, so it will stay that way).
3. Check if the time stored in `ts` is greater than 0 seconds or 1 millisecond (1,000,000 nanoseconds). If either condition is true, the function returns. However, this does not make sure `ts.tv_sec` or `ts.tv_nsec` contain valid data.
4. Only set CLOCK_MONOTONIC if all the above succeeds.

The proposed new code does this:
1. Set the `static bInitialized` flag to false. If it's false, continue executing.
2. Try to get the time from `CLOCK_MONOTONIC_RAW`. If it succeeds, set g_Clock to `CLOCK_MONOTONIC_RAW`.
3. If that fails, try to get the time from `CLOCK_MONOTONIC`. If it succeeds, set g_Clock to `CLOCK_MONOTONIC`.
4. If that fails, return since g_Clock is already `CLOCK_REALTIME`.
6. Set the `static bInitialized` flag to true to prevent repeated execution.