### PR TITLE
PulseAudio: Hold mainloop lock during GetPosition() call

### DIFF
--- a/src/arch/Sound/RageSoundDriver_PulseAudio.h
+++ b/src/arch/Sound/RageSoundDriver_PulseAudio.h
@@ -18,10 +18,12 @@ public:
 
 	RString Init();
 
-	inline std::int64_t GetPosition() const;
+	std::int64_t GetPosition() const;
 	inline int GetSampleRate() const { return m_ss.rate; };
 
 protected:
+	std::int64_t GetPositionUnlocked() const;
+
 	std::int64_t m_LastPosition;
 	pa_sample_spec m_ss;
 	char *m_Error;


### PR DESCRIPTION
Mainloop lock needs to be held to access PulseAudio object from outside the event loop thread, in particular in `GetPosition()` calls. Otherwise we might hit a race condition and have the call fail. There's also a possibility that the call might randomly fail if it's called before first timing data is received for the stream, so handle that case as well.

Also fix the stream write callback to call `Mix()` with correct parameters, as well as do the work in a loop in case `pa_stream_begin_write()` returns smaller memory buffer than was requested.