### PR TITLE
🌠 Standalone mt19937 RNG function

### DIFF
--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -3,12 +3,12 @@
 #include "XmlFile.h"
 #include "FontManager.h"
 #include "RageLog.h"
-#include "RageTimer.h"
 #include "RageDisplay.h"
 #include "ThemeManager.h"
 #include "Font.h"
 #include "ActorUtil.h"
 #include "LuaBinding.h"
+#include "RandomSeed.h"
 
 #include <cmath>
 #include <cstddef>
@@ -330,16 +330,14 @@ void BitmapText::BuildChars()
 
 	if( m_bUsingDistortion )
 	{
-		int iSeed = std::lrint( RageTimer::GetTimeSinceStartFast()*500000.0f );
-		RandomGen rnd( iSeed );
 		for(unsigned int i= 0; i < m_aVertices.size(); i+=4)
 		{
 			float w= m_aVertices[i+2].p.x - m_aVertices[i].p.x;
 			float h= m_aVertices[i+2].p.y - m_aVertices[i].p.y;
 			for(unsigned int ioff= 0; ioff < 4; ++ioff)
 			{
-				m_aVertices[i+ioff].p.x += ((rnd()%9) / 8.0f - .5f) * m_fDistortion * w;
-				m_aVertices[i+ioff].p.y += ((rnd()%9) / 8.0f - .5f) * m_fDistortion * h;
+				m_aVertices[i+ioff].p.x += ((GetRandomInt() % 9) / 8.0f - .5f) * m_fDistortion * w;
+				m_aVertices[i+ioff].p.y += ((GetRandomInt() % 9) / 8.0f - .5f) * m_fDistortion * h;
 			}
 		}
 	}
@@ -711,7 +709,7 @@ void BitmapText::DrawPrimitives()
 		// render the diffuse pass
 		if( m_bRainbowScroll )
 		{
-			int color_index = int(RageTimer::GetTimeSinceStartFast() / 0.200) % RAINBOW_COLORS.size();
+			int color_index = (GetRandomInt() % RAINBOW_COLORS.size());
 			for( unsigned i=0; i<m_aVertices.size(); i+=4 )
 			{
 				const RageColor color = RAINBOW_COLORS[color_index];
@@ -770,12 +768,9 @@ void BitmapText::DrawPrimitives()
 		std::vector<RageVector3> vGlyphJitter;
 		if( m_bJitter )
 		{
-			int iSeed = std::lrint( RageTimer::GetTimeSinceStartFast()*8 );
-			RandomGen rnd( iSeed );
-
 			for( unsigned i=0; i<m_aVertices.size(); i+=4 )
 			{
-				RageVector3 jitter( rnd()%2, rnd()%3, 0 );
+				RageVector3 jitter( GetRandomInt() % 2, GetRandomInt() % 3, 0);
 				vGlyphJitter.push_back( jitter );
 
 				m_aVertices[i+0].p += jitter;	// top left

--- a/src/CMakeData-singletons.cmake
+++ b/src/CMakeData-singletons.cmake
@@ -45,6 +45,7 @@ list(APPEND SMDATA_GLOBAL_SINGLETON_HPP
             "NoteSkinManager.h"
             "PrefsManager.h"
             "ProfileManager.h"
+            "RandomSeed.h"
             "ScreenManager.h"
             "SongManager.h"
             "StatsManager.h"

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -2,7 +2,6 @@
 #include "Player.h"
 #include "GameConstantsAndTypes.h"
 #include "RageUtil.h"
-#include "RageTimer.h"
 #include "PrefsManager.h"
 #include "GameManager.h"
 #include "InputMapper.h"
@@ -40,6 +39,7 @@
 #include "GameCommand.h"
 #include "LocalizedString.h"
 #include "AdjustSync.h"
+#include "RandomSeed.h"
 
 #include <cmath>
 #include <cstddef>
@@ -3475,11 +3475,7 @@ RString Player::ApplyRandomAttack()
 	if( GAMESTATE->m_RandomAttacks.size() < 1 )
 		return "";
 
-	//int iAttackToUse = rand() % GAMESTATE->m_RandomAttacks.size();
-	DateTime now = DateTime::GetNowDate();
-	int iSeed = now.tm_hour * now.tm_min * now.tm_sec * now.tm_mday;
-	RandomGen rnd( GAMESTATE->m_iStageSeed * iSeed );
-	int iAttackToUse = rnd() % GAMESTATE->m_RandomAttacks.size();
+	int iAttackToUse = GetRandomInt() % GAMESTATE->m_RandomAttacks.size();
 	return GAMESTATE->m_RandomAttacks[iAttackToUse];
 }
 

--- a/src/RandomSeed.h
+++ b/src/RandomSeed.h
@@ -1,0 +1,39 @@
+#ifndef RANDOMSEED_H
+#define RANDOMSEED_H
+
+#include <random>
+#include <climits>
+
+inline int GetRandomInt()
+{
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    return std::uniform_int_distribution<int>(0, INT_MAX)(gen);
+}
+
+#endif // RANDOMSEED_H
+
+/*
+ * (c) 2024 sukibaby
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */


### PR DESCRIPTION
Several places in the code are using `RageTimer::GetTimeSinceStart` as an RNG seed.

This is bad for two reasons:

- Entropy from this value is very poor
    - with the time value as a RNG seed, Random Attacks often feels very samey, in my opinion
    - I play with Random Attacks a good amount, and I feel this change makes it a lot more random feeling
- Calls to `GetTimeSinceStart` should be reserved for things that really need it