### PR TITLE
Revert some thread priority level changes

### DIFF
--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -24,10 +24,6 @@
 #include <cmath>
 #include <vector>
 
-#ifdef _WIN32
-#include "archutils/Win32/ThreadPriorityHelper.h"
-#endif
-
 static RageTimer g_GameplayTimer;
 
 static Preference<bool> g_bNeverBoostAppPriority( "NeverBoostAppPriority", false );
@@ -413,13 +409,6 @@ void ConcurrentRenderer::RenderThread()
 
 		if( m_State == RENDERING_START )
 		{
-#ifdef _WIN32
-			bool setThreadSuccess = BoostThreadPriorityToHighest();
-			if (!setThreadSuccess)
-			{
-				ASSERT_M(0, "Failed to set thread priority to highest.");
-			}
-#endif
 			/* We're starting to render. Set up, and then kick the event to wake
 			 * up the calling thread. */
 			DISPLAY->BeginConcurrentRendering();

--- a/src/RageSoundReader_ThreadedBuffer.h
+++ b/src/RageSoundReader_ThreadedBuffer.h
@@ -8,10 +8,6 @@
 #include "RageThreads.h"
 #include <list>
 
-#ifdef _WIN32
-#include "archutils/Win32/ThreadPriorityHelper.h"
-#endif
-
 class RageThread;
 class RageSoundReader_ThreadedBuffer: public RageSoundReader_Filter
 {
@@ -76,13 +72,6 @@ private:
 	bool m_bShutdownThread;
 	static int StartBufferingThread(void* p)
 	{
-#ifdef _WIN32
-		bool setThreadSuccess = BoostThreadPriorityToHighest();
-		if (!setThreadSuccess)
-		{
-			ASSERT_M(0, "Failed to set thread priority to highest.");
-		}
-#endif
 		((RageSoundReader_ThreadedBuffer*)p)->BufferingThread();
 		return 0;
 	}


### PR DESCRIPTION
Reverting these thread priority changes while I re-evaluate the ideal thread priority structure.

I have not removed ThreadPriorityHelper in this commit because I plan to continue using it after further evaluating the priority structures.