### PR TITLE
Port ColumnCues calculations to game engine

### DIFF
--- a/src/CMakeData-data.cmake
+++ b/src/CMakeData-data.cmake
@@ -52,12 +52,14 @@ source_group("Data Structures\\\\Courses and Trails"
 list(APPEND SM_DATA_NOTEDATA_SRC
             "NoteData.cpp"
             "NoteDataUtil.cpp"
-            "NoteDataWithScoring.cpp")
+            "NoteDataWithScoring.cpp"
+            "ColumnCues.cpp")
 
 list(APPEND SM_DATA_NOTEDATA_HPP
             "NoteData.h"
             "NoteDataUtil.h"
-            "NoteDataWithScoring.h")
+            "NoteDataWithScoring.h"
+            "ColumnCues.h")
 
 source_group("Data Structures\\\\Note Data"
              FILES

--- a/src/ColumnCues.cpp
+++ b/src/ColumnCues.cpp
@@ -26,13 +26,13 @@ void ColumnCue::CalculateColumnCues(const NoteData &in, std::vector<ColumnCue> &
 			curr_row = curr_note.Row();
 		}
 
-		if (curr_note->type == TapNoteType_Tap || curr_note->type == TapNoteType_HoldHead)
+		
+		if (curr_note->type == TapNoteType_Tap
+			|| curr_note->type == TapNoteType_HoldHead
+			|| curr_note->type == TapNoteType_Mine
+			|| curr_note->type == TapNoteType_Lift)
 		{
-			currentCue.columns.push_back(ColumnCueColumn(curr_note.Track() + 1, false));
-		}
-		else if(curr_note->type == TapNoteType_Mine)
-		{
-			currentCue.columns.push_back(ColumnCueColumn(curr_note.Track() + 1, true));
+			currentCue.columns.push_back(ColumnCueColumn(curr_note.Track() + 1, curr_note->type));
 		}
 		
 		++curr_note;

--- a/src/ColumnCues.cpp
+++ b/src/ColumnCues.cpp
@@ -1,0 +1,61 @@
+#include "global.h"
+#include "ColumnCues.h"
+#include "GameState.h"
+#include "NoteData.h"
+#include "TimingData.h"
+
+void ColumnCue::CalculateColumnCues(const NoteData &in, std::vector<ColumnCue> &out, float minDuration)
+{
+	TimingData *timing = GAMESTATE->GetProcessedTimingData();
+	NoteData::all_tracks_const_iterator curr_note = in.GetTapNoteRangeAllTracks(0, MAX_NOTE_ROW);
+	int curr_row = -1;
+
+	std::vector<ColumnCue> allColumnCues;
+	ColumnCue currentCue = ColumnCue();
+
+	while (!curr_note.IsAtEnd())
+	{
+		if(curr_note.Row() != curr_row)
+		{
+			if (currentCue.startTime != -1 )
+			{
+				allColumnCues.push_back(currentCue);
+			}
+			currentCue = ColumnCue();
+			currentCue.startTime = timing->GetElapsedTimeFromBeat(NoteRowToBeat(curr_note.Row()));
+			curr_row = curr_note.Row();
+		}
+
+		if (curr_note->type == TapNoteType_Tap || curr_note->type == TapNoteType_HoldHead)
+		{
+			currentCue.columns.push_back(ColumnCueColumn(curr_note.Track() + 1, false));
+		}
+		else if(curr_note->type == TapNoteType_Mine)
+		{
+			currentCue.columns.push_back(ColumnCueColumn(curr_note.Track() + 1, true));
+		}
+		
+		++curr_note;
+	}
+
+	// If there's a remaining columnCue from the last row, add it
+	if( currentCue.startTime != -1)
+	{
+		allColumnCues.push_back(currentCue);
+	}
+
+	float previousCueTime = 0;
+	std::vector<ColumnCue> columnCues;
+	for( ColumnCue columnCue : allColumnCues )
+	{
+		float duration = columnCue.startTime - previousCueTime;
+		if( duration > minDuration || previousCueTime == 0)
+		{
+			columnCues.push_back(ColumnCue(previousCueTime, duration, columnCue.columns));
+		}
+		previousCueTime = columnCue.startTime;
+	}
+
+	out.clear();
+	out.assign(columnCues.begin(), columnCues.end());
+}

--- a/src/ColumnCues.cpp
+++ b/src/ColumnCues.cpp
@@ -1,7 +1,6 @@
 #include "global.h"
 #include "ColumnCues.h"
 #include "GameState.h"
-#include "NoteData.h"
 #include "TimingData.h"
 
 void ColumnCue::CalculateColumnCues(const NoteData &in, std::vector<ColumnCue> &out, float minDuration)

--- a/src/ColumnCues.h
+++ b/src/ColumnCues.h
@@ -1,0 +1,51 @@
+#ifndef COLUMN_CUES_H
+#define COLUMN_CUES_H
+
+#include "GameConstantsAndTypes.h"
+class NoteData;
+
+/* ColumnCues are used to indicate to the player which column the next note will occur
+ after a long gap in the stepchart.
+ This info is made available to the theme via lua functions in Steps.cpp
+ */
+struct ColumnCueColumn
+{
+	int colNum;
+	bool isMine;
+	ColumnCueColumn()
+	{
+		colNum = 0;
+		isMine = false;
+	}
+	ColumnCueColumn(int c, bool m)
+	{
+		colNum = c;
+		isMine = m;
+	}
+};
+
+struct ColumnCue
+{
+	float startTime;
+	float duration;
+	std::vector<ColumnCueColumn> columns;
+
+	ColumnCue()
+	{
+		startTime = -1;
+		duration = -1;
+	}
+
+	ColumnCue(float s, float d, std::vector<ColumnCueColumn> c)
+	{
+		startTime = s;
+		duration = d;
+		columns.assign(c.begin(), c.end());
+	}
+	/** @brief Calculates the set of ColumnCues for the given NoteData. Each "cue" is for any note that has a
+	 * minimum of minDuration seconds between it and the previous note on that same column.
+	*/
+	static void CalculateColumnCues(const NoteData &in, std::vector<ColumnCue> &out, float minDuration);
+};
+
+#endif

--- a/src/ColumnCues.h
+++ b/src/ColumnCues.h
@@ -3,8 +3,7 @@
 
 #include "GameConstantsAndTypes.h"
 #include "NoteTypes.h"
-
-class NoteData;
+#include "NoteData.h"
 
 /* ColumnCues are used to indicate to the player which column the next note will occur
  after a long gap in the stepchart.

--- a/src/ColumnCues.h
+++ b/src/ColumnCues.h
@@ -2,6 +2,8 @@
 #define COLUMN_CUES_H
 
 #include "GameConstantsAndTypes.h"
+#include "NoteTypes.h"
+
 class NoteData;
 
 /* ColumnCues are used to indicate to the player which column the next note will occur
@@ -11,16 +13,16 @@ class NoteData;
 struct ColumnCueColumn
 {
 	int colNum;
-	bool isMine;
+	TapNoteType noteType;
 	ColumnCueColumn()
 	{
 		colNum = 0;
-		isMine = false;
+		noteType = TapNoteType_Invalid;
 	}
-	ColumnCueColumn(int c, bool m)
+	ColumnCueColumn(int c, TapNoteType n)
 	{
 		colNum = c;
-		isMine = m;
+		noteType = n;
 	}
 };
 

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -844,8 +844,8 @@ public:
 				lua_pushinteger(L, cues[i].columns[c].colNum);
 				lua_settable(L, -3);
 
-				lua_pushstring(L, "isMine");
-				lua_pushboolean(L, cues[i].columns[c].isMine);
+				lua_pushstring(L, "noteType");
+				lua_pushinteger(L, cues[i].columns[c].noteType);
 				lua_settable(L, -3);
 
 				lua_rawseti(L, -2, c + 1);

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -9,6 +9,7 @@
 #include "Difficulty.h"
 #include "RageUtil_AutoPtr.h"
 #include "TimingData.h"
+#include "ColumnCues.h"
 
 #include <vector>
 
@@ -210,6 +211,8 @@ public:
 	{
 		return join(":", this->m_sAttackString);
 	}
+    
+    std::vector<ColumnCue> GetColumnCues(float minDuration);
 
 private:
 	inline const Steps *Real() const		{ return parent ? parent : this; }


### PR DESCRIPTION
This ports the ColumnCues calculations from [SimplyLove](https://github.com/Simply-Love/Simply-Love-SM5/blob/affce8d2406de715bdf60bd002df857bdc43f4fa/Scripts/SL-ChartParser.lua#L386), and provides access to them through a Lua method `Steps:GetColumnCues()`.

I've included a patch for `ColumnCues.lua` so that you can test this and make sure it functions as expected.
[columncues-patch.txt](https://github.com/user-attachments/files/16355198/columncues-patch.txt)
