### PR TITLE
Use SetWindowPos to prevent interruptions in Windows when fullscreen/OpenGL

### DIFF
--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -89,6 +89,7 @@ static LRESULT CALLBACK GraphicsWindow_WndProc( HWND hWnd, UINT msg, WPARAM wPar
 				{
 					ChangeDisplaySettings( &g_FullScreenDevMode, CDS_FULLSCREEN );
 					ShowWindow( g_hWndMain, SW_SHOWNORMAL );
+					SetWindowPos( g_hWndMain, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE );
 				}
 				else if( !g_bHasFocus && bHadFocus )
 				{


### PR DESCRIPTION
On Windows, setting the priority of the game higher isn't enough to ensure the game won't be interrupted by something like a Windows Update notification, Discord notification, etc.

This affects OpenGL on Windows only which I figure is the common use case anyway.

The flags SWP_NOMOVE and SWP_NOSIZE indicate that the window's position and size should not change. This may not be optimal so I am open to suggestions on this.