### PR TITLE
Add FrameHolder struct and logic around finding totalFrames of movies. Rename DecodeSeconds->UpdateMovie.

### DIFF
--- a/src/ActorMultiVertex.cpp
+++ b/src/ActorMultiVertex.cpp
@@ -611,7 +611,7 @@ void ActorMultiVertex::Update(float fDelta)
 	UpdateAnimationState();
 	if(!skip_this_movie_update && _decode_movie)
 	{
-		_Texture->DecodeSeconds(std::max(0.0f, time_passed));
+		_Texture->UpdateMovie(std::max(0.0f, time_passed));
 	}
 }
 

--- a/src/RageTexture.h
+++ b/src/RageTexture.h
@@ -23,7 +23,7 @@ public:
 
 	// movie texture/animated texture stuff
 	virtual void SetPosition( float /* fSeconds */ ) {} // seek
-	virtual void DecodeSeconds( float /* fSeconds */ ) {} // decode
+	virtual void UpdateMovie( float /* fSeconds */ ) {} // decode and update
 	virtual void SetPlaybackRate( float ) {}
 	virtual bool IsAMovie() const { return false; }
 	virtual void SetLooping(bool) { }

--- a/src/Sprite.cpp
+++ b/src/Sprite.cpp
@@ -474,7 +474,7 @@ void Sprite::Update( float fDelta )
 
 	// If the texture is a movie, decode frames.
 	if(!bSkipThisMovieUpdate && m_DecodeMovie)
-		m_pTexture->DecodeSeconds( std::max(0.0f, fTimePassed) );
+		m_pTexture->UpdateMovie( std::max(0.0f, fTimePassed) );
 
 	// update scrolling
 	if( m_fTexCoordVelocityX != 0 || m_fTexCoordVelocityY != 0 )

--- a/src/arch/MovieTexture/MovieTexture_Generic.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Generic.cpp
@@ -413,7 +413,7 @@ float MovieTexture_Generic::CheckFrameTime()
 }
 
 /* Decode data. */
-void MovieTexture_Generic::DecodeSeconds( float fSeconds )
+void MovieTexture_Generic::UpdateMovie( float fSeconds )
 {
 	m_fClock += fSeconds * m_fRate;
 

--- a/src/arch/MovieTexture/MovieTexture_Generic.h
+++ b/src/arch/MovieTexture/MovieTexture_Generic.h
@@ -92,7 +92,7 @@ public:
 	virtual void Reload();
 
 	virtual void SetPosition( float fSeconds );
-	virtual void DecodeSeconds( float fSeconds );
+	virtual void UpdateMovie( float fSeconds );
 	virtual void SetPlaybackRate( float fRate ) { m_fRate = fRate; }
 	void SetLooping( bool bLooping=true ) { m_bLoop = bLooping; }
 	std::uintptr_t GetTexHandle() const;


### PR DESCRIPTION
The FrameHolder struct is intended hold pre-decoded frames and their related data.

Total frames is intended to be used for pre-allocating space for a buffer to hold these FrameHolders.

DecodeSeconds is renamed to more accurately reflect what it's doing, as future changes will remove the "decoding" aspect from it.

See https://github.com/itgmania/itgmania/pull/361 for full context.