### PR TITLE
[High Priority] [Thoroughly community tested] Use uint64_t for ArchHooks::GetMicrosecondsSinceStart

### DIFF
--- a/src/arch/ArchHooks/ArchHooks.h
+++ b/src/arch/ArchHooks/ArchHooks.h
@@ -87,7 +87,7 @@ public:
 	 * underlying timers may be 32-bit, but implementations should try to avoid
 	 * wrapping if possible.
 	 */
-	static std::int64_t GetMicrosecondsSinceStart( bool bAccurate );
+	static std::uint64_t GetMicrosecondsSinceStart( bool bAccurate );
 
 	/*
 	 * Add file search paths, higher priority first.

--- a/src/arch/ArchHooks/ArchHooks_MacOSX.mm
+++ b/src/arch/ArchHooks/ArchHooks_MacOSX.mm
@@ -258,9 +258,8 @@ bool ArchHooks_MacOSX::GoToURL( RString sUrl )
 	return result == 0;
 }
 
-std::int64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate )
+std::uint64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate )
 {
-	// http://developer.apple.com/qa/qa2004/qa1398.html
 	static double factor = 0.0;
 
 	if( unlikely(factor == 0.0) )
@@ -270,7 +269,7 @@ std::int64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate )
 		mach_timebase_info( &timeBase );
 		factor = timeBase.numer / ( 1000.0 * timeBase.denom );
 	}
-	return std::int64_t( mach_absolute_time() * factor );
+	return static_cast<std::uint64_t>( mach_absolute_time() * factor );
 }
 
 #include "RageFileManager.h"

--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -149,26 +149,27 @@ clockid_t ArchHooks_Unix::GetClock()
 	return g_Clock;
 }
 
-std::int64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate )
+std::uint64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate )
 {
 	OpenGetTime();
-
 	timespec ts;
-	clock_gettime( g_Clock, &ts );
-
-	std::int64_t iRet = std::int64_t(ts.tv_sec) * 1000000 + std::int64_t(ts.tv_nsec)/1000;
+	if (clock_gettime(g_Clock, &ts) == -1)
+	{
+		ASSERT_M(false, "clock_gettime returned -1");
+	}
+	std::uint64_t iRet = static_cast<std::uint64_t>(ts.tv_sec) * 1000000ULL + static_cast<std::uint64_t>(ts.tv_nsec) / 1000;
 	if( g_Clock != CLOCK_MONOTONIC )
-		iRet = ArchHooks::FixupTimeIfBackwards( iRet );
+		iRet = ArchHooks::FixupTimeIfBackwards(iRet);
 	return iRet;
 }
 #else
-std::int64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate )
+std::uint64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate )
 {
 	struct timeval tv;
 	gettimeofday( &tv, nullptr );
 
-	std::int64_t iRet = std::int64_t(tv.tv_sec) * 1000000 + std::int64_t(tv.tv_usec);
-	ret = FixupTimeIfBackwards( ret );
+	std::uint64_t iRet = static_cast<std::uint64_t>(tv.tv_sec) * 1000000ULL + static_cast<std::uint64_t>(tv.tv_usec);
+	iRet = FixupTimeIfBackwards( iRet );
 	return iRet;
 }
 #endif

--- a/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
@@ -30,12 +30,14 @@ static void InitTimer()
 		return;
 	g_bTimerInitialized = true;
 
-	// Grab important information for QPC during the timer initialization
+	/* Grab important information for QPC during
+	 * the timer initialization. The frequency is
+	 * constant, so we only need to grab it once. */
 	QueryPerformanceCounter(&g_liStartTime);
 	QueryPerformanceFrequency(&g_liFrequency);
 }
 
-std::int64_t ArchHooks::GetMicrosecondsSinceStart(bool bAccurate)
+std::uint64_t ArchHooks::GetMicrosecondsSinceStart(bool bAccurate)
 {
 	// Make sure the timer is initialized
 	if (!g_bTimerInitialized)
@@ -45,7 +47,7 @@ std::int64_t ArchHooks::GetMicrosecondsSinceStart(bool bAccurate)
 	QueryPerformanceCounter(&g_liCurrentTime);
 
 	// Calculate the elapsed time in microseconds.
-	return ((g_liCurrentTime.QuadPart - g_liStartTime.QuadPart) * 1000000.0) / g_liFrequency.QuadPart;
+	return ((g_liCurrentTime.QuadPart - g_liStartTime.QuadPart) * 1000000ULL) / g_liFrequency.QuadPart;
 }
 
 static RString GetMountDir( const RString &sDirOfExecutable )


### PR DESCRIPTION
# Closed in favor of PR 362 "Integer based time keeping"

RageTimer expects a `uint64_t`, so we should give it a `uint64_t`. The time isn't going to be negative, anyway - we got rid of the old code that could give a negative time. 

RageTimer is storing the value into a `uint64_t`, we might as well do integer math the whole time:

https://github.com/itgmania/itgmania/blob/5d4f9dcb07493ed4c51d6be23e9b41978162305a/src/RageTimer.cpp#L36

A comparison of performance between release (where ArchHooks is passing an int64_t to RageTimer which then treats it as a uint64_t) and this PR (where it's a uint64_t the whole time).

On my hardware this is a consistent boost of 20ish FPS. It's easiest to tell during the stream section as the FPS stays very consistent during streams. (not sure what to make of the 'av FPS' value though - according to RageDisplay.h 'av FPS' is "average FPS since last reset", but I don't know what causes a reset).


https://github.com/itgmania/itgmania/assets/163092272/0c84168a-1d2c-4b74-a824-06a0d6ef8d2d


https://github.com/itgmania/itgmania/assets/163092272/33e44c40-2394-4733-b7cf-f2c361a70e67



These were re-encoded with Handbrake to meet GitHub's file size limit, so don't pay too much attention to the quality of the video - the important part to note is the rendering statistics display.