### PR TITLE
Preallocate memory for two audio buffers and swap between them

### DIFF
--- a/src/RageSoundMixBuffer.cpp
+++ b/src/RageSoundMixBuffer.cpp
@@ -14,8 +14,8 @@ static bool g_bVector = Vector::CheckForVector();
 
 RageSoundMixBuffer::RageSoundMixBuffer()
 {
-	// Set m_iBufSize to 16MB.
-	m_iBufSize = 16 * 1024 * 1024 / sizeof(float);
+	// Set m_iBufSize to 4MB.
+	m_iBufSize = 4 * 1024 * 1024 / sizeof(float);
 
 	// Allocate memory
 	m_pMixbuf = static_cast<float*>(std::malloc(m_iBufSize * sizeof(float)));

--- a/src/RageSoundMixBuffer.cpp
+++ b/src/RageSoundMixBuffer.cpp
@@ -31,19 +31,36 @@ void RageSoundMixBuffer::SetWriteOffset( int iOffset )
 	m_iOffset = iOffset;
 }
 
-void RageSoundMixBuffer::Extend( unsigned iSamples )
+void RageSoundMixBuffer::Extend(unsigned iSamples)
 {
-	const unsigned realsize = iSamples+m_iOffset;
-	if( m_iBufSize < realsize )
+	const std::uint64_t intendedBufferSize = static_cast<std::uint64_t>(iSamples) + m_iOffset;
+	if (m_iBufSize < intendedBufferSize)
 	{
-		m_pMixbuf = (float *) realloc( m_pMixbuf, sizeof(float) * realsize );
-		m_iBufSize = realsize;
+		m_pMixbufBackup = static_cast<float*>(realloc(m_pMixbufBackup, sizeof(float) * m_iBufSize));
+		if (m_pMixbufBackup != nullptr && m_pMixbuf != nullptr)
+		{
+			memcpy(m_pMixbufBackup, m_pMixbuf, m_iBufSize * sizeof(float));
+		}
+
+		float *m_pMixbufNew = static_cast<float*>(realloc(m_pMixbuf, sizeof(float) * intendedBufferSize));
+		if (m_pMixbufNew == nullptr)
+		{
+			if (m_pMixbufBackup != nullptr)
+			{
+				memcpy(m_pMixbuf, m_pMixbufBackup, m_iBufSize * sizeof(float));
+			}
+		}
+		else
+		{
+			m_pMixbuf = m_pMixbufNew;
+			m_iBufSize = intendedBufferSize;
+		}
 	}
 
-	if( m_iBufUsed < realsize )
+	if (m_iBufUsed < intendedBufferSize)
 	{
-		memset( m_pMixbuf + m_iBufUsed, 0, (realsize - m_iBufUsed) * sizeof(float) );
-		m_iBufUsed = realsize;
+		memset(m_pMixbuf + m_iBufUsed, 0, (intendedBufferSize - m_iBufUsed) * sizeof(float));
+		m_iBufUsed = intendedBufferSize;
 	}
 }
 

--- a/src/RageSoundMixBuffer.h
+++ b/src/RageSoundMixBuffer.h
@@ -26,8 +26,9 @@ public:
 
 private:
 	float *m_pMixbuf;
-	unsigned m_iBufSize; /* actual allocated samples */
-	unsigned m_iBufUsed; /* used samples */
+	float *m_pMixbufBackup;
+	std::uint64_t m_iBufSize; /* actual allocated samples */
+	std::uint64_t m_iBufUsed; /* used samples */
 	int m_iOffset;
 };
 


### PR DESCRIPTION
**5/21/2024 - This has been abandoned in favor of a better performing alternative featured in #255** 

----

### This code change improves performance by preventing random stutters caused by unexpected or frequent memory reallocations, and drastically lowers RAM consumption (~1.4GB to ~250MB on Windows 11).

This is ITGMania with the code of this PR:
![image](https://github.com/itgmania/itgmania/assets/163092272/85c93a5a-b2bc-4230-bbe1-41d4fbd05c04)

This is the current beta of ITGMania:
![image](https://github.com/itgmania/itgmania/assets/163092272/dbf5f18d-c30f-4a94-929d-9173ef12693d)

In each instance above, the game was compiled with Visual Studio 2022, loaded a guest profile, and started playing the same song with the default modifiers on AutoPlay. The screenshot was taken at the results screen. This is a 5.3x savings in memory consumption simply by keeping the audio buffer under control.

---

### Benefits of this code:

- The new code pre-allocates a safe amount of memory (8MB split between two buffers of 4MB each) instead of initializing the buffer to a size of 0.
- The new code fills the buffer with 0's before use to avoid difficult to diagnose undefined behavior.
- If the buffer needs to be extended beyond the existing buffer size, the buffers are swapped for safety and then memory is reallocated. In the original code, the buffer is reallocated without any backups or error checking.

### How is the new code saving over 1GB of RAM usage?

- The original `Extend` function reallocates memory every time the buffer size is less than the required size. The buffer starts with a size of 0, and the number of samples the game occurs upon startup is large, so this quickly grows rapidly and frequently allocates new memory for the buffer. The buffer is moved many times before the player starts their first song.
    - This will cause runaway external fragmentation due to the game continuously searching for a new and larger unused memory space.
    - It also causes bad in-game performance due to constant memory reallocations and large amounts of wasted RAM.
- The new `Extend` function only reallocates memory if more than the pre-allocated amount is needed at a time, which is very unlikely to begin with, and will bounce back and forth between the two buffers if one needs to be resized. This will prevent unpredictable delays caused by the game trying to find an unused memory block to move into, and will ensure the gameplay is not interrupted by having a fallback buffer available. It will also ensure the buffer isn't corrupted or in a limbo state while the game looks for new memory to allocate.
- In most cases, 4MB is perfectly sufficient for the audio buffer at all times, and the audio buffer can safely live in that space. Since the buffer never needs to exceed 4MB in most cases, this significant reduces the number of memory reallocation calls, and the backup buffer is rarely used.