### PR TITLE
Update FFmpeg URL in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,7 @@
 	shallow = true
 [submodule "extern/ffmpeg"]
 	path = extern/ffmpeg
-	url = https://git.ffmpeg.org/ffmpeg.git
+	url = https://github.com/FFmpeg/FFmpeg.git
 [submodule "extern/libpng"]
 	path = extern/libpng
 	url = https://github.com/glennrp/libpng.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,4 @@
 	path = extern/libtomcrypt
 	url = https://github.com/libtom/libtomcrypt.git
 	shallow = true
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -37,4 +37,3 @@
 	path = extern/libtomcrypt
 	url = https://github.com/libtom/libtomcrypt.git
 	shallow = true
-


### PR DESCRIPTION
Not sure if this is a temporary problem or a change at FFmpeg's git, but it hasn't come back online as-is, so I've pointed to their GitHub mirror in `.gitmodules`.

Sorry about the two commits. I forgot to change the base branch to `beta`, so I added a new line to the end of the file so it would do the checks again after correcting that.

![image](https://github.com/itgmania/itgmania/assets/163092272/c3dd21e9-64d9-4cda-ad22-ae35d301a570)
