### PR TITLE
Windows: Mark executable as DPI aware

### DIFF
--- a/src/archutils/Win32/StepMania.in.manifest
+++ b/src/archutils/Win32/StepMania.in.manifest
@@ -4,6 +4,7 @@
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
     </windowsSettings>
   </application>
 </assembly>


### PR DESCRIPTION
When any scaling other than 100% is set for a display, Windows will automatically scale any DPI unaware applications. This leads to ITGmania being unusable in fullscreen mode, as parts of the screen are cut off. Add a DPI aware indication to the manifest to prevent this from happening. Note that ITGmania won't actually adjust its rendering to the new DPI, it will just prevent the automatic scaling.