### PR TITLE
Implement a method to get MMSSMsMsMs timestamps via integer math

### DIFF
--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -268,7 +268,7 @@ void RageLog::Write( int where, const RString &sLine )
 		puts( sWarningSeparator );
 	}
 
-	RString sTimestamp = SecondsToMMSSMsMsMs( RageTimer::GetTimeSinceStart() ) + ": ";
+	RString sTimestamp = UsecsToMMSSMsMsMs( RageTimer::GetUsecsSinceStart() ) + ": ";
 	RString sWarning;
 	if( where & WRITE_LOUD )
 		sWarning = "WARNING: ";

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -261,6 +261,16 @@ RString SecondsToMMSSMsMsMs( float fSecs )
 	return sReturn;
 }
 
+RString UsecsToMMSSMsMsMs( std::uint64_t usecs )
+{
+	std::uint64_t totalSeconds = usecs / 1000000;
+	std::uint64_t minutes = totalSeconds / 60;
+	std::uint64_t seconds = totalSeconds % 60;
+	std::uint64_t milliseconds = (usecs % 1000000) / 1000;
+	RString result = ssprintf("%02llu:%02llu.%03llu", minutes, seconds, milliseconds);
+	return result;
+}
+
 RString SecondsToMSS( float fSecs )
 {
 	const int iMinsDisplay = static_cast<int>(fSecs/60);

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -328,6 +328,7 @@ float HHMMSSToSeconds( const RString &sHMS );
 RString SecondsToHHMMSS( float fSecs );
 RString SecondsToMSSMsMs( float fSecs );
 RString SecondsToMMSSMsMs( float fSecs );
+RString UsecsToMMSSMsMsMs( std::uint64_t usecs );
 RString SecondsToMMSSMsMsMs( float fSecs );
 RString SecondsToMSS( float fSecs );
 RString SecondsToMMSS( float fSecs );

--- a/src/ScreenDebugOverlay.cpp
+++ b/src/ScreenDebugOverlay.cpp
@@ -1319,7 +1319,7 @@ class DebugLineForceCrash : public IDebugLine
 class DebugLineUptime : public IDebugLine
 {
 	virtual RString GetDisplayTitle() { return UPTIME.GetValue(); }
-	virtual RString GetDisplayValue() { return SecondsToMMSSMsMsMs(RageTimer::GetTimeSinceStart()); }
+	virtual RString GetDisplayValue() { return UsecsToMMSSMsMsMs(RageTimer::GetUsecsSinceStart()); }
 	virtual bool IsEnabled() { return false; }
 	virtual void DoAndLog( RString &sMessageOut ) {}
 };


### PR DESCRIPTION
From top to bottom,

- Use `UsecsToMMSSMsMsMs` instead of `SecondsToMMSSMsMsMs` in RageLog.cpp
- Define `UsecsToMMSSMsMsMs` in RageUtil.cpp
- Define `UsecsToMMSSMsMsMs` in RageUtil.h
- Use `UsecsToMMSSMsMsMs` in ScreenDebugOverlap.cpp

This has considerably less overhead than the floating-point math based `SecondsToMMSSMsMsMs`.