### PR TITLE
✨Prevent buffer underrun in the WaveOut driver✨

### DIFF
--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -19,14 +19,6 @@
 
 REGISTER_SOUND_DRIVER_CLASS( WaveOut );
 
-const int channels = 2;
-const int bytes_per_frame = channels*2;		/* 16-bit */
-const int buffersize_frames = 1024*8;	/* in frames */
-const int buffersize = buffersize_frames * bytes_per_frame; /* in bytes */
-
-const int num_chunks = 8;
-const int chunksize_frames = buffersize_frames / num_chunks;
-const int chunksize = buffersize / num_chunks; /* in bytes */
 
 static RString wo_ssprintf( MMRESULT err, const char *szFmt, ...)
 {

--- a/src/arch/Sound/RageSoundDriver_WaveOut.h
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.h
@@ -21,6 +21,18 @@ public:
 	int GetSampleRate() const { return m_iSampleRate; }
 
 private:
+	// Note: it's better to have more buffers of smaller size.
+	// You can give WaveOut as many buffers as you want,
+	// but if they are each too large, then we won't fill data
+	// as fast as we'd hope to, and that can lead to underrun.
+	static const int channels = 2;
+	static const int bytes_per_frame = channels * 2;  /* 16-bit */
+	static const int buffersize_frames = 1024 * 8;	  /* in frames */
+	static const int buffersize = buffersize_frames * bytes_per_frame; /* in bytes */
+	static const int num_chunks = 16;
+	static const int chunksize_frames = buffersize_frames / num_chunks;
+	static const int chunksize = buffersize / num_chunks; /* in bytes */
+
 	static int MixerThread_start( void *p );
 	void MixerThread();
 	RageThread MixingThread;
@@ -29,7 +41,7 @@ private:
 
 	HWAVEOUT m_hWaveOut;
 	HANDLE m_hSoundEvent;
-	WAVEHDR m_aBuffers[8];
+	WAVEHDR m_aBuffers[num_chunks];
 	int m_iSampleRate;
 	bool m_bShutdown;
 	int m_iLastCursorPos;


### PR DESCRIPTION
it's better to have more buffers of smaller size.

You can give WaveOut as many buffers as you want, but if they are each too large, then we won't fill data as fast as we'd hope to, and that can lead to underrun. This seems to do a great job of preventing "Audio frame out of range..." errors on Windows/WaveOut.

The fix was to increase the number of buffers. When the value for `num_chunks` is increased, each buffer will be smaller, because `chunksize` will become smaller as the value of `num_chunks` increases.

In the original code, each of the eight buffers represents approximately 0.02322 seconds (or 23.22 milliseconds) of audio data at a sample rate of 44.1 kHz.

With this change, each of the sixteen buffers would represent approximately 0.01161 seconds (or 11.61 milliseconds) of audio data at a sample rate of 44.1 kHz.

The constants were moved from `RageSoundDriver_WaveOut.cpp` to `RageSoundDriver_WaveOut.h` to avoid hard-coding the value of `num_chunks` into the header file.

This won't have as big of an effect without the 🌠 PR's also merged, but will still be an improvement until then.