### PR TITLE
RageSoundDriver.cpp rewrite

### DIFF
--- a/src/arch/Sound/RageSoundDriver.cpp
+++ b/src/arch/Sound/RageSoundDriver.cpp
@@ -9,67 +9,111 @@
 #include <cstddef>
 #include <vector>
 
-
-DriverList RageSoundDriver::m_pDriverList;
-
-RageSoundDriver *RageSoundDriver::Create( const RString& drivers )
+// Function to initialize the default driver list
+std::vector<RString> InitializeDefaultDriverList()
 {
-	std::vector<RString> drivers_to_try;
-	if(drivers.empty())
+	std::vector<RString> driverList;
+	split(DEFAULT_SOUND_DRIVER_LIST, ",", driverList);
+	return driverList;
+}
+
+static std::vector<RString> defaultDriverList = InitializeDefaultDriverList();
+DriverList RageSoundDriver::m_pDriverList;
+static bool removedUnusableDriver = false;
+
+// AttemptToInitializeDriver is a function that attempts to initialize a sound driver.
+// The function takes a driver name as an argument and returns a pointer to the initialized driver.
+// If initialization succeeds, we will receive an empty string from Init().
+// If the driver fails to initialize, we will log the error message and delete the driver.
+RageSoundDriver* AttemptToInitializeDriver(const RString& evaluated_driver)
+{
+	RageDriver* baseDriver = RageSoundDriver::m_pDriverList.Create(evaluated_driver);
+	if (baseDriver == nullptr)
 	{
-		split(DEFAULT_SOUND_DRIVER_LIST, ",", drivers_to_try);
+		LOG->Trace("Unknown sound driver: %s", evaluated_driver.c_str());
+		return nullptr;
 	}
-	else
+	RageSoundDriver* soundDriver = dynamic_cast<RageSoundDriver*>(baseDriver);
+	
+	const RString initializationResult = soundDriver->Init();
+	if (initializationResult.empty())
 	{
-		split(drivers, ",", drivers_to_try);
-		std::size_t to_try= 0;
-		bool had_to_erase= false;
-		while(to_try < drivers_to_try.size())
+		return soundDriver;
+	}
+
+	LOG->Info("Couldn't load driver %s:", evaluated_driver.c_str());
+	SAFE_DELETE(soundDriver);
+	return nullptr;
+}
+
+// InitializeDriverFromList is a function that initializes a sound driver from a list of drivers.
+// The function takes a vector of driver names as an argument and returns a pointer to the initialized driver,
+// or returns a null pointer if no driver was successfully initialized.
+RageSoundDriver* InitializeDriverFromList(const std::vector<RString>& driverList)
+{
+	for (const RString& driverName : driverList)
+	{
+		RageSoundDriver* initializedDriver = AttemptToInitializeDriver(driverName);
+		if (initializedDriver != nullptr)
 		{
-			if(m_pDriverList.m_pRegistrees->find(istring(drivers_to_try[to_try]))
-				== m_pDriverList.m_pRegistrees->end())
-			{
-				LOG->Warn("Removed unusable sound driver %s", drivers_to_try[to_try].c_str());
-				drivers_to_try.erase(drivers_to_try.begin() + to_try);
-				had_to_erase= true;
-			}
-			else
-			{
-				++to_try;
-			}
+			LOG->Trace("Sound driver '%s' was loaded successfully.", driverName.c_str());
+			return initializedDriver;
 		}
-		if(had_to_erase)
+	}
+	return nullptr; // No driver was successfully initialized.
+}
+
+// RageSoundDriver::Create is a function that creates a sound driver.
+// It attempts to initialize a driver from the default driver list.
+// If the driver is successfully initialized, the function will return the driver and exit.
+// If the driver fails to initialize, the function will attempt use the custom driver list.
+// The function will ultimately call sm_crash if all attempts to get a sound driver fail.
+RageSoundDriver* RageSoundDriver::Create(const RString& drivers)
+{
+	// Attempt to initialize a driver from the default driver list
+	RageSoundDriver* initializedDriver = InitializeDriverFromList(defaultDriverList);
+	if (initializedDriver != nullptr)
+	{
+		// The function will exit here if the driver was successfully initialized via the default list.
+		return initializedDriver;
+	}
+
+	// If no driver was initialized using the default list, prepare the custom driver list
+	std::vector<RString> customDriverList;
+	split(drivers, ",", customDriverList);
+	std::size_t currentDriverIndex = 0;
+	removedUnusableDriver = false;
+
+	// Create a new list to hold only the usable drivers.
+	std::vector<RString> usableDriverList;
+	for (const auto& driverName : customDriverList)
+	{
+		auto currentSearchKey = istring(driverName);
+		if (m_pDriverList.m_pRegistrees->find(currentSearchKey) != m_pDriverList.m_pRegistrees->end())
 		{
-			SOUNDMAN->fix_bogus_sound_driver_pref(join(",", drivers_to_try));
+			usableDriverList.push_back(driverName);
 		}
-		if(drivers_to_try.empty())
+		else
 		{
-			split(DEFAULT_SOUND_DRIVER_LIST, ",", drivers_to_try);
+			LOG->Warn("Removed unusable sound driver %s", driverName.c_str());
+			removedUnusableDriver = true;
 		}
 	}
 
-	for (RString const &Driver : drivers_to_try)
-	{
-		RageDriver *pDriver = m_pDriverList.Create( Driver );
-		char const *driverString = Driver.c_str();
-		if( pDriver == nullptr )
-		{
-			LOG->Trace( "Unknown sound driver: %s", driverString );
-			continue;
-		}
-
-		RageSoundDriver *pRet = dynamic_cast<RageSoundDriver *>( pDriver );
-		ASSERT( pRet != nullptr );
-
-		const RString sError = pRet->Init();
-		if( sError.empty() )
-		{
-			LOG->Info( "Sound driver: %s", driverString );
-			return pRet;
-		}
-		LOG->Info( "Couldn't load driver %s: %s", driverString, sError.c_str() );
-		SAFE_DELETE( pRet );
+	// As per the original logic, if any unusable drivers were removed, we will update the custom driver list.
+	if (removedUnusableDriver) {
+		SOUNDMAN->fix_bogus_sound_driver_pref(join(",", usableDriverList));
 	}
+
+	// Attempt to initialize a driver from the custom driver list.
+	initializedDriver = InitializeDriverFromList(usableDriverList);
+	if (initializedDriver != nullptr)
+	{
+		return initializedDriver;
+	}
+
+	// The function will call sm_crash if all attempts to get a sound driver fail.
+	FAIL_M("No sound driver could be loaded.");
 	return nullptr;
 }
 
@@ -80,6 +124,7 @@ RString RageSoundDriver::GetDefaultSoundDriverList()
 
 /*
  * (c) 2002-2006 Glenn Maynard, Steve Checkoway
+ * Rewritten 2024 sukibaby
  * All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a


### PR DESCRIPTION
### Summary: Aiming to de-mystify this code by making it easier to follow and more robust.

The only changed functionality here is the default driver list is tried first, whereas the original code checks tries everything in the custom driver list and selects something from the default driver list if not.

Otherwise this is mostly encapsulating repeated functionality into dedicated functions, rewriting stuff to be easier to understand, etc.

From top to bottom,

- Renamed variable names to be less confusing

- Dedicated function for the purpose of initializing the default driver list (as opposed to having the same code sprinkled throughout the source file)

- Dedicated function for attempting to initialize an individual driver

- Dedicated function for loading from the driver list

- `FAIL_M` call if no usable drivers can be found (instead of appearing to fail to launch, etc)