### PR TITLE
Revert "Windows: Compile with /utf-8 flag"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -150,7 +150,7 @@ endif()
 
 if(MSVC)
   # TODO: Find a way to do this cleanly for non MSVC users.
-  set(SM_COMPILE_FLAGS "${SM_COMPILE_FLAGS} /MP2 /utf-8")
+  set(SM_COMPILE_FLAGS "${SM_COMPILE_FLAGS} /MP2")
 endif()
 
 set_target_properties("${SM_EXE_NAME}"


### PR DESCRIPTION
This reverts commit 58a45d91f4f4a62e5b0e5562fb0962409e4d27e4.

I am building with MSVC and tracked down an overall performance decrease between release and beta branch to this. A debugger will show this leads to inefficiencies anywhere RString is used.