### PR TITLE
Bump macos-build-x86_64 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
   macos-build-x86_64:
     name: macOS (Intel)
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - name: Checkout submodules


### PR DESCRIPTION
Reference https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories, or look to implement https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs alternatively.