### PR TITLE
Raspberry Pi 5 / ARM support

### DIFF
--- a/CMake/DefineOptions.cmake
+++ b/CMake/DefineOptions.cmake
@@ -62,3 +62,6 @@ if(LINUX)
   option(WITH_LIBXTST "Build with libXtst support" ON)
   option(WITH_X11 "Build with X11 support" ON)
 endif()
+
+option(WITH_MINIMAID "Build with Minimaid support." ON)
+

--- a/src/CMakeData-arch.cmake
+++ b/src/CMakeData-arch.cmake
@@ -190,15 +190,19 @@ list(APPEND SMDATA_ARCH_LIGHTS_HPP "arch/Lights/LightsDriver.h"
 if(NOT APPLE)
   if(WIN32)
     list(APPEND SMDATA_ARCH_LIGHTS_SRC
-                "arch/Lights/LightsDriver_Win32Minimaid.cpp"
                 "arch/Lights/LightsDriver_Win32Serial.cpp"
                 "arch/Lights/LightsDriver_Win32Parallel.cpp"
                 "arch/Lights/LightsDriver_PacDrive.cpp")
     list(APPEND SMDATA_ARCH_LIGHTS_HPP
-                "arch/Lights/LightsDriver_Win32Minimaid.h"
                 "arch/Lights/LightsDriver_Win32Parallel.h"
                 "arch/Lights/LightsDriver_Win32Serial.h"
                 "arch/Lights/LightsDriver_PacDrive.h")
+    if(WITH_MINIMAID)
+      list(APPEND SMDATA_ARCH_LIGHTS_SRC
+                  "arch/Lights/LightsDriver_Win32Minimaid.cpp")
+      list(APPEND SMDATA_ARCH_LIGHTS_HPP
+                  "arch/Lights/LightsDriver_Win32Minimaid.h")
+    endif()
   else() # Unix/Linux TODO: Linux HAVE_PARALLEL_PORT
     if(LINUX)
       list(APPEND SMDATA_LINK_LIB "udev")
@@ -209,7 +213,6 @@ if(NOT APPLE)
                   "arch/Lights/LightsDriver_Linux_PIUIOBTN_Leds.cpp"
                   "arch/Lights/LightsDriver_Linux_ITGIO.cpp"
                   "arch/Lights/LightsDriver_Linux_stac.cpp"
-                  "arch/Lights/LightsDriver_LinuxMinimaid.cpp"
                   "arch/Lights/LightsDriver_LinuxPacDrive.cpp"
                   "arch/Lights/LightsDriver_LinuxWeedTech.cpp")
       list(APPEND SMDATA_ARCH_LIGHTS_HPP
@@ -219,9 +222,15 @@ if(NOT APPLE)
                   "arch/Lights/LightsDriver_Linux_PIUIOBTN_Leds.h"
                   "arch/Lights/LightsDriver_Linux_ITGIO.h"
                   "arch/Lights/LightsDriver_Linux_stac.h"
-                  "arch/Lights/LightsDriver_LinuxMinimaid.h"
                   "arch/Lights/LightsDriver_LinuxPacDrive.h"
                   "arch/Lights/LightsDriver_LinuxWeedTech.h")
+      if(WITH_MINIMAID)
+        list(APPEND SMDATA_ARCH_LIGHTS_SRC
+                    "arch/Lights/LightsDriver_LinuxMinimaid.cpp")
+        list(APPEND SMDATA_ARCH_LIGHTS_HPP
+                    "arch/Lights/LightsDriver_LinuxMinimaid.h")
+      endif()
+
       if(WITH_PARALLEL_PORT)
         list(APPEND SMDATA_ARCH_LIGHTS_SRC
                     "arch/Lights/LightsDriver_LinuxParallel.cpp")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,7 +123,7 @@ endif()
 
 target_compile_options("${SM_EXE_NAME}" PRIVATE
   $<$<CXX_COMPILER_ID:GNU>:
-    -Wall -Wextra -Wno-unused -Wno-unused-parameter -Wno-unknown-pragmas>
+  -Wall -Wextra -Wno-unused -Wno-unused-parameter -Wno-unknown-pragmas -Werror=type-limits>
   $<$<CXX_COMPILER_ID:Clang>:
     -Wall -Wextra -Wno-unused -Wno-unused-parameter -Wno-unknown-pragmas -Wno-undefined-var-template>
   $<$<CXX_COMPILER_ID:AppleClang>:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -323,7 +323,10 @@ endif()
 set_property(TARGET "${SM_EXE_NAME}" PROPERTY FOLDER "Internal Libraries")
 
 list(APPEND SMDATA_LINK_LIB "lua-5.1" "miniz")
-include(../extern/CMakeProject-mmmagic.cmake)
+
+if(WITH_MINIMAID)
+  include(../extern/CMakeProject-mmmagic.cmake)
+endif()
 
 list(APPEND SMDATA_LINK_LIB "mad"
                             "pcre"

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -352,8 +352,16 @@ const glyph &Font::GetGlyph( wchar_t c ) const
 	 * with non-roman song titles, and looking at it, I'm gonna guess that
 	 * this is how ITG2 prevented crashing with them --infamouspat */
 	//ASSERT(c >= 0 && c <= 0xFFFFFF);
-	if (c < 0 || c > 0xFFFFFF)
+
+	// wchar_t can be signed or unsigned depending on the platform and the compiler.
+	// We use WCHAR_MIN to determine a valid condition that won't emit a type-limits warning.
+	#if WCHAR_MIN != 0
+	if (c < 0 || c > 0xFFFFFF) {
+	#else
+	if (c > 0xFFFFFF) {
+	#endif
 		c = 1;
+	}
 
 	// Fast path:
 	if( c < (int) ARRAYLEN(m_iCharToGlyphCache) && m_iCharToGlyphCache[c] )

--- a/src/ModelTypes.h
+++ b/src/ModelTypes.h
@@ -18,14 +18,14 @@ struct msTriangle
 struct msMesh
 {
 	RString			sName;
-	char			nMaterialIndex;
+	std::int8_t			nMaterialIndex;
 
 	std::vector<RageModelVertex>	Vertices;
 
 	// OPTIMIZATION: If all verts in a mesh are transformed by the same bone,
 	// then send the transform to the graphics card for the whole mesh instead
 	// of transforming each vertex on the CPU;
-	char			m_iBoneIndex;	// -1 = no bone
+	std::int8_t			m_iBoneIndex;	// -1 = no bone
 
 	std::vector<msTriangle>	Triangles;
 };

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -1819,8 +1819,15 @@ void UnicodeUpperLower( wchar_t *p, std::size_t iLen, const unsigned char pMappi
 	wchar_t *pEnd = p + iLen;
 	while( p != pEnd )
 	{
-		if( *p >= 0 && *p < 256 )
+		// wchar_t can be signed or unsigned depending on the platform and the compiler.
+		// We use WCHAR_MIN to determine a valid condition that won't emit a type-limits warning.
+		#if WCHAR_MIN != 0
+		if( *p >= 0 && *p < 256 ) {
+		#else
+		if( *p < 256 ) {
+		#endif
 			*p = pMapping[*p];
+		}
 		++p;
 	}
 }


### PR DESCRIPTION
## Summary
- @geefr suggested in #220 to make Minimaid optional (I cherry-picked the commit) so we can build on aarch64 without investing extra work on porting (which should be possible but can be done separately if needed)
- changed `char` to `std::int8_t` where needed for consistency between platforms
- added guards for wchars based on the wchar limits because the change wouldn't be local (and/or is also related to external API) and this will probably be redone anyway with proper utf8 support in the future
- added `-Werror=type-limits` for GNU compilation (I guess it should also work for clang but it's not in the CI anyway) to avoid introducing potential platform/compiler-dependent code in the future

Unfortunately, github is still working on bringing ARM CI runners to production:
- https://github.blog/changelog/2023-10-30-accelerate-your-ci-cd-with-arm-based-hosted-runners-in-github-actions/
- https://github.com/orgs/community/discussions/19197
so I couldn't add a separate build to CI. Technically it should be possible to cross-compile, but it seems like a lot of extra work.

## Playtests
I couldn't do a normal playtest, but I gave it a go using keyboard (unfortunately, I'm way less accurate on keyboard than on pad). It was playable with pretty consistent framerates during gameplay, no noticeable timing deviations:
- 1280x720 ~200fps
- 1920x1080 ~115fps
-  2560x1440 ~65fps

on a freshly installed Raspberry Pi OS on a Raspberry Pi 5 without any overclocking or tweaking.
