### PR TITLE
⚠️(0.7.1) Removal of macros from TimingData.h (REPLACED BY #499, WONT REOPEN)

### DIFF
--- a/src/TimingData.h
+++ b/src/TimingData.h
@@ -193,50 +193,330 @@ public:
 		return GetSegmentAtRow( BeatToNoteRow(fBeat), tst );
 	}
 
-	#define DefineSegmentWithName(Seg, SegName, SegType) \
-		const Seg* Get##Seg##AtRow( int iNoteRow ) const \
-		{ \
-			const TimingSegment *t = GetSegmentAtRow( iNoteRow, SegType ); \
-			return To##SegName( t ); \
-		} \
-		Seg* Get##Seg##AtRow( int iNoteRow ) \
-		{ \
-			return const_cast<Seg*> (((const TimingData*)this)->Get##Seg##AtRow(iNoteRow) ); \
-		} \
-		const Seg* Get##Seg##AtBeat( float fBeat ) const \
-		{ \
-			return Get##Seg##AtRow( BeatToNoteRow(fBeat) ); \
-		} \
-		Seg* Get##Seg##AtBeat( float fBeat ) \
-		{ \
-			return const_cast<Seg*> (((const TimingData*)this)->Get##Seg##AtBeat(fBeat) ); \
-		} \
-		void AddSegment( const Seg &seg ) \
-		{ \
-			AddSegment( &seg ); \
-		}
+/// NOTE(sukibaby): Below is a large section of visually similar code, which
+/// handles different timing segments within the TimingData class.
+///
+/// The common functions are:
+///
+///   - Get Segment At Row (constant and non-constant variants)
+///   - Get Segment At Beat (constant and non-constant variants)
+///   - Add Segment
+///
+/// Each section is marked with a comment to indicate which segment that block is
+/// handling. You can use the following regex to find the start of each block:
+///
+///   ^\s*\/\/\s*(.*)
+///
+/// The 'AddSegment' functions are not causing endless recursion - they are
+/// calling the pointer variant of the function which is in TimingData.cpp.  
 
-	// "XXX: this comment (and quote mark) exists so nano won't
-	// display the rest of this file as one giant string
+		// BPM / BPM
 
-	// (TimeSignature,TIME_SIG) -> (TimeSignatureSegment,SEGMENT_TIME_SIG)
-	#define DefineSegment(Seg, SegType ) \
-		DefineSegmentWithName( Seg##Segment, Seg, SEGMENT_##SegType )
+	const BPMSegment* GetBPMSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_BPM);
+		return ToBPM(t);
+	}
+	
+	BPMSegment* GetBPMSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<BPMSegment*> (((const TimingData*)this)->GetBPMSegmentAtRow(iNoteRow));
+	}
+	
+	const BPMSegment* GetBPMSegmentAtBeat(float fBeat) const
+	{
+		return GetBPMSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	BPMSegment* GetBPMSegmentAtBeat(float fBeat)
+	{
+		return const_cast<BPMSegment*> (((const TimingData*)this)->GetBPMSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const BPMSegment& seg)
+	{
+		AddSegment(&seg);
+	}
 
-	DefineSegment( BPM, BPM );
-	DefineSegment( Stop, STOP );
-	DefineSegment( Delay, DELAY );
-	DefineSegment( Warp, WARP );
-	DefineSegment( Label, LABEL );
-	DefineSegment( Tickcount, TICKCOUNT );
-	DefineSegment( Combo, COMBO );
-	DefineSegment( Speed, SPEED );
-	DefineSegment( Scroll, SCROLL );
-	DefineSegment( Fake, FAKE );
-	DefineSegment( TimeSignature, TIME_SIG );
+		// Stop / STOP
 
-	#undef DefineSegmentWithName
-	#undef DefineSegment
+	const StopSegment* GetStopSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_STOP);
+		return ToStop(t);
+	}
+	
+	StopSegment* GetStopSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<StopSegment*>(((const TimingData*)this)->GetStopSegmentAtRow(iNoteRow));
+	}
+	
+	const StopSegment* GetStopSegmentAtBeat(float fBeat) const
+	{
+		return GetStopSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	StopSegment* GetStopSegmentAtBeat(float fBeat)
+	{
+		return const_cast<StopSegment*>(((const TimingData*)this)->GetStopSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const StopSegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// Delay / DELAY
+
+	const DelaySegment* GetDelaySegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_DELAY);
+		return ToDelay(t);
+	}
+	
+	DelaySegment* GetDelaySegmentAtRow(int iNoteRow)
+	{
+		return const_cast<DelaySegment*>(((const TimingData*)this)->GetDelaySegmentAtRow(iNoteRow));
+	}
+	
+	const DelaySegment* GetDelaySegmentAtBeat(float fBeat) const
+	{
+		return GetDelaySegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	DelaySegment* GetDelaySegmentAtBeat(float fBeat)
+	{
+		return const_cast<DelaySegment*>(((const TimingData*)this)->GetDelaySegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const DelaySegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// Warp / WARP
+
+	const WarpSegment* GetWarpSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_WARP);
+		return ToWarp(t);
+	}
+	
+	WarpSegment* GetWarpSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<WarpSegment*>(((const TimingData*)this)->GetWarpSegmentAtRow(iNoteRow));
+	}
+	
+	const WarpSegment* GetWarpSegmentAtBeat(float fBeat) const
+	{
+		return GetWarpSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	WarpSegment* GetWarpSegmentAtBeat(float fBeat)
+	{
+		return const_cast<WarpSegment*>(((const TimingData*)this)->GetWarpSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const WarpSegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// Label / LABEL
+
+	const LabelSegment* GetLabelSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_LABEL);
+		return ToLabel(t);
+	}
+	
+	LabelSegment* GetLabelSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<LabelSegment*>(((const TimingData*)this)->GetLabelSegmentAtRow(iNoteRow));
+	}
+	
+	const LabelSegment* GetLabelSegmentAtBeat(float fBeat) const
+	{
+		return GetLabelSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	LabelSegment* GetLabelSegmentAtBeat(float fBeat)
+	{
+		return const_cast<LabelSegment*>(((const TimingData*)this)->GetLabelSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const LabelSegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// Tickcount / TICKCOUNT
+
+	const TickcountSegment* GetTickcountSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_TICKCOUNT);
+		return ToTickcount(t);
+	}
+	
+	TickcountSegment* GetTickcountSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<TickcountSegment*>(((const TimingData*)this)->GetTickcountSegmentAtRow(iNoteRow));
+	}
+	
+	const TickcountSegment* GetTickcountSegmentAtBeat(float fBeat) const
+	{
+		return GetTickcountSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	TickcountSegment* GetTickcountSegmentAtBeat(float fBeat)
+	{
+		return const_cast<TickcountSegment*>(((const TimingData*)this)->GetTickcountSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const TickcountSegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// Combo / COMBO
+
+	const ComboSegment* GetComboSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_COMBO);
+		return ToCombo(t);
+	}
+	
+	ComboSegment* GetComboSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<ComboSegment*>(((const TimingData*)this)->GetComboSegmentAtRow(iNoteRow));
+	}
+	
+	const ComboSegment* GetComboSegmentAtBeat(float fBeat) const
+	{
+		return GetComboSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	ComboSegment* GetComboSegmentAtBeat(float fBeat)
+	{
+		return const_cast<ComboSegment*>(((const TimingData*)this)->GetComboSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const ComboSegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// Speed / SPEED
+
+	const SpeedSegment* GetSpeedSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_SPEED);
+		return ToSpeed(t);
+	}
+	
+	SpeedSegment* GetSpeedSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<SpeedSegment*>(((const TimingData*)this)->GetSpeedSegmentAtRow(iNoteRow));
+	}
+	
+	const SpeedSegment* GetSpeedSegmentAtBeat(float fBeat) const
+	{
+		return GetSpeedSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	SpeedSegment* GetSpeedSegmentAtBeat(float fBeat)
+	{
+		return const_cast<SpeedSegment*>(((const TimingData*)this)->GetSpeedSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const SpeedSegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// Scroll / SCROLL
+
+	const ScrollSegment* GetScrollSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_SCROLL);
+		return ToScroll(t);
+	}
+	
+	ScrollSegment* GetScrollSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<ScrollSegment*>(((const TimingData*)this)->GetScrollSegmentAtRow(iNoteRow));
+	}
+	
+	const ScrollSegment* GetScrollSegmentAtBeat(float fBeat) const
+	{
+		return GetScrollSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	ScrollSegment* GetScrollSegmentAtBeat(float fBeat)
+	{
+		return const_cast<ScrollSegment*>(((const TimingData*)this)->GetScrollSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const ScrollSegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// Fake / FAKE
+
+	const FakeSegment* GetFakeSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_FAKE);
+		return ToFake(t);
+	}
+	
+	FakeSegment* GetFakeSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<FakeSegment*>(((const TimingData*)this)->GetFakeSegmentAtRow(iNoteRow));
+	}
+	
+	const FakeSegment* GetFakeSegmentAtBeat(float fBeat) const
+	{
+		return GetFakeSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	FakeSegment* GetFakeSegmentAtBeat(float fBeat)
+	{
+		return const_cast<FakeSegment*>(((const TimingData*)this)->GetFakeSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const FakeSegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// TimeSignature / TIME_SIG
+
+	const TimeSignatureSegment* GetTimeSignatureSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_TIME_SIG);
+		return ToTimeSignature(t);
+	}
+	
+	TimeSignatureSegment* GetTimeSignatureSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<TimeSignatureSegment*>(((const TimingData*)this)->GetTimeSignatureSegmentAtRow(iNoteRow));
+	}
+	
+	const TimeSignatureSegment* GetTimeSignatureSegmentAtBeat(float fBeat) const
+	{
+		return GetTimeSignatureSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	TimeSignatureSegment* GetTimeSignatureSegmentAtBeat(float fBeat)
+	{
+		return const_cast<TimeSignatureSegment*>(((const TimingData*)this)->GetTimeSignatureSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const TimeSignatureSegment& seg)
+	{
+		AddSegment(&seg);
+	}
 
 	/* convenience aliases (Set functions are deprecated) */
 	float GetBPMAtRow( int iNoteRow ) const { return GetBPMSegmentAtRow(iNoteRow)->GetBPM(); }

--- a/src/TimingData.h
+++ b/src/TimingData.h
@@ -27,36 +27,182 @@ inline T ToDerived( const TimingSegment *t, TimingSegmentType tst )
 	return static_cast<T>( t );
 }
 
-#define TimingSegmentToXWithName(Seg, SegName, SegType) \
-	inline const Seg* To##SegName( const TimingSegment *t ) \
-	{ \
-		ASSERT( t->GetType() == SegType ); \
-		return static_cast<const Seg*>( t ); \
-	} \
-	inline Seg* To##SegName( TimingSegment *t ) \
-	{ \
-		ASSERT( t->GetType() == SegType ); \
-		return static_cast<Seg*>( t ); \
-	}
+/// NOTE(sukibaby): Below is a large section of visually similar code, which all
+///  cast a TimingSegment pointer to a specific segment type.  They will ASSERT
+///  to ensure that the segment type matches the expected type.  
+/// 
+///  These segments are represented in the following functions:
+/// 
+///   - ToBPM
+///   - ToStop
+///   - ToDelay
+///   - ToTimeSignature
+///   - ToWarp
+///   - ToLabel
+///   - ToTickcount
+///   - ToCombo
+///   - ToSpeed
+///   - ToScroll
+///   - ToFake
+///  
+///  Each section is marked with a comment to indicate which segment that block is
+///  handling. You can use the following regex to find the start of each block:
+/// 
+///   ^\s*\/\/\s*(.*)
 
-#define TimingSegmentToX(Seg, SegType) \
-	TimingSegmentToXWithName(Seg##Segment, Seg, SEGMENT_##SegType)
+	// ToBPM
 
-/* ToBPM(TimingSegment*), ToTimeSignature(TimingSegment*), etc. */
-TimingSegmentToX( BPM, BPM );
-TimingSegmentToX( Stop, STOP );
-TimingSegmentToX( Delay, DELAY );
-TimingSegmentToX( TimeSignature, TIME_SIG );
-TimingSegmentToX( Warp, WARP );
-TimingSegmentToX( Label, LABEL );
-TimingSegmentToX( Tickcount, TICKCOUNT );
-TimingSegmentToX( Combo, COMBO );
-TimingSegmentToX( Speed, SPEED );
-TimingSegmentToX( Scroll, SCROLL );
-TimingSegmentToX( Fake, FAKE );
+inline const BPMSegment* ToBPM(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_BPM);
+	return static_cast<const BPMSegment*>(t);
+}
 
-#undef TimingSegmentToXWithName
-#undef TimingSegmentToX
+inline BPMSegment* ToBPM(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_BPM);
+	return static_cast<BPMSegment*>(t);
+}
+
+	// ToStop
+
+inline const StopSegment* ToStop(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_STOP);
+	return static_cast<const StopSegment*>(t);
+}
+
+inline StopSegment* ToStop(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_STOP);
+	return static_cast<StopSegment*>(t);
+}
+
+	// ToDelay
+
+inline const DelaySegment* ToDelay(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_DELAY);
+	return static_cast<const DelaySegment*>(t);
+}
+
+inline DelaySegment* ToDelay(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_DELAY);
+	return static_cast<DelaySegment*>(t);
+}
+
+	// ToTimeSignature
+
+inline const TimeSignatureSegment* ToTimeSignature(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_TIME_SIG);
+	return static_cast<const TimeSignatureSegment*>(t);
+}
+
+inline TimeSignatureSegment* ToTimeSignature(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_TIME_SIG);
+	return static_cast<TimeSignatureSegment*>(t);
+}
+
+	// ToWarp
+
+inline const WarpSegment* ToWarp(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_WARP);
+	return static_cast<const WarpSegment*>(t);
+}
+
+inline WarpSegment* ToWarp(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_WARP);
+	return static_cast<WarpSegment*>(t);
+}
+
+	// ToLabel
+
+inline const LabelSegment* ToLabel(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_LABEL);
+	return static_cast<const LabelSegment*>(t);
+}
+
+inline LabelSegment* ToLabel(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_LABEL);
+	return static_cast<LabelSegment*>(t);
+}
+
+	// ToTickcount
+
+inline const TickcountSegment* ToTickcount(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_TICKCOUNT);
+	return static_cast<const TickcountSegment*>(t);
+}
+
+inline TickcountSegment* ToTickcount(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_TICKCOUNT);
+	return static_cast<TickcountSegment*>(t);
+}
+
+	// ToCombo
+	
+inline const ComboSegment* ToCombo(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_COMBO);
+	return static_cast<const ComboSegment*>(t);
+}
+
+inline ComboSegment* ToCombo(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_COMBO);
+	return static_cast<ComboSegment*>(t);
+}
+
+	// ToSpeed
+	
+inline const SpeedSegment* ToSpeed(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_SPEED);
+	return static_cast<const SpeedSegment*>(t);
+}
+
+inline SpeedSegment* ToSpeed(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_SPEED);
+	return static_cast<SpeedSegment*>(t);
+}
+
+	// ToScroll
+	
+inline const ScrollSegment* ToScroll(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_SCROLL);
+	return static_cast<const ScrollSegment*>(t);
+}
+
+inline ScrollSegment* ToScroll(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_SCROLL);
+	return static_cast<ScrollSegment*>(t);
+}
+
+	// ToFake
+
+inline const FakeSegment* ToFake(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_FAKE);
+	return static_cast<const FakeSegment*>(t);
+}
+
+inline FakeSegment* ToFake(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_FAKE);
+	return static_cast<FakeSegment*>(t);
+}
 
 /**
  * @brief Holds data for translating beats<->seconds.


### PR DESCRIPTION
Un-does a set of complicated macros. The reasons are that this allows the compiler to better optimize than it would as a macro, and many errors were found to be hiding behind that macro.

Because this replaces the macro with a large section of visually similar code handling different forms of timing segments, a comment has been added explaining the purpose of the functions.