### PR TITLE
Win32 code refresh & audio buffer enhancements

### DIFF
--- a/src/GameLoop.h
+++ b/src/GameLoop.h
@@ -1,6 +1,13 @@
 #ifndef GAME_LOOP_H
 #define GAME_LOOP_H
 /** @brief Main rendering and update loop. */
+
+// for BoostThreadPriorityForWin32
+#ifdef _WIN32 
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
 namespace GameLoop
 {
 	void RunGameLoop();
@@ -10,6 +17,10 @@ namespace GameLoop
 	void ChangeGame(const RString& new_game, const RString& new_theme= "");
 	void StartConcurrentRendering();
 	void FinishConcurrentRendering();
+
+#ifdef _WIN32
+	void BoostThreadPriorityForWin32(HANDLE hThread);
+#endif
 
 };
 

--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -288,7 +288,7 @@ int RageSound::GetDataToPlay( float *pBuffer, int iFrames, std::int64_t &iStream
 		/* Read data from our source. */
 		int iGotFrames = m_pSource->RetriedRead( pBuffer + (iFramesStored * m_pSource->GetNumChannels()), iFrames, &iSourceFrame, &fRate );
 
-		if( iGotFrames == RageSoundReader::ERROR )
+		if( iGotFrames == -1 ) // RageSoundReader::ERROR = -1
 		{
 			m_sError = m_pSource->GetError();
 			LOG->Warn( "Decoding %s failed: %s", GetLoadedFilePath().c_str(), m_sError.c_str() );

--- a/src/RageSoundMixBuffer.h
+++ b/src/RageSoundMixBuffer.h
@@ -11,10 +11,15 @@ public:
 	RageSoundMixBuffer();
 	~RageSoundMixBuffer();
 
-	/* Mix the given buffer of samples. */
+	// See how many samples we can stuff into BUFFER_SIZE_IN_MEGABYTES.
+	static constexpr std::size_t SIZE_OF_FLOAT = sizeof(float);
+	static constexpr std::uint64_t BUFFER_SIZE_IN_MEGABYTES = 2;
+	static const std::uint64_t BUF_SIZE = BUFFER_SIZE_IN_MEGABYTES * 1024 * 1024 / SIZE_OF_FLOAT;
+
+	// Mix the given buffer of samples.
 	void write( const float *pBuf, unsigned iSize, int iSourceStride = 1, int iDestStride = 1 );
 
-	/* Extend the buffer as if write() was called with a buffer of silence. */
+	// Extend the buffer as if write() was called with a buffer of silence.
 	void Extend( unsigned iSamples );
 
 	void read( std::int16_t *pBuf );
@@ -26,8 +31,8 @@ public:
 
 private:
 	float *m_pMixbuf;
-	unsigned m_iBufSize; /* actual allocated samples */
-	unsigned m_iBufUsed; /* used samples */
+	std::uint64_t m_iBufSize; // actual allocated samples
+	std::uint64_t m_iBufUsed; // used samples
 	int m_iOffset;
 };
 

--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -40,10 +40,18 @@ RageSoundReader_Chain::~RageSoundReader_Chain()
 		delete it;
 }
 
-RageSoundReader_Chain *RageSoundReader_Chain::Copy() const
+RageSoundReader_Chain* RageSoundReader_Chain::Copy() const
 {
-	// XXX
-	FAIL_M("unimplemented");
+	RageSoundReader_Chain* copy = new RageSoundReader_Chain();
+	copy->m_iPreferredSampleRate = this->m_iPreferredSampleRate;
+	copy->m_iActualSampleRate = this->m_iActualSampleRate;
+	copy->m_iChannels = this->m_iChannels;
+	copy->m_iCurrentFrame = this->m_iCurrentFrame;
+	copy->m_iNextSound = this->m_iNextSound;
+	copy->m_apActiveSounds = this->m_apActiveSounds; // Shallow copy
+	copy->m_apLoadedSounds = this->m_apLoadedSounds; // Shallow copy
+	copy->m_aSounds = this->m_aSounds; // Shallow copy
+	return copy;
 }
 
 /* The same sound may be used several times, and by several different chains.  Avoid
@@ -200,15 +208,18 @@ int RageSoundReader_Chain::SetPosition( int iFrame )
 			break;
 
 		/* Find the RageSoundReader. */
-		ActivateSound( pSound );
-		RageSoundReader *pReader = pSound->pSound;
-
-		int iOffsetFrames = iFrame - iOffsetFrame;
-		if( pReader->SetPosition(iOffsetFrames) == 0 )
+		if (pSound->pSound == nullptr) // Only activate if not already active
 		{
-			/* We're past the end of this sound. */
-			ReleaseSound( pSound );
-			continue;
+			ActivateSound(pSound);
+			RageSoundReader* pReader = pSound->pSound;
+
+			int iOffsetFrames = iFrame - iOffsetFrame;
+			if (pReader->SetPosition(iOffsetFrames) == 0)
+			{
+				/* We're past the end of this sound. */
+				ReleaseSound(pSound);
+				continue;
+			}
 		}
 	}
 

--- a/src/RageSoundReader_ThreadedBuffer.h
+++ b/src/RageSoundReader_ThreadedBuffer.h
@@ -6,7 +6,13 @@
 #include "RageSoundReader_Filter.h"
 #include "RageUtil_CircularBuffer.h"
 #include "RageThreads.h"
+
 #include <list>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
 
 class RageThread;
 class RageSoundReader_ThreadedBuffer: public RageSoundReader_Filter
@@ -70,7 +76,20 @@ private:
 
 	RageThread m_Thread;
 	bool m_bShutdownThread;
-	static int StartBufferingThread( void *p ) { ((RageSoundReader_ThreadedBuffer *) p)->BufferingThread(); return 0; }
+	static int StartBufferingThread(void* p)
+	{
+#ifdef _WIN32
+		// Get the current thread handle
+		HANDLE hThread = GetCurrentThread();
+
+		// Attempt to set the thread to highest priority
+		SetThreadPriority(hThread, THREAD_PRIORITY_HIGHEST);
+#endif
+
+		((RageSoundReader_ThreadedBuffer*)p)->BufferingThread();
+		return 0;
+	}
+
 	void BufferingThread();
 };
 

--- a/src/arch/ArchHooks/ArchHooks_Win32.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32.cpp
@@ -151,12 +151,12 @@ void ArchHooks_Win32::SetTime( tm newtime )
 void ArchHooks_Win32::BoostPriority()
 {
 	// Be sure to boost the app, not the thread, to make sure the sound thread stays higher priority than the main thread.
-	SetPriorityClass( GetCurrentProcess(), HIGH_PRIORITY_CLASS );
+	SetPriorityClass( GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS );
 }
 
 void ArchHooks_Win32::UnBoostPriority()
 {
-	SetPriorityClass( GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS );
+	SetPriorityClass( GetCurrentProcess(), NORMAL_PRIORITY_CLASS );
 }
 
 void ArchHooks_Win32::SetupConcurrentRenderingThread()

--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -186,8 +186,8 @@ RString DSoundBuf::Init( DSound &ds, DSoundBuf::hw hardware,
 
 	/* The size of the actual DSound buffer.  This can be large; we generally
 	 * won't fill it completely. */
-	m_iBufferSize = 1024*64;
-	m_iBufferSize = std::max( m_iBufferSize, m_iWriteAhead );
+	m_iBufferSize = 512 * 1024; // 512KB
+	m_iBufferSize = std::max(m_iBufferSize, m_iWriteAhead);
 
 	WAVEFORMATEX waveformat;
 	memset( &waveformat, 0, sizeof(waveformat) );

--- a/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
@@ -24,8 +24,17 @@ static int chunksize() { return g_iMaxWriteahead / num_chunks; }
 void RageSoundDriver_DSound_Software::MixerThread()
 {
 	if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL) )
-		if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL) )
-			LOG->Warn(werr_ssprintf(GetLastError(), "Failed to set sound thread priority"));
+		{
+		if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST) )
+			{
+			LOG->Warn( werr_ssprintf(GetLastError(), "Failed to set sound mixer thread priority") );
+			}
+		else
+			{
+			LOG->Warn( werr_ssprintf(GetLastError(), "Failed to set sound mixer thread priority to TIME_CRITICAL, set to HIGHEST instead") );
+			}
+	}
+
 
 	/* Fill a buffer before we start playing, so we don't play whatever junk is
 	 * in the buffer. */

--- a/src/arch/Sound/RageSoundDriver_WDMKS.cpp
+++ b/src/arch/Sound/RageSoundDriver_WDMKS.cpp
@@ -1108,35 +1108,29 @@ void RageSoundDriver_WDMKS::Read( void *pData, int iFrames, int iLastCursorPos, 
 	/* If we need conversion, read into a temporary buffer.  Otherwise, read directly
 	 * into the target buffer. */
 	int iChannels = 2;
-	if( m_pStream->m_iDeviceOutputChannels == iChannels &&
-		m_pStream->m_DeviceSampleFormat == DeviceSampleFormat_Int16 )
-	{
-		std::int16_t *pBuf = (std::int16_t *) pData;
-		this->Mix( pBuf, iFrames, iLastCursorPos, iCurrentFrame );
-		return;
-	}
+	int iMaxFrames = std::max(iChannels, static_cast<int>(m_pStream->m_iDeviceOutputChannels));
+	int iMaxBytesPerSample = std::max(static_cast<int>(sizeof(std::int16_t)), static_cast<int>(m_pStream->m_iBytesPerOutputSample));
+	std::int16_t* pBuf = (std::int16_t*)alloca(iFrames * iMaxFrames * iMaxBytesPerSample);
 
-	std::int16_t *pBuf = (std::int16_t *) alloca( iFrames * iChannels * sizeof(std::int16_t) );
-	this->Mix( (std::int16_t *) pBuf, iFrames, iLastCursorPos, iCurrentFrame );
+	this->Mix(pBuf, iFrames, iLastCursorPos, iCurrentFrame);
 
 	/* If the device has other than 2 channels, convert. */
 	if( m_pStream->m_iDeviceOutputChannels != iChannels )
 	{
-		std::int16_t *pTempBuf = (std::int16_t *) alloca( iFrames * m_pStream->m_iBytesPerOutputSample * m_pStream->m_iDeviceOutputChannels );
-		MapChannels( (std::int16_t *) pBuf, pTempBuf, iChannels, m_pStream->m_iDeviceOutputChannels, iFrames );
+		std::int16_t* pTempBuf = pBuf + iFrames * iChannels;
+		MapChannels(pBuf, pTempBuf, iChannels, m_pStream->m_iDeviceOutputChannels, iFrames);
 		pBuf = pTempBuf;
 	}
 
-	/* If the device format isn't std::int16_t, convert. */
 	if( m_pStream->m_DeviceSampleFormat != DeviceSampleFormat_Int16 )
 	{
 		int iSamples = iFrames * m_pStream->m_iDeviceOutputChannels;
-		void *pTempBuf = alloca( iSamples * m_pStream->m_iBytesPerOutputSample );
-		MapSampleFormatFromInt16( (std::int16_t *) pBuf, pTempBuf, iSamples, m_pStream->m_DeviceSampleFormat );
+		void* pTempBuf = pBuf + iSamples;
+		MapSampleFormatFromInt16(pBuf, pTempBuf, iSamples, m_pStream->m_DeviceSampleFormat);
 		pBuf = (std::int16_t *) pTempBuf;
 	}
 
-	memcpy( pData, pBuf, iFrames * m_pStream->m_iDeviceOutputChannels * m_pStream->m_iBytesPerOutputSample );
+	std::memcpy(pData, pBuf, iFrames * m_pStream->m_iDeviceOutputChannels * m_pStream->m_iBytesPerOutputSample);
 }
 
 bool RageSoundDriver_WDMKS::Fill( int iPacket, RString &sError )
@@ -1156,10 +1150,17 @@ bool RageSoundDriver_WDMKS::Fill( int iPacket, RString &sError )
 
 void RageSoundDriver_WDMKS::MixerThread()
 {
-	/* I don't trust this driver with THREAD_PRIORITY_TIME_CRITICAL just yet. */
-	if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST) )
-//	if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL) )
-		LOG->Warn( werr_ssprintf(GetLastError(), "Failed to set sound thread priority") );
+	if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL) )
+		{
+		if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST) )
+			{
+			LOG->Warn( werr_ssprintf(GetLastError(), "Failed to set sound mixer thread priority") );
+			}
+		else
+			{
+			LOG->Warn( werr_ssprintf(GetLastError(), "Failed to set sound mixer thread priority to TIME_CRITICAL, set to HIGHEST instead") );
+			}
+	}
 
 	/* Enable priority boosting. */
 	SetThreadPriorityBoost( GetCurrentThread(), FALSE );

--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -49,8 +49,17 @@ int RageSoundDriver_WaveOut::MixerThread_start( void *p )
 
 void RageSoundDriver_WaveOut::MixerThread()
 {
-	if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL) )
-		LOG->Warn( werr_ssprintf(GetLastError(), "Failed to set sound thread priority") );
+	if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL) )
+		{
+		if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST) )
+			{
+			LOG->Warn( werr_ssprintf(GetLastError(), "Failed to set sound mixer thread priority") );
+			}
+		else
+			{
+			LOG->Warn( werr_ssprintf(GetLastError(), "Failed to set sound mixer thread priority to TIME_CRITICAL, set to HIGHEST instead") );
+			}
+	}
 
 	while( !m_bShutdown )
 	{
@@ -89,7 +98,7 @@ bool RageSoundDriver_WaveOut::GetData()
 void RageSoundDriver_WaveOut::SetupDecodingThread()
 {
 	if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL) )
-		LOG->Warn( werr_ssprintf(GetLastError(), "Failed to set sound thread priority") );
+		LOG->Warn( werr_ssprintf(GetLastError(), "Failed to set sound decoding thread priority") );
 }
 
 std::int64_t RageSoundDriver_WaveOut::GetPosition() const

--- a/src/arch/Threads/Threads_Win32.cpp
+++ b/src/arch/Threads/Threads_Win32.cpp
@@ -75,42 +75,46 @@ typedef struct tagTHREADNAME_INFO
 
 static void SetThreadName( DWORD dwThreadID, LPCTSTR szThreadName )
 {
+#if defined(_MSC_VER)
 	THREADNAME_INFO info;
 	info.dwType = 0x1000;
 	info.szName = szThreadName;
 	info.dwThreadID = dwThreadID;
 	info.dwFlags = 0;
 
-	// FIXME: Need to find a GCC/GDB-friendly way to do this.
-#if defined(_MSC_VER)
 	__try {
-		RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(DWORD), (ULONG_PTR *)&info);
-	} __except (EXCEPTION_CONTINUE_EXECUTION) {
+		RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(DWORD), (ULONG_PTR*)&info);
 	}
+	__except (EXCEPTION_CONTINUE_EXECUTION) {
+	}
+#elif defined(__GNUC__)
+	pthread_setname_np(pthread_self(), szThreadName);
 #endif
 }
 
-static DWORD WINAPI StartThread( LPVOID pData )
+static DWORD WINAPI StartThread(LPVOID pData)
 {
-	ThreadImpl_Win32 *pThis = (ThreadImpl_Win32 *) pData;
+	ThreadImpl_Win32* pThis = static_cast<ThreadImpl_Win32*>(pData);
 
-	SetThreadName( GetCurrentThreadId(), RageThread::GetCurrentThreadName() );
+	SetThreadName(GetCurrentThreadId(), RageThread::GetCurrentThreadName());
 
-	DWORD ret = (DWORD) pThis->m_pFunc( pThis->m_pData );
+	DWORD ret = static_cast<DWORD>(pThis->m_pFunc(pThis->m_pData));
 
-	for( int i = 0; i < MAX_THREADS; ++i )
+	bool found = false;
+	std::uint64_t currentThreadId = RageThread::GetCurrentThreadID();
+	for (int i = 0; i < MAX_THREADS; ++i)
 	{
-		if( g_ThreadIds[i] == RageThread::GetCurrentThreadID() )
+		if (g_ThreadIds[i] == currentThreadId) // Use the stored value
 		{
 			g_ThreadHandles[i] = nullptr;
 			g_ThreadIds[i] = 0;
+			found = true;
 			break;
 		}
 	}
 
 	return ret;
 }
-
 static int GetOpenSlot( std::uint64_t iID )
 {
 	InitThreadIdMutex();
@@ -213,26 +217,25 @@ static bool SimpleWaitForSingleObject( HANDLE h, DWORD ms )
 	}
 }
 
-bool MutexImpl_Win32::Lock()
-{
-	int len = 15000;
-	int tries = 5;
-
-	while( tries-- )
+	bool MutexImpl_Win32::Lock()
 	{
-		// Wait for fifteen seconds. If it takes longer than that, we're probably deadlocked.
-		if( SimpleWaitForSingleObject( mutex, len ) )
+		DWORD dwWaitResult = WaitForSingleObject(mutex, INFINITE);
+		switch (dwWaitResult)
+		{
+		case WAIT_OBJECT_0:
 			return true;
+	
+		case WAIT_TIMEOUT:
+			return false;
 
-		/* Timed out; probably deadlocked. Try a couple more times, with
-		 * a smaller timeout, just in case we're debugging and happened
-		 * to stop while waiting on the mutex. */
-		len = 1000;
+		case WAIT_ABANDONED:
+			return false;
+
+		default:
+			// Possibly throw an exception?
+			return false;
+		}
 	}
-
-	return false;
-}
-
 
 bool MutexImpl_Win32::TryLock()
 {
@@ -283,55 +286,22 @@ EventImpl_Win32::~EventImpl_Win32()
 	CloseHandle( m_WaitersDone );
 }
 
-/* SignalObjectAndWait is atomic, which leads to more fair event handling.
- * However, we don't guarantee or depend upon fair events, and
- * SignalObjectAndWait is only available in NT. I also can't find a single
- * function to signal an object like SignalObjectAndWait, so we need to
- * know if the object is a mutex or an event. */
-static bool PortableSignalObjectAndWait( HANDLE hObjectToSignal, HANDLE hObjectToWaitOn, bool bFirstParamIsMutex, unsigned iMilliseconds = INFINITE )
+static bool PortableSignalObjectAndWait(HANDLE hObjectToSignal, HANDLE hObjectToWaitOn, bool bFirstParamIsMutex, unsigned iMilliseconds = INFINITE)
 {
-	static bool bSignalObjectAndWaitUnavailable = false;
-	// Watch out: SignalObjectAndWait doesn't work when iMilliseconds is zero.
-	if( !bSignalObjectAndWaitUnavailable && iMilliseconds != 0 )
+	// If the first parameter is a mutex, release it
+	if (bFirstParamIsMutex)
 	{
-		DWORD ret = SignalObjectAndWait( hObjectToSignal, hObjectToWaitOn, iMilliseconds, false );
-		switch( ret )
-		{
-		case WAIT_OBJECT_0:
-			return true;
-
-		case WAIT_ABANDONED:
-			// The docs aren't particular about what this does, but it should never happen.
-			FAIL_M( "WAIT_ABANDONED" );
-
-		case 1: // bogus Win98 return value
-		case WAIT_FAILED:
-			if( GetLastError() == ERROR_CALL_NOT_IMPLEMENTED )
-			{
-				// We're probably on 9x.
-				bSignalObjectAndWaitUnavailable = true;
-				break;
-			}
-
-			FAIL_M( werr_ssprintf(GetLastError(), "SignalObjectAndWait") );
-
-		case WAIT_TIMEOUT:
-			return false;
-
-		default:
-			FAIL_M( ssprintf("Unexpected code from SignalObjectAndWait: %d",ret ));
-		}
-	}
-
-	if( bFirstParamIsMutex )
-	{
-		const bool bRet = !!ReleaseMutex( hObjectToSignal );
-		if( !bRet )
-			sm_crash( werr_ssprintf( GetLastError(), "ReleaseMutex failed" ) );
+		const bool bRet = !!ReleaseMutex(hObjectToSignal);
+		if (!bRet)
+			sm_crash(werr_ssprintf(GetLastError(), "ReleaseMutex failed"));
 	}
 	else
-		SetEvent( hObjectToSignal );
+	{
+		// If the first parameter is not a mutex, signal the event
+		SetEvent(hObjectToSignal);
+	}
 
+	// Wait for the second object
 	DWORD ret = WaitForSingleObject( hObjectToWaitOn, iMilliseconds );
 	switch( ret )
 	{
@@ -361,7 +331,7 @@ bool EventImpl_Win32::Wait( RageTimer *pTimeout )
 	if( pTimeout != nullptr )
 	{
 		float fSecondsInFuture = -pTimeout->Ago();
-		iMilliseconds = (unsigned) std::max( 0, int( fSecondsInFuture * 1000 ) );
+		iMilliseconds = (unsigned)std::max(0, int(fSecondsInFuture * 1000));
 	}
 
 	// Unlock the mutex and wait for a signal.


### PR DESCRIPTION
The old PR #255 has lasted through a large number of changes to the `beta` branch, as a result the history became very messy and could not be rebased or squashed. For this reason I have made a new branch from the finalized state of that PR so everything can live in one commit.

### Overview
The goal of this PR is to solve the problem of unpredictable glitches on Windows hosts. On Windows, many time critical threads, including all rendering threads, are run at normal priority, meaning the system views them as very unimportant. 

When going through the code to resolve these issues, a large amount of Windows 9x compatibility code was found, and replaced with modernized code compatible with Windows 7 and up.

Bad code in the sound mixing buffer would lead to runaway memory fragmentation, causing a significant amount of RAM to be wasted. The sound mixing buffer now pre-allocates a safe amount of memory which results in a significant decrease in RAM consumption (from ~1.4GB to ~450MB on my Windows 11 PC).

There is a separate sound buffer for the Windows audio driver, and this now pre-allocates a larger amount of memory to avoid frequent reallocations.

These changes are largely interdependent so they are all in one PR.

**GameLoop.cpp**
- Check if the OS is Windows, and if so ensure the rendering thread is set to the highest priority

**RageSound.cpp**
- Use `-1` instead of `RageSoundReader::ERROR` to prevent needing to undefine ERROR

**RageSoundMixBuffer.cpp / RageSoundMixBuffer.h**

- Set a buffer of 2MB instead of setting the buffer to nullptr and depend on it being grown by assets being loaded at the game launch
- Update some C style casts to C++ style casts
- Improve `Extend` feature to support handling a larger number of samples, and error handling in case of a memory allocation failure
    - I don't really like using std::exit in case the new buffer is nullptr, but I haven't decided what I would like to do here if it is nullptr

**RageSoundReader_Chain.cpp**

- Prevent code running needlessly on a null pointer

**RageSoundReader_ThreadedBuffer.cpp**

- BufferingThread(): Calculate unchanging values outside of the loop for better performance

**RageSoundReader_ThreadedBuffer.h**

- Include `windows.h` if the OS is Windows so that the sound buffer can be set to high priority

**arch/ArchHooks/ArchHooks_Win32.cpp**

- Set the main thread back to `ABOVE_NORMAL_PRIORITY_CLASS` to ensure the sound and rendering threads stay higher priority (reverts #228)

**arch/Sound/DSoundHelpers.cpp**

- Set the DirectSound buffer to 512KB instead of 64KB

**arch/Sound/RageSoundDriver_DSound_Software.cpp**

- Set the DirectSound decoding thread to `THREAD_PRIORITY_HIGHEST`

**arch/Sound/RageSoundDriver_WDMKS.cpp**

- Allow the buffer size to adapt to the number of channels and maximum bytes per sample
- Set one temporary buffer big enough to reuse multiple times instead of setting the buffer to ~2-4KB and reallocating it as needed
- Keep track of the starting position of `pBuf`
- Set the WDM decoding thread to `THREAD_PRIORITY_HIGHEST`

**arch/Threads/Threads_Win32.cpp**

- Rewrite `SetThreadName` to be GCC/GDB-friendly
- Update `StartThread` to use modern Windows features
- Update `MutexImpl_Win32::Lock` to use modern Windows features
- Replace all Win 9x compatibility code in `PortableSignalObjectAndWait`