### PR TITLE
Win32 refresh: Boost RenderThread priority

### DIFF
--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -24,6 +24,11 @@
 #include <cmath>
 #include <vector>
 
+// for BoostThreadPriorityForWin32
+#ifdef _WIN32 
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
 
 static RageTimer g_GameplayTimer;
 
@@ -397,8 +402,27 @@ void ConcurrentRenderer::Stop()
 	DISPLAY->EndConcurrentRenderingMainThread();
 }
 
+#ifdef _WIN32
+void BoostThreadPriorityForWin32(HANDLE hThread)
+{
+	if (!SetThreadPriority(hThread, THREAD_PRIORITY_HIGHEST))
+	{
+		if (!SetThreadPriority(hThread, THREAD_PRIORITY_TIME_CRITICAL))
+		{
+			LOG->Warn("Failed to boost thread priority in GameLoop.cpp");
+		}
+	}
+}
+#endif _WIN32
+
 void ConcurrentRenderer::RenderThread()
 {
+
+#ifdef _WIN32 // Boost thread priority if running on Windows
+	HANDLE hThread = GetCurrentThread();
+	BoostThreadPriorityForWin32(hThread);
+#endif
+
 	ASSERT( SCREENMAN != nullptr );
 
 	while( !m_bShutdown )

--- a/src/GameLoop.h
+++ b/src/GameLoop.h
@@ -1,6 +1,13 @@
 #ifndef GAME_LOOP_H
 #define GAME_LOOP_H
 /** @brief Main rendering and update loop. */
+
+// for BoostThreadPriorityForWin32
+#ifdef _WIN32 
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
 namespace GameLoop
 {
 	void RunGameLoop();
@@ -10,6 +17,10 @@ namespace GameLoop
 	void ChangeGame(const RString& new_game, const RString& new_theme= "");
 	void StartConcurrentRendering();
 	void FinishConcurrentRendering();
+
+#ifdef _WIN32
+	void BoostThreadPriorityForWin32(HANDLE hThread);
+#endif
 
 };
 


### PR DESCRIPTION
`windows.h` is pulled in (with `WIN32_LEAN_AND_MEAN` to reduce the number of headers pulled in) so that the rendering thread can be properly boosted.