### PR TITLE
Fix Level and Preferred Sorts to account for a song being in multiple…

### DIFF
--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -175,7 +175,7 @@ GameState::GameState() :
 	m_Environment = new LuaTable;
 
 	m_bDopefish = false;
-
+	sLastOpenSection = "";
 	sExpandedSectionName = "";
 
 	// Don't reset yet; let the first screen do it, so we can use PREFSMAN and THEME.

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -222,6 +222,8 @@ public:
 
 	RString sExpandedSectionName;
 
+	RString sLastOpenSection;
+
 	static int GetNumStagesMultiplierForSong( const Song* pSong );
 	static int GetNumStagesForSongAndStyleType( const Song* pSong, StyleType st );
 	int GetNumStagesForCurrentSongAndStepsOrCourse() const;

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -335,16 +335,28 @@ bool MusicWheel::SelectSong( const Song *p )
 
 	unsigned i;
 	std::vector<MusicWheelItemData *> &from = getWheelItemsData(GAMESTATE->m_SortOrder);
-	for( i=0; i<from.size(); i++ )
-	{
-		if( from[i]->m_pSong == p )
+	if (GAMESTATE->sLastOpenSection != "" && (GAMESTATE->m_SortOrder == SORT_PREFERRED || GAMESTATE->m_SortOrder == SORT_METER)) {
+		// Return to the last open section if it is defined and exists in the current sort
+		for( i=0; i<from.size(); i++ )
 		{
-			// make its group the currently expanded group
-			SetOpenSection( from[i]->m_sText );
-			break;
+			if( from[i]->m_sText == GAMESTATE->sLastOpenSection )
+			{
+				// make its group the currently expanded group
+				SetOpenSection( from[i]->m_sText );
+				break;
+			}
+		}
+	} else {
+		for( i=0; i<from.size(); i++ )
+		{
+			if( from[i]->m_pSong == p )
+			{
+				// make its group the currently expanded group
+				SetOpenSection( from[i]->m_sText );
+				break;
+			}
 		}
 	}
-
 	if( i == from.size() )
 		return false;
 
@@ -1262,6 +1274,8 @@ void MusicWheel::ChangeMusic( int iDist )
 bool MusicWheel::ChangeSort( SortOrder new_so, bool allowSameSort )	// return true if change successful
 {
 	ASSERT( new_so < NUM_SortOrder );
+	// Reset LastOpenSection as sections differ between sorts
+	GAMESTATE->sLastOpenSection = "";
 	// NOTE(crashcringle): Ignore allowSameSort if we're using SORT_PREFERRED.
 	// Each player has their own preferred songs which sorts the songs differently
 	if( GAMESTATE->m_SortOrder == new_so && (!allowSameSort && new_so != SORT_PREFERRED ))
@@ -1503,7 +1517,15 @@ void MusicWheel::SetOpenSection( RString group )
 
 		for( unsigned i=0; i<m_CurWheelItemData.size(); i++ )
 		{
-			if( m_CurWheelItemData[i] == old )
+			if (GAMESTATE->m_SortOrder == SORT_PREFERRED && !GAMESTATE->sLastOpenSection.empty()) {
+				
+				// old doesn't always have data, use LastOpenSection instead
+				if( m_CurWheelItemData[i]->m_sText == GAMESTATE->sLastOpenSection)
+				{
+					m_iSelection=i;
+					break;
+				}
+			} else if( m_CurWheelItemData[i] == old )
 			{
 				m_iSelection=i;
 				break;

--- a/src/WheelBase.cpp
+++ b/src/WheelBase.cpp
@@ -288,16 +288,17 @@ bool WheelBase::Select()	// return true if this selection can end the screen
 	case WheelItemDataType_Section:
 		{
 			RString sThisItemSectionName = m_CurWheelItemData[m_iSelection]->m_sText;
+			// Keep track of the open section so that we can restore it
+			// when navigating back to ScreenSelectMusic.
+			GAMESTATE->sLastOpenSection = sThisItemSectionName;
 			if( m_sExpandedSectionName == sThisItemSectionName ) // already expanded
 			{
-				GAMESTATE->sLastOpenSection = sThisItemSectionName; // remember this section
 				SetOpenSection( "" ); // collapse it
 				m_soundCollapse.Play(true);
 			}
 			else // already collapsed
 			{
 				SetOpenSection( sThisItemSectionName ); // expand it
-				GAMESTATE->sLastOpenSection = sThisItemSectionName; // remember this section
 				m_soundExpand.Play(true);
 			}
 		}

--- a/src/WheelBase.cpp
+++ b/src/WheelBase.cpp
@@ -290,12 +290,14 @@ bool WheelBase::Select()	// return true if this selection can end the screen
 			RString sThisItemSectionName = m_CurWheelItemData[m_iSelection]->m_sText;
 			if( m_sExpandedSectionName == sThisItemSectionName ) // already expanded
 			{
+				GAMESTATE->sLastOpenSection = sThisItemSectionName; // remember this section
 				SetOpenSection( "" ); // collapse it
 				m_soundCollapse.Play(true);
 			}
 			else // already collapsed
 			{
 				SetOpenSection( sThisItemSectionName ); // expand it
+				GAMESTATE->sLastOpenSection = sThisItemSectionName; // remember this section
 				m_soundExpand.Play(true);
 			}
 		}


### PR DESCRIPTION
Fix Level and Preferred Sorts to account for a song being in multiple sections as described in the following issues:
 https://github.com/itgmania/itgmania/issues/190 
https://github.com/itgmania/itgmania/issues/181
https://github.com/Simply-Love/Simply-Love-SM5/issues/553 


This commit properly returns you to the correct pack when leaving a folder or returning from another screen.
This is achieved by returning you to your last open section. Previously behavior searched for the first instance of the song in your sort and put you in that section.