### PR TITLE
X11: Don't call any X11 functions on fatal error

### DIFF
--- a/src/arch/InputHandler/InputHandler_X11.cpp
+++ b/src/arch/InputHandler/InputHandler_X11.cpp
@@ -138,7 +138,7 @@ static DeviceButton XSymToDeviceButton( int key )
 
 InputHandler_X11::InputHandler_X11()
 {
-	if( Dpy == nullptr  || Win == None )
+	if( Dpy == nullptr || Win == None )
 		return;
 	XWindowAttributes winAttrib;
 
@@ -154,7 +154,7 @@ InputHandler_X11::InputHandler_X11()
 
 InputHandler_X11::~InputHandler_X11()
 {
-	if( Dpy == nullptr || Win == None )
+	if( Dpy == nullptr || Win == None || FatalError )
 		return;
 	// TODO: Determine if we even need to set this back (or is the window
 	// destroyed just after this?)

--- a/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
@@ -92,6 +92,9 @@ LowLevelWindow_X11::LowLevelWindow_X11()
 
 LowLevelWindow_X11::~LowLevelWindow_X11()
 {
+	if( FatalError )
+		return;
+
 	// Reset the display
 	if( !m_bWasWindowed )
 	{

--- a/src/archutils/Unix/X11Helper.cpp
+++ b/src/archutils/Unix/X11Helper.cpp
@@ -11,6 +11,7 @@
 
 Display *X11Helper::Dpy = nullptr;
 Window X11Helper::Win = None;
+bool X11Helper::FatalError = false;
 
 static int ErrorCallback( Display*, XErrorEvent* );
 static int FatalCallback( Display* );
@@ -160,6 +161,7 @@ int ErrorCallback( Display *d, XErrorEvent *err )
 
 int FatalCallback( Display *d )
 {
+	X11Helper::FatalError = true;
 	RageException::Throw( "Fatal I/O error communicating with X server." );
 }
 

--- a/src/archutils/Unix/X11Helper.h
+++ b/src/archutils/Unix/X11Helper.h
@@ -24,6 +24,9 @@ namespace X11Helper
 	// The Window used by LowLevelWindow_X11 as the main window.
 	extern Window Win;
 
+	// Set to true when fatal error has occured and no further X11 calls should be made.
+	extern bool FatalError;
+
 	// (Re)create the Window win.
 	bool MakeWindow( Window &win, int screenNum, int depth, Visual *visual,
 			 int width, int height, bool overrideRedirect );


### PR DESCRIPTION
If X11 functions are called after a fatal error then it just triggers the fatal error handler again eventually leading to stack overflow.