### PR TITLE
Make BUF_SIZE static const in RageSoundMixBuffer

### DIFF
--- a/src/RageSoundMixBuffer.cpp
+++ b/src/RageSoundMixBuffer.cpp
@@ -8,14 +8,11 @@
 
 RageSoundMixBuffer::RageSoundMixBuffer()
 {
-	// See how many samples we can stuff into 2MB.
-	size_t BUF_SIZE = 2 * 1024 * 1024 / sizeof(float);
-	
 	m_pMixbuf = static_cast<float*>(std::malloc(BUF_SIZE * sizeof(float)));
-	if (m_pMixbuf == nullptr) {
+	if (m_pMixbuf == nullptr)
+	{
 		ASSERT_M(false, "Failed to allocate memory for the sound mixing buffer");
 	}
-	
 	m_iBufSize = BUF_SIZE;
 	std::memset(m_pMixbuf, 0, m_iBufSize * sizeof(float));
 	m_iBufUsed = 0;

--- a/src/RageSoundMixBuffer.h
+++ b/src/RageSoundMixBuffer.h
@@ -11,6 +11,9 @@ public:
 	RageSoundMixBuffer();
 	~RageSoundMixBuffer();
 
+	// See how many samples we can stuff into 2MB.
+	static constexpr size_t BUF_SIZE = 2 * 1024 * 1024 / sizeof(float);
+
 	// Mix the given buffer of samples.
 	void write( const float *pBuf, unsigned iSize, int iSourceStride = 1, int iDestStride = 1 );
 


### PR DESCRIPTION
I should have thought of this when making this commit earlier... it should have been static const because we don't need to figure this out every time.