### PR TITLE
[MACRO]  Remove RadianToDegree macro from ModelTypes

### DIFF
--- a/src/ModelTypes.cpp
+++ b/src/ModelTypes.cpp
@@ -29,6 +29,23 @@ AnimatedTexture::~AnimatedTexture()
 	Unload();
 }
 
+RageVector3 RadianToDegree(RageVector3 radian)
+{
+	// This is more accurate than the original SM5 implementation,
+	// but that raises a double-to-float mismatch warning, so this
+	// prevents that issue from occurring.
+	//
+	// A way to implement the original code exactly would be:
+	//
+	// RageVector3 radian = { radian.x * (180.0f / PI) };
+
+	return RageVector3(
+		static_cast<float>(radian.x * (180.0f / PI)),
+		static_cast<float>(radian.y * (180.0f / PI)),
+		static_cast<float>(radian.z * (180.0f / PI))
+	);
+}
+
 void AnimatedTexture::LoadBlank()
 {
 	AnimatedTextureState state(

--- a/src/ModelTypes.h
+++ b/src/ModelTypes.h
@@ -38,6 +38,8 @@ class AnimatedTexture
 public:
 	AnimatedTexture();
 	~AnimatedTexture();
+	
+	RageVector3 RadianToDegree(RageVector3 radian);
 
 	void LoadBlank();
 	void Load( const RString &sTexOrIniFile );

--- a/src/RageMath.h
+++ b/src/RageMath.h
@@ -6,9 +6,6 @@
 #include <vector>
 
 #define PI		(3.141592653589793f)
-#define DegreeToRadian( degree ) ((degree) * (PI / 180.0f))
-#define RadianToDegree( radian ) ((radian) * (180.0f / PI))
-
 
 struct lua_State;
 struct RageVector2;


### PR DESCRIPTION
This is the only place this is used. 

Planning on removing those two macros in a general RageMath update, since DegreeToRadian isn't used anywhere, and if this PR is merged, RadianToDegree won't be used anywhere.

https://github.com/itgmania/itgmania/blob/5d4f9dcb07493ed4c51d6be23e9b41978162305a/src/RageMath.h#L9-L10