### PR TITLE
Update FFmpeg URL in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,7 @@
 	shallow = true
 [submodule "extern/ffmpeg"]
 	path = extern/ffmpeg
-	url = https://git.ffmpeg.org/ffmpeg.git
+	url = https://github.com/FFmpeg/FFmpeg.git
 [submodule "extern/libpng"]
 	path = extern/libpng
 	url = https://github.com/glennrp/libpng.git


### PR DESCRIPTION
My local Git is trapped in an error cycle because of the broken FFmpeg URL, so it was easier to make a new pull request than squash the old one.