### PR TITLE
Zero-initialize m_Buffer in RageSoundDriver.h

### DIFF
--- a/src/arch/Sound/RageSoundDriver.h
+++ b/src/arch/Sound/RageSoundDriver.h
@@ -154,7 +154,7 @@ private:
 	 */
 	struct sound_block
 	{
-		float m_Buffer[samples_per_block];
+		float m_Buffer[samples_per_block]{}; // zero-initialize the array
 		float *m_BufferNext; // beginning of the unread data
 		int m_FramesInBuffer; // total number of frames at m_BufferNext
 		std::int64_t m_iPosition; // stream frame of m_BufferNext


### PR DESCRIPTION
This prevents a compiler warning about the uninitialized member variable m_Buffer, and also makes the function safer by having it begin in a predictable state.