### PR TITLE
Two new RageTimer methods (GetTimeSinceStartFast, GetSecsSinceStart)

### DIFF
--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -55,9 +55,21 @@ double RageTimer::GetTimeSinceStart(bool bAccurate)
 	return usecs / 1000000.0;
 }
 
+float RageTimer::GetTimeSinceStartFast()
+{
+	long double seconds = static_cast<long double>(GetSecsSinceStart());
+	return static_cast<float>(seconds);
+}
+
 std::uint64_t RageTimer::GetUsecsSinceStart()
 {
 	return GetTime(true) - g_iStartTime;
+}
+
+std::uint64_t RageTimer::GetSecsSinceStart()
+{
+    std::uint64_t usecs = GetTime(true) - g_iStartTime;
+    return usecs / TIMESTAMP_RESOLUTION;
 }
 
 void RageTimer::Touch()

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -24,8 +24,9 @@ public:
 	float PeekDeltaTime() const { return Ago(); }
 
 	static double GetTimeSinceStart( bool bAccurate = true );	// seconds since the program was started
-	static float GetTimeSinceStartFast() { return GetTimeSinceStart(false); }
-	static std::uint64_t GetUsecsSinceStart();
+	static float GetTimeSinceStartFast();	// same as above, but calculated with integer math
+	static std::uint64_t GetUsecsSinceStart(); // microseconds since the program was started
+	static std::uint64_t GetSecsSinceStart();  // seconds since the program was started
 
 	/* Get a timer representing half of the time ago as this one. */
 	RageTimer Half() const;


### PR DESCRIPTION
Apologies, I was going to implement these as separate PR's but decided it was best to do it all together so I've just combined them.

GetTimeSinceStartFast: previously was an alias to GetTimeSinceStart which didn't do anything, now quickly provides a very accurate float value.

GetSecsSinceStart: very fast way to get seconds since start as an integer if the conversion to floating point in GetTimeSinceStart is not needed.