### PR TITLE
Implement thread affinity for QueryPerformanceCounter

### DIFF
--- a/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
@@ -41,9 +41,21 @@ std::int64_t ArchHooks::GetMicrosecondsSinceStart(bool bAccurate)
 	if (!g_bTimerInitialized)
 		InitTimer();
 
+	/* Retrieve the current thread handle.
+	 * To prevent sync issues caused by the
+	 * OS moving the thread to another core,
+	 * the thread is restricted to the first
+	 * core. This is more of a concern with
+	 * AMD/Ryzen CPU's than it is with Intel,
+	 * as of the time of writing. sukibaby */
+	HANDLE hThread = GetCurrentThread();
+	DWORD_PTR dwOriginalAffinity = SetThreadAffinityMask(hThread, 1);
+	SetThreadAffinityMask(hThread, 1);
+	
 	// Get the current time
 	QueryPerformanceCounter(&g_liCurrentTime);
-
+	SetThreadAffinityMask(hThread, dwOriginalAffinity);
+	
 	// Calculate the elapsed time in microseconds.
 	return ((g_liCurrentTime.QuadPart - g_liStartTime.QuadPart) * 1000000.0) / g_liFrequency.QuadPart;
 }


### PR DESCRIPTION
Started looking into this as a result of multiple reports that the game might feel "off" on Ryzen CPU's. I can confirm something feels strange on a mobile Ryzen PC I tested on for a few days so I looked into what might be causing this.

CPU core switching can negatively affect timing accuracy, especially as it's not done in a high priority thread, and moreso when different cores are clocked differently.

There doesn't seem to be a clear consensus, but there's reports that TSC / HPET behavior can be strange on Ryzens, so it'd be advised to make sure this operation stays on one core. See this thread for example which kept coming up when searching for information on the matter: https://www.reddit.com/r/Amd/comments/jyx7v5/disabling_hpet_gave_my_5600x_a_massive/

There is no error checking implemented when setting the thread affinity because it is very unlikely that a failure would occur and the conditional check would provide unwanted delays in the response of the function if it does.