### PR TITLE
🌠Use stdlib for trigonometric functions

### DIFF
--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -544,7 +544,7 @@ void Actor::PreDraw() // calculate actor properties
 			ssprintf("PercentThroughEffect: %f", fPercentThroughEffect) );
 
 		bool bBlinkOn = fPercentThroughEffect > 0.5f;
-		float fPercentBetweenColors = RageFastSin( (fPercentThroughEffect + 0.25f) * 2 * PI ) / 2 + 0.5f;
+		float fPercentBetweenColors = std::sin( (fPercentThroughEffect + 0.25f) * 2 * PI ) / 2 + 0.5f;
 		ASSERT_M( fPercentBetweenColors >= 0 && fPercentBetweenColors <= 1,
 			ssprintf("PercentBetweenColors: %f, PercentThroughEffect: %f", fPercentBetweenColors, fPercentThroughEffect) );
 		float fOriginalAlpha = m_current_with_effects.diffuse[0].a;
@@ -590,15 +590,15 @@ void Actor::PreDraw() // calculate actor properties
 			break;
 		case rainbow:
 			m_current_with_effects.diffuse[0] = RageColor(
-				RageFastCos( fPercentBetweenColors*2*PI ) * 0.5f + 0.5f,
-				RageFastCos( fPercentBetweenColors*2*PI + PI * 2.0f / 3.0f ) * 0.5f + 0.5f,
-				RageFastCos( fPercentBetweenColors*2*PI + PI * 4.0f / 3.0f) * 0.5f + 0.5f,
+				std::cos( fPercentBetweenColors*2*PI ) * 0.5f + 0.5f,
+				std::cos( fPercentBetweenColors*2*PI + PI * 2.0f / 3.0f ) * 0.5f + 0.5f,
+				std::cos( fPercentBetweenColors*2*PI + PI * 4.0f / 3.0f) * 0.5f + 0.5f,
 				fOriginalAlpha );
 			for( int i=1; i<NUM_DIFFUSE_COLORS; i++ )
 				m_current_with_effects.diffuse[i] = m_current_with_effects.diffuse[0];
 			break;
 		case wag:
-			m_current_with_effects.rotation += m_vEffectMagnitude * RageFastSin( fPercentThroughEffect * 2.0f * PI );
+			m_current_with_effects.rotation += m_vEffectMagnitude * std::sin( fPercentThroughEffect * 2.0f * PI );
 			break;
 		case spin:
 			// nothing needs to be here
@@ -610,13 +610,13 @@ void Actor::PreDraw() // calculate actor properties
 			break;
 		case bounce:
 			{
-				float fPercentOffset = RageFastSin( fPercentThroughEffect*PI );
+				float fPercentOffset = std::sin( fPercentThroughEffect*PI );
 				m_current_with_effects.pos += m_vEffectMagnitude * fPercentOffset;
 			}
 			break;
 		case bob:
 			{
-				float fPercentOffset = RageFastSin( fPercentThroughEffect*PI*2 );
+				float fPercentOffset = std::sin( fPercentThroughEffect*PI*2 );
 				m_current_with_effects.pos += m_vEffectMagnitude * fPercentOffset;
 			}
 			break;
@@ -624,7 +624,7 @@ void Actor::PreDraw() // calculate actor properties
 			{
 				float fMinZoom = m_vEffectMagnitude[0];
 				float fMaxZoom = m_vEffectMagnitude[1];
-				float fPercentOffset = RageFastSin( fPercentThroughEffect*PI );
+				float fPercentOffset = std::sin( fPercentThroughEffect*PI );
 				float fZoom = SCALE( fPercentOffset, 0.f, 1.f, fMinZoom, fMaxZoom );
 				m_current_with_effects.scale *= fZoom;
 

--- a/src/ArrowEffects.cpp
+++ b/src/ArrowEffects.cpp
@@ -147,9 +147,9 @@ namespace
 static float SelectTanType(float angle, bool is_cosec)
 {
 	if (is_cosec)
-	    return RageFastCsc(angle);
+	    return (1 / std::sin(angle)); // cosecant
 	else
-	    return RageFastTan(angle);
+	    return std::tan(angle);
 }
 
 static float CalculateTornadoOffsetFromMagnitude(int dimension, int col_id,
@@ -166,7 +166,7 @@ static float CalculateTornadoOffsetFromMagnitude(int dimension, int col_id,
 	float rads= std::acos(position_between);
 	float frequency= tornado_offset_frequency[dimension];
 	rads+= (y_offset + effect_offset) * ((period * frequency) + frequency) / SCREEN_HEIGHT;
-	float processed_rads = is_tan ? SelectTanType(rads, curr_options->m_bCosecant) : RageFastCos(rads);
+	float processed_rads = is_tan ? SelectTanType(rads, curr_options->m_bCosecant) : std::cos(rads);
 
 	float const adjusted_pixel_offset= SCALE(processed_rads,
 		tornado_offset_scale_from_low[dimension],
@@ -249,9 +249,9 @@ static void UpdateTipsy(float * tipsy_result, float * tipsy_offset_result, float
 		}
 		else
 		{
-			tipsy_result[col]= RageFastCos(time_times_timer + (col * ((offset *
+			tipsy_result[col]= std::cos(time_times_timer + (col * ((offset *
 				TIPSY_COLUMN_FREQUENCY) + TIPSY_COLUMN_FREQUENCY))) * arrow_times_mag;
-			tipsy_offset_result[col]= RageFastCos(time_times_offset_timer + (col *
+			tipsy_offset_result[col]= std::cos(time_times_offset_timer + (col *
 				TIPSY_OFFSET_COLUMN_FREQUENCY)) * arrow_times_offset_mag;
 		}
 	}
@@ -547,7 +547,7 @@ float ArrowEffects::GetYOffset( const PlayerState* pPlayerState, int iCol, float
 		fYAdjust += fBrakeYAdjust;
 	}
 	if( fAccels[PlayerOptions::ACCEL_WAVE] != 0 )
-		fYAdjust +=	fAccels[PlayerOptions::ACCEL_WAVE] * WAVE_MOD_MAGNITUDE *RageFastSin( fYOffset/((fAccels[PlayerOptions::ACCEL_WAVE_PERIOD]*WAVE_MOD_HEIGHT)+WAVE_MOD_HEIGHT) );
+		fYAdjust +=	fAccels[PlayerOptions::ACCEL_WAVE] * WAVE_MOD_MAGNITUDE *std::sin( fYOffset/((fAccels[PlayerOptions::ACCEL_WAVE_PERIOD]*WAVE_MOD_HEIGHT)+WAVE_MOD_HEIGHT) );
 
 	if( fEffects[PlayerOptions::EFFECT_PARABOLA_Y] != 0 )
 		fYAdjust += fEffects[PlayerOptions::EFFECT_PARABOLA_Y] * (fYOffset/ARROW_SIZE) * (fYOffset/ARROW_SIZE);
@@ -583,7 +583,7 @@ float ArrowEffects::GetYOffset( const PlayerState* pPlayerState, int iCol, float
 
 	if( fAccels[PlayerOptions::ACCEL_EXPAND] != 0 )
 	{
-		float fExpandMultiplier = SCALE( RageFastCos(data.m_fExpandSeconds*EXPAND_MULTIPLIER_FREQUENCY*(fAccels[PlayerOptions::ACCEL_EXPAND_PERIOD]+1)),
+		float fExpandMultiplier = SCALE( std::cos(data.m_fExpandSeconds*EXPAND_MULTIPLIER_FREQUENCY*(fAccels[PlayerOptions::ACCEL_EXPAND_PERIOD]+1)),
 						EXPAND_MULTIPLIER_SCALE_FROM_LOW, EXPAND_MULTIPLIER_SCALE_FROM_HIGH,
 						EXPAND_MULTIPLIER_SCALE_TO_LOW, EXPAND_MULTIPLIER_SCALE_TO_HIGH );
 		fScrollSpeed *=	SCALE( fAccels[PlayerOptions::ACCEL_EXPAND],
@@ -659,7 +659,7 @@ float ArrowEffects::GetYPos( const PlayerState* pPlayerState, int iCol, float fY
 
 	if( fEffects[PlayerOptions::EFFECT_BEAT_Y] != 0 )
 	{
-		const float fShift = data.m_fBeatFactor[dim_y]*RageFastSin( fYOffset / ((fEffects[PlayerOptions::EFFECT_BEAT_Y_PERIOD]*BEAT_Y_OFFSET_HEIGHT)+BEAT_Y_OFFSET_HEIGHT) + PI/BEAT_Y_PI_HEIGHT );
+		const float fShift = data.m_fBeatFactor[dim_y]*std::sin( fYOffset / ((fEffects[PlayerOptions::EFFECT_BEAT_Y_PERIOD]*BEAT_Y_OFFSET_HEIGHT)+BEAT_Y_OFFSET_HEIGHT) + PI/BEAT_Y_PI_HEIGHT );
 		f += fEffects[PlayerOptions::EFFECT_BEAT_Y] * fShift;
 	}
 
@@ -725,7 +725,7 @@ float ArrowEffects::GetXPos( const PlayerState* pPlayerState, int iColNum, float
 
 	if( fEffects[PlayerOptions::EFFECT_BUMPY_X] != 0 )
 		fPixelOffsetFromCenter += fEffects[PlayerOptions::EFFECT_BUMPY_X] *
-			40*RageFastSin( CalculateBumpyAngle(fYOffset,
+			40*std::sin( CalculateBumpyAngle(fYOffset,
 			fEffects[PlayerOptions::EFFECT_BUMPY_X_OFFSET],
 			fEffects[PlayerOptions::EFFECT_BUMPY_X_PERIOD]) );
 
@@ -737,7 +737,7 @@ float ArrowEffects::GetXPos( const PlayerState* pPlayerState, int iColNum, float
 
 	if( fEffects[PlayerOptions::EFFECT_DRUNK] != 0 )
 		fPixelOffsetFromCenter += fEffects[PlayerOptions::EFFECT_DRUNK] *
-			( RageFastCos( CalculateDrunkAngle(fEffects[PlayerOptions::EFFECT_DRUNK_SPEED], iColNum,
+			( std::cos( CalculateDrunkAngle(fEffects[PlayerOptions::EFFECT_DRUNK_SPEED], iColNum,
 					fEffects[PlayerOptions::EFFECT_DRUNK_OFFSET], DRUNK_COLUMN_FREQUENCY,
 					fYOffset, fEffects[PlayerOptions::EFFECT_DRUNK_PERIOD],
 					DRUNK_OFFSET_FREQUENCY) ) * ARROW_SIZE*DRUNK_ARROW_MAGNITUDE );
@@ -765,7 +765,7 @@ float ArrowEffects::GetXPos( const PlayerState* pPlayerState, int iColNum, float
 
 	if( fEffects[PlayerOptions::EFFECT_BEAT] != 0 )
 	{
-		const float fShift = data.m_fBeatFactor[dim_x]*RageFastSin( fYOffset / ((fEffects[PlayerOptions::EFFECT_BEAT_PERIOD]*BEAT_OFFSET_HEIGHT)+BEAT_OFFSET_HEIGHT) + PI/BEAT_PI_HEIGHT );
+		const float fShift = data.m_fBeatFactor[dim_x]*std::sin( fYOffset / ((fEffects[PlayerOptions::EFFECT_BEAT_PERIOD]*BEAT_OFFSET_HEIGHT)+BEAT_OFFSET_HEIGHT) + PI/BEAT_PI_HEIGHT );
 		fPixelOffsetFromCenter += fEffects[PlayerOptions::EFFECT_BEAT] * fShift;
 	}
 
@@ -793,7 +793,7 @@ float ArrowEffects::GetXPos( const PlayerState* pPlayerState, int iColNum, float
 
 	if( fEffects[PlayerOptions::EFFECT_DIGITAL] != 0 )
 		fPixelOffsetFromCenter += (fEffects[PlayerOptions::EFFECT_DIGITAL] * ARROW_SIZE * 0.5f) *
-			std::round((fEffects[PlayerOptions::EFFECT_DIGITAL_STEPS]+1) * RageFastSin(
+			std::round((fEffects[PlayerOptions::EFFECT_DIGITAL_STEPS]+1) * std::sin(
 				CalculateDigitalAngle(fYOffset,
 				fEffects[PlayerOptions::EFFECT_DIGITAL_OFFSET],
 				fEffects[PlayerOptions::EFFECT_DIGITAL_PERIOD]) ) )/(fEffects[PlayerOptions::EFFECT_DIGITAL_STEPS]+1);
@@ -816,7 +816,7 @@ float ArrowEffects::GetXPos( const PlayerState* pPlayerState, int iColNum, float
 
 	if( fEffects[PlayerOptions::EFFECT_BOUNCE] != 0 )
 	{
-		float fBounceAmt = std::abs( RageFastSin( ( (fYOffset + (1.0f * (fEffects[PlayerOptions::EFFECT_BOUNCE_OFFSET]) ) ) /
+		float fBounceAmt = std::abs( std::sin( ( (fYOffset + (1.0f * (fEffects[PlayerOptions::EFFECT_BOUNCE_OFFSET]) ) ) /
 			( 60 + (fEffects[PlayerOptions::EFFECT_BOUNCE_PERIOD]*60) ) ) ) );
 
 		fPixelOffsetFromCenter += fEffects[PlayerOptions::EFFECT_BOUNCE] * ARROW_SIZE * 0.5f * fBounceAmt;
@@ -1113,7 +1113,7 @@ float ArrowGetPercentVisible(float fYPosWithoutReverse, int iCol, float fYOffset
 	}
 	if( fAppearances[PlayerOptions::APPEARANCE_BLINK] != 0 )
 	{
-		float f = RageFastSin(ArrowEffects::GetTime()*10);
+		float f = std::sin(ArrowEffects::GetTime()*10);
 		f = Quantize( f, BLINK_MOD_FREQUENCY );
 		fVisibleAdjust += SCALE( f, 0, 1, -1, 0 );
 	}
@@ -1204,13 +1204,13 @@ float ArrowEffects::GetZPos( const PlayerState* pPlayerState, int iCol, float fY
 	}
 
 	if( fEffects[PlayerOptions::EFFECT_BUMPY] != 0 )
-		fZPos += fEffects[PlayerOptions::EFFECT_BUMPY] * 40*RageFastSin(
+		fZPos += fEffects[PlayerOptions::EFFECT_BUMPY] * 40*std::sin(
 			CalculateBumpyAngle(fYOffset,
 			fEffects[PlayerOptions::EFFECT_BUMPY_OFFSET],
 			fEffects[PlayerOptions::EFFECT_BUMPY_PERIOD]) );
 
 	if( curr_options->m_fBumpy[iCol] != 0 )
-		fZPos += curr_options->m_fBumpy[iCol] * 40*RageFastSin(
+		fZPos += curr_options->m_fBumpy[iCol] * 40*std::sin(
 			CalculateBumpyAngle(fYOffset,
 			fEffects[PlayerOptions::EFFECT_BUMPY_OFFSET],
 			fEffects[PlayerOptions::EFFECT_BUMPY_PERIOD]) );
@@ -1245,7 +1245,7 @@ float ArrowEffects::GetZPos( const PlayerState* pPlayerState, int iCol, float fY
 
 	if( fEffects[PlayerOptions::EFFECT_DRUNK_Z] != 0 )
 		fZPos += fEffects[PlayerOptions::EFFECT_DRUNK_Z] *
-			( RageFastCos( CalculateDrunkAngle(fEffects[PlayerOptions::EFFECT_DRUNK_Z_SPEED], iCol,
+			( std::cos( CalculateDrunkAngle(fEffects[PlayerOptions::EFFECT_DRUNK_Z_SPEED], iCol,
 					fEffects[PlayerOptions::EFFECT_DRUNK_Z_OFFSET], DRUNK_Z_COLUMN_FREQUENCY,
 					fYOffset, fEffects[PlayerOptions::EFFECT_DRUNK_Z_PERIOD],
 					DRUNK_Z_OFFSET_FREQUENCY) ) * ARROW_SIZE*DRUNK_Z_ARROW_MAGNITUDE );
@@ -1261,13 +1261,13 @@ float ArrowEffects::GetZPos( const PlayerState* pPlayerState, int iCol, float fY
 
 	if( fEffects[PlayerOptions::EFFECT_BEAT_Z] != 0 )
 	{
-		const float fShift = data.m_fBeatFactor[dim_z]*RageFastSin( fYOffset / ((fEffects[PlayerOptions::EFFECT_BEAT_Z_PERIOD]*BEAT_Z_OFFSET_HEIGHT)+BEAT_Z_OFFSET_HEIGHT) + PI/BEAT_Z_PI_HEIGHT );
+		const float fShift = data.m_fBeatFactor[dim_z]*std::sin( fYOffset / ((fEffects[PlayerOptions::EFFECT_BEAT_Z_PERIOD]*BEAT_Z_OFFSET_HEIGHT)+BEAT_Z_OFFSET_HEIGHT) + PI/BEAT_Z_PI_HEIGHT );
 		fZPos += fEffects[PlayerOptions::EFFECT_BEAT_Z] * fShift;
 	}
 
 	if( fEffects[PlayerOptions::EFFECT_DIGITAL_Z] != 0 )
 		fZPos += (fEffects[PlayerOptions::EFFECT_DIGITAL_Z] * ARROW_SIZE * 0.5f) *
-			std::round((fEffects[PlayerOptions::EFFECT_DIGITAL_Z_STEPS]+1) * RageFastSin(
+			std::round((fEffects[PlayerOptions::EFFECT_DIGITAL_Z_STEPS]+1) * std::sin(
 				CalculateDigitalAngle(fYOffset,
 				fEffects[PlayerOptions::EFFECT_DIGITAL_Z_OFFSET],
 				fEffects[PlayerOptions::EFFECT_DIGITAL_Z_PERIOD]) ) ) /(fEffects[PlayerOptions::EFFECT_DIGITAL_Z_STEPS]+1);
@@ -1289,7 +1289,7 @@ float ArrowEffects::GetZPos( const PlayerState* pPlayerState, int iCol, float fY
 
 	if( fEffects[PlayerOptions::EFFECT_BOUNCE_Z] != 0 )
 	{
-		float fBounceAmt = std::abs( RageFastSin( ( (fYOffset + (1.0f * (fEffects[PlayerOptions::EFFECT_BOUNCE_Z_OFFSET]) ) ) /
+		float fBounceAmt = std::abs( std::sin( ( (fYOffset + (1.0f * (fEffects[PlayerOptions::EFFECT_BOUNCE_Z_OFFSET]) ) ) /
 			( 60 + (fEffects[PlayerOptions::EFFECT_BOUNCE_Z_PERIOD]*60) ) ) ) );
 
 		fZPos += fEffects[PlayerOptions::EFFECT_BOUNCE_Z] * ARROW_SIZE * 0.5f * fBounceAmt;
@@ -1365,7 +1365,7 @@ float ArrowEffects::GetZoomVariable( float fYOffset, int iCol, float fCurZoom )
 	float fZoom = fCurZoom;
 	if( curr_options->m_fEffects[PlayerOptions::EFFECT_PULSE_INNER] != 0 || curr_options->m_fEffects[PlayerOptions::EFFECT_PULSE_OUTER] != 0 )
 	{
-		float sine = RageFastSin(((fYOffset+(100.0f*(curr_options->m_fEffects[PlayerOptions::EFFECT_PULSE_OFFSET])))/(0.4f*(ARROW_SIZE+(curr_options->m_fEffects[PlayerOptions::EFFECT_PULSE_PERIOD]*ARROW_SIZE)))));
+		float sine = std::sin(((fYOffset+(100.0f*(curr_options->m_fEffects[PlayerOptions::EFFECT_PULSE_OFFSET])))/(0.4f*(ARROW_SIZE+(curr_options->m_fEffects[PlayerOptions::EFFECT_PULSE_PERIOD]*ARROW_SIZE)))));
 
 		fZoom *= (sine*(curr_options->m_fEffects[PlayerOptions::EFFECT_PULSE_OUTER]*0.5f))+GetPulseInner();
 	}

--- a/src/GraphDisplay.cpp
+++ b/src/GraphDisplay.cpp
@@ -54,8 +54,8 @@ public:
 		for( int i = 0; i < iSubdivisions+1; ++i )
 		{
 			const float fRotation = float(i) / iSubdivisions * 2*PI;
-			const float fX = RageFastCos(fRotation) * fRadius;
-			const float fY = -RageFastSin(fRotation) * fRadius;
+			const float fX = std::cos(fRotation) * fRadius;
+			const float fY = -std::sin(fRotation) * fRadius;
 			pVerts[1+i] = v;
 			pVerts[1+i].p.x += fX;
 			pVerts[1+i].p.y += fY;

--- a/src/GrooveRadar.cpp
+++ b/src/GrooveRadar.cpp
@@ -173,8 +173,8 @@ void GrooveRadar::GrooveRadarValueMap::DrawPrimitives()
 		const float fDistFromCenter =
 			( m_fValuesOld[c] * (1-m_PercentTowardNew) + m_fValuesNew[c] * m_PercentTowardNew + 0.07f ) * fRadius;
 		const float fRotation = RADAR_VALUE_ROTATION(i);
-		const float fX = RageFastCos(fRotation) * fDistFromCenter;
-		const float fY = -RageFastSin(fRotation) * fDistFromCenter;
+		const float fX = std::cos(fRotation) * fDistFromCenter;
+		const float fY = -std::sin(fRotation) * fDistFromCenter;
 
 		v[1+i].p = RageVector3( fX, fY, 0 );
 		v[1+i].c = v[1].c;
@@ -189,8 +189,8 @@ void GrooveRadar::GrooveRadarValueMap::DrawPrimitives()
 		const float fDistFromCenter =
 			( m_fValuesOld[c] * (1-m_PercentTowardNew) + m_fValuesNew[c] * m_PercentTowardNew + 0.07f ) * fRadius;
 		const float fRotation = RADAR_VALUE_ROTATION(i);
-		const float fX = RageFastCos(fRotation) * fDistFromCenter;
-		const float fY = -RageFastSin(fRotation) * fDistFromCenter;
+		const float fX = std::cos(fRotation) * fDistFromCenter;
+		const float fY = -std::sin(fRotation) * fDistFromCenter;
 
 		v[i].p = RageVector3( fX, fY, 0 );
 		v[i].c = this->m_pTempState->diffuse[0];

--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -7,7 +7,6 @@
 #include "GameState.h"
 #include "RageTimer.h"
 #include "RageLog.h"
-#include "RageMath.h"
 #include "ThemeManager.h"
 #include "NoteSkinManager.h"
 #include "Song.h"
@@ -868,7 +867,7 @@ void NoteField::DrawPrimitives()
 		ASSERT(GAMESTATE->m_pCurSong != nullptr);
 
 		const TimingData &timing = *pTiming;
-		const RageColor text_glow= RageColor(1,1,1,RageFastCos(RageTimer::GetTimeSinceStartFast()*2)/2+0.5f);
+		const RageColor text_glow= RageColor(1,1,1,std::cos(RageTimer::GetTimeSinceStartFast()*2)/2+0.5f);
 
 		float horiz_align= align_right;
 		float side_sign= 1;
@@ -1055,7 +1054,7 @@ void NoteField::DrawPrimitives()
 		*m_FieldRenderArgs.selection_end_marker != -1)
 	{
 		m_FieldRenderArgs.selection_glow= SCALE(
-			RageFastCos(RageTimer::GetTimeSinceStartFast()*2), -1, 1, 0.1f, 0.3f);
+			std::cos(RageTimer::GetTimeSinceStartFast()*2), -1, 1, 0.1f, 0.3f);
 	}
 	m_FieldRenderArgs.fade_before_targets= FADE_BEFORE_TARGETS_PERCENT;
 

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -255,8 +255,8 @@ void RageDisplay::DrawCircleInternal( const RageSpriteVertex &p, float radius )
 	for(int i = 0; i < subdivisions+1; ++i)
 	{
 		const float fRotation = float(i) / subdivisions * 2*PI;
-		const float fX = RageFastCos(fRotation) * radius;
-		const float fY = -RageFastSin(fRotation) * radius;
+		const float fX = std::cos(fRotation) * radius;
+		const float fY = -std::sin(fRotation) * radius;
 		v[1+i] = v[0];
 		v[1+i].p.x += fX;
 		v[1+i].p.y += fY;

--- a/src/RageMath.cpp
+++ b/src/RageMath.cpp
@@ -250,10 +250,10 @@ void RageMatrixRotationX( RageMatrix* pOut, float theta )
 	theta *= PI/180;
 
 	RageMatrixIdentity(pOut);
-	pOut->m[1][1] = RageFastCos(theta);
+	pOut->m[1][1] = std::cos(theta);
 	pOut->m[2][2] = pOut->m[1][1];
 
-	pOut->m[2][1] = RageFastSin(theta);
+	pOut->m[2][1] = std::sin(theta);
 	pOut->m[1][2] = -pOut->m[2][1];
 }
 
@@ -262,10 +262,10 @@ void RageMatrixRotationY( RageMatrix* pOut, float theta )
 	theta *= PI/180;
 
 	RageMatrixIdentity(pOut);
-	pOut->m[0][0] = RageFastCos(theta);
+	pOut->m[0][0] = std::cos(theta);
 	pOut->m[2][2] = pOut->m[0][0];
 
-	pOut->m[0][2] = RageFastSin(theta);
+	pOut->m[0][2] = std::sin(theta);
 	pOut->m[2][0] = -pOut->m[0][2];
 }
 
@@ -274,10 +274,10 @@ void RageMatrixRotationZ( RageMatrix* pOut, float theta )
 	theta *= PI/180;
 
 	RageMatrixIdentity(pOut);
-	pOut->m[0][0] = RageFastCos(theta);
+	pOut->m[0][0] = std::cos(theta);
 	pOut->m[1][1] = pOut->m[0][0];
 
-	pOut->m[0][1] = RageFastSin(theta);
+	pOut->m[0][1] = std::sin(theta);
 	pOut->m[1][0] = -pOut->m[0][1];
 }
 
@@ -290,12 +290,12 @@ void RageMatrixRotationXYZ( RageMatrix* pOut, float rX, float rY, float rZ )
 	rY *= PI/180;
 	rZ *= PI/180;
 
-	const float cX = RageFastCos(rX);
-	const float sX = RageFastSin(rX);
-	const float cY = RageFastCos(rY);
-	const float sY = RageFastSin(rY);
-	const float cZ = RageFastCos(rZ);
-	const float sZ = RageFastSin(rZ);
+	const float cX = std::cos(rX);
+	const float sX = std::sin(rX);
+	const float cY = std::cos(rY);
+	const float sY = std::sin(rY);
+	const float cZ = std::cos(rZ);
+	const float sZ = std::sin(rZ);
 
 	/*
 	 * X*Y:
@@ -337,8 +337,8 @@ void RageMatrixRotationXYZ( RageMatrix* pOut, float rX, float rY, float rZ )
 void RageAARotate(RageVector3* inret, RageVector3 const* axis, float angle)
 {
 	float ha= angle/2.0f;
-	float ca2= RageFastCos(ha);
-	float sa2= RageFastSin(ha);
+	float ca2= std::cos(ha);
+	float sa2= std::sin(ha);
 	RageVector4 quat(axis->x * sa2, axis->y * sa2, axis->z * sa2, ca2);
 	RageVector4 quatc(-quat.x, -quat.y, -quat.z, ca2);
 	RageVector4 point(inret->x, inret->y, inret->z, 0.0f);
@@ -378,8 +378,8 @@ RageVector4 RageQuatFromH(float theta )
 	theta *= PI/180.0f;
 	theta /= 2.0f;
 	theta *= -1;
-	const float c = RageFastCos(theta);
-	const float s = RageFastSin(theta);
+	const float c = std::cos(theta);
+	const float s = std::sin(theta);
 
 	return RageVector4(0, s, 0, c);
 }
@@ -389,8 +389,8 @@ RageVector4 RageQuatFromP(float theta )
 	theta *= PI/180.0f;
 	theta /= 2.0f;
 	theta *= -1;
-	const float c = RageFastCos(theta);
-	const float s = RageFastSin(theta);
+	const float c = std::cos(theta);
+	const float s = std::sin(theta);
 
 	return RageVector4(s, 0, 0, c);
 }
@@ -400,8 +400,8 @@ RageVector4 RageQuatFromR(float theta )
 	theta *= PI/180.0f;
 	theta /= 2.0f;
 	theta *= -1;
-	const float c = RageFastCos(theta);
-	const float s = RageFastSin(theta);
+	const float c = std::cos(theta);
+	const float s = std::sin(theta);
 
 	return RageVector4(0, 0, s, c);
 }
@@ -416,12 +416,12 @@ void RageQuatFromHPR(RageVector4* pOut, RageVector3 hpr )
 	hpr /= 180.0f;
 	hpr /= 2.0f;
 
-	const float sX = RageFastSin(hpr.x);
-	const float cX = RageFastCos(hpr.x);
-	const float sY = RageFastSin(hpr.y);
-	const float cY = RageFastCos(hpr.y);
-	const float sZ = RageFastSin(hpr.z);
-	const float cZ = RageFastCos(hpr.z);
+	const float sX = std::sin(hpr.x);
+	const float cX = std::cos(hpr.x);
+	const float sY = std::sin(hpr.y);
+	const float cY = std::cos(hpr.y);
+	const float sZ = std::sin(hpr.z);
+	const float cZ = std::cos(hpr.z);
 
 	pOut->w = cX * cY * cZ + sX * sY * sZ;
 	pOut->x = sX * cY * cZ - cX * sY * sZ;
@@ -444,12 +444,12 @@ void RageQuatFromPRH(RageVector4* pOut, RageVector3 prh )
 	/* Set cX to the cosine of the angle we want to rotate on the X axis,
 	 * and so on.  Here, hpr.z (roll) rotates on the Z axis, hpr.x (heading)
 	 * on Y, and hpr.y (pitch) on X. */
-	const float sX = RageFastSin(prh.y);
-	const float cX = RageFastCos(prh.y);
-	const float sY = RageFastSin(prh.x);
-	const float cY = RageFastCos(prh.x);
-	const float sZ = RageFastSin(prh.z);
-	const float cZ = RageFastCos(prh.z);
+	const float sX = std::sin(prh.y);
+	const float cX = std::cos(prh.y);
+	const float sY = std::sin(prh.x);
+	const float cY = std::cos(prh.x);
+	const float sZ = std::sin(prh.z);
+	const float cZ = std::cos(prh.z);
 
 	pOut->w = cX * cY * cZ + sX * sY * sZ;
 	pOut->x = sX * cY * cZ - cX * sY * sZ;
@@ -510,9 +510,9 @@ void RageQuatSlerp(RageVector4 *pOut, const RageVector4 &from, const RageVector4
 	{
 		// standard case (slerp)
 		float omega = std::acos(cosom);
-		float sinom = RageFastSin(omega);
-		scale0 = RageFastSin((1.0f - t) * omega) / sinom;
-		scale1 = RageFastSin(t * omega) / sinom;
+		float sinom = std::sin(omega);
+		scale0 = std::sin((1.0f - t) * omega) / sinom;
+		scale1 = std::sin(t * omega) / sinom;
 	}
 	else
 	{
@@ -570,12 +570,12 @@ void RageMatrixAngles( RageMatrix* pOut, const RageVector3 &angles )
 {
 	const RageVector3 angles_radians( angles * 2*PI / 360 );
 
-	const float sy = RageFastSin( angles_radians[2] );
-	const float cy = RageFastCos( angles_radians[2] );
-	const float sp = RageFastSin( angles_radians[1] );
-	const float cp = RageFastCos( angles_radians[1] );
-	const float sr = RageFastSin( angles_radians[0] );
-	const float cr = RageFastCos( angles_radians[0] );
+	const float sy = std::sin( angles_radians[2] );
+	const float cy = std::cos( angles_radians[2] );
+	const float sp = std::sin( angles_radians[1] );
+	const float cp = std::cos( angles_radians[1] );
+	const float sr = std::sin( angles_radians[0] );
+	const float cr = std::cos( angles_radians[0] );
 
 	RageMatrixIdentity( pOut );
 
@@ -597,63 +597,6 @@ void RageMatrixTranspose( RageMatrix* pOut, const RageMatrix* pIn )
 	for( int i=0; i<4; i++)
 		for( int j=0; j<4; j++)
 			pOut->m[j][i] = pIn->m[i][j];
-}
-
-static const unsigned int sine_table_size= 1024;
-static const unsigned int sine_index_mod= sine_table_size * 2;
-static const double sine_table_index_mult= static_cast<double>(sine_index_mod) / (PI*2);
-static float sine_table[sine_table_size];
-struct sine_initter
-{
-	sine_initter()
-	{
-		for(unsigned int i= 0; i < sine_table_size; ++i)
-		{
-			float angle= SCALE(i, 0, sine_table_size, 0.0f, PI);
-			sine_table[i]= std::sin(angle);
-		}
-	}
-};
-static sine_initter sinner;
-
-float RageFastSin(float angle)
-{
-	if(angle == 0) { return 0; }
-	float index= angle * sine_table_index_mult;
-	int first_index= static_cast<int>(index);
-	int second_index= (first_index + 1) % sine_index_mod;
-	float remainder= index - first_index;
-	first_index%= sine_index_mod;
-	float first= 0.0f;
-	float second= 0.0f;
-#define SET_SAMPLE(sample) \
-	if(sample##_index >= static_cast<int>(sine_table_size)) \
-	{ \
-		sample= -sine_table[sample##_index - sine_table_size]; \
-	} \
-	else \
-	{ \
-		sample= sine_table[sample##_index]; \
-	}
-	SET_SAMPLE(first);
-	SET_SAMPLE(second);
-#undef SET_SAMPLE
-	return lerp(remainder, first, second);
-}
-
-float RageFastCos( float x )
-{
-	return RageFastSin( x + 0.5f*PI );
-}
-
-float RageFastTan( float x )
-{
-	return RageFastSin( x ) / RageFastCos( x );
-}
-
-float RageFastCsc( float x )
-{
-	return 1 / RageFastSin( x );
 }
 
 float RageSquare( float angle )

--- a/src/RageMath.h
+++ b/src/RageMath.h
@@ -55,11 +55,6 @@ RageMatrix RageLookAt(
 void RageMatrixAngles( RageMatrix* pOut, const RageVector3 &angles );
 void RageMatrixTranspose( RageMatrix* pOut, const RageMatrix* pIn );
 
-float RageFastSin( float x ) CONST_FUNCTION;
-float RageFastCos( float x ) CONST_FUNCTION;
-float RageFastTan( float x ) CONST_FUNCTION;
-float RageFastCsc( float x ) CONST_FUNCTION;
-
 float RageSquare( float x) CONST_FUNCTION;
 float RageTriangle( float x) CONST_FUNCTION;
 

--- a/src/Tween.cpp
+++ b/src/Tween.cpp
@@ -33,7 +33,7 @@ struct TweenDecelerate: public ITween
 };
 struct TweenSpring: public ITween
 {
-	float Tween( float f ) const { return 1 - RageFastCos( f*PI*2.5f )/(1+f*3); }
+	float Tween( float f ) const { return 1 - std::cos( f*PI*2.5f )/(1+f*3); }
 	ITween *Copy() const { return new TweenSpring(*this); }
 };
 


### PR DESCRIPTION
We can get a nice overall performance boost by replacing some clunky code in RageMath with standard library functions.

I don't know, maybe something was different in 2016, but I'm not seeing how the RageFast___ code was faster (https://github.com/itgmania/itgmania/commit/86470b797783ea95e16a578589158a1b90e27221)

In fact, I attempted to implement a fast non-standard library method of taking the sine but could not come close to the speed of `std::sin`, even though it was faster than Kyz's method.

**This even includes purposely slowing down `std::sin` to ensure it was measurable!**

Example output of my [RageFastSin test case:](https://cpp.sh/?source=%23include+%3Ciostream%3E%0D%0A%23include+%3Ccmath%3E%0D%0A%23include+%3Cchrono%3E%0D%0A%0D%0A%23ifndef+PI%0D%0A%23define+PI+3.14159265358979323846%0D%0A%23endif%0D%0A%0D%0A%2F%2F+KYZ%27S+RAGEFASTSIN%0D%0A%23define+SCALE(x%2C+l1%2C+h1%2C+l2%2C+h2)+(((x)+-+(l1))+*+((h2)+-+(l2))+%2F+((h1)+-+(l1))+%2B+(l2))%0D%0Atemplate%3Ctypename+T%2C+typename+U%3E%0D%0Ainline+U+lerp(T+x%2C+U+l%2C+U+h)%0D%0A%7B%0D%0A++++return+U(x+*+(h+-+l)+%2B+l)%3B%0D%0A%7D%0D%0Astatic+const+unsigned+int+sine_table_size+%3D+1024%3B%0D%0Astatic+const+unsigned+int+sine_index_mod+%3D+sine_table_size+*+2%3B%0D%0Astatic+const+double+sine_table_index_mult+%3D+static_cast%3Cdouble%3E(sine_index_mod)+%2F+(PI+*+2)%3B%0D%0Astatic+float+sine_table%5Bsine_table_size%5D%3B%0D%0Astruct+SineTableInitializer+%7B%0D%0A++++SineTableInitializer()+%7B%0D%0A++++++++for+(unsigned+int+i+%3D+0%3B+i+%3C+sine_table_size%3B+%2B%2Bi)+%7B%0D%0A++++++++++++float+angle+%3D+SCALE(i%2C+0%2C+sine_table_size%2C+0.0f%2C+PI)%3B%0D%0A++++++++++++sine_table%5Bi%5D+%3D+std%3A%3Asin(angle)%3B%0D%0A++++++++%7D%0D%0A++++%7D%0D%0A%7D%3B%0D%0Astatic+SineTableInitializer+sineTableInitializer%3B%0D%0Afloat+RageFastSinKyz(float+angle)%0D%0A%7B%0D%0A++++if+(angle+%3D%3D+0)+%7B+return+0%3B+%7D%0D%0A++++float+index+%3D+angle+*+sine_table_index_mult%3B%0D%0A++++int+first_index+%3D+static_cast%3Cint%3E(index)%3B%0D%0A++++int+second_index+%3D+(first_index+%2B+1)+%25+sine_index_mod%3B%0D%0A++++float+remainder+%3D+index+-+first_index%3B%0D%0A++++first_index+%25%3D+sine_index_mod%3B%0D%0A++++float+first+%3D+0.0f%3B%0D%0A++++float+second+%3D+0.0f%3B%0D%0A%23define+SET_SAMPLE(sample)+%5C%0D%0A++++if(sample%23%23_index+%3E%3D+static_cast%3Cint%3E(sine_table_size))+%5C%0D%0A++++%7B+%5C%0D%0A++++++++sample%3D+-sine_table%5Bsample%23%23_index+-+sine_table_size%5D%3B+%5C%0D%0A++++%7D+%5C%0D%0A++++else+%5C%0D%0A++++%7B+%5C%0D%0A++++++++sample%3D+sine_table%5Bsample%23%23_index%5D%3B+%5C%0D%0A++++%7D%0D%0A++++SET_SAMPLE(first)%3B%0D%0A++++SET_SAMPLE(second)%3B%0D%0A%23undef+SET_SAMPLE%0D%0A++++return+lerp(remainder%2C+first%2C+second)%3B%0D%0A%7D%0D%0A%0D%0A%2F%2F+SUKIBABY%27S+RAGEFASTSIN%0D%0Afloat+RageFastSinSuki(float+angle)%0D%0A%7B%0D%0A++++angle+%3D+fmod(angle%2C+2+*+M_PI)%3B%0D%0A++++if+(angle+%3C+0)+angle+%2B%3D+2+*+M_PI%3B%0D%0A++++if+(angle+%3E+M_PI)+angle+-%3D+2+*+M_PI%3B%0D%0A++++const+float+B+%3D+4+%2F+M_PI%3B%0D%0A++++const+float+C+%3D+-4+%2F+(M_PI+*+M_PI)%3B%0D%0A++++float+y+%3D+B+*+angle+%2B+C+*+angle+*+std%3A%3Aabs(angle)%3B%0D%0A++++return+y%3B%0D%0A%7D%0D%0A%0D%0Aint+main()+%7B%0D%0A++++const+long+long+numIterations+%3D+5%3B%0D%0A++++float+angle+%3D+(0.69+*+2.0f+*+PI)%3B%0D%0A%0D%0A++++auto+startRageFastSinKyz+%3D+std%3A%3Achrono%3A%3Ahigh_resolution_clock%3A%3Anow()%3B%0D%0A++++for+(long+long+i+%3D+0%3B+i+%3C+numIterations%3B+%2B%2Bi)+%7B%0D%0A++++++++RageFastSinKyz(angle)%3B%0D%0A++++%7D%0D%0A++++auto+endRageFastSinKyz+%3D+std%3A%3Achrono%3A%3Ahigh_resolution_clock%3A%3Anow()%3B%0D%0A%0D%0A++++auto+startRageFastSinSuki+%3D+std%3A%3Achrono%3A%3Ahigh_resolution_clock%3A%3Anow()%3B%0D%0A++++for+(long+long+i+%3D+0%3B+i+%3C+numIterations%3B+%2B%2Bi)+%7B%0D%0A++++++++RageFastSinSuki(angle)%3B%0D%0A++++%7D%0D%0A++++auto+endRageFastSinSuki+%3D+std%3A%3Achrono%3A%3Ahigh_resolution_clock%3A%3Anow()%3B%0D%0A%0D%0A++++auto+startStdSin+%3D+std%3A%3Achrono%3A%3Ahigh_resolution_clock%3A%3Anow()%3B%0D%0A++++volatile+float+accumulator+%3D+0%3B+%2F%2F+Use+volatile+to+prevent+optimization%0D%0A++++for+(long+long+i+%3D+0%3B+i+%3C+numIterations%3B+%2B%2Bi)+%7B%0D%0A++++++++accumulator+%2B%3D+std%3A%3Asin(angle+%2B+i)%3B+%2F%2F+Slightly+vary+the+input+to+prevent+caching%0D%0A++++%7D%0D%0A++++auto+endStdSin+%3D+std%3A%3Achrono%3A%3Ahigh_resolution_clock%3A%3Anow()%3B%0D%0A++++%2F%2F+Use+the+accumulator+in+some+way+to+ensure+the+loop+isn%27t+optimized+out%0D%0A++++std%3A%3Acout+%3C%3C+%22Accumulator+(to+prevent+optimization)%3A+%22+%3C%3C+accumulator+%3C%3C+std%3A%3Aendl%3B%0D%0A%0D%0A++++auto+durationRageFastSinKyz+%3D+std%3A%3Achrono%3A%3Aduration_cast%3Cstd%3A%3Achrono%3A%3Amicroseconds%3E(endRageFastSinKyz+-+startRageFastSinKyz).count()%3B%0D%0A++++auto+durationRageFastSinSuki+%3D+std%3A%3Achrono%3A%3Aduration_cast%3Cstd%3A%3Achrono%3A%3Amicroseconds%3E(endRageFastSinSuki+-+startRageFastSinSuki).count()%3B%0D%0A++++auto+durationStdSin+%3D+std%3A%3Achrono%3A%3Aduration_cast%3Cstd%3A%3Achrono%3A%3Amicroseconds%3E(endStdSin+-+startStdSin).count()%3B%0D%0A%0D%0A++++std%3A%3Acout+%3C%3C+%22RageFastSin+(Kyz)+took+%22+%3C%3C+durationRageFastSinKyz+%3C%3C+%22+microseconds.%5Cn%22%3B%0D%0A++++std%3A%3Acout+%3C%3C+%22RageFastSin+(Sukibaby)+took+%22+%3C%3C+durationRageFastSinSuki+%3C%3C+%22+microseconds.%5Cn%22%3B%0D%0A++++std%3A%3Acout+%3C%3C+%22std%3A%3Asin+took+%22+%3C%3C+durationStdSin+%3C%3C+%22+microseconds.%5Cn%22%3B%0D%0A%0D%0A++++return+0%3B%0D%0A%7D%0D%0A)
```
Accumulator (to prevent optimization): 0.0651476
RageFastSin (Kyz) took 95 microseconds.
RageFastSin (Sukibaby) took 60 microseconds.
std::sin took 19 microseconds.
```

Example output of my [RageFastCos test case](https://cpp.sh/?source=%23include+%3Ciostream%3E%0D%0A%23include+%3Cchrono%3E%0D%0A%23include+%3Ccmath%3E%0D%0A%0D%0A%23define+SCALE(x%2C+l1%2C+h1%2C+l2%2C+h2)+(((x)+-+(l1))+*+((h2)+-+(l2))+%2F+((h1)+-+(l1))+%2B+(l2))%0D%0A%23define+PI+3.141592653589793238462643383279%0D%0A%0D%0Astatic+const+unsigned+int+sine_table_size+%3D+1024%3B%0D%0Astatic+const+unsigned+int+sine_index_mod+%3D+sine_table_size+*+2%3B%0D%0Astatic+const+double+sine_table_index_mult+%3D+static_cast%3Cdouble%3E(sine_index_mod)+%2F+(PI+*+2)%3B%0D%0Astatic+float+sine_table%5Bsine_table_size%5D%3B%0D%0A%0D%0A%2F%2F+Linear+interpolation+function%0D%0Afloat+lerp(float+t%2C+float+a%2C+float+b)+%7B%0D%0A++++return+a+%2B+t+*+(b+-+a)%3B%0D%0A%7D%0D%0A%0D%0Astruct+sine_initter+%7B%0D%0A++++sine_initter()+%7B%0D%0A++++++++for+(unsigned+int+i+%3D+0%3B+i+%3C+sine_table_size%3B+%2B%2Bi)+%7B%0D%0A++++++++++++float+angle+%3D+SCALE(i%2C+0%2C+sine_table_size%2C+0.0f%2C+PI)%3B%0D%0A++++++++++++sine_table%5Bi%5D+%3D+std%3A%3Asin(angle)%3B%0D%0A++++++++%7D%0D%0A++++%7D%0D%0A%7D%3B%0D%0Astatic+sine_initter+sinner%3B%0D%0A%0D%0Afloat+RageFastSin(float+angle)+%7B%0D%0A++++if+(angle+%3D%3D+0)+%7B+return+0%3B+%7D%0D%0A++++float+index+%3D+angle+*+sine_table_index_mult%3B%0D%0A++++int+first_index+%3D+static_cast%3Cint%3E(index)%3B%0D%0A++++int+second_index+%3D+(first_index+%2B+1)+%25+sine_index_mod%3B%0D%0A++++float+remainder+%3D+index+-+first_index%3B%0D%0A++++first_index+%25%3D+sine_index_mod%3B%0D%0A++++float+first+%3D+0.0f%3B%0D%0A++++float+second+%3D+0.0f%3B%0D%0A%23define+SET_SAMPLE(sample)+%5C%0D%0A++++if(sample%23%23_index+%3E%3D+static_cast%3Cint%3E(sine_table_size))+%5C%0D%0A++++%7B+%5C%0D%0A++++++++sample+%3D+-sine_table%5Bsample%23%23_index+-+sine_table_size%5D%3B+%5C%0D%0A++++%7D+%5C%0D%0A++++else+%5C%0D%0A++++%7B+%5C%0D%0A++++++++sample+%3D+sine_table%5Bsample%23%23_index%5D%3B+%5C%0D%0A++++%7D%0D%0A++++SET_SAMPLE(first)%3B%0D%0A++++SET_SAMPLE(second)%3B%0D%0A%23undef+SET_SAMPLE%0D%0A++++return+lerp(remainder%2C+first%2C+second)%3B%0D%0A%7D%0D%0A%0D%0Aint+main()+%7B%0D%0A++++%0D%0A++++std%3A%3Acout+%3C%3C+%22Hello%2C+World!%22+%3C%3C+std%3A%3Aendl%3B%0D%0A%0D%0A++++%2F%2F+Example+angle+to+test%0D%0A++++float+angle+%3D+0.5f%3B%0D%0A%0D%0A++++%2F%2F+Start+measuring+time%0D%0A++++auto+start+%3D+std%3A%3Achrono%3A%3Ahigh_resolution_clock%3A%3Anow()%3B%0D%0A%0D%0A++++%2F%2F+Call+the+function%0D%0A++++float+result+%3D+RageFastSin(angle)%3B%0D%0A%0D%0A++++%2F%2F+Stop+measuring+time%0D%0A++++auto+stop+%3D+std%3A%3Achrono%3A%3Ahigh_resolution_clock%3A%3Anow()%3B%0D%0A%0D%0A++++%2F%2F+Calculate+the+duration%0D%0A++++auto+duration+%3D+std%3A%3Achrono%3A%3Aduration_cast%3Cstd%3A%3Achrono%3A%3Amicroseconds%3E(stop+-+start)%3B%0D%0A%0D%0A++++%2F%2F+Print+the+result+and+the+time+taken%0D%0A++++std%3A%3Acout+%3C%3C+%22RageFastSin(%22+%3C%3C+angle+%3C%3C+%22)+%3D+%22+%3C%3C+result+%3C%3C+std%3A%3Aendl%3B%0D%0A++++std%3A%3Acout+%3C%3C+%22Time+taken%3A+%22+%3C%3C+duration.count()+%3C%3C+%22+microseconds%22+%3C%3C+std%3A%3Aendl%3B%0D%0A%0D%0A++++return+0%3B%0D%0A%7D%0D%0A):
```
std::sin(x + 0.5f * PI) = 0.877583
Time taken: 20 microseconds
std::cos(x) = 0.877583
Time taken: 1 microseconds
```

I didn't provide Godbolt links because it would show "0 microseconds" for a lot of these test cases, though I'm sure that's fixable, the main thing was I wanted to try a few different online and offline compilers to ensure the standard library functions are faster.