### PR TITLE
Integer-based time keeping⌚🔥

### DIFF
--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -919,7 +919,7 @@ void Actor::UpdateInternal(float delta_time)
 		}
 		break;
 	case CLOCK_TIMER_GLOBAL:
-		generic_global_timer_update(RageTimer::GetUsecsSinceStart(), m_fEffectDelta, m_fSecsIntoEffect);
+		generic_global_timer_update(RageTimer::deltaMicrosecondsAsUnsigned(), m_fEffectDelta, m_fSecsIntoEffect);
 		break;
 	case CLOCK_BGM_BEAT:
 		generic_global_timer_update(g_fCurrentBGMBeat, m_fEffectDelta, m_fSecsIntoEffect);

--- a/src/Inventory.cpp
+++ b/src/Inventory.cpp
@@ -132,8 +132,8 @@ void Inventory::Update( float fDelta )
 		GAMESTATE->m_Position.m_fSongBeat < song.GetLastBeat() )
 	{
 		// every 1 seconds, try to use an item
-		int iLastSecond = (int)(RageTimer::GetTimeSinceStartFast() - fDelta);
-		int iThisSecond = (int)RageTimer::GetTimeSinceStartFast();
+		std::uint64_t iLastSecond = RageTimer::deltaSecondsAsUnsigned() - static_cast<uint64_t>(fDelta);
+		std::uint64_t iThisSecond = RageTimer::deltaSecondsAsUnsigned();
 		if( iLastSecond != iThisSecond )
 		{
 			for( int s=0; s<NUM_INVENTORY_SLOTS; s++ )

--- a/src/LightsManager.cpp
+++ b/src/LightsManager.cpp
@@ -217,8 +217,8 @@ void LightsManager::Update( float fDeltaTime )
 
 		case LIGHTSMODE_ATTRACT:
 		{
-			int iSec = (int)RageTimer::GetTimeSinceStartFast();
-			int iTopIndex = iSec % 4;
+			std::uint64_t iSec = RageTimer::deltaSecondsAsUnsigned();
+			std::uint64_t iTopIndex = iSec % 4;
 
 			// Aldo: Disabled this line, apparently it was a forgotten initialization
 			//CabinetLight cl = CabinetLight_Invalid;

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -984,7 +984,7 @@ void MusicWheel::readyWheelItemsData(SortOrder so) {
 		if (so != SORT_PREFERRED) {
 			m_WheelItemDatasStatus[so]=VALID;
 		}
-		LOG->Trace( "MusicWheel sorting took: %f", timer.GetTimeSinceStart() );
+		LOG->Trace( "MusicWheel sorting took: %f", timer.GetDeltaTime() );
 	}
 
 }

--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -268,7 +268,7 @@ void RageLog::Write( int where, const RString &sLine )
 		puts( sWarningSeparator );
 	}
 
-	RString sTimestamp = SecondsToMMSSMsMsMs( RageTimer::GetTimeSinceStart() ) + ": ";
+	RString sTimestamp = DeltaToMMSSMsMsMs( RageTimer::deltaMicrosecondsAsSigned() ) + ": ";
 	RString sWarning;
 	if( where & WRITE_LOUD )
 		sWarning = "WARNING: ";

--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -15,6 +15,7 @@
 #include "RageTimer.h"
 #include "RageLog.h"
 #include "RageUtil.h"
+#include <cinttypes>
 
 #include <cerrno>
 #include <cstdint>
@@ -662,7 +663,7 @@ LockMutex::LockMutex( RageMutex &pMutex, const char *file_, int line_ ):
 	mutex( pMutex ),
 	file( file_ ),
 	line( line_ ),
-	locked_at( RageTimer::GetTimeSinceStart() ),
+	locked_at( RageTimer::deltaMicrosecondsAsSigned() ),
 	locked(false) // ensure it gets locked inside.
 {
 	mutex.Lock();
@@ -684,9 +685,9 @@ void LockMutex::Unlock()
 
 	if( file && locked_at != -1 )
 	{
-		const float dur = RageTimer::GetTimeSinceStart() - locked_at;
-		if( dur > 0.015f )
-			LOG->Trace( "Lock at %s:%i took %f", file, line, dur );
+		const std::int64_t dur = RageTimer::deltaMicrosecondsAsSigned() - locked_at;
+		if( dur > 15000 ) // 0.015 seconds
+			LOG->Trace( "Lock at %s:%" PRId64 " took %" PRId64, file, line, dur );
 	}
 }
 

--- a/src/RageThreads.h
+++ b/src/RageThreads.h
@@ -127,8 +127,8 @@ class LockMutex
 	RageMutex &mutex;
 
 	const char *file;
-	int line;
-	float locked_at;
+	std::int64_t line;
+	std::int64_t locked_at;
 	bool locked;
 
 public:

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -23,9 +23,23 @@ public:
 	/* (alias) */
 	float PeekDeltaTime() const { return Ago(); }
 
-	static double GetTimeSinceStart( bool bAccurate = true );	// seconds since the program was started
-	static float GetTimeSinceStartFast() { return GetTimeSinceStart(false); }
-	static std::uint64_t GetUsecsSinceStart();
+	// Time storage variables
+		// Time since the program was started in seconds.
+		static double GetTimeSinceStart( bool bAccurate = true );
+		static float GetTimeSinceStartFast( bool bAccurate = true );
+		static std::uint64_t deltaSecondsAsUnsigned();
+		static std::int64_t deltaSecondsAsSigned();
+
+		// Time since the program was started in microseconds.
+		static std::uint64_t deltaMicrosecondsAsUnsigned();
+		static std::int64_t deltaMicrosecondsAsSigned();
+
+		/* The following is a "time since start" RageTimer. Splitting the seconds and
+		 * microseconds values into two integers and combining them later allows for
+		 * better precision. Use caution when changing data types, since resolution
+		 * mismatch errors are easy to cause when changing things in RageTimer. */
+		std::uint64_t m_secs, m_us;
+	// End time storage variables
 
 	/* Get a timer representing half of the time ago as this one. */
 	RageTimer Half() const;
@@ -41,12 +55,6 @@ public:
 
 	bool operator<( const RageTimer &rhs ) const;
 
-	/* The following is a "time since start" RageTimer. Splitting the seconds and
-	 * microseconds values into two integers and combining them later allows for
-	 * better precision. Use caution when changing data types, since resolution
-	 * mismatch errors are easy to cause when changing things in RageTimer. */
-	std::uint64_t m_secs, m_us;
-
 private:
 	static RageTimer Sum( const RageTimer &lhs, float tm );
 	static double Difference( const RageTimer &lhs, const RageTimer &rhs );
@@ -55,10 +63,10 @@ private:
 extern const RageTimer RageZeroTimer;
 
 // For profiling how long some chunk of code takes. -Kyz
-#define START_TIME(name) std::uint64_t name##_start_time= RageTimer::GetUsecsSinceStart();
+#define START_TIME(name) std::uint64_t name##_start_time= RageTimer::deltaMicrosecondsAsUnsigned();
 #define START_TIME_CALL_COUNT(name) START_TIME(name); ++name##_call_count;
-#define END_TIME(name) std::uint64_t name##_end_time= RageTimer::GetUsecsSinceStart();  LOG->Time(#name " time: %zu to %zu = %zu", name##_start_time, name##_end_time, name##_end_time - name##_start_time);
-#define END_TIME_ADD_TO(name) std::uint64_t name##_end_time= RageTimer::GetUsecsSinceStart();  name##_total += name##_end_time - name##_start_time;
+#define END_TIME(name) std::uint64_t name##_end_time= RageTimer::deltaMicrosecondsAsUnsigned();  LOG->Time(#name " time: %zu to %zu = %zu", name##_start_time, name##_end_time, name##_end_time - name##_start_time);
+#define END_TIME_ADD_TO(name) std::uint64_t name##_end_time= RageTimer::deltaMicrosecondsAsUnsigned();  name##_total += name##_end_time - name##_start_time;
 #define END_TIME_CALL_COUNT(name) END_TIME_ADD_TO(name); ++name##_end_count;
 
 #define DECL_TOTAL_TIME(name) extern std::uint64_t name##_total;

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -226,6 +226,26 @@ float HHMMSSToSeconds( const RString &sHHMMSS )
 	return fSeconds;
 }
 
+RString DeltaToMMSSMsMs(std::int64_t fMicrosecs)
+{
+    const std::int64_t fSecs = fMicrosecs / 1000000;
+    const std::int64_t iMinsDisplay = fSecs / 60;
+    const std::int64_t iSecsDisplay = fSecs % 60; 
+    const std::int64_t iLeftoverDisplay = (fMicrosecs / 10000) % 100;
+    RString sReturn = ssprintf("%02lld:%02lld.%02lld", iMinsDisplay, iSecsDisplay, iLeftoverDisplay);
+    return sReturn;
+}
+
+RString DeltaToMMSSMsMsMs(std::int64_t fMicrosecs)
+{
+    const std::int64_t fSecs = fMicrosecs / 1000000;
+    const std::int64_t iMinsDisplay = fSecs / 60;
+    const std::int64_t iSecsDisplay = fSecs % 60; 
+    const std::int64_t iLeftoverDisplay = (fMicrosecs / 1000) % 1000;
+    RString sReturn = ssprintf("%02lld:%02lld.%03lld", iMinsDisplay, iSecsDisplay, iLeftoverDisplay);
+    return sReturn;
+}
+
 RString SecondsToHHMMSS(float fSecs)
 {
 	const int iMinsDisplay = static_cast<int>(fSecs / 60);

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -325,6 +325,8 @@ RString BinaryToHex( const RString &sString );
 bool HexToBinary( const RString &s, unsigned char *stringOut );
 bool HexToBinary( const RString &s, RString *sOut );
 float HHMMSSToSeconds( const RString &sHMS );
+RString DeltaToMMSSMsMs(std::int64_t fMicrosecs);
+RString DeltaToMMSSMsMsMs(std::int64_t fMicrosecs);
 RString SecondsToHHMMSS( float fSecs );
 RString SecondsToMSSMsMs( float fSecs );
 RString SecondsToMMSSMsMs( float fSecs );

--- a/src/ScreenDebugOverlay.cpp
+++ b/src/ScreenDebugOverlay.cpp
@@ -1319,7 +1319,7 @@ class DebugLineForceCrash : public IDebugLine
 class DebugLineUptime : public IDebugLine
 {
 	virtual RString GetDisplayTitle() { return UPTIME.GetValue(); }
-	virtual RString GetDisplayValue() { return SecondsToMMSSMsMsMs(RageTimer::GetTimeSinceStart()); }
+	virtual RString GetDisplayValue() { return DeltaToMMSSMsMsMs(RageTimer::deltaMicrosecondsAsSigned()); }
 	virtual bool IsEnabled() { return false; }
 	virtual void DoAndLog( RString &sMessageOut ) {}
 };

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -48,9 +48,9 @@ static Preference<float> g_iDefaultRecordLength( "DefaultRecordLength", 4 );
 static Preference<bool> g_bEditorShowBGChangesPlay( "EditorShowBGChangesPlay", true );
 
 /** @brief How long must the button be held to generate a hold in record mode? */
-const float record_hold_default= 0.3f;
-float record_hold_seconds = record_hold_default;
-const float time_between_autosave= 300.0f; // 5 minutes. -Kyz
+const std::int64_t record_hold_default= 0.3;
+std::int64_t record_hold_seconds = record_hold_default;
+const std::int64_t time_between_autosave= 300; // 5 minutes. -Kyz
 
 #define PLAYER_X		(SCREEN_CENTER_X)
 #define PLAYER_Y		(SCREEN_CENTER_Y)
@@ -1667,7 +1667,7 @@ void ScreenEdit::Update( float fDeltaTime )
 	if(m_EditState == STATE_EDITING)
 	{
 		if(IsDirty() && m_next_autosave_time > -1.0f &&
-			RageTimer::GetTimeSinceStartFast() > m_next_autosave_time)
+			RageTimer::deltaSecondsAsSigned() > m_next_autosave_time)
 		{
 			PerformSave(true);
 		}
@@ -4362,7 +4362,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 	else if( SM == SM_AutoSaveSuccessful )
 	{
 		LOG->Trace("AutoSave successful.");
-		m_next_autosave_time= RageTimer::GetTimeSinceStartFast() + time_between_autosave;
+		m_next_autosave_time= RageTimer::deltaSecondsAsSigned() + time_between_autosave;
 		SCREENMAN->SystemMessage(AUTOSAVE_SUCCESSFUL);
 	}
 	else if( SM == SM_SaveFailed ) // save failed; stay in the editor
@@ -4438,19 +4438,19 @@ void ScreenEdit::SetDirty(bool dirty)
 	if(EDIT_MODE.GetValue() != EditMode_Full)
 	{
 		m_dirty= false;
-		m_next_autosave_time= -1.0f;
+		m_next_autosave_time= -1;
 		return;
 	}
 	if(dirty)
 	{
 		if(!m_dirty)
 		{
-			m_next_autosave_time= RageTimer::GetTimeSinceStartFast() + time_between_autosave;
+			m_next_autosave_time= RageTimer::deltaSecondsAsSigned() + time_between_autosave;
 		}
 	}
 	else
 	{
-		m_next_autosave_time= -1.0f;
+		m_next_autosave_time= -1;
 	}
 	m_dirty= dirty;
 }

--- a/src/ScreenEdit.h
+++ b/src/ScreenEdit.h
@@ -340,7 +340,7 @@ protected:
 
 	/** @brief Has the NoteData been changed such that a user should be prompted to save? */
 	bool			m_dirty;
-	float m_next_autosave_time;
+	std::int64_t	m_next_autosave_time;
 
 	/** @brief The sound that is played when a note is added. */
 	RageSound		m_soundAddNote;

--- a/src/ScreenStatsOverlay.cpp
+++ b/src/ScreenStatsOverlay.cpp
@@ -125,7 +125,7 @@ void ScreenStatsOverlay::UpdateSkips()
 
 	if( skip )
 	{
-		RString sTime( SecondsToMMSSMsMs(RageTimer::GetTimeSinceStartFast()) );
+		RString sTime( DeltaToMMSSMsMs(RageTimer::deltaMicrosecondsAsSigned()) );
 
 		static const RageColor colors[] =
 		{

--- a/src/WheelNotifyIcon.cpp
+++ b/src/WheelNotifyIcon.cpp
@@ -87,7 +87,7 @@ void WheelNotifyIcon::Update( float fDeltaTime )
 		 * insert flag icons based on "priority". Easy to do, hopefully
 			- Midiman */
 		const float fSecondFraction = std::fmod( RageTimer::GetTimeSinceStartFast(), 1 );
-		const int index = (int)(fSecondFraction*m_vIconsToShow.size());
+		const int index = static_cast<int>(fSecondFraction * m_vIconsToShow.size());
 		Sprite::SetState( m_vIconsToShow[index] );
 	}
 

--- a/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
@@ -292,8 +292,8 @@ void RageSoundDriver::Update()
 //		LOG->Trace("set (#%i) %p from STOPPING to HALTING", i, m_Sounds[i].m_pSound);
 	}
 
-	static float fNext = 0;
-	if( RageTimer::GetTimeSinceStart() >= fNext )
+	static std::uint64_t fNext = 0;
+	if( RageTimer::deltaMicrosecondsAsUnsigned() >= fNext )
 	{
 		/* Lockless: only Mix() can write to underruns. */
 		int current_underruns = underruns;
@@ -305,7 +305,7 @@ void RageSoundDriver::Update()
 
 			/* Don't log again for at least a second, or we'll burst output
 			 * and possibly cause more underruns. */
-			fNext = RageTimer::GetTimeSinceStart() + 1;
+			fNext = RageTimer::deltaMicrosecondsAsUnsigned() + 1000000;
 		}
 	}
 

--- a/src/arch/Sound/RageSoundDriver_Null.cpp
+++ b/src/arch/Sound/RageSoundDriver_Null.cpp
@@ -25,7 +25,9 @@ void RageSoundDriver_Null::Update()
 
 std::int64_t RageSoundDriver_Null::GetPosition() const
 {
-	return std::int64_t( RageTimer::GetTimeSinceStart() * m_iSampleRate );
+	std::int64_t usec = RageTimer::deltaSecondsAsSigned();
+	std::int64_t sampleRate = static_cast<int64_t>(m_iSampleRate);
+	return usec * sampleRate;
 }
 
 RageSoundDriver_Null::RageSoundDriver_Null()


### PR DESCRIPTION
# Closing in favor of Wallclock.h


### The core idea of this PR is to use an integer-based clock in the game anywhere possible. 

### I've combined all the aforementioned PR's in #377 so anyone can test or patch it on top of their build.


We get the time in microseconds very precisely as a 64-bit integer, but then the game's sync stability hinges on the accurate conversion of that integer to floating point, as it's typically called via `GetTimeSinceStart`, and this value is then stored as a float. It's a significant amount of accuracy loss and data type conversions. In order to resolve these issues, we can directly utilize the value of microseconds as an integer which we get via **ArchHooks** or use a value of seconds derived via integer math.

I've evaluated everywhere `GetTimeSinceStart`, `GetUsecsSinceStart` or `GetTimeSinceStartFast` is being used. I came to the conclusion it's more appropriate to use the microseconds value directly in most cases. Certain places do require a floating-point value. They are typically calling `GetTimeSinceStartFast` in places where higher accuracy is not needed.

I've moved instances of `GetTimeSinceStart` being used as an RNG seed with calls to a new lightweight mt19937 implementation in PR #358.

### The major changes

- **RageTimer** gets new features `deltaSecondsAsUnsigned`, `deltaSecondsAsSigned`, and `deltaMicrosecondsAsSigned` (`deltaMicrosecondsAsUnsigned` is not a new function but is a new name for `GetUsecsSinceStart` in order to fit new the naming scheme). These return `std::int64_t` or `std_uint64_t`, respectively.
   -  A major advantage of these functions is the ability for time-critical functions to use this very low cost and accurate way to get the system time value to use in time difference measurements. Setting up a RageTimer for measuring time differences takes longer and is based on an arbitrary position in time with an unknown priority. This way, time critical functions can make time difference calculations more efficiently and with relevance to the same clock the game is using.
 - **RageThreads**, **ScreenEdit** and **RageSoundDriver_Generic_Software**, and **RageSoundDriver_Null** use the time since start internally, so it's a performance improvement as well as an accuracy improvement to go from `float` to `std::uint64_t` here.

- **RageUtil** gets two new functions to generate more accurate MMSSMsMs / MMSSMsMsMs timestamps directly from the microseconds value with lower overhead.
  - Files affected only by this are: RageLog.cpp, ScreenDebugOverlay.cpp, and ScreenStatsOverlay.cpp
  - ![image](https://github.com/user-attachments/assets/585e3b3c-ebbd-4298-bfd9-59d510dc9dfa)


### Other RageTimer adjustments in this PR

 1. I made constants called `USEC_TO_SEC_AS_INTEGER`, `UEC_TO_SEC_AS_FLOAT` and `USEC_TO_SEC_AS_DOUBLE` to ensure math is being done in the expected resolution.
2. I changed `GetTime` and `g_iStartTime` from `std::uint64_t` to `std::int64_t` to match the type ArchHooks is returning.
3. A couple instances of `std::int64_t` missing its `std::` prefix and a C style cast I hadn't noticed before are fixed now.
4. I made `g_iStartTime` a const variable.
5. In **RageTimer.h**, I put all the time storage variables/functions together for clarity.

### Smaller changes worth noting

  - In **WheelNotifyIcon.cpp**, I replaced a C style cast with a static cast. I had to dig back 22 years in commit history to determine when this command got added, and while I feel like it probably is used to generate some degree of randomness, I'm not confident enough to replace it at this time.
  - **MusicWheel.cpp** was incorrectly calling `GetTimeSinceStart` when it should have been calling `GetDeltaTime` - this is fixed now.
  - `cinttypes` is included in **RageThreads.cpp** to make use of the `PRId64` macro