### PR TITLE
Prevent out-of-order grading of steps in Player.cpp

### DIFF
--- a/src/Player.h
+++ b/src/Player.h
@@ -196,6 +196,7 @@ protected:
 	NoteField		*m_pNoteField;
 
 	std::vector<HoldJudgment*>	m_vpHoldJudgment;
+	std::vector<int> m_vLastJudgedRowPerColumn;
 
 	AutoActor		m_sprJudgment;
 	AutoActor		m_sprCombo;


### PR DESCRIPTION
I ended up looking through Player.cpp because I was tracking down where `GetBeatAndBPSFromElapsedTime` was being called, so I could get an idea of why it was affecting NPS calculations in the song wheel.

...this commit isn't related to that, but this comment caught my eye:

> 	XXX: This seems wrong. If a player steps twice quickly and two notes are
> 	 close together in the same column then it is possible for the two notes
> 	 to be graded out of order.
> 	 Two possible fixes:
> 	 1. Adjust the fSongBeat (or the resulting note row) backward by
> 	 iStepSearchRows and search forward two iStepSearchRows lengths,
> 	 disallowing graded. This doesn't seem right because if a second note has
> 	 passed, an earlier one should not be graded.
> 	 2. Clamp the distance searched backward to the previous row graded.
> 	 Either option would fundamentally change the grading of two quick notes
> 	 "jack hammers." Hmm.

I didn't like the idea of out-of-order judgements, and this code seems to predate `std::vector`, so I thought this would be a great place to implement a dynamic array and solve this old quandary. 

The original code can result in out-of-order grading due to how the search distance is calculated as well as the method to detect the nearest note.
- `iStepSearchRows` calculates a distance to search based on the current music position plus or minus `StepSearchDistance`, which is a fixed value, so different BPMs and scroll speeds may not be judged equally.
- The search range is the maximum distance plus `ROWS_PER_BEAT`.
- If `row` is `-1`, which means there isn't a specific note being judged, `GetClosestNote` will look both ahead and backwards for notes to judge. This method does not check sequentially so it is not ideal.

In short, nothing ensures the notes are judged in the order they are supposed to be hit based on the song's timing.

This is how I improved it:
- Define a dynamic array to keep track of the last judged row per column
- Before judging a note, make sure the current row is less or equal to the last judged row of that specific column
- Prevent premature judgement of notes which are displayed on screen due to timing window miscalculations 
- Make sure notes are both judged in the correct order, and inside a valid timing window
- Make sure notes are not skipped or missed due to being outside of the expected timing range