### PR TITLE
RageSoundReader_Chain::Read, RageSoundMixBuffer::copyBufferAndReturnSize

### DIFF
--- a/src/RageSoundMixBuffer.cpp
+++ b/src/RageSoundMixBuffer.cpp
@@ -92,6 +92,14 @@ void RageSoundMixBuffer::read( float *pBuf )
 	m_iBufUsed = 0;
 }
 
+int RageSoundMixBuffer::copyBufferAndReturnSize( float* pBuf )
+{
+	std::memcpy( pBuf, m_pMixbuf, m_iBufUsed * sizeof(float) );
+	int iBufUsed = m_iBufUsed;
+	m_iBufUsed = 0;
+	return iBufUsed;
+}
+
 void RageSoundMixBuffer::read_deinterlace( float **pBufs, int channels )
 {
 	for( unsigned i = 0; i < m_iBufUsed / channels; ++i )

--- a/src/RageSoundMixBuffer.h
+++ b/src/RageSoundMixBuffer.h
@@ -19,6 +19,7 @@ public:
 
 	void read( std::int16_t *pBuf );
 	void read( float *pBuf );
+	int copyBufferAndReturnSize( float* pBuf );
 	void read_deinterlace( float **pBufs, int channels );
 	float *read() { return m_pMixbuf; }
 	unsigned size() const { return m_iBufUsed; }


### PR DESCRIPTION
Proposal: Improve the efficiency of RageSoundReader methods as much as possible, considering compiler optimizations are mostly not being used. I've been running this code for about a week and haven't encountered any unexpected behavior - it should not be changing any functionality though, just making it more efficient.

Explanation of changes:

- Minimize the number of conditional checks.
  -  The initial loop that activates sounds was unrolled.
  -  Implement early return for a single active sound.
  -  Write directly into the mix buffer without intermediate checks once the number of frames to read is known.
- Use more modern algorithms when it'll be more efficient.
  -  Use auto iterators
  -  Iterating over active sounds allows efficient removal of sounds from `m_apActiveSounds`, also prevents indexing issues after sounds are removed.
- Directly use the actual size of the buffer and number of channels in calculations.
  -  Required adding a modified version of `RageSoundMixBuffer::read(float *pBuf)` which returns the buffer size.