### PR TITLE
Win32 refresh: audio drivers, priority changes

### DIFF
--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -183,7 +183,7 @@ RString DSoundBuf::Init( DSound &ds, DSoundBuf::hw hardware,
 
 	/* The size of the actual DSound buffer.  This can be large; we generally
 	 * won't fill it completely. */
-	m_iBufferSize = KB_512_AS_BYTES;
+	m_iBufferSize = 512 * 1024; // 512kb
 
 	WAVEFORMATEX waveformat;
 	memset( &waveformat, 0, sizeof(waveformat) );

--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -365,16 +365,16 @@ void DSoundBuf::CheckUnderrun( int iCursorStart, int iCursorEnd )
 	// Store the buffer size in a variable to avoid multiple calls
 	int storedSizeOfBuffer = m_iBufferSize;
 
-	// If the buffer is full or nothing is expected to be filled, stop.
-	if( m_iBufferBytesFilled >= storedSizeOfBuffer || iCursorStart == iCursorEnd || m_iExtraWriteahead )
+	/* If nothing is expected to be filled, we can't underrun. */
+	if( iCursorStart == iCursorEnd )
+		return;
+
+	// If we're already in a recovering-from-underrun state, stop.
+	if( m_iExtraWriteahead )
 		return;
 
 	int iFirstByteFilled = m_iWriteCursor - m_iBufferBytesFilled;
 	wrap( iFirstByteFilled, storedSizeOfBuffer );
-
-	// If the end of the play cursor has data, we haven't underrun.
-	if( m_iBufferBytesFilled > 0 && contained(iFirstByteFilled, m_iWriteCursor, iCursorEnd) )
-		return;
 
 	// Calculate the required write-ahead size. This is the distance from the first filled byte
 	// to the end of the play cursor. If the buffer wraps around, the wrap function adjusts the value.

--- a/src/arch/Sound/DSoundHelpers.h
+++ b/src/arch/Sound/DSoundHelpers.h
@@ -31,8 +31,6 @@ private:
 class DSoundBuf
 {
 public:
-	static constexpr int KB_512_AS_BYTES = 524288; /* 512k for setting the buffer */
-
 	enum hw { HW_HARDWARE, HW_SOFTWARE, HW_DONT_CARE };
 
 	/* If samplerate is DYNAMIC_SAMPLERATE, then call SetSampleRate before

--- a/src/arch/Sound/DSoundHelpers.h
+++ b/src/arch/Sound/DSoundHelpers.h
@@ -31,6 +31,8 @@ private:
 class DSoundBuf
 {
 public:
+	static constexpr int KB_512_AS_BYTES = 524288; /* 512k for setting the buffer */
+
 	enum hw { HW_HARDWARE, HW_SOFTWARE, HW_DONT_CARE };
 
 	/* If samplerate is DYNAMIC_SAMPLERATE, then call SetSampleRate before

--- a/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
@@ -24,8 +24,17 @@ static int chunksize() { return g_iMaxWriteahead / num_chunks; }
 void RageSoundDriver_DSound_Software::MixerThread()
 {
 	if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL) )
-		if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL) )
-			LOG->Warn(werr_ssprintf(GetLastError(), "Failed to set sound thread priority"));
+		{
+		if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST) )
+			{
+			LOG->Warn( werr_ssprintf(GetLastError(), "Failed to set sound mixer thread priority") );
+			}
+		else
+			{
+			LOG->Warn( werr_ssprintf(GetLastError(), "Failed to set sound mixer thread priority to TIME_CRITICAL, set to HIGHEST instead") );
+			}
+	}
+
 
 	/* Fill a buffer before we start playing, so we don't play whatever junk is
 	 * in the buffer. */

--- a/src/arch/Sound/RageSoundDriver_WDMKS.cpp
+++ b/src/arch/Sound/RageSoundDriver_WDMKS.cpp
@@ -1020,9 +1020,8 @@ bool WinWdmStream::SubmitPacket( int iPacket, RString &sError )
 	return false;
 }
 
-
-#include <windows.h>
 #define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 namespace
 {
 	void MapChannels( const std::int16_t *pIn, std::int16_t *pOut, int iInChannels, int iOutChannels, int iFrames, const int *pChannelMap )

--- a/src/arch/Sound/RageSoundDriver_WaveOut.h
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.h
@@ -29,7 +29,7 @@ private:
 
 	HWAVEOUT m_hWaveOut;
 	HANDLE m_hSoundEvent;
-	WAVEHDR m_aBuffers[8];
+	std::vector<WAVEHDR> m_aBuffers;
 	int m_iSampleRate;
 	bool m_bShutdown;
 	int m_iLastCursorPos;


### PR DESCRIPTION
The main changes in this are:  restructuring the thread priority and taking the heavy lifting off the audio driver, to improve consistency between different people's setups.

The thread priority restructuring follows this theory:

1) Rendering thread, Audio mixing thread **<- should run at Highest or Time Critical priority**
2) Audio decoding thread, audio streaming thread **<- should run at Highest priority**
3) Main game thread **<- should run at Normal or Above Normal priority**
4) Worker threads **<- should run at Below Normal or Normal priority** [worker threads were not changed in this PR]

-------

**arch/Sound/DSoundHelpers.cpp**

* Set the DirectSound buffer to 512KB instead of 64KB
* General modernization

**arch/Sound/RageSoundDriver_DSound_Software.cpp**

* Priority fixes

**arch/Sound/RageSoundDriver_WaveOut.cpp**

* More buffers instead of larger buffers so that latency isn't affected
* Priority fixes
* General modernization

**arch/Sound/RageSoundDriver_WDMKS.cpp**

* Allow the buffer size to adapt to the number of channels and maximum bytes per sample
* Set one temporary buffer big enough to reuse multiple times instead of setting the buffer to ~2-4KB and reallocating it as needed
* Keep track of the starting position of `pBuf`
* Priority fixes