### PR TITLE
[low priority]  WaveOut: Attempt to re-initialize on failure

### DIFF
--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -77,8 +77,14 @@ bool RageSoundDriver_WaveOut::GetData()
 	this->Mix( (std::int16_t *) m_aBuffers[b].lpData, chunksize_frames, m_iLastCursorPos, GetPosition() );
 
 	MMRESULT ret = waveOutWrite( m_hWaveOut, &m_aBuffers[b], sizeof(m_aBuffers[b]) );
-  	if( ret != MMSYSERR_NOERROR )
-		FAIL_M( wo_ssprintf(ret, "waveOutWrite failed") );
+	if( ret != MMSYSERR_NOERROR )
+	{
+		Init();
+		if (b_InitSuccess == false)
+		{
+			FAIL_M(wo_ssprintf(ret, "waveOutWrite failed"));
+		}
+	}
 
 	/* Increment m_iLastCursorPos. */
 	m_iLastCursorPos += chunksize_frames;
@@ -115,6 +121,7 @@ RageSoundDriver_WaveOut::RageSoundDriver_WaveOut()
 
 RString RageSoundDriver_WaveOut::Init()
 {
+	b_InitSuccess = false;
 	m_iSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
 	if( m_iSampleRate == 0 )
 		m_iSampleRate = 44100;
@@ -174,6 +181,7 @@ RString RageSoundDriver_WaveOut::Init()
 	MixingThread.SetName( "Mixer thread" );
 	MixingThread.Create( MixerThread_start, this );
 
+	b_InitSuccess = true;
 	return RString();
 }
 

--- a/src/arch/Sound/RageSoundDriver_WaveOut.h
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.h
@@ -15,7 +15,6 @@ public:
 	RageSoundDriver_WaveOut();
 	~RageSoundDriver_WaveOut();
 	RString Init();
-
 	std::int64_t GetPosition() const;
 	float GetPlayLatency() const;
 	int GetSampleRate() const { return m_iSampleRate; }
@@ -33,6 +32,7 @@ private:
 	int m_iSampleRate;
 	bool m_bShutdown;
 	int m_iLastCursorPos;
+	bool b_InitSuccess;
 };
 
 #endif


### PR DESCRIPTION
Let's say the audio cable is unplugged mid-game, as it is the game will crash immediately upon not being able to write to the buffer.

This would have it attempt one single time to re-initialize. 

I don't know which of the two is preferred behavior, since maybe we do want to crash if the sound device changes unexpectedly?