### PR TITLE
Fix two small RageFile bugs

### DIFF
--- a/src/RageFileDriverDirect.cpp
+++ b/src/RageFileDriverDirect.cpp
@@ -40,7 +40,7 @@ static struct FileDriverEntry_DIRRO: public FileDriverEntry
 } const g_RegisterDriver2;
 
 RageFileDriverDirect::RageFileDriverDirect( const RString &sRoot ):
-	RageFileDriver( new DirectFilenameDB(sRoot) )
+	RageFileDriver( new DirectFilenameDB(sRoot) ), m_sRoot(sRoot)
 {
 	Remount( sRoot );
 }
@@ -158,7 +158,7 @@ bool RageFileDriverDirect::Move( const RString &sOldPath_, const RString &sNewPa
 
 bool RageFileDriverDirect::Remove( const RString &sPath_ )
 {
-	if( m_sRoot == "(empty)" )
+	if( m_sRoot.empty() || m_sRoot == "(empty)")
 	{
 		return false;
 	}

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -716,16 +716,13 @@ bool RageFileManager::Mount( const RString &sType, const RString &sRoot_, const 
 	RageFileDriver *pDriver = MakeFileDriver( sType, sRoot );
 	if( pDriver == nullptr )
 	{
-		CHECKPOINT_M( ssprintf("Can't mount unknown VFS type \"%s\", root \"%s\"", sType.c_str(), sRoot.c_str() ) );
-
-		if( LOG )
-			LOG->Warn("Can't mount unknown VFS type \"%s\", root \"%s\"", sType.c_str(), sRoot.c_str() );
-		else
-			fprintf( stderr, "Can't mount unknown VFS type \"%s\", root \"%s\"\n", sType.c_str(), sRoot.c_str() );
+		const RString errorMsg = ssprintf("Can't mount unknown VFS type \"%s\", root \"%s\"", sType.c_str(), sRoot.c_str());
+		CHECKPOINT_M( errorMsg );
+		LOG->Warn( "%s", errorMsg.c_str() );
 		return false;
 	}
 
-	CHECKPOINT_M("Driver %s successfully made.");
+	CHECKPOINT_M("Driver successfully made.");
 
 	LoadedDriver *pLoadedDriver = new LoadedDriver;
 	pLoadedDriver->m_pDriver = pDriver;


### PR DESCRIPTION
1) Initialize `m_sRoot` with the value of `sRoot`. This is because `m_sRoot` is defined at compile time, and as it stands, nothing changes the value of m_sRoot, meaning it will always return the path the game was compiled at. 

2) Not really a bug, but improved check if m_sRoot is empty.

3) Fix a semi-broken logging method in RageFileManager.