### PR TITLE
Cleanup end of fallback language files

### DIFF
--- a/Themes/_fallback/Languages/de.ini
+++ b/Themes/_fallback/Languages/de.ini
@@ -2723,4 +2723,3 @@ UnknownPreference=Unknown preference "%s"
 ChoicesSizeMismatch=Choices and Values have different sizes (%d, %d)
 NoDefaultInValues=Preference "%s" has no values matching default
 TypeMismatch=Type mismatch between default (%s) and value %d (%s)
->>>>>>> other

--- a/Themes/_fallback/Languages/en.ini
+++ b/Themes/_fallback/Languages/en.ini
@@ -2784,4 +2784,3 @@ UnknownPreference=Unknown preference "%s"
 ChoicesSizeMismatch=Choices and Values have different sizes (%d, %d)
 NoDefaultInValues=Preference "%s" has no values matching default
 TypeMismatch=Type mismatch between default (%s) and value %d (%s)
->>>>>>> other

--- a/Themes/_fallback/Languages/es.ini
+++ b/Themes/_fallback/Languages/es.ini
@@ -2696,4 +2696,3 @@ UnknownPreference=Opción "%s" desconocida
 ChoicesSizeMismatch=Las elecciones y los valores tienen tamaños diferentes (%d, %d)
 NoDefaultInValues=La opción "%s" no tiene valores equivalentes al de por defecto.
 TypeMismatch=El tipo no coincide con el por defecto (%s) y el valor %d (%s)
->>>>>>> other

--- a/Themes/_fallback/Languages/fr.ini
+++ b/Themes/_fallback/Languages/fr.ini
@@ -2704,4 +2704,3 @@ UnknownPreference=Préférence Inconnue "%s"
 ChoicesSizeMismatch=Les Choix et les Valeurs ont différentes tailles (%d, %d)
 NoDefaultInValues=Préférence "%s" n'a aucune valeur correspondante au paramètre par défaut.
 TypeMismatch=Incohérence de Type entre défaut (%s) et la valeur %d (%s)
->>>>>>> Autre

--- a/Themes/_fallback/Languages/ja.ini
+++ b/Themes/_fallback/Languages/ja.ini
@@ -2929,4 +2929,3 @@ UnknownPreference="%s"は未知の設定です。
 ChoicesSizeMismatch=選択値と実際の値が食い違っています。(%d, %d)
 NoDefaultInValues=設定"%s"の設定値は省略できません。
 TypeMismatch=引数(%s)と入力値%d(%s)の変数型が違います。
->>>>>>> other

--- a/Themes/_fallback/Languages/nl.ini
+++ b/Themes/_fallback/Languages/nl.ini
@@ -2719,4 +2719,3 @@ UnknownPreference=Onbekende instelling "%s"
 ChoicesSizeMismatch=Keuzen en Waardes hebben verschillende grootten (%d, %d)
 NoDefaultInValues=Instelling "%s" heeft geen waarden vergelijkbaar met de standaard
 TypeMismatch=De typen van de standaard (%s) en de waarde %d (%s) komen niet overeen. 
->>>>>>> anders

--- a/Themes/_fallback/Languages/pl.ini
+++ b/Themes/_fallback/Languages/pl.ini
@@ -2684,4 +2684,3 @@ UnknownPreference=Nieznane ustawienie "%s"
 ChoicesSizeMismatch=Opcje i Wartości mają różne rozmiary (%d, %d)
 NoDefaultInValues=Ustawienie "%s" nie posiada wartości odpowiadającej domyślnej.
 TypeMismatch=Niezgodność typów pomiędzy domyślną (%s) i wartością %d (%s)
->>>>>>> inne

--- a/Themes/_fallback/Languages/zh-Hant.ini
+++ b/Themes/_fallback/Languages/zh-Hant.ini
@@ -2751,4 +2751,3 @@ UnknownPreference=未知參數 "%s"
 ChoicesSizeMismatch=Choices and Values have different sizes (%d, %d)
 NoDefaultInValues=沒有與預設相符的參數數値 "%s"
 TypeMismatch=預設 (%s) 與數値 %d (%s) 不匹配
->>>>>>> other


### PR DESCRIPTION
After implementing the additional warnings in IniFile.cpp, I noticed this error was cropping up every so often each time I ran the game.

```
/////////////////////////////////////////
14:36.230: WARNING: No '=' found in line of file 'Themes/_fallback/Languages/en.ini': >>>>>>> other
/////////////////////////////////////////
```

This was added to the language ini files in a gigantic commit and I can not really tell if it was intentional or not but I do not believe it is. It would be easy to overlook one line in a 500,000 line merge commit. https://github.com/itgmania/itgmania/commit/0c457ba55bf4d6ca6bf5edc2b4873e0aeb83b1fc

There is no comment or anything telling me why this line exists. I could be wrong, but to me this looks like it was left over from a git merge or something like that.

I think it is safe to remove these, because certain language files don't have this at the end, but I can't imagine that these lines are actually doing anything in the game, are they? Personally I'm not seeing any effect at all from removing this line.