### PR TITLE
Optimize UpdateSongPosition

### DIFF
--- a/src/SongPosition.cpp
+++ b/src/SongPosition.cpp
@@ -21,16 +21,18 @@ void SongPosition::UpdateSongPosition( float fPositionSeconds, const TimingData 
 	m_iWarpBeginRow= beat_info.warp_begin_out;
 	m_fWarpDestination= beat_info.warp_dest_out;
 	
+#ifdef DEBUG
 	// "Crash reason : -243478.890625 -48695.773438"
 	// The question is why is -2000 used as the limit? -aj
 	ASSERT_M( m_fSongBeat > -2000, ssprintf("Song beat %f at %f seconds is less than -2000!", m_fSongBeat, fPositionSeconds) );
 
+#endif
 	m_fMusicSeconds = fPositionSeconds;
 
 	m_fLightSongBeat = timing.GetBeatFromElapsedTime( fPositionSeconds + g_fLightsAheadSeconds );
 
 	m_fSongBeatNoOffset = timing.GetBeatFromElapsedTimeNoOffset( fPositionSeconds );
-	
+
 	m_fMusicSecondsVisible = fPositionSeconds - g_fVisualDelaySeconds.Get() - fAdditionalVisualDelay;
 	beat_info.elapsed_time= m_fMusicSecondsVisible;
 	timing.GetBeatAndBPSFromElapsedTime(beat_info);


### PR DESCRIPTION
The idea is to handle cases of receiving repeated timestamps more efficiently, given that we will be constantly receiving new timestamps.

From top to bottom,

- Simply don't update if we already received this timestamp
- Remove RageTimer methods to log the amount of time difference received
- Remove commented-out debug logs
- Use ifdef's to only run ASSERT_M on the song beat on debug builds