### PR TITLE
Decouple the decoding of movie frames from display in ffmpeg

### DIFF
--- a/src/ActorMultiVertex.cpp
+++ b/src/ActorMultiVertex.cpp
@@ -611,7 +611,7 @@ void ActorMultiVertex::Update(float fDelta)
 	UpdateAnimationState();
 	if(!skip_this_movie_update && _decode_movie)
 	{
-		_Texture->DecodeSeconds(std::max(0.0f, time_passed));
+		_Texture->UpdateMovie(std::max(0.0f, time_passed));
 	}
 }
 

--- a/src/Banner.cpp
+++ b/src/Banner.cpp
@@ -43,7 +43,6 @@ void Banner::Load( RageTextureID ID, bool bIsBanner )
 	m_bScrolling = false;
 
 	TEXTUREMAN->DisableOddDimensionWarning();
-	TEXTUREMAN->VolatileTexture( ID );
 	Sprite::Load( ID );
 	TEXTUREMAN->EnableOddDimensionWarning();
 };

--- a/src/RageTexture.h
+++ b/src/RageTexture.h
@@ -23,7 +23,7 @@ public:
 
 	// movie texture/animated texture stuff
 	virtual void SetPosition( float /* fSeconds */ ) {} // seek
-	virtual void DecodeSeconds( float /* fSeconds */ ) {} // decode
+	virtual void UpdateMovie( float /* fSeconds */ ) {} // decode
 	virtual void SetPlaybackRate( float ) {}
 	virtual bool IsAMovie() const { return false; }
 	virtual void SetLooping(bool) { }

--- a/src/Sprite.cpp
+++ b/src/Sprite.cpp
@@ -1299,7 +1299,7 @@ public:
 	DEFINE_METHOD(GetDecodeMovie, m_DecodeMovie);
 	static int SetDecodeMovie(T* p, lua_State *L)
 	{
-		p->m_DecodeMovie= BArg(1);
+		p->m_DecodeMovie = BArg(1);
 		COMMON_RETURN_SELF;
 	}
 	static int LoadFromCached( T* p, lua_State *L )

--- a/src/Sprite.cpp
+++ b/src/Sprite.cpp
@@ -474,7 +474,7 @@ void Sprite::Update( float fDelta )
 
 	// If the texture is a movie, decode frames.
 	if(!bSkipThisMovieUpdate && m_DecodeMovie)
-		m_pTexture->DecodeSeconds( std::max(0.0f, fTimePassed) );
+		m_pTexture->UpdateMovie( std::max(0.0f, fTimePassed) );
 
 	// update scrolling
 	if( m_fTexCoordVelocityX != 0 || m_fTexCoordVelocityY != 0 )

--- a/src/arch/MovieTexture/MovieTexture_Generic.h
+++ b/src/arch/MovieTexture/MovieTexture_Generic.h
@@ -29,18 +29,10 @@ public:
 	virtual void Close() = 0;
 	virtual void Rewind() = 0;
 
-	/*
-	 * Decode a frame.  Return 1 on success, 0 on EOF, -1 on fatal error.
-	 *
-	 * If we're lagging behind the video, fTargetTime will be the target
-	 * timestamp.  The decoder may skip frames to catch up.  On return,
-	 * the current timestamp must be <= fTargetTime.
-	 *
-	 * Otherwise, fTargetTime will be -1, and the next frame should be
-	 * decoded; skip frames only if necessary to recover from errors.
-	 */
-	virtual int DecodeFrame(int frameNumber) = 0;
-	virtual void DecodeMovie() = 0;
+	// Decode the next frame.
+	// Return 1 on success, 0 on EOF, -1 on fatal error, -2 on cancel.
+	virtual int DecodeNextFrame() = 0;
+	virtual int DecodeMovie() = 0;
 
 	// Returns true if the frame we want to display has been decoded already.
 	virtual bool IsCurrentFrameReady() = 0;
@@ -102,7 +94,10 @@ public:
 	virtual void Reload();
 
 	virtual void SetPosition( float fSeconds );
-	virtual void DecodeSeconds( float fSeconds );
+	// UpdateMovie tells the MovieTexture to update the displayed frame based
+	// on fSeconds passed in. (e.g., 5.9 input means show the frame that should
+	// be displayed 5.9 seconds into the movie).
+	virtual void UpdateMovie( float fSeconds );
 	virtual void SetPlaybackRate( float fRate ) { m_fRate = fRate; }
 	void SetLooping( bool bLooping=true ) { m_bLoop = bLooping; }
 	std::uintptr_t GetTexHandle() const;
@@ -116,6 +111,9 @@ private:
 
 	float m_fRate;
 	bool m_bLoop;
+
+	// If true, halts all decoding and display.
+	bool m_failure = false;
 
 	std::uintptr_t m_uTexHandle;
 	RageTextureRenderTarget *m_pRenderTarget;


### PR DESCRIPTION
This PR is not intended to be merged in it's entirety. It will be broken up for easier review. See below,
* https://github.com/itgmania/itgmania/pull/363
* https://github.com/itgmania/itgmania/pull/371
* https://github.com/itgmania/itgmania/pull/378
* https://github.com/itgmania/itgmania/pull/385

Marked in-progress while I clean this up.

This PR overhauls the ffmpeg movie decoder to decouple the decoding from display. It creates a frame buffer for the whole movie, and begins decoding to it in a separate thread in  `MovieTexture_Generic::Init`.

Some implementation notes.
* Removing the VolatileTexture load in `Banner::Load` as it causes an extraneous load and unload on the banner file.
* This PR changes the default behavior of video banners in the song wheel to always try and load until the destructor is called. In practice, the game keeps the last three songs loaded on the song wheel--meaning there could be wasted cycles until the movie texture is destroyed.
* There is an existing issue with the offset of movie banners looping not matching the preview music. This is still unfixed, but a default 0.5 second delay in the movie looping seems to help.
* Not every video file gives us a (correct) frame count. To compensate, approximation logic was added, and when the decoder hits the end of the file, it is corrected in code. The total frames are only used to know when to loop the video, and as a quick optimization when initializing the buffer.
* There is an artificial rate limit of 1000fps on decoding. This is to prevent long videos (the bee movie chart) from completely destroying ITGm's framerate by decoding as fast as possible. This might need to be configurable for low performance machines.
* The FrameHolder does have a mutex, though I wouldn't expect it to be 100% necessary given decoding should be faster than display. It's more of a sanity check than anything else.

Some potential TODOs still:
* Limit the memory consumption of the buffer, since we may get extremely large or long videos.
* Fix the looping offset properly in the song wheel.
* There is a small bug, where in SL on the overall session results screen, if the final song had a video banner, the playback speed is uncapped on that particular banner. It's likely related to the banner not unloading/rewinding properly during the screen transition, but I haven't been able to trace it all the way