### PR TITLE
Cleanup DoChangeTheme()

### DIFF
--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -114,6 +114,25 @@ void GameLoop::ChangeGame(const RString& new_game, const RString& new_theme)
 #include "Game.h"
 namespace
 {
+	RString GetNewScreenName()
+	{
+		if (THEME->HasMetric("Common", "AfterThemeChangeScreen"))
+		{
+			RString after_screen = THEME->GetMetric("Common", "AfterThemeChangeScreen");
+			if (SCREENMAN->IsScreenNameValid(after_screen))
+			{
+				return after_screen;
+			}
+		}
+
+		RString new_screen = THEME->GetMetric("Common", "InitialScreen");
+		if (!SCREENMAN->IsScreenNameValid(new_screen))
+		{
+			return "ScreenInitialScreenIsInvalid";
+		}
+		return new_screen;
+	}
+
 	void DoChangeTheme()
 	{
 		SAFE_DELETE( SCREENMAN );
@@ -142,21 +161,10 @@ namespace
 		// So now the correct thing to do is for a theme to specify its entry
 		// point after a theme change, ensuring that we are going to a valid
 		// screen and not crashing. -Kyz
-		RString new_screen= THEME->GetMetric("Common", "InitialScreen");
-		if(THEME->HasMetric("Common", "AfterThemeChangeScreen"))
-		{
-			RString after_screen= THEME->GetMetric("Common", "AfterThemeChangeScreen");
-			if(SCREENMAN->IsScreenNameValid(after_screen))
-			{
-				new_screen= after_screen;
-			}
-		}
-		if(!SCREENMAN->IsScreenNameValid(new_screen))
-		{
-			new_screen= "ScreenInitialScreenIsInvalid";
-		}
-		SCREENMAN->SetNewScreen(new_screen);
+		RString newScreenName = GetNewScreenName();
+		SCREENMAN->SetNewScreen(newScreenName);
 
+		// Indicate no further theme change is needed
 		g_NewTheme = RString();
 	}
 


### PR DESCRIPTION
This part of the code was a little bit of a mess so I wanted to clean it up. This should be a no-op.

I moved the logic for getting the new screen name into a separate function GetNewScreenName(), for the sake of containing the logic for getting the new screen name in one place.

I tried some different optimizations for `GetNewScreenName()`, however none of them were much of a performance savings over the original code, if any, when viewed in a disassembler, so I ultimately chose to keep the original code.