### PR TITLE
Convert the global offset from seconds to beats before using it in TimingData calculations

### DIFF
--- a/src/BPMDisplay.h
+++ b/src/BPMDisplay.h
@@ -61,6 +61,13 @@ public:
 	/** @brief Have the GameState determine which BPMs to display. */
 	void SetFromGameState();
 
+    // I need to be able to access this from TimingData.cpp as a backup method to get the BPM.
+    static float PublicGetActiveBPM()
+    {
+		BPMDisplay display;
+		return display.GetActiveBPM();
+    }
+
 	// Lua
 	virtual void PushSelf( lua_State *L );
 

--- a/src/TimingData.h
+++ b/src/TimingData.h
@@ -135,6 +135,8 @@ public:
 	void DumpOneTable(const beat_start_lookup_t& lookup, const RString& name);
 	void DumpLookupTables();
 
+	float GetCurrentBPM() const;
+	float GetAdjustedGlobalOffset() const;
 	int GetSegmentIndexAtRow(TimingSegmentType tst, int row) const;
 	int GetSegmentIndexAtBeat(TimingSegmentType tst, float beat) const
 	{


### PR DESCRIPTION
I've listed @phantom10111 as a co-author on this commit for their work on PR #300. Thank you!

The theory here is that converting the global offset to beats, instead of mixing beats and seconds, should keep the sync tighter when rate modding a song.

I'd like this to be tested by someone who has a better sense of timing accuracy than I do, but I think it's a better solution than going back to the old code (which seems to only work at the song level) or keeping the current code (Which seems to only work at the engine level).

-----------

The if-else statements inside `TimingData::GetElapsedTimeFromBeat(float fBeat)` and `TimingData::GetBeatAndBPSFromElapsedTime(GetBeatArgs& args)` only execute the new code if `m_fMusicRate` is anything other than 1. They are necessary because stuff will break theme side if it's not done like this. Without the if-else statements, [this will happen](https://github.com/itgmania/itgmania/assets/163092272/a9bf32b4-06ee-4683-a316-21c1dd1fa44d).