### PR TITLE
Don't change priority if game loses focus

### DIFF
--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -85,14 +85,6 @@ static void CheckFocus()
 
 	// If we lose focus, we may lose input events, especially key releases.
 	INPUTFILTER->Reset();
-
-	if( ChangeAppPri() )
-	{
-		if( HOOKS->AppHasFocus() )
-			HOOKS->BoostPriority();
-		else
-			HOOKS->UnBoostPriority();
-	}
 }
 
 // On the next update, change themes, and load sNewScreen.


### PR DESCRIPTION
This is what really causes problems when alt-tabbing in and out of the game, with OBS, etc. 

ITGmania uses less than 5% CPU usage on my 10 year old CPU. I can leave ITGmania running in the background with assist tick going and no notes are getting lost or stuttering.

I can also switch back and forth between OBS while it's streaming and ITGmania and not get such bad stutters. It's even possible to switch in and out of the game without any stuttering now.

It's not really worth shifting all the threads to a lower priority if focus is lost, considering how few resources the game consumes. There's no other reason I can tell that this would need to be around. This chunk of code is at least 20 years old, I traced it back 19 years in the blame layer, so we can assume it's Win 9x / NT era compatibility code, or something to not keep machines of that era from being too weighed down if someone alt-tabbed out of the game.