### PR TITLE
Revert "Fix interaction between global offset and music rate."

### DIFF
--- a/src/TimingData.cpp
+++ b/src/TimingData.cpp
@@ -1,7 +1,6 @@
 #include "global.h"
 #include "TimingData.h"
 #include "PrefsManager.h"
-#include "GameState.h"
 #include "RageUtil.h"
 #include "RageLog.h"
 #include "ThemeManager.h"
@@ -755,7 +754,7 @@ bool TimingData::DoesLabelExist( const RString& sLabel ) const
 
 void TimingData::GetBeatAndBPSFromElapsedTime(GetBeatArgs& args) const
 {
-	args.elapsed_time += GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate * PREFSMAN->m_fGlobalOffsetSeconds;
+	args.elapsed_time += PREFSMAN->m_fGlobalOffsetSeconds;
 	GetBeatAndBPSFromElapsedTimeNoOffset(args);
 }
 
@@ -995,8 +994,7 @@ float TimingData::GetElapsedTimeInternal(GetBeatStarts& start, float beat,
 
 float TimingData::GetElapsedTimeFromBeat( float fBeat ) const
 {
-	return TimingData::GetElapsedTimeFromBeatNoOffset( fBeat )
-		- GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate * PREFSMAN->m_fGlobalOffsetSeconds;
+	return TimingData::GetElapsedTimeFromBeatNoOffset( fBeat ) - PREFSMAN->m_fGlobalOffsetSeconds;
 }
 
 float TimingData::GetElapsedTimeFromBeatNoOffset( float fBeat ) const


### PR DESCRIPTION
This reverts commit 343bbd0e5638bb6f4e8d741473a8fd1a92f2838d.

Global offset is intended to compensate for input and audio latency in the PC used for playing. This latency stays constant regardless of music rate, so it's incorrect to multiply it. The original commit states that we need the multiply to arrive at the same position in the sound file regardless of music rate, but in fact we want the position to be different for different rates in order to compensate for the latency correctly.