### PR TITLE
WaveOut: double decoder buffer size

### DIFF
--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -168,7 +168,7 @@ RString RageSoundDriver_WaveOut::Init()
 
 	/* We have a very large writeahead; make sure we have a large enough decode
 	 * buffer to recover cleanly from underruns. */
-	SetDecodeBufferSize( buffersize_frames * 3/2 );
+	SetDecodeBufferSize( buffersize_frames * 2 );
 	StartDecodeThread();
 
 	MixingThread.SetName( "Mixer thread" );


### PR DESCRIPTION
No reason really to limit ourselves to 1.5x size buffer, 2x buffer size here remains a negligible amount of memory on modern computers, and can help prevent mixing underruns.