### PR TITLE
⭐ Revert "Prevent setting the position of a nullptr" ⭐

### DIFF
--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -208,18 +208,15 @@ int RageSoundReader_Chain::SetPosition( int iFrame )
 			break;
 
 		/* Find the RageSoundReader. */
-		if (pSound->pSound == nullptr) // Only activate if not already active
-		{
-			ActivateSound(pSound);
-			RageSoundReader* pReader = pSound->pSound;
+		ActivateSound( pSound );
+		RageSoundReader *pReader = pSound->pSound;
 
-			int iOffsetFrames = iFrame - iOffsetFrame;
-			if (pReader->SetPosition(iOffsetFrames) == 0)
-			{
-				/* We're past the end of this sound. */
-				ReleaseSound(pSound);
-				continue;
-			}
+		int iOffsetFrames = iFrame - iOffsetFrame;
+		if( pReader->SetPosition(iOffsetFrames) == 0 )
+		{
+			/* We're past the end of this sound. */
+			ReleaseSound( pSound );
+			continue;
 		}
 	}
 


### PR DESCRIPTION
**Revert "Prevent setting the position of a nullptr"**
This reverts commit 47ff2cf0952ecf7b965a685dacd140f8329aa2e9.

- Testers preferred builds without this so I am removing it
- I suppose the nullptr check is getting in the way. Maybe even the amount of time checking for a nullptr is enough to get in the way?