### PR TITLE
Prevent name collision in RageSound.cpp

### DIFF
--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -287,7 +287,7 @@ int RageSound::GetDataToPlay( float *pBuffer, int iFrames, std::int64_t &iStream
 		/* Read data from our source. */
 		int iGotFrames = m_pSource->RetriedRead( pBuffer + (iFramesStored * m_pSource->GetNumChannels()), iFrames, &iSourceFrame, &fRate );
 
-		if( iGotFrames == RageSoundReader::ERROR )
+		if( iGotFrames == -1 ) // -1 = RageSoundReader::ERROR
 		{
 			m_sError = m_pSource->GetError();
 			// This error probably indicates an I/O error, rather than a decoding error.


### PR DESCRIPTION
Pulling in `windows.h` elsewhere will cause an issue with ERROR being used here, it's not used anywhere else in the rest of the code base as far as I'm aware. Changing this to -1 instead of RageSoundReader::ERROR prevents needing to undefine ERROR here.

EDIT: this has to coexist with the changes in #288 so i am moving it there and closing this.