### PR TITLE
Don't log FPS by default

### DIFF
--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -51,7 +51,7 @@ static std::vector<Centering> g_CenteringStack( 1, Centering(0, 0, 0, 0) );
 
 RageDisplay*		DISPLAY	= nullptr; // global and accessible from anywhere in our program
 
-Preference<bool>  LOG_FPS( "LogFPS", true );
+Preference<bool>  LOG_FPS( "LogFPS", false );
 Preference<float> g_fFrameLimitPercent( "FrameLimitPercent", 0.0f );
 
 static const char *RagePixelFormatNames[] = {


### PR DESCRIPTION
The existing code logs the FPS once every second by default.

I feel that most users don't care about logging their FPS, so this seems like a lot of avoidable I/O activity which is happening mid-song.

Anyone who wants to enable FPS logging can still switch it on in `Preferences.ini`.