### PR TITLE
Consistency in WIN32 definitions

### DIFF
--- a/src/CommandLineActions.cpp
+++ b/src/CommandLineActions.cpp
@@ -21,7 +21,8 @@
 #include <vector>
 
 // only used for Version()
-#if defined(_WINDOWS)
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <conio.h>
 #endif
@@ -51,7 +52,7 @@ static void LuaInformation()
  * regardless of any preferences (tested by shakesoda on Mac). -aj */
 static void Version()
 {
-	#if defined(WIN32)
+	#if defined(_WIN32)
 		RString sProductID = ssprintf("%s", (std::string(PRODUCT_FAMILY) + product_version).c_str() );
 		RString sVersion = ssprintf("build %s\nCompile Date: %s @ %s", ::sm_version_git_hash, version_date, version_time);
 

--- a/src/CreateZip.cpp
+++ b/src/CreateZip.cpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <cstdio>
 
-#if defined(_WINDOWS)
+#if defined(_WIN32)
 #include <tchar.h>
 #else
 #define _tcslen strlen

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -171,7 +171,7 @@ RString RageDisplay::GetStats() const
 
 	s = ssprintf( "%i FPS\n%i av FPS\n%i VPF", GetFPS(), GetCumFPS(), GetVPF() );
 
-//	#if defined(_WINDOWS)
+//	#if defined(_WIN32)
 	s += "\n"+this->GetApiDescription();
 //	#endif
 

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -549,7 +549,7 @@ RString RageDisplay_Legacy::Init( const VideoModeParams &p, bool bAllowUnacceler
 		LOG->Warn( "Low-performance OpenGL renderer: %s", sError.c_str() );
 	}
 
-#if defined(_WINDOWS)
+#if defined(_WIN32)
 	/* GLDirect is a Direct3D wrapper for OpenGL.  It's rather buggy; and if in
 	 * any case GLDirect can successfully render us, we should be able to do so
 	 * too using Direct3D directly.  (If we can't, it's a bug that we can work

--- a/src/RageDisplay_OGL_Helpers.h
+++ b/src/RageDisplay_OGL_Helpers.h
@@ -6,7 +6,8 @@
 
 #include <cstdint>
 
-#if defined(WIN32)
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 

--- a/src/RageException.cpp
+++ b/src/RageException.cpp
@@ -7,7 +7,8 @@
 #include <cstdarg>
 #include <cstdint>
 
-#if defined(_WINDOWS) && defined(DEBUG)
+#if defined(_WIN32) && defined(DEBUG)
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #elif defined(MACOSX)
 #include "archutils/Darwin/Crash.h"

--- a/src/RageFileDriverDeflate.cpp
+++ b/src/RageFileDriverDeflate.cpp
@@ -9,7 +9,7 @@
 #include <cstdint>
 #include <memory>
 
-#if defined(_WINDOWS)
+#if defined(_WIN32)
 #include "zlib.h"
 #if defined(_MSC_VER)
 #if defined(BINARY_ZDL)

--- a/src/RageFileDriverDirect.cpp
+++ b/src/RageFileDriverDirect.cpp
@@ -14,17 +14,16 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#if !defined(WIN32)
-
-#if defined(HAVE_DIRENT_H)
-#include <dirent.h>
-#endif
-
+#if defined(_WIN32)
+    #include "archutils/Win32/ErrorStrings.h"
+    #define WIN32_LEAN_AND_MEAN
+    #include <windows.h>
+    #include <io.h>
 #else
-#include "archutils/Win32/ErrorStrings.h"
-#include <windows.h>
-#include <io.h>
-#endif // !defined(WIN32)
+    #if defined(HAVE_DIRENT_H)
+        #include <dirent.h>
+    #endif
+#endif
 
 /* Direct filesystem access: */
 static struct FileDriverEntry_DIR: public FileDriverEntry
@@ -255,7 +254,7 @@ RageFileObjDirect::RageFileObjDirect( const RString &sPath, int iFD, int iMode )
 
 namespace
 {
-#if !defined(WIN32)
+#if !defined(_WIN32)
 	bool FlushDir( RString sPath, RString &sError )
 	{
 		/* Wait for the directory to be flushed. */
@@ -351,7 +350,7 @@ RageFileObjDirect::~RageFileObjDirect()
 		RString sOldPath = MakeTempFilename(m_sPath);
 		RString sNewPath = m_sPath;
 
-#if defined(WIN32)
+#if defined(_WIN32)
 		if( WinMoveFile(DoPathReplace(sOldPath), DoPathReplace(sNewPath)) )
 			return;
 

--- a/src/RageFileDriverDirectHelpers.cpp
+++ b/src/RageFileDriverDirectHelpers.cpp
@@ -8,15 +8,14 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#if !defined(WIN32)
-
-#if defined(HAVE_DIRENT_H)
-#include <dirent.h>
-#endif
-
+#if defined(_WIN32)
+    #define WIN32_LEAN_AND_MEAN
+    #include <windows.h>
+    #include <io.h>
 #else
-#include <windows.h>
-#include <io.h>
+    #if defined(HAVE_DIRENT_H)
+        #include <dirent.h>
+    #endif
 #endif
 
 RString DoPathReplace(const RString &sPath)
@@ -26,7 +25,7 @@ RString DoPathReplace(const RString &sPath)
 }
 
 
-#if defined(WIN32)
+#if defined(_WIN32)
 static bool WinMoveFileInternal( const RString &sOldPath, const RString &sNewPath )
 {
 	static bool Win9x = false;
@@ -94,7 +93,7 @@ bool CreateDirectories( RString Path )
 			curpath += "/";
 		curpath += parts[i];
 
-#if defined(WIN32)
+#if defined(_WIN32)
 		if( curpath.size() == 2 && curpath[1] == ':' )  /* C: */
 		{
 			/* Don't try to create the drive letter alone. */
@@ -105,7 +104,7 @@ bool CreateDirectories( RString Path )
 		if( DoMkdir(curpath, 0777) == 0 )
 			continue;
 
-#if defined(WIN32)
+#if defined(_WIN32)
 		/* When creating a directory that already exists over Samba, Windows is
 		 * returning ENOENT instead of EEXIST. */
 		/* I can't reproduce this anymore.  If we get ENOENT, log it but keep
@@ -170,7 +169,7 @@ void DirectFilenameDB::CacheFile( const RString &sPath )
 	while( !pFileSet->m_bFilled )
 		m_Mutex.Wait();
 
-#if defined(WIN32)
+#if defined(_WIN32)
 	// There is almost surely a better way to do this
 	WIN32_FIND_DATA fd;
 	HANDLE hFind = DoFindFirstFile( root+sPath, &fd );
@@ -220,7 +219,7 @@ void DirectFilenameDB::PopulateFileSet( FileSet &fs, const RString &path )
 	fs.age.GetDeltaTime(); // reset
 	fs.files.clear();
 
-#if defined(WIN32)
+#if defined(_WIN32)
 	WIN32_FIND_DATA fd;
 
 	if ( sPath.size() > 0  && sPath.Right(1) == "/" )

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -15,7 +15,8 @@
 #include <sstream>
 #include <vector>
 
-#if defined(WIN32)
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #elif defined(UNIX) || defined(MACOSX)
 #include <paths.h>
@@ -339,7 +340,7 @@ static RString GetDirOfExecutable( RString argv0 )
 	// argv[0] can be wrong in most OS's; try to avoid using it.
 
 	RString sPath;
-#if defined(WIN32)
+#if defined(_WIN32)
 	char szBuf[MAX_PATH];
 	GetModuleFileName( nullptr, szBuf, sizeof(szBuf) );
 	sPath = szBuf;
@@ -352,7 +353,7 @@ static RString GetDirOfExecutable( RString argv0 )
 	bool bIsAbsolutePath = false;
 	if( sPath.size() == 0 || sPath[0] == '/' )
 		bIsAbsolutePath = true;
-#if defined(WIN32)
+#if defined(_WIN32)
 	if( sPath.size() > 2 && sPath[1] == ':' && sPath[2] == '/' )
 		bIsAbsolutePath = true;
 #endif

--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -9,7 +9,7 @@
 #include <map>
 #include <vector>
 
-#if defined(_WINDOWS)
+#if defined(_WIN32)
 #include <windows.h>
 #endif
 
@@ -183,7 +183,7 @@ void RageLog::SetShowLogOutput( bool show )
 {
 	m_bShowLogOutput = show;
 
-#if defined(WIN32)
+#if defined(_WIN32)
 	if( m_bShowLogOutput )
 	{
 		// create a new console window and attach standard handles

--- a/src/RageMath.cpp
+++ b/src/RageMath.cpp
@@ -133,7 +133,7 @@ RageMatrix RageMatrix::GetTranspose() const
 
 void RageMatrixMultiply( RageMatrix* pOut, const RageMatrix* pA, const RageMatrix* pB )
 {
-//#if defined(_WINDOWS)
+//#if defined(_WIN32)
 //	// <30 cycles for theirs versus >100 for ours.
 //	D3DXMatrixMultiply( (D3DMATRIX*)pOut, (D3DMATRIX*)pA, (D3DMATRIX*)pB );
 //#else

--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -24,7 +24,7 @@
 #include "arch/Dialog/Dialog.h"
 
 #if defined(CRASH_HANDLER)
-#if defined(_WINDOWS)
+#if defined(_WIN32)
 #include "archutils/Win32/crash.h"
 #elif defined(LINUX) || defined(MACOSX)
 #include "archutils/Unix/CrashHandler.h"

--- a/src/RageUtil_CharConversions.cpp
+++ b/src/RageUtil_CharConversions.cpp
@@ -5,9 +5,10 @@
 
 #include <vector>
 
-#if defined(_WINDOWS)
+#if defined(_WIN32)
 
 #include "archutils/Win32/ErrorStrings.h"
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 /* Convert from the given codepage to UTF-8.  Return true if successful. */

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -73,7 +73,8 @@
 #include <ctime>
 #include <vector>
 
-#if defined(WIN32)
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 
@@ -386,13 +387,13 @@ RString StepMania::GetSelectMusicScreen()
 	return SELECT_MUSIC_SCREEN.GetValue();
 }
 
-#if defined(WIN32)
+#if defined(_WIN32)
 static Preference<int> g_iLastSeenMemory( "LastSeenMemory", 0 );
 #endif
 
 static void AdjustForChangedSystemCapabilities()
 {
-#if defined(WIN32)
+#if defined(_WIN32)
 	// Has the amount of memory changed?
 	MEMORYSTATUS mem;
 	GlobalMemoryStatus(&mem);
@@ -429,7 +430,7 @@ static void AdjustForChangedSystemCapabilities()
 #endif
 }
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #include "RageDisplay_D3D.h"
 #include "archutils/Win32/VideoDriverInfo.h"
 #endif
@@ -508,7 +509,7 @@ struct VideoCardDefaults
 
 static RString GetVideoDriverName()
 {
-#if defined(_WINDOWS)
+#if defined(_WIN32)
 	return GetPrimaryVideoDriverName();
 #else
 	return "OpenGL";

--- a/src/arch/InputHandler/InputHandler_SextetStream.cpp
+++ b/src/arch/InputHandler/InputHandler_SextetStream.cpp
@@ -316,7 +316,7 @@ InputHandler_SextetStream::~InputHandler_SextetStream()
 
 REGISTER_INPUT_HANDLER_CLASS (SextetStreamFromFile);
 
-#if defined(_WINDOWS)
+#if defined(_WIN32)
 	#define DEFAULT_INPUT_FILENAME "\\\\.\\pipe\\StepMania-Input-SextetStream"
 #else
 	#define DEFAULT_INPUT_FILENAME "Data/StepMania-Input-SextetStream.in"

--- a/src/arch/InputHandler/InputHandler_Win32_MIDI.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_MIDI.cpp
@@ -5,6 +5,7 @@
 
 #include <vector>
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <mmsystem.h>
 

--- a/src/arch/InputHandler/InputHandler_Win32_RTIO.h
+++ b/src/arch/InputHandler/InputHandler_Win32_RTIO.h
@@ -4,6 +4,7 @@
 #include "InputHandler.h"
 #include "RageThreads.h"
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <string>
 #include <vector>

--- a/src/arch/InputHandler/InputHandler_Win32_ddrio.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_ddrio.cpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <vector>
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <process.h>
 

--- a/src/arch/Lights/LightsDriver_PacDrive.cpp
+++ b/src/arch/Lights/LightsDriver_PacDrive.cpp
@@ -3,6 +3,7 @@
 
 #include "global.h"
 #include "LightsDriver_PacDrive.h"
+#define WIN32_LEAN_AND_MEAN
 #include "windows.h"
 #include "RageUtil.h"
 #include "Preference.h"

--- a/src/arch/Lights/LightsDriver_SextetStream.cpp
+++ b/src/arch/Lights/LightsDriver_SextetStream.cpp
@@ -93,7 +93,7 @@ void LightsDriver_SextetStream::Set(const LightsState *ls)
 
 REGISTER_LIGHTS_DRIVER_CLASS(SextetStreamToFile);
 
-#if defined(_WINDOWS)
+#if defined(_WIN32)
 	#define DEFAULT_OUTPUT_FILENAME "\\\\.\\pipe\\StepMania-Lights-SextetStream"
 #else
 	#define DEFAULT_OUTPUT_FILENAME "Data/StepMania-Lights-SextetStream.out"

--- a/src/arch/Lights/LightsDriver_Win32Minimaid.cpp
+++ b/src/arch/Lights/LightsDriver_Win32Minimaid.cpp
@@ -6,6 +6,7 @@
 
 #include "global.h"
 #include "LightsDriver_Win32Minimaid.h"
+#define WIN32_LEAN_AND_MEAN
 #include "windows.h"
 
 REGISTER_LIGHTS_DRIVER_CLASS( Win32Minimaid );

--- a/src/arch/Lights/LightsDriver_Win32Parallel.cpp
+++ b/src/arch/Lights/LightsDriver_Win32Parallel.cpp
@@ -1,5 +1,6 @@
 #include "global.h"
 #include "LightsDriver_Win32Parallel.h"
+#define WIN32_LEAN_AND_MEAN
 #include "windows.h"
 #include "RageUtil.h"
 

--- a/src/arch/Lights/LightsDriver_Win32Serial.cpp
+++ b/src/arch/Lights/LightsDriver_Win32Serial.cpp
@@ -1,5 +1,6 @@
 #include "global.h"
 #include "LightsDriver_Win32Serial.h"
+#define WIN32_LEAN_AND_MEAN
 #include "windows.h"
 #include "RageUtil.h"
 

--- a/src/arch/LoadingWindow/LoadingWindow_Win32.cpp
+++ b/src/arch/LoadingWindow/LoadingWindow_Win32.cpp
@@ -7,6 +7,7 @@
 #include "archutils/win32/WindowIcon.h"
 #include "archutils/win32/ErrorStrings.h"
 #include "arch/ArchHooks/ArchHooks.h"
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include "CommCtrl.h"
 #include "RageSurface_Load.h"

--- a/src/arch/LoadingWindow/LoadingWindow_Win32.h
+++ b/src/arch/LoadingWindow/LoadingWindow_Win32.h
@@ -4,6 +4,7 @@
 #define LOADING_WINDOW_WIN32_H
 
 #include "LoadingWindow.h"
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include "archutils/Win32/AppInstance.h"
 

--- a/src/arch/MemoryCard/MemoryCardDriverThreaded_Windows.h
+++ b/src/arch/MemoryCard/MemoryCardDriverThreaded_Windows.h
@@ -4,6 +4,7 @@
 #include "MemoryCardDriver.h"
 
 #include <vector>
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 

--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -8,7 +8,7 @@
 #include <cmath>
 #include <cstdint>
 
-#if defined(_WINDOWS)
+#if defined(_WIN32)
 #include <mmsystem.h>
 #endif
 #define DIRECTSOUND_VERSION 0x0700

--- a/src/arch/Sound/DSoundHelpers.h
+++ b/src/arch/Sound/DSoundHelpers.h
@@ -3,7 +3,7 @@
 
 #include <cstdint>
 
-#if defined(_WINDOWS)
+#if defined(_WIN32)
 #include <windows.h>
 #include <wtypes.h>
 #endif

--- a/src/arch/Sound/RageSoundDriver_WDMKS.cpp
+++ b/src/arch/Sound/RageSoundDriver_WDMKS.cpp
@@ -16,6 +16,7 @@
 #define DEFINE_WAVEFORMATEX_GUID(x) (USHORT)(x), 0x0000, 0x0010, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71
 #endif
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <winioctl.h>
 #include <ks.h>

--- a/src/arch/Threads/Threads_Win32.h
+++ b/src/arch/Threads/Threads_Win32.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 
 #include "Threads.h"
-#if defined(_WINDOWS)
+#if defined(_WIN32)
 #  include <windows.h>
 #else
 #  include <windef.h>

--- a/src/archutils/SpecialDirs.h
+++ b/src/archutils/SpecialDirs.h
@@ -1,6 +1,6 @@
 #if defined(ANDROID)
 #include "Android/SpecialDirs.h"
-#elif defined(_WINDOWS)
+#elif defined(_WIN32)
 #include "Win32/SpecialDirs.h"
 #elif defined(MACOSX)
 #include "Darwin/SpecialDirs.h"

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -3,31 +3,31 @@
 #include <cstdlib>
 
 #if defined(HAVE_UNISTD_H)
-#include <unistd.h>
+    #include <unistd.h>
 #endif
 
-#if defined(_WINDOWS)
-#  if defined(CRASH_HANDLER)
-#    define _WIN32_WINDOWS 0x0410 // include Win98 stuff
-#    include "windows.h"
-#    include "archutils/Win32/Crash.h"
-#  endif
-#  if defined(_MSC_VER)
-#    include <intrin.h>
-#  endif
+#if defined(_WIN32)
+    #if defined(CRASH_HANDLER)
+        #define WIN32_LEAN_AND_MEAN
+        #include "windows.h"
+        #include "archutils/Win32/Crash.h"
+    #endif
+    #if defined(_MSC_VER)
+        #include <intrin.h>
+    #endif
 #elif defined(MACOSX)
-#  include "archutils/Darwin/Crash.h"
-using CrashHandler::IsDebuggerPresent;
-using CrashHandler::DebugBreak;
+    #include "archutils/Darwin/Crash.h"
+    using CrashHandler::IsDebuggerPresent;
+    using CrashHandler::DebugBreak;
 #endif
 
 #if defined(CRASH_HANDLER) && (defined(UNIX) || defined(MACOSX))
-#include "archutils/Unix/CrashHandler.h"
+    #include "archutils/Unix/CrashHandler.h"
 #endif
 
 void sm_crash( const char *reason )
 {
-#if ( defined(_WINDOWS) && defined(CRASH_HANDLER) ) || defined(MACOSX) || defined(_XDBG)
+#if ( defined(_WIN32) && defined(CRASH_HANDLER) ) || defined(MACOSX) || defined(_XDBG)
 	/* If we're being debugged, throw a debug break so it'll suspend the process. */
 	if( IsDebuggerPresent() )
 	{
@@ -46,7 +46,7 @@ void sm_crash( const char *reason )
 	for(;;);
 #endif
 
-#if defined(_WINDOWS)
+#if defined(_WIN32)
 	/* Do something after the above, so the call/return isn't optimized to a jmp; that
 	 * way, this function will appear in backtrace stack traces. */
 #if defined(_MSC_VER)

--- a/src/global.h
+++ b/src/global.h
@@ -13,7 +13,7 @@
 #define __STDC_CONSTANT_MACROS
 
 /* Platform-specific fixes. */
-#if defined(WIN32)
+#if defined(_WIN32)
 #include "archutils/Win32/arch_setup.h"
 #elif defined(PBBUILD)
 #include "archutils/Darwin/arch_setup.h"


### PR DESCRIPTION
Changing all defined(_WINDOWS) to defined(_WIN32)

- The code is currently using a mix of `WINDOWS`, `_WINDOWS`, `_WIN32` and `WIN32` - it would be better to use one and stick with it.
  - `_WIN32` is the ideal choice.
     - https://stackoverflow.com/questions/2989810/which-cross-platform-preprocessor-defines-win32-or-win32-or-win32
     - https://groups.google.com/g/fltkcoredev/c/BwKvvtJ_Mog

Defining WIN32_LEAN_AND_MEAN in all files including windows.h, except those in Archutils/Win32

- `WIN32_LEAN_AND_MEAN` prevents infrequently used Windows headers from being pulled in during compilation.
  - I've made sure these headers are never needed, so this is safe to do.
      - https://learn.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers
  - `WIN32_LEAN_AND_MEAN` is already defined a few places in the code base.
  - I left files in Archutils/Win32 alone because I did not check if they use features that would be used.

Also cleaned up a few messy or strangely written ifdefs.