### PR TITLE
Reinforce retrieval of system time for Win32

### DIFF
--- a/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
@@ -45,8 +45,8 @@ std::int64_t ArchHooks::GetMicrosecondsSinceStart(bool bAccurate)
 	if (!QueryPerformanceCounter(&g_liCurrentTime))
 	{
 		// Just in case QPC() fails, fall back to the old method of getting time.
-		return timeGetTime() * std::int64_t(1000);
 		LOG->Warn("QueryPerformanceCounter failed - fell back to timeGetTime");
+		return timeGetTime() * std::int64_t(1000);
 	}
 	else
 	{

--- a/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
@@ -37,22 +37,18 @@ static void InitTimer()
 
 std::int64_t ArchHooks::GetMicrosecondsSinceStart(bool bAccurate)
 {
-	// Make sure the timer is initialized
 	if (!g_bTimerInitialized)
 		InitTimer();
 
-	// Get the current time
-	if (!QueryPerformanceCounter(&g_liCurrentTime))
-	{
-		// Just in case QPC() fails, fall back to the old method of getting time.
-		LOG->Warn("QueryPerformanceCounter failed - fell back to timeGetTime");
-		return timeGetTime() * std::int64_t(1000);
-	}
-	else
-	{
-		// Calculate the elapsed time in microseconds.
-		return ((g_liCurrentTime.QuadPart - g_liStartTime.QuadPart) * 1000000.0) / g_liFrequency.QuadPart;
-	}
+	/* Starting with Win XP, QueryPerformanceCounter should never fail to return a usable value:
+     * https://learn.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancecounter
+	 * If a user is having problems, ensure the AMD Cool'N'Quiet BIOS setting is not active because it can negatively impact performance:
+     * https://learn.microsoft.com/en-us/troubleshoot/windows-server/performance/programs-queryperformancecounter-function-perform-poorly
+	 * ITGMania doesn't run on 32 bit platforms, so the section of the information above regarding issues on 32-bit CPU's can be ignored. */
+ 	QueryPerformanceCounter(&g_liCurrentTime);
+
+	// Calculate the elapsed time in microseconds.
+	return ((g_liCurrentTime.QuadPart - g_liStartTime.QuadPart) * 1000000.0) / g_liFrequency.QuadPart;
 }
 
 static RString GetMountDir( const RString &sDirOfExecutable )

--- a/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
@@ -42,10 +42,17 @@ std::int64_t ArchHooks::GetMicrosecondsSinceStart(bool bAccurate)
 		InitTimer();
 
 	// Get the current time
-	QueryPerformanceCounter(&g_liCurrentTime);
-
-	// Calculate the elapsed time in microseconds.
-	return ((g_liCurrentTime.QuadPart - g_liStartTime.QuadPart) * 1000000.0) / g_liFrequency.QuadPart;
+	if (!QueryPerformanceCounter(&g_liCurrentTime))
+	{
+		// Just in case QPC() fails, fall back to the old method of getting time.
+		return timeGetTime() * std::int64_t(1000);
+		LOG->Warn("QueryPerformanceCounter failed - fell back to timeGetTime");
+	}
+	else
+	{
+		// Calculate the elapsed time in microseconds.
+		return ((g_liCurrentTime.QuadPart - g_liStartTime.QuadPart) * 1000000.0) / g_liFrequency.QuadPart;
+	}
 }
 
 static RString GetMountDir( const RString &sDirOfExecutable )


### PR DESCRIPTION
I should have thought of this when I made #234 - if `QueryPerformanceCounter()` was to fail, the game would immediately crash and close out. Instead, implement the old method of getting time as a backup, and log the event, so the game keeps running if this ever happens.

It should be noted I've never had `QueryPerformanceCounter()` fail, and sudden crashes/failures were never experienced by anyone who's tested a build using `QueryPerformanceCounter()`, but I did want to add this protection just in case.