### PR TITLE
Drop libbz2 dependency

### DIFF
--- a/CMake/SetupFfmpeg.cmake
+++ b/CMake/SetupFfmpeg.cmake
@@ -22,7 +22,7 @@ list(APPEND FFMPEG_CONFIGURE
             "--disable-programs"
             "--disable-swresample"
             "--disable-vaapi"
-            "--enable-bzlib"
+            "--disable-bzlib"
             "--enable-gpl"
             "--enable-pthreads"
             "--enable-static"

--- a/StepmaniaCore.cmake
+++ b/StepmaniaCore.cmake
@@ -158,12 +158,6 @@ include(ExternalProject)
 
 find_package(nasm)
 find_package(yasm)
-
-find_package(BZip2)
-if(NOT ${BZIP2_FOUND} AND NOT MSVC)
-  message(FATAL_ERROR "Bzip2 support required.")
-endif()
-
 find_package(Iconv)
 
 find_package(Threads)

--- a/Utils/Dockerfile-linux-amd64
+++ b/Utils/Dockerfile-linux-amd64
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl g++ gcc git make nasm
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libgtk-3-dev
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libasound2-dev libbz2-dev libgl1-mesa-dev libglu1-mesa-dev libjack-dev libpulse-dev libssl-dev libudev-dev libva-dev libxinerama-dev libxrandr-dev libxtst-dev libusb-dev
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libasound2-dev libgl1-mesa-dev libglu1-mesa-dev libjack-dev libpulse-dev libssl-dev libudev-dev libva-dev libxinerama-dev libxrandr-dev libxtst-dev libusb-dev
 
 RUN cd ~ && curl -L -o cmake.sh https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2-linux-x86_64.sh && sh cmake.sh --skip-license --prefix=/usr/local && rm cmake.sh
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -387,7 +387,6 @@ elseif(APPLE)
               ${MAC_FRAME_COREAUDIO}
               ${MAC_FRAME_CORESERVICES}
               ${MAC_FRAME_SYSTEM}
-              "${BZIP2_LIBRARY_RELEASE}"
               "${ICONV_LIBRARIES}"
               "${SM_FFMPEG_LIB}/libavformat.a"
               "${SM_FFMPEG_LIB}/libavcodec.a"
@@ -412,7 +411,7 @@ else() # Unix / Linux TODO: Remember to find and locate the zip archive files.
     list(APPEND SMDATA_LINK_LIB "${GTK3_LIBRARIES}")
   endif()
 
-  list(APPEND SMDATA_LINK_LIB "${BZIP2_LIBRARIES}" "${CMAKE_THREAD_LIBS_INIT}")
+  list(APPEND SMDATA_LINK_LIB "${CMAKE_THREAD_LIBS_INIT}")
 
   if(HAS_ALSA)
     list(APPEND SMDATA_LINK_LIB ${ALSA_LIBRARIES})


### PR DESCRIPTION
Dynamic linking against `libbz2` was problematic on some distributions. We only needed it for `pcre`'s CLI (which we don't use) and `ffmpeg`'s MKV decompression in case a user forced encoder to use it, because its usage is discouraged by the standard.

See https://github.com/itgmania/itgmania/issues/217 for the related discussion.

I made a build using `Utils/build-release-linux.sh` and compared it against the data from the linked issue:
![image](https://github.com/itgmania/itgmania/assets/9034451/059cdf4d-9696-44a7-a8ee-5f0bab1c9250)

