### PR TITLE
Minor RageSound improvements

### DIFF
--- a/src/RageSoundManager.cpp
+++ b/src/RageSoundManager.cpp
@@ -112,20 +112,18 @@ void RageSoundManager::Update()
 	/* Scan m_mapPreloadedSounds for sounds that are no longer loaded, and delete them. */
 	g_SoundManMutex.Lock(); /* lock for access to m_mapPreloadedSounds, owned_sounds */
 	{
-		std::map<RString, RageSoundReader_Preload*>::iterator it, next;
-		it = m_mapPreloadedSounds.begin();
-
-		while( it != m_mapPreloadedSounds.end() )
+		for( auto it = m_mapPreloadedSounds.begin(); it != m_mapPreloadedSounds.end(); )
 		{
-			next = it; ++next;
 			if( it->second->GetReferenceCount() == 1 )
 			{
 				LOG->Trace( "Deleted old sound \"%s\"", it->first.c_str() );
 				delete it->second;
-				m_mapPreloadedSounds.erase( it );
+				it = m_mapPreloadedSounds.erase(it);
 			}
-
-			it = next;
+			else
+			{
+				++it;
+			}
 		}
 	}
 

--- a/src/RageSoundReader.cpp
+++ b/src/RageSoundReader.cpp
@@ -8,13 +8,10 @@ REGISTER_CLASS_TRAITS( RageSoundReader, pCopy->Copy() );
 /* Read(), handling the STREAM_LOOPED and empty return cases. */
 int RageSoundReader::RetriedRead( float *pBuffer, int iFrames, int *iSourceFrame, float *fRate )
 {
-	if( iFrames == 0 )
-		return 0;
-
 	/* pReader may return 0, which means "try again immediately".  As a failsafe,
 	 * only try this a finite number of times.  Use a high number, because in
 	 * principle each filter in the stack may cause this. */
-	int iTries = 100;
+	int iTries = 10;
 	while( --iTries )
 	{
 		if( fRate )
@@ -29,9 +26,12 @@ int RageSoundReader::RetriedRead( float *pBuffer, int iFrames, int *iSourceFrame
 
 		if( iGotFrames != 0 )
 			return iGotFrames;
+
+		// If the user is having I/O issues, give them a hint in the logs.
+		LOG->Warn( "Read() failed, retrying..." );
 	}
 
-	LOG->Warn( "Read() busy looping" );
+	LOG->Warn( "Read() returned a failure status after 10 attempts to read the file; likely an I/O error" );
 
 	/* Pretend we got EOF. */
 	return RageSoundReader::END_OF_FILE;


### PR DESCRIPTION
Nothing major here - updating C style casts, moving repeated function calls into variables, changing lrint's...

**RageSound.cpp**

- Initialize m_pSource to nullptr in the member initializer list, rather than in the body of the constructor
- Define an undefined variable `iSourceFrame`
- Change a `lrint` to a `static_cast<int>+0.5`
- Store some repeated function calls into variables
- Implement missing error handling in `SetStopModeFromString` with a log message

**RageSoundManager**

- Combined the iterator increment and the erase operation for `Update` into one line to prevent needing to create the `next` variable, since GameLoop calls this method frequently

**RageSoundReader**

- This method is called from RageSound just after making sure iFrames isn't equal to 0, so it's not needed for RageSoundReader to do it again.
- We will never fail to read a file 100 times. If we do, it's because of I/O errors, so make that more clear.

~~**RageSoundUtil**~~

- ~~Store a repeated function call into a variable~~