### PR TITLE
RageSoundDriver_Null GetPosition() use GetUsecsSinceStart

### DIFF
--- a/src/arch/Sound/RageSoundDriver_Null.cpp
+++ b/src/arch/Sound/RageSoundDriver_Null.cpp
@@ -25,7 +25,8 @@ void RageSoundDriver_Null::Update()
 
 std::int64_t RageSoundDriver_Null::GetPosition() const
 {
-	return std::int64_t( RageTimer::GetTimeSinceStart() * m_iSampleRate );
+	uint64_t usec = RageTimer::GetUsecsSinceStart() / 1000000;
+	return static_cast<std::int64_t>(usec) * m_iSampleRate;
 }
 
 RageSoundDriver_Null::RageSoundDriver_Null()


### PR DESCRIPTION
Because doing integer math the whole time is much faster than pulling in floating point values.