### PR TITLE
Port Tech Counts, Measure Info to game engine (oh and also a whole algorithm for predicting player position)

### DIFF
--- a/src/CMakeData-data.cmake
+++ b/src/CMakeData-data.cmake
@@ -53,13 +53,15 @@ list(APPEND SM_DATA_NOTEDATA_SRC
             "NoteData.cpp"
             "NoteDataUtil.cpp"
             "NoteDataWithScoring.cpp"
-            "ColumnCues.cpp")
+            "ColumnCues.cpp"
+            "MeasureInfo.cpp")
 
 list(APPEND SM_DATA_NOTEDATA_HPP
             "NoteData.h"
             "NoteDataUtil.h"
             "NoteDataWithScoring.h"
-            "ColumnCues.h")
+            "ColumnCues.h"
+            "MeasureInfo.h")
 
 source_group("Data Structures\\\\Note Data"
              FILES

--- a/src/CMakeData-data.cmake
+++ b/src/CMakeData-data.cmake
@@ -54,14 +54,22 @@ list(APPEND SM_DATA_NOTEDATA_SRC
             "NoteDataUtil.cpp"
             "NoteDataWithScoring.cpp"
             "ColumnCues.cpp"
-            "MeasureInfo.cpp")
+            "TechCounts.cpp"
+            "MeasureInfo.cpp"
+            "StepParityGenerator.cpp"
+            "StepParityDatastructs.cpp"
+            "StepParityCost.cpp")
 
 list(APPEND SM_DATA_NOTEDATA_HPP
             "NoteData.h"
             "NoteDataUtil.h"
             "NoteDataWithScoring.h"
             "ColumnCues.h"
-            "MeasureInfo.h")
+            "TechCounts.h"
+            "MeasureInfo.h"
+            "StepParityGenerator.h"
+            "StepParityDatastructs.h"
+            "StepParityCost.h")
 
 source_group("Data Structures\\\\Note Data"
              FILES

--- a/src/GameConstantsAndTypes.cpp
+++ b/src/GameConstantsAndTypes.cpp
@@ -15,8 +15,6 @@
 #include <vector>
 
 
-RString StepsTypeToString( StepsType st );
-
 static std::vector<RString> GenerateRankingToFillInMarker()
 {
 	std::vector<RString> vRankings;

--- a/src/GameConstantsAndTypes.h
+++ b/src/GameConstantsAndTypes.h
@@ -120,6 +120,8 @@ enum StepsType
 };
 LuaDeclareType( StepsType );
 
+RString StepsTypeToString( StepsType st );
+
 /** @brief The various play modes available. */
 enum PlayMode
 {

--- a/src/MeasureInfo.cpp
+++ b/src/MeasureInfo.cpp
@@ -1,0 +1,133 @@
+#include "global.h"
+#include "MeasureInfo.h"
+#include "NoteData.h"
+#include "RageLog.h"
+#include "LocalizedString.h"
+#include "LuaBinding.h"
+#include "TimingData.h"
+#include "GameState.h"
+
+
+RString MeasureInfo::ToString() const
+{
+	std::vector<RString> asMeasureInfo;
+	for (unsigned i = 0; i < npsPerMeasure.size(); i++)
+	{
+		asMeasureInfo.push_back(ssprintf("%.6f", npsPerMeasure[i]));
+	}
+
+	for (unsigned i = 0; i < notesPerMeasure.size(); i++)
+	{
+		asMeasureInfo.push_back(ssprintf("%d", notesPerMeasure[i]));
+	}
+
+	return join(",", asMeasureInfo);
+}
+
+void MeasureInfo::FromString(RString sValues)
+{
+	std::vector<RString> asValues;
+	split( sValues, ",", asValues, true );
+	int half_size = static_cast<int>(asValues.size()) / 2;
+
+	float peak_nps = 0;
+	for (int i = 0; i < half_size; i++)
+	{
+		float nps = StringToFloat(asValues[i]);
+		this->npsPerMeasure.push_back(nps);
+		if(nps > peak_nps)
+		{
+			peak_nps = nps;
+		}
+	}
+	for (unsigned i = half_size; i < asValues.size(); i++)
+	{
+		this->notesPerMeasure.push_back(StringToInt(asValues[i]));
+	}
+	this->measureCount = half_size;
+	this->peakNps = peak_nps;
+}
+
+void MeasureInfo::CalculateMeasureInfo(const NoteData &in, MeasureInfo &out)
+{
+	int lastRow = in.GetLastRow();
+	int lastRowMeasureIndex = 0;
+	int lastRowBeatIndex = 0;
+	int lastRowRemainder = 0;
+	TimingData *timing = GAMESTATE->GetProcessedTimingData();
+	timing->NoteRowToMeasureAndBeat(lastRow, lastRowMeasureIndex, lastRowBeatIndex, lastRowRemainder);
+
+	int totalMeasureCount = lastRowMeasureIndex + 1;
+	
+	out.notesPerMeasure.clear();
+	out.npsPerMeasure.clear();
+	
+	out.notesPerMeasure.resize(totalMeasureCount, 0);
+	out.npsPerMeasure.resize(totalMeasureCount, 0);
+	
+	NoteData::all_tracks_const_iterator curr_note = in.GetTapNoteRangeAllTracks(0, MAX_NOTE_ROW);
+
+	int iMeasureIndexOut = 0;
+	int iBeatIndexOut = 0;
+	int iRowsRemainder = 0;
+
+	float peak_nps = 0;
+	int curr_row = -1;
+	int notes_this_row = 0;
+
+	while (!curr_note.IsAtEnd())
+	{
+		if(curr_note.Row() != curr_row)
+		{
+			// Before moving on to a new row, update the row count for the "current" measure
+			// Note that we're only add
+			out.notesPerMeasure[iMeasureIndexOut] += notes_this_row;
+			// Update iMeasureIndex for the current row
+			timing->NoteRowToMeasureAndBeat(curr_note.Row(), iMeasureIndexOut, iBeatIndexOut, iRowsRemainder);
+			curr_row = curr_note.Row();
+			notes_this_row = 0;
+		}
+		// Update tap and mine count for the current measure
+		// Regardless of how many notes are on this row, it's only considered 1 "note" when we want to
+		// calculate nps. So jumps/brackets don't inflate the nps value. Maybe we should call it
+		// "steps per second" or something like that?
+		if (curr_note->type == TapNoteType_Tap || curr_note->type == TapNoteType_HoldHead)
+		{
+			notes_this_row = 1;
+		}
+		++curr_note;
+	}
+	
+	// And handle the final note...
+	out.notesPerMeasure[iMeasureIndexOut] += notes_this_row;
+
+	// Now that all of the notes have been parsed, calculate nps for each measure
+	for (int m = 0; m < totalMeasureCount; m++)
+	{
+		if(out.notesPerMeasure[m] == 0)
+		{
+			out.npsPerMeasure[m] = 0;
+			continue;
+		}
+		
+		float measureDuration = timing->GetElapsedTimeFromBeat(4 * (m+1)) - timing->GetElapsedTimeFromBeat(4 * m);
+		float nps = out.notesPerMeasure[m] / measureDuration;
+		
+		if(measureDuration < 0.12)
+		{
+			out.npsPerMeasure[m] = 0;
+		}
+		else
+		{
+			out.npsPerMeasure[m] = nps;
+		}
+
+		if(nps > peak_nps)
+		{
+			peak_nps = nps;
+		}
+	}
+
+	out.peakNps = peak_nps;
+	out.measureCount = totalMeasureCount;
+}

--- a/src/MeasureInfo.cpp
+++ b/src/MeasureInfo.cpp
@@ -13,7 +13,7 @@ RString MeasureInfo::ToString() const
 	std::vector<RString> asMeasureInfo;
 	for (unsigned i = 0; i < npsPerMeasure.size(); i++)
 	{
-		asMeasureInfo.push_back(ssprintf("%.6f", npsPerMeasure[i]));
+		asMeasureInfo.push_back(ssprintf("%.3f", npsPerMeasure[i]));
 	}
 
 	for (unsigned i = 0; i < notesPerMeasure.size(); i++)

--- a/src/MeasureInfo.cpp
+++ b/src/MeasureInfo.cpp
@@ -34,7 +34,7 @@ void MeasureInfo::FromString(const RString& sValues)
 	for (int i = 0; i < half_size; i++)
 	{
 		float nps = StringToFloat(asValues[i]);
-		this->npsPerMeasure.push_back(nps);
+		npsPerMeasure.push_back(nps);
 		if(nps > peak_nps)
 		{
 			peak_nps = nps;
@@ -42,10 +42,10 @@ void MeasureInfo::FromString(const RString& sValues)
 	}
 	for (unsigned i = half_size; i < asValues.size(); i++)
 	{
-		this->notesPerMeasure.push_back(StringToInt(asValues[i]));
+		notesPerMeasure.push_back(StringToInt(asValues[i]));
 	}
-	this->measureCount = half_size;
-	this->peakNps = peak_nps;
+	measureCount = half_size;
+	peakNps = peak_nps;
 }
 
 void MeasureInfo::CalculateMeasureInfo(const NoteData &in, MeasureInfo &out)
@@ -79,18 +79,16 @@ void MeasureInfo::CalculateMeasureInfo(const NoteData &in, MeasureInfo &out)
 	{
 		if(curr_note.Row() != curr_row)
 		{
-			// Before moving on to a new row, update the row count for the "current" measure
-			// Note that we're only add
+			// Before moving on to a new row, update the notes per measure for the current measure.
 			out.notesPerMeasure[iMeasureIndexOut] += notes_this_row;
 			// Update iMeasureIndex for the current row
 			timing->NoteRowToMeasureAndBeat(curr_note.Row(), iMeasureIndexOut, iBeatIndexOut, iRowsRemainder);
 			curr_row = curr_note.Row();
 			notes_this_row = 0;
 		}
-		// Update tap and mine count for the current measure
+		
 		// Regardless of how many notes are on this row, it's only considered 1 "note" when we want to
-		// calculate nps. So jumps/brackets don't inflate the nps value. Maybe we should call it
-		// "steps per second" or something like that?
+		// calculate nps. So jumps/brackets don't inflate the nps value.
 		if (curr_note->type == TapNoteType_Tap || curr_note->type == TapNoteType_HoldHead)
 		{
 			notes_this_row = 1;
@@ -112,6 +110,20 @@ void MeasureInfo::CalculateMeasureInfo(const NoteData &in, MeasureInfo &out)
 		
 		float measureDuration = timing->GetElapsedTimeFromBeat(4 * (m+1)) - timing->GetElapsedTimeFromBeat(4 * m);
 		float nps = out.notesPerMeasure[m] / measureDuration;
+		
+		// FIXME: We subtract the time at the current measure from the time at the next measure to determine
+		// the duration of this measure in seconds, and use that to calculate notes per second.
+		//
+		// Measures *normally* occur over some positive quantity of seconds.  Measures that use warps,
+		// negative BPMs, and negative stops are normally reported by the SM5 engine as having a duration
+		// of 0 seconds, and when that happens, we safely assume that there were 0 notes in that measure.
+		//
+		// This doesn't always hold true.  Measures 48 and 49 of "Mudkyp Korea/Can't Nobody" use a properly
+		// timed negative stop, but the engine reports them as having very small but positive durations
+		// which erroneously inflates the notes per second calculation.
+		//
+		// As a hold over for this case, we check that the duration is <= 0.12 (instead of 0), so this only
+		// breaks for cases where charts are of 2,000 BPM (which are likely rarer than those with warps).
 		
 		if(measureDuration < 0.12)
 		{

--- a/src/MeasureInfo.cpp
+++ b/src/MeasureInfo.cpp
@@ -24,7 +24,7 @@ RString MeasureInfo::ToString() const
 	return join(",", asMeasureInfo);
 }
 
-void MeasureInfo::FromString(RString sValues)
+void MeasureInfo::FromString(const RString& sValues)
 {
 	std::vector<RString> asValues;
 	split( sValues, ",", asValues, true );

--- a/src/MeasureInfo.h
+++ b/src/MeasureInfo.h
@@ -1,0 +1,37 @@
+#ifndef MEASURE_INFO_H
+#define MEASURE_INFO_H
+
+#include "GameConstantsAndTypes.h"
+class NoteData;
+
+/** This is a container for per-measure stats of a stepchart.
+ This data is calculated and saved to the song cache files as the #MEASUREINFO tag.
+ This data is provided to the theme via lua functions in Steps.cpp and Trail.cpp,
+ */
+
+struct MeasureInfo
+{
+	int measureCount;
+	float peakNps;
+	std::vector<float> npsPerMeasure;
+	std::vector<int> notesPerMeasure;
+
+	MeasureInfo()
+	{
+		Zero();
+	}
+	
+	void Zero()
+	{
+		measureCount = 0;
+		peakNps = 0;
+		npsPerMeasure.clear();
+		notesPerMeasure.clear();
+	}
+
+	RString ToString() const;
+	void FromString( RString sValues );
+	static void CalculateMeasureInfo(const NoteData &in, MeasureInfo &out);
+};
+
+#endif

--- a/src/MeasureInfo.h
+++ b/src/MeasureInfo.h
@@ -2,7 +2,7 @@
 #define MEASURE_INFO_H
 
 #include "GameConstantsAndTypes.h"
-class NoteData;
+#include "NoteData.h"
 
 /** This is a container for per-measure stats of a stepchart.
  This data is calculated and saved to the song cache files as the #MEASUREINFO tag.
@@ -30,7 +30,7 @@ struct MeasureInfo
 	}
 
 	RString ToString() const;
-	void FromString( RString sValues );
+	void FromString(const RString& sValues );
 	static void CalculateMeasureInfo(const NoteData &in, MeasureInfo &out);
 };
 

--- a/src/NoteData.cpp
+++ b/src/NoteData.cpp
@@ -545,6 +545,17 @@ int NoteData::GetNumRowsWithTap( int iStartIndex, int iEndIndex ) const
 	return iNumNotes;
 }
 
+int NoteData::GetNumMinesInRow(int iRow) const
+{
+	int iNumMines = 0;
+	for( int t=0; t<GetNumTracks(); t++ )
+	{
+		if (this->IsMine(GetTapNote(t, iRow), iRow))
+			iNumMines++;
+	}
+	return iNumMines;
+}
+
 int NoteData::GetNumMines( int iStartIndex, int iEndIndex ) const
 {
 	int iNumMines = 0;

--- a/src/NoteData.h
+++ b/src/NoteData.h
@@ -310,7 +310,8 @@ public:
 	int GetNumTapNotes( int iStartIndex = 0, int iEndIndex = MAX_NOTE_ROW ) const;
 	int GetNumTapNotesNoTiming( int iStartIndex = 0, int iEndIndex = MAX_NOTE_ROW ) const;
 	int GetNumTapNotesInRow( int iRow ) const;
-	int GetNumMines( int iStartIndex = 0, int iEndIndex = MAX_NOTE_ROW ) const;
+	int GetNumMinesInRow( int iRow ) const;
+    int GetNumMines( int iStartIndex = 0, int iEndIndex = MAX_NOTE_ROW ) const;
 	int GetNumRowsWithTap( int iStartIndex = 0, int iEndIndex = MAX_NOTE_ROW ) const;
 	int GetNumRowsWithTapOrHoldHead( int iStartIndex = 0, int iEndIndex = MAX_NOTE_ROW ) const;
 	/* Optimization: for the default of start to end, use the second (faster). XXX: Second what? -- Steve */

--- a/src/NoteData.h
+++ b/src/NoteData.h
@@ -311,7 +311,7 @@ public:
 	int GetNumTapNotesNoTiming( int iStartIndex = 0, int iEndIndex = MAX_NOTE_ROW ) const;
 	int GetNumTapNotesInRow( int iRow ) const;
 	int GetNumMinesInRow( int iRow ) const;
-    int GetNumMines( int iStartIndex = 0, int iEndIndex = MAX_NOTE_ROW ) const;
+	int GetNumMines( int iStartIndex = 0, int iEndIndex = MAX_NOTE_ROW ) const;
 	int GetNumRowsWithTap( int iStartIndex = 0, int iEndIndex = MAX_NOTE_ROW ) const;
 	int GetNumRowsWithTapOrHoldHead( int iStartIndex = 0, int iEndIndex = MAX_NOTE_ROW ) const;
 	/* Optimization: for the default of start to end, use the second (faster). XXX: Second what? -- Steve */

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -383,6 +383,30 @@ void SetRadarValues(StepsTagInfo& info)
 	}
 	info.ssc_format= true;
 }
+
+void SetMeasureInfo(StepsTagInfo& info)
+{
+	if (info.from_cache || info.for_load_edit)
+	{
+		std::vector<RString> values;
+		split((*info.params)[1], "|", values, true);
+
+		MeasureInfo v[NUM_PLAYERS];
+		FOREACH_PlayerNumber(pn)
+		{
+			v[pn].FromString(values[pn]);
+			
+		}
+		info.steps->SetCachedMeasureInfo(v);
+	}
+	else
+	{
+		// just recalc at time.
+	}
+	info.ssc_format= true;
+}
+
+
 void SetCredit(StepsTagInfo& info)
 {
 	info.steps->SetCredit((*info.params)[1]);
@@ -623,6 +647,8 @@ struct ssc_parser_helper_t
 		steps_tag_handlers["SCROLLS"]= &SetStepsScrolls;
 		steps_tag_handlers["FAKES"]= &SetStepsFakes;
 		steps_tag_handlers["LABELS"]= &SetStepsLabels;
+		steps_tag_handlers["MEASUREINFO"] = &SetMeasureInfo;
+		
 		/* If this is called, the chart does not use the same attacks
 		 * as the Song's timing. No other changes are required. */
 		steps_tag_handlers["ATTACKS"]= &SetStepsAttacks;

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -419,7 +419,6 @@ void SetMeasureInfo(StepsTagInfo& info)
 		FOREACH_PlayerNumber(pn)
 		{
 			v[pn].FromString(values[pn]);
-			
 		}
 		info.steps->SetCachedMeasureInfo(v);
 	}

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -430,16 +430,6 @@ void SetMeasureInfo(StepsTagInfo& info)
 	info.ssc_format= true;
 }
 
-void SetGrooveStatsHash(StepsTagInfo& info)
-{
-	if (info.from_cache || info.for_load_edit)
-	{
-		RString value = (*info.params)[1];
-		info.steps->SetCachedGrooveStatsHash(value);
-	}
-	info.ssc_format = true;
-}
-
 void SetCredit(StepsTagInfo& info)
 {
 	info.steps->SetCredit((*info.params)[1]);

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -384,6 +384,30 @@ void SetRadarValues(StepsTagInfo& info)
 	info.ssc_format= true;
 }
 
+void SetTechCounts(StepsTagInfo& info)
+{
+	if (info.from_cache || info.for_load_edit)
+	{
+		std::vector<RString> values;
+		split((*info.params)[1], ",", values, true);
+		std::size_t cats_per_player= values.size() / NUM_PlayerNumber;
+		TechCounts v[NUM_PLAYERS];
+		FOREACH_PlayerNumber(pn)
+		{
+			for(std::size_t i= 0; i < cats_per_player; ++i)
+			{
+				v[pn][i]= StringToFloat(values[pn * cats_per_player + i]);
+			}
+		}
+		info.steps->SetCachedTechCounts(v);
+	}
+	else
+	{
+		// just recalc at time.
+	}
+	info.ssc_format= true;
+}
+
 void SetMeasureInfo(StepsTagInfo& info)
 {
 	if (info.from_cache || info.for_load_edit)
@@ -406,6 +430,15 @@ void SetMeasureInfo(StepsTagInfo& info)
 	info.ssc_format= true;
 }
 
+void SetGrooveStatsHash(StepsTagInfo& info)
+{
+	if (info.from_cache || info.for_load_edit)
+	{
+		RString value = (*info.params)[1];
+		info.steps->SetCachedGrooveStatsHash(value);
+	}
+	info.ssc_format = true;
+}
 
 void SetCredit(StepsTagInfo& info)
 {
@@ -647,8 +680,9 @@ struct ssc_parser_helper_t
 		steps_tag_handlers["SCROLLS"]= &SetStepsScrolls;
 		steps_tag_handlers["FAKES"]= &SetStepsFakes;
 		steps_tag_handlers["LABELS"]= &SetStepsLabels;
+		steps_tag_handlers["TECHCOUNTS"] = &SetTechCounts;
 		steps_tag_handlers["MEASUREINFO"] = &SetMeasureInfo;
-		
+
 		/* If this is called, the chart does not use the same attacks
 		 * as the Song's timing. No other changes are required. */
 		steps_tag_handlers["ATTACKS"]= &SetStepsAttacks;

--- a/src/NotesLoaderSSC.h
+++ b/src/NotesLoaderSSC.h
@@ -34,6 +34,8 @@ const float VERSION_CHART_NAME_TAG = 0.74f;
 const float VERSION_CACHE_SWITCH_TAG = 0.77f;
 /** @brief The version where note count was added as a radar category. */
 const float VERSION_RADAR_NOTECOUNT = 0.83f;
+/** @brief The version where tech stats, measure stats, and GrooveStats key were added. */
+const float VERSION_TECH_STATS = 0.84f;
 
 /**
  * @brief The SSCLoader handles all of the parsing needed for .ssc files.

--- a/src/NotesLoaderSSC.h
+++ b/src/NotesLoaderSSC.h
@@ -34,8 +34,6 @@ const float VERSION_CHART_NAME_TAG = 0.74f;
 const float VERSION_CACHE_SWITCH_TAG = 0.77f;
 /** @brief The version where note count was added as a radar category. */
 const float VERSION_RADAR_NOTECOUNT = 0.83f;
-/** @brief The version where tech stats, measure stats, and GrooveStats key were added. */
-const float VERSION_TECH_STATS = 0.84f;
 
 /**
  * @brief The SSCLoader handles all of the parsing needed for .ssc files.

--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -428,6 +428,14 @@ static RString GetSSCNoteData( const Song &song, const Steps &in, bool bSavingCa
 	}
 	if (bSavingCache)
 	{
+		std::vector<RString> asMeasureInfo;
+		FOREACH_PlayerNumber( pn )
+		{
+			const MeasureInfo &ms = in.GetMeasureInfo(pn);
+			asMeasureInfo.push_back(ms.ToString());
+		}
+		lines.push_back(ssprintf("#MEASUREINFO:%s;", join("|", asMeasureInfo).c_str()));
+		
 		lines.push_back(ssprintf("#STEPFILENAME:%s;", in.GetFilename().c_str()));
 	}
 	else

--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -428,6 +428,18 @@ static RString GetSSCNoteData( const Song &song, const Steps &in, bool bSavingCa
 	}
 	if (bSavingCache)
 	{
+		lines.push_back( ssprintf( "// step cache tags:" ) );
+		std::vector<RString> asTechCounts;
+		FOREACH_PlayerNumber( pn )
+		{
+			const TechCounts &ts = in.GetTechCounts(pn);
+			FOREACH_ENUM( TechCountsCategory, tc )
+			{
+				asTechCounts.push_back(ssprintf("%.6f", ts[tc]));
+			}
+		}
+		lines.push_back(ssprintf("#TECHCOUNTS:%s;", join(",", asTechCounts).c_str()));
+
 		std::vector<RString> asMeasureInfo;
 		FOREACH_PlayerNumber( pn )
 		{
@@ -435,8 +447,14 @@ static RString GetSSCNoteData( const Song &song, const Steps &in, bool bSavingCa
 			asMeasureInfo.push_back(ms.ToString());
 		}
 		lines.push_back(ssprintf("#MEASUREINFO:%s;", join("|", asMeasureInfo).c_str()));
+
+		// MV: #STEPFILENAME has to be at the end of the cache tags,
+		// because it's used in SSCLoader::LoadFromSimfile to determine when
+		// to switch the state back to GETTING_SONG_INFO, which means any tags
+		// after it will be ignored.
 		
 		lines.push_back(ssprintf("#STEPFILENAME:%s;", in.GetFilename().c_str()));
+		lines.push_back( ssprintf( "// end step cache tags" ) );
 	}
 	else
 	{

--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -446,7 +446,8 @@ static RString GetSSCNoteData( const Song &song, const Steps &in, bool bSavingCa
 			const MeasureInfo &ms = in.GetMeasureInfo(pn);
 			asMeasureInfo.push_back(ms.ToString());
 		}
-		lines.push_back(ssprintf("#MEASUREINFO:%s;", join("|", asMeasureInfo).c_str()));
+		RString allMeasureInfo = "#MEASUREINFO:" + join("|", asMeasureInfo) + ";";
+		lines.push_back(allMeasureInfo);
 
 		// NOTE(MV): #STEPFILENAME has to be at the end of the cache tags,
 		// because it's used in SSCLoader::LoadFromSimfile to determine when

--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -448,7 +448,7 @@ static RString GetSSCNoteData( const Song &song, const Steps &in, bool bSavingCa
 		}
 		lines.push_back(ssprintf("#MEASUREINFO:%s;", join("|", asMeasureInfo).c_str()));
 
-		// MV: #STEPFILENAME has to be at the end of the cache tags,
+		// NOTE(MV): #STEPFILENAME has to be at the end of the cache tags,
 		// because it's used in SSCLoader::LoadFromSimfile to determine when
 		// to switch the state back to GETTING_SONG_INFO, which means any tags
 		// after it will be ignored.

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -3436,7 +3436,7 @@ void ScreenEdit::TransitionEditState( EditState em )
 			Steps* pSteps = GAMESTATE->m_pCurSteps[main_player_];
 			ASSERT(pSteps != nullptr);
 			pSteps->SetNoteData(m_NoteDataEdit);
-			m_pSong->ReCalculateRadarValuesAndLastSecond();
+			m_pSong->ReCalculateStepStatsAndLastSecond();
 
 			// TODO: Background videos don't support seeking, when they do, make sure
 			// to load the appropriate part of the video.
@@ -4470,7 +4470,7 @@ void ScreenEdit::PerformSave(bool autosave)
 				ASSERT( m_pSteps->IsAnEdit() );
 
 				RString sError;
-				m_pSteps->CalculateRadarValues( m_pSong->m_fMusicLengthSeconds );
+				m_pSteps->CalculateStepStats( m_pSong->m_fMusicLengthSeconds );
 				if( !NotesWriterSM::WriteEditFileToMachine(m_pSong, m_pSteps, sError) )
 				{
 					ScreenPrompt::Prompt( SM_None, sError );

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -51,7 +51,7 @@
  * @brief The internal version of the cache for StepMania.
  *
  * Increment this value to invalidate the current cache. */
-const int FILE_CACHE_VERSION = 227;
+const int FILE_CACHE_VERSION = 232;
 
 /** @brief How long does a song sample last by default? */
 const float DEFAULT_MUSIC_SAMPLE_LENGTH = 12.f;

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -51,7 +51,7 @@
  * @brief The internal version of the cache for StepMania.
  *
  * Increment this value to invalidate the current cache. */
-const int FILE_CACHE_VERSION = 232;
+const int FILE_CACHE_VERSION = 228;
 
 /** @brief How long does a song sample last by default? */
 const float DEFAULT_MUSIC_SAMPLE_LENGTH = 12.f;

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -1110,7 +1110,7 @@ void Song::TidyUpData( bool from_cache, bool /* duringCache */ )
 
 	/* Generate these before we autogen notes, so the new notes can inherit
 	 * their source's values. */
-	ReCalculateRadarValuesAndLastSecond(from_cache, true);
+	ReCalculateStepStatsAndLastSecond(from_cache, true);
 	// If the music length is suspiciously shorter than the last second, adjust
 	// the length.  This prevents the ogg patch from setting a false length. -Kyz
 	if(m_fMusicLengthSeconds < lastSecond - 10.0f)
@@ -1131,13 +1131,15 @@ void Song::TranslateTitles()
 						m_sMainTitleTranslit, m_sSubTitleTranslit, m_sArtistTranslit );
 }
 
-void Song::ReCalculateRadarValuesAndLastSecond(bool fromCache, bool duringCache)
+void Song::ReCalculateStepStatsAndLastSecond(bool fromCache, bool duringCache)
 {
 	if( fromCache && this->GetFirstSecond() >= 0 && this->GetLastSecond() > 0 )
 	{
 		// this is loaded from cache, then we just have to calculate the radar values.
 		for( unsigned i=0; i<m_vpSteps.size(); i++ )
-			m_vpSteps[i]->CalculateRadarValues( m_fMusicLengthSeconds );
+		{
+			m_vpSteps[i]->CalculateStepStats( m_fMusicLengthSeconds );
+		}
 		return;
 	}
 
@@ -1148,9 +1150,8 @@ void Song::ReCalculateRadarValuesAndLastSecond(bool fromCache, bool duringCache)
 	for( unsigned i=0; i<m_vpSteps.size(); i++ )
 	{
 		Steps* pSteps = m_vpSteps[i];
-
-		pSteps->CalculateRadarValues( m_fMusicLengthSeconds );
-
+		pSteps->CalculateStepStats(m_fMusicLengthSeconds);
+		
 		// Must initialize before the gotos.
 		NoteData tempNoteData;
 		pSteps->GetNoteData( tempNoteData );
@@ -1214,7 +1215,7 @@ void Song::Save(bool autosave)
 {
 	LOG->Trace( "Song::SaveToSongFile()" );
 
-	ReCalculateRadarValuesAndLastSecond();
+	ReCalculateStepStatsAndLastSecond();
 	TranslateTitles();
 
 	// Save the new files. These calls make backups on their own.

--- a/src/Song.h
+++ b/src/Song.h
@@ -108,11 +108,11 @@ public:
 	void TidyUpData( bool fromCache = false, bool duringCache = false );
 
 	/**
-	 * @brief Get the new radar values, and determine the last second at the same time.
+	 * @brief Get the new step stats, and determine the last second at the same time.
 	 * This is called by TidyUpData, after saving the Song.
 	 * @param fromCache was this data loaded from the cache file?
 	 * @param duringCache was this data loaded during the cache process? */
-	void ReCalculateRadarValuesAndLastSecond(bool fromCache = false, bool duringCache = false);
+	void ReCalculateStepStatsAndLastSecond(bool fromCache = false, bool duringCache = false);
 	/**
 	 * @brief Translate any titles that aren't in english.
 	 * This is called by TidyUpData. */

--- a/src/StepParityCost.cpp
+++ b/src/StepParityCost.cpp
@@ -25,12 +25,12 @@ float* StepParityCost::getActionCost(State * initialState, State * resultState, 
 	Row &row = rows[rowIndex];
 	int columnCount = row.columnCount;
 	float elapsedTime = resultState->second - initialState->second;
-    
-    float* costs = new float[NUM_Cost];
-    for(int i = 0; i < NUM_Cost; i++)
-    {
-        costs[i] = 0;
-    }
+	
+	float* costs = new float[NUM_Cost];
+	for(int i = 0; i < NUM_Cost; i++)
+	{
+		costs[i] = 0;
+	}
 
 	std::vector<StepParity::Foot> combinedColumns(columnCount, NONE);
 
@@ -63,8 +63,7 @@ float* StepParityCost::getActionCost(State * initialState, State * resultState, 
 	  }
 	}
 
-    costs[COST_MINE] += calcMineCost( initialState, resultState, row, combinedColumns, columnCount);
-    
+	costs[COST_MINE] += calcMineCost( initialState, resultState, row, combinedColumns, columnCount);
 	costs[COST_HOLDSWITCH] += calcHoldSwitchCost( initialState, resultState, row, combinedColumns, columnCount);
 	costs[COST_BRACKETTAP] += calcBracketTapCost( initialState, resultState, row, leftHeel, leftToe, rightHeel, rightToe, elapsedTime, columnCount);
 //	costs[COST_OTHER] += calcMovingFootWhileOtherIsntOnPadCost( initialState, resultState, columnCount);
@@ -96,36 +95,36 @@ float* StepParityCost::getActionCost(State * initialState, State * resultState, 
 	// Doublestep weighting doesn't apply if you just did a jump or a jack
 
 	costs[COST_BRACKETJACK] += calcBracketJackCost( initialState, resultState, rows, rowIndex, movedLeft, movedRight, jackedLeft, jackedRight, didJump, columnCount);
-    costs[COST_DOUBLESTEP] += calcDoublestepCost(initialState, resultState, rows, rowIndex, movedLeft, movedRight, jackedLeft, jackedRight, didJump, columnCount);
+	costs[COST_DOUBLESTEP] += calcDoublestepCost(initialState, resultState, rows, rowIndex, movedLeft, movedRight, jackedLeft, jackedRight, didJump, columnCount);
 //	costs[COST_JUMP] += calcJumpCost( row, movedLeft, movedRight, elapsedTime, columnCount);
 	costs[COST_SLOW_BRACKET] += calcSlowBracketCost(row, movedLeft, movedRight, elapsedTime);
 	costs[COST_TWISTED_FOOT] += calcTwistedFootCost(resultState);
 	costs[COST_FACING] += calcFacingCosts( initialState, resultState, combinedColumns, columnCount);
-    costs[COST_SPIN] += calcSpinCosts(initialState, resultState, combinedColumns, columnCount);
+	costs[COST_SPIN] += calcSpinCosts(initialState, resultState, combinedColumns, columnCount);
 	costs[COST_FOOTSWITCH] += caclFootswitchCost( initialState, resultState, row, combinedColumns, elapsedTime, columnCount);
 	costs[COST_SIDESWITCH] += calcSideswitchCost( initialState, resultState, columnCount);
 	costs[COST_MISSED_FOOTSWITCH] += calcMissedFootswitchCost( row, jackedLeft, jackedRight, columnCount);
 	costs[COST_JACK] += calcJackCost( movedLeft, movedRight, jackedLeft, jackedRight, elapsedTime, columnCount);
 	costs[COST_DISTANCE] += calcBigMovementsQuicklyCost( initialState, resultState, elapsedTime, columnCount);
-//    costs[COST_CROWDED_BRACKET] += calcCrowdedBracketCost(initialState, resultState, elapsedTime, columnCount);
-    
-    // I don't like that we're updating columns here like this.
-    // We're basically updating columns with the final position of the feet
-    // for the next iteration when this is initialState
+//	costs[COST_CROWDED_BRACKET] += calcCrowdedBracketCost(initialState, resultState, elapsedTime, columnCount);
+	
+	// I don't like that we're updating columns here like this.
+	// We're basically updating columns with the final position of the feet
+	// for the next iteration when this is initialState
 	resultState->columns = combinedColumns;
-    for(int i = 0; i < columnCount; i++)
-    {
-        if(combinedColumns[i] >= NONE)
-        {
-            resultState->whereTheFeetAre[combinedColumns[i]] = i;
-        }
-    }
-    for(int i = 0; i < COST_TOTAL; i++)
-    {
-        costs[COST_TOTAL] += costs[i];
-    }
+	for(int i = 0; i < columnCount; i++)
+	{
+		if(combinedColumns[i] >= NONE)
+		{
+			resultState->whereTheFeetAre[combinedColumns[i]] = i;
+		}
+	}
+	for(int i = 0; i < COST_TOTAL; i++)
+	{
+		costs[COST_TOTAL] += costs[i];
+	}
 
-    return costs;
+	return costs;
 }
 
 // This merges the `columns` properties of initialState and resultState, which
@@ -174,10 +173,10 @@ void StepParityCost::mergeInitialAndResultPosition(State * initialState, State *
 // Calculate the cost of avoiding a mine before the current step
 // If a mine occurred just before a step, add to the cost
 // ex: 00M0
-//     0010 <- add cost
+//	 0010 <- add cost
 //
-//     00M0
-//     0100 <- no cost
+//	 00M0
+//	 0100 <- no cost
 float StepParityCost::calcMineCost(State * initialState, State * resultState, Row &row, std::vector<StepParity::Foot>& combinedColumns, int columnCount)
 {
 	float cost = 0;
@@ -186,7 +185,7 @@ float StepParityCost::calcMineCost(State * initialState, State * resultState, Ro
 		if (combinedColumns[i] != NONE && row.mines[i] != 0) {
 			cost += MINE;
 			break;
-	  	}
+		}
 	}
 	return cost;
 }
@@ -227,9 +226,9 @@ float StepParityCost::calcHoldSwitchCost(State * initialState, State * resultSta
 // Calculate the cost of tapping a bracket during a hold note
 //
 // ex: 0200
-//     0000
-//     1000	<- maybe bracketable, if left heel is holding Down arrow
-//     0300
+//	 0000
+//	 1000	<- maybe bracketable, if left heel is holding Down arrow
+//	 0300
 
 float StepParityCost::calcBracketTapCost(State * initialState, State * resultState, Row &row, int leftHeel, int leftToe, int rightHeel, int rightToe, float elapsedTime, int columnCount)
 {
@@ -347,20 +346,20 @@ float StepParityCost::calcBracketJackCost(State * initialState, State * resultSt
 
 float StepParityCost::calcDoublestepCost(State * initialState, State * resultState, std::vector<Row> & rows, int rowIndex, bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, bool didJump, int columnCount)
 {
-    float cost = 0;
-    if (
-        movedLeft != movedRight &&
-        (movedLeft || movedRight) &&
-        isEmpty(resultState->holdFeet, columnCount) &&
-        !didJump)
-    {
-        bool doublestepped = didDoubleStep(initialState, resultState, rows, rowIndex, movedLeft, jackedLeft, movedRight, jackedRight, columnCount);
-        
-        if (doublestepped) {
-            cost += DOUBLESTEP;
-        }
-    }
-    return cost;
+	float cost = 0;
+	if (
+		movedLeft != movedRight &&
+		(movedLeft || movedRight) &&
+		isEmpty(resultState->holdFeet, columnCount) &&
+		!didJump)
+	{
+		bool doublestepped = didDoubleStep(initialState, resultState, rows, rowIndex, movedLeft, jackedLeft, movedRight, jackedRight, columnCount);
+		
+		if (doublestepped) {
+			cost += DOUBLESTEP;
+		}
+	}
+	return cost;
 
 }
 float StepParityCost::calcJumpCost(Row & row, bool movedLeft, bool movedRight, float elapsedTime, int columnCount)
@@ -493,11 +492,11 @@ float StepParityCost::calcFacingCosts(State * initialState, State * resultState,
 
 	if (heelFacingPenalty > 0)
 		cost += heelFacingPenalty * FACING;
-	if (toesFacingPenalty > 0) 
+	if (toesFacingPenalty > 0)
 		cost += toesFacingPenalty * FACING;
-	if (leftFacingPenalty > 0) 
+	if (leftFacingPenalty > 0)
 		cost += leftFacingPenalty * FACING;
-	if (rightFacingPenalty > 0) 
+	if (rightFacingPenalty > 0)
 		cost += rightFacingPenalty * FACING;
 
 	return cost;
@@ -505,65 +504,65 @@ float StepParityCost::calcFacingCosts(State * initialState, State * resultState,
 
 float StepParityCost::calcSpinCosts(State * initialState, State * resultState, std::vector<StepParity::Foot> & combinedColumns, int columnCount)
 {
-    float cost = 0;
-    
-    float endLeftHeel = -1;
-    float endLeftToe = -1;
-    float endRightHeel = -1;
-    float endRightToe = -1;
+	float cost = 0;
+	
+	float endLeftHeel = -1;
+	float endLeftToe = -1;
+	float endRightHeel = -1;
+	float endRightToe = -1;
 
-    for (int i = 0; i < columnCount; i++) {
-      switch (combinedColumns[i]) {
-        case NONE:
-          break;
-        case LEFT_HEEL:
-          endLeftHeel = i;
-          break;
-        case LEFT_TOE:
-          endLeftToe = i;
-          break;
-        case RIGHT_HEEL:
-          endRightHeel = i;
-          break;
-        case RIGHT_TOE:
-          endRightToe = i;
-        default:
-          break;
-      }
-    }
+	for (int i = 0; i < columnCount; i++) {
+	  switch (combinedColumns[i]) {
+		case NONE:
+		  break;
+		case LEFT_HEEL:
+		  endLeftHeel = i;
+		  break;
+		case LEFT_TOE:
+		  endLeftToe = i;
+		  break;
+		case RIGHT_HEEL:
+		  endRightHeel = i;
+		  break;
+		case RIGHT_TOE:
+		  endRightToe = i;
+		default:
+		  break;
+	  }
+	}
 
-    if (endLeftToe == -1) endLeftToe = endLeftHeel;
-    if (endRightToe == -1) endRightToe = endRightHeel;
-    
-    // spin
-    StagePoint previousLeftPos = layout.averagePoint(
-     initialState->whereTheFeetAre[LEFT_HEEL],
-     initialState->whereTheFeetAre[LEFT_TOE]
-    );
-    StagePoint previousRightPos = layout.averagePoint(
-     initialState->whereTheFeetAre[RIGHT_HEEL],
-     initialState->whereTheFeetAre[RIGHT_TOE]
-    );
-    StagePoint leftPos = layout.averagePoint(endLeftHeel, endLeftToe);
-    StagePoint rightPos = layout.averagePoint(endRightHeel, endRightToe);
+	if (endLeftToe == -1) endLeftToe = endLeftHeel;
+	if (endRightToe == -1) endRightToe = endRightHeel;
+	
+	// spin
+	StagePoint previousLeftPos = layout.averagePoint(
+	 initialState->whereTheFeetAre[LEFT_HEEL],
+	 initialState->whereTheFeetAre[LEFT_TOE]
+	);
+	StagePoint previousRightPos = layout.averagePoint(
+	 initialState->whereTheFeetAre[RIGHT_HEEL],
+	 initialState->whereTheFeetAre[RIGHT_TOE]
+	);
+	StagePoint leftPos = layout.averagePoint(endLeftHeel, endLeftToe);
+	StagePoint rightPos = layout.averagePoint(endRightHeel, endRightToe);
 
-    if (
-      rightPos.x < leftPos.x &&
-      previousRightPos.x < previousLeftPos.x &&
-      rightPos.y < leftPos.y &&
-      previousRightPos.y > previousLeftPos.y
-    ) {
-      cost += SPIN;
-    }
-    if (
-      rightPos.x < leftPos.x &&
-      previousRightPos.x < previousLeftPos.x &&
-      rightPos.y > leftPos.y &&
-      previousRightPos.y < previousLeftPos.y
-    ) {
-      cost += SPIN;
-    }
-    return cost;
+	if (
+	  rightPos.x < leftPos.x &&
+	  previousRightPos.x < previousLeftPos.x &&
+	  rightPos.y < leftPos.y &&
+	  previousRightPos.y > previousLeftPos.y
+	) {
+	  cost += SPIN;
+	}
+	if (
+	  rightPos.x < leftPos.x &&
+	  previousRightPos.x < previousLeftPos.x &&
+	  rightPos.y > leftPos.y &&
+	  previousRightPos.y < previousLeftPos.y
+	) {
+	  cost += SPIN;
+	}
+	return cost;
 }
 
 // Footswitches are harder to do when they get too slow.
@@ -680,65 +679,65 @@ float StepParityCost::calcBigMovementsQuicklyCost(State * initialState, State * 
 
 float StepParityCost::calcCrowdedBracketCost(State * initialState, State * resultState, float elapsedTime, int columnCount)
 {
-    float cost = 0;
-    
-    bool resultLeftBracket = resultState->whereTheFeetAre[LEFT_HEEL] > -1 && resultState->whereTheFeetAre[LEFT_TOE] > -1;
-    bool resultRightBracket = resultState->whereTheFeetAre[RIGHT_HEEL] > -1 && resultState->whereTheFeetAre[RIGHT_TOE] > -1;
-    
-    bool initialLeftBracket = initialState->whereTheFeetAre[LEFT_HEEL] > -1 && initialState->whereTheFeetAre[LEFT_TOE] > -1;
-    bool initialRightBracket = initialState->whereTheFeetAre[RIGHT_HEEL] > -1 && initialState->whereTheFeetAre[RIGHT_TOE] > -1;
-    
-    // if we're trying to bracket with left foot, does it overlap the right foot
-    // in previous state?
-    if(
-       (resultLeftBracket)
-       && (
-           initialState->columns[resultState->whereTheFeetAre[LEFT_HEEL]] == RIGHT_HEEL ||
-           initialState->columns[resultState->whereTheFeetAre[LEFT_HEEL]] == RIGHT_TOE ||
-           initialState->columns[resultState->whereTheFeetAre[LEFT_TOE]] == RIGHT_HEEL ||
-           initialState->columns[resultState->whereTheFeetAre[LEFT_TOE]] == RIGHT_TOE
-           )
-       )
-    {
-        cost += CROWDED_BRACKET / elapsedTime;
-    }
-    else if(initialLeftBracket
-        && (
-            resultState->columns[initialState->whereTheFeetAre[LEFT_HEEL]] == RIGHT_HEEL ||
-            resultState->columns[initialState->whereTheFeetAre[LEFT_HEEL]] == RIGHT_TOE ||
-            resultState->columns[initialState->whereTheFeetAre[LEFT_TOE]] == RIGHT_HEEL ||
-            resultState->columns[initialState->whereTheFeetAre[LEFT_TOE]] == RIGHT_TOE
-            )
-        )
-    {
-        cost += CROWDED_BRACKET / elapsedTime;
-    }
-    
-    // and if we're trying to bracket with right foot, does it overlap the left ?
-    if((resultRightBracket )
-       && (
-           initialState->columns[resultState->whereTheFeetAre[RIGHT_HEEL]] == LEFT_HEEL ||
-           initialState->columns[resultState->whereTheFeetAre[RIGHT_HEEL]] == LEFT_TOE ||
-           initialState->columns[resultState->whereTheFeetAre[RIGHT_TOE]] == LEFT_HEEL ||
-           initialState->columns[resultState->whereTheFeetAre[RIGHT_TOE]] == LEFT_TOE
-           )
-       )
-    {
-        cost += CROWDED_BRACKET / elapsedTime;
-    }
-    else if( initialRightBracket
-        && (
-            resultState->columns[initialState->whereTheFeetAre[RIGHT_HEEL]] == LEFT_HEEL ||
-            resultState->columns[initialState->whereTheFeetAre[RIGHT_HEEL]] == LEFT_TOE ||
-            resultState->columns[initialState->whereTheFeetAre[RIGHT_TOE]] == LEFT_HEEL ||
-            resultState->columns[initialState->whereTheFeetAre[RIGHT_TOE]] == LEFT_TOE
-            )
-        )
-    {
-        cost += CROWDED_BRACKET / elapsedTime;
-    }
-    
-    return cost;
+	float cost = 0;
+	
+	bool resultLeftBracket = resultState->whereTheFeetAre[LEFT_HEEL] > -1 && resultState->whereTheFeetAre[LEFT_TOE] > -1;
+	bool resultRightBracket = resultState->whereTheFeetAre[RIGHT_HEEL] > -1 && resultState->whereTheFeetAre[RIGHT_TOE] > -1;
+	
+	bool initialLeftBracket = initialState->whereTheFeetAre[LEFT_HEEL] > -1 && initialState->whereTheFeetAre[LEFT_TOE] > -1;
+	bool initialRightBracket = initialState->whereTheFeetAre[RIGHT_HEEL] > -1 && initialState->whereTheFeetAre[RIGHT_TOE] > -1;
+	
+	// if we're trying to bracket with left foot, does it overlap the right foot
+	// in previous state?
+	if(
+	   (resultLeftBracket)
+	   && (
+		   initialState->columns[resultState->whereTheFeetAre[LEFT_HEEL]] == RIGHT_HEEL ||
+		   initialState->columns[resultState->whereTheFeetAre[LEFT_HEEL]] == RIGHT_TOE ||
+		   initialState->columns[resultState->whereTheFeetAre[LEFT_TOE]] == RIGHT_HEEL ||
+		   initialState->columns[resultState->whereTheFeetAre[LEFT_TOE]] == RIGHT_TOE
+		   )
+	   )
+	{
+		cost += CROWDED_BRACKET / elapsedTime;
+	}
+	else if(initialLeftBracket
+		&& (
+			resultState->columns[initialState->whereTheFeetAre[LEFT_HEEL]] == RIGHT_HEEL ||
+			resultState->columns[initialState->whereTheFeetAre[LEFT_HEEL]] == RIGHT_TOE ||
+			resultState->columns[initialState->whereTheFeetAre[LEFT_TOE]] == RIGHT_HEEL ||
+			resultState->columns[initialState->whereTheFeetAre[LEFT_TOE]] == RIGHT_TOE
+			)
+		)
+	{
+		cost += CROWDED_BRACKET / elapsedTime;
+	}
+	
+	// and if we're trying to bracket with right foot, does it overlap the left ?
+	if((resultRightBracket )
+	   && (
+		   initialState->columns[resultState->whereTheFeetAre[RIGHT_HEEL]] == LEFT_HEEL ||
+		   initialState->columns[resultState->whereTheFeetAre[RIGHT_HEEL]] == LEFT_TOE ||
+		   initialState->columns[resultState->whereTheFeetAre[RIGHT_TOE]] == LEFT_HEEL ||
+		   initialState->columns[resultState->whereTheFeetAre[RIGHT_TOE]] == LEFT_TOE
+		   )
+	   )
+	{
+		cost += CROWDED_BRACKET / elapsedTime;
+	}
+	else if( initialRightBracket
+		&& (
+			resultState->columns[initialState->whereTheFeetAre[RIGHT_HEEL]] == LEFT_HEEL ||
+			resultState->columns[initialState->whereTheFeetAre[RIGHT_HEEL]] == LEFT_TOE ||
+			resultState->columns[initialState->whereTheFeetAre[RIGHT_TOE]] == LEFT_HEEL ||
+			resultState->columns[initialState->whereTheFeetAre[RIGHT_TOE]] == LEFT_TOE
+			)
+		)
+	{
+		cost += CROWDED_BRACKET / elapsedTime;
+	}
+	
+	return cost;
 }
 
 
@@ -769,7 +768,7 @@ bool StepParityCost::didDoubleStep(State * initialState, State * resultState, st
 
 	  if (rowIndex - 1 > -1)
 	  {
-	  	StepParity::Row &lastRow = rows[rowIndex - 1];
+		StepParity::Row &lastRow = rows[rowIndex - 1];
 		for (StepParity::IntermediateNoteData hold: lastRow.holds) {
 		  if (hold.type == TapNoteType_Empty) continue;
 		  float endBeat = row.beat;

--- a/src/StepParityCost.cpp
+++ b/src/StepParityCost.cpp
@@ -6,19 +6,19 @@
 
 using namespace StepParity;
 
-
-template <typename T>
-bool isEmpty(const std::vector<T> & vec, int columnCount) {
-	for (int i = 0; i < columnCount; i++)
-	{
-		if(static_cast<int>(vec[i]) != 0)
+namespace {
+	template <typename T>
+	bool isEmpty(const std::vector<T> & vec, int columnCount) {
+		for (int i = 0; i < columnCount; i++)
 		{
-			return false;
+			if(static_cast<int>(vec[i]) != 0)
+			{
+				return false;
+			}
 		}
+		return true;
 	}
-	return true;
 }
-
 
 float StepParityCost::getActionCost(State * initialState, State * resultState, std::vector<Row>& rows, int rowIndex, float elapsedTime)
 {
@@ -339,7 +339,7 @@ float StepParityCost::calcTwistedFootCost(State * resultState)
 	{
 		cost += TWISTED_FOOT;
 	}
-	   return cost;
+	return cost;
 }
 
 float StepParityCost::calcMissedFootswitchCost(Row & row, bool jackedLeft, bool jackedRight, int columnCount)

--- a/src/StepParityCost.cpp
+++ b/src/StepParityCost.cpp
@@ -128,7 +128,7 @@ float* StepParityCost::getActionCost(State * initialState, State * resultState, 
     costs[COST_SPIN] += calcSpinCosts(initialState, resultState, combinedColumns, columnCount);
 	costs[COST_FOOTSWITCH] += caclFootswitchCost( initialState, resultState, row, combinedColumns, elapsedTime, columnCount);
 	costs[COST_SIDESWITCH] += calcSideswitchCost( initialState, resultState, columnCount);
-	costs[COST_MISSED_FOOTSWITCH] += calcMissedFootswitchCost( row, jackedLeft, jackedRight, columnCount)
+	costs[COST_MISSED_FOOTSWITCH] += calcMissedFootswitchCost( row, jackedLeft, jackedRight, columnCount);
 	costs[COST_JACK] += calcJackCost( movedLeft, movedRight, jackedLeft, jackedRight, elapsedTime, columnCount);
 	costs[COST_DISTANCE] += calcBigMovementsQuicklyCost( initialState, resultState, elapsedTime, columnCount);
 //    costs[COST_CROWDED_BRACKET] += calcCrowdedBracketCost(initialState, resultState, elapsedTime, columnCount);

--- a/src/StepParityCost.cpp
+++ b/src/StepParityCost.cpp
@@ -1,0 +1,891 @@
+#include "global.h"
+#include "StepParityCost.h"
+#include "NoteData.h"
+#include "TechCounts.h"
+#include "GameState.h"
+	
+using namespace StepParity;
+
+
+template <typename T>
+bool vectorIncludes(const std::vector<T>& vec, const T& value, int columnCount) {
+	for (int i = 0; i < columnCount; i++)
+	{
+		if(vec[i] == value)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+template <typename T>
+int indexOf(const std::vector<T>& vec, const T& value, int columnCount) {
+	for (int i = 0; i < columnCount; i++)
+	{
+		if(vec[i] == value)
+		{
+			return i;
+		}
+	}
+	return -1;
+}
+
+template <typename T>
+bool isEmpty(const std::vector<T> & vec, int columnCount) {
+	for (int i = 0; i < columnCount; i++)
+	{
+		if(static_cast<int>(vec[i]) != 0)
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+
+float* StepParityCost::getActionCost(State * initialState, State * resultState, std::vector<Row>& rows, int rowIndex)
+{
+	Row &row = rows[rowIndex];
+	int columnCount = row.columnCount;
+	float elapsedTime = resultState->second - initialState->second;
+    
+    float* costs = new float[NUM_Cost];
+    for(int i = 0; i < NUM_Cost; i++)
+    {
+        costs[i] = 0;
+    }
+
+	std::vector<StepParity::Foot> combinedColumns(columnCount, NONE);
+
+	mergeInitialAndResultPosition(initialState, resultState, combinedColumns, columnCount);
+	
+	// Mine weighting
+	int leftHeel = -1;
+	int leftToe = -1;
+	int rightHeel = -1;
+	int rightToe = -1;
+
+	for (int i = 0; i < columnCount; i++) {
+	  switch (resultState->columns[i]) {
+		case NONE:
+		  break;
+		case LEFT_HEEL:
+		  leftHeel = i;
+		  break;
+		case LEFT_TOE:
+		  leftToe = i;
+		  break;
+		case RIGHT_HEEL:
+		  rightHeel = i;
+		  break;
+		case RIGHT_TOE:
+		  rightToe = i;
+		  break;
+	  default:
+		  break;
+	  }
+	}
+
+    costs[COST_MINE] += calcMineCost( initialState, resultState, row, combinedColumns, columnCount);
+    
+	costs[COST_HOLDSWITCH] += calcHoldSwitchCost( initialState, resultState, row, combinedColumns, columnCount);
+	costs[COST_BRACKETTAP] += calcBracketTapCost( initialState, resultState, row, leftHeel, leftToe, rightHeel, rightToe, elapsedTime, columnCount);
+	costs[COST_OTHER] += calcMovingFootWhileOtherIsntOnPadCost( initialState, resultState, columnCount);
+
+	bool movedLeft =
+	  resultState->didTheFootMove[LEFT_HEEL] ||
+	  resultState->didTheFootMove[LEFT_TOE];
+	
+	bool movedRight =
+	  resultState->didTheFootMove[RIGHT_HEEL] ||
+	  resultState->didTheFootMove[RIGHT_TOE];
+
+	// Note that this is checking whether the previous state was a jump, not whether the current state is
+	bool didJump =
+	  ((initialState->didTheFootMove[LEFT_HEEL] &&
+		!initialState->isTheFootHolding[LEFT_HEEL]) ||
+		(initialState->didTheFootMove[LEFT_TOE] &&
+		  !initialState->isTheFootHolding[LEFT_TOE])) &&
+	  ((initialState->didTheFootMove[RIGHT_HEEL] &&
+		!initialState->isTheFootHolding[RIGHT_HEEL]) ||
+		(initialState->didTheFootMove[RIGHT_TOE] &&
+		  !initialState->isTheFootHolding[RIGHT_TOE]));
+
+	// jacks don't matter if you did a jump before
+
+	bool jackedLeft = didJackLeft(initialState, resultState, leftHeel, leftToe, movedLeft, didJump, columnCount);
+	bool jackedRight = didJackRight(initialState, resultState, rightHeel, rightToe, movedRight, didJump, columnCount);
+
+	// Doublestep weighting doesn't apply if you just did a jump or a jack
+
+	costs[COST_BRACKETJACK] += calcBracketJackCost( initialState, resultState, rows, rowIndex, movedLeft, movedRight, jackedLeft, jackedRight, didJump, columnCount);
+    costs[COST_DOUBLESTEP] += calcDoublestepCost(initialState, resultState, rows, rowIndex, movedLeft, movedRight, jackedLeft, jackedRight, didJump, columnCount);
+	costs[COST_JUMP] += calcJumpCost( row, movedLeft, movedRight, elapsedTime, columnCount);
+	costs[COST_FACING] += calcFacingCosts( initialState, resultState, combinedColumns, columnCount);
+    costs[COST_SPIN] += calcSpinCosts(initialState, resultState, combinedColumns, columnCount);
+	costs[COST_FOOTSWITCH] += caclFootswitchCost( initialState, resultState, row, combinedColumns, elapsedTime, columnCount);
+	costs[COST_SIDESWITCH] += calcSideswitchCost( initialState, resultState, columnCount);
+	costs[COST_MISSED_FOOTSWITCH] += calcMissedFootswitchCost( row, jackedLeft, jackedRight, columnCount);
+
+	// To do: small weighting for swapping heel with toe or toe with heel (both add up)
+	// To do: huge weighting for having foot direction opposite of eachother (can't twist one leg 180 degrees)
+	costs[COST_JACK] += calcJackCost( movedLeft, movedRight, jackedLeft, jackedRight, elapsedTime, columnCount);
+	
+	// To do: weighting for moving a foot a far distance in a fast time
+	costs[COST_DISTANCE] += calcBigMovementsQuicklyCost( initialState, resultState, elapsedTime, columnCount);
+    costs[COST_CROWDED_BRACKET] += calcCrowdedBracketCost(initialState, resultState, elapsedTime, columnCount);
+    
+    // I don't like that we're updating columns here like this.
+    // We're basically updating columns with the final position of the feet
+    // for the next iteration when this is initialState
+	resultState->columns = combinedColumns;
+    for(int i = 0; i < columnCount; i++)
+    {
+        if(combinedColumns[i] >= NONE)
+        {
+            resultState->whereTheFeetAre[combinedColumns[i]] = i;
+        }
+    }
+    for(int i = 0; i < COST_TOTAL; i++)
+    {
+        costs[COST_TOTAL] += costs[i];
+    }
+
+    return costs;
+}
+
+// This merges the `columns` properties of initialState and resultState, which
+// fully represents the player's position on the dance stage.
+// For example:
+// initialState.columns = [1,0,0,3]
+// resultState.columns = [0,1,0,0]
+// combinedColumns = [0,1,0,3]
+// This eventually gets saved back to resultState
+void StepParityCost::mergeInitialAndResultPosition(State * initialState, State * resultState, std::vector<StepParity::Foot> & combinedColumns, int columnCount)
+{
+	// Merge initial + result position
+	for (int i = 0; i < columnCount; i++) {
+	  // copy in data from resultState over the top which overrides it, as long as it's not nothing
+	  if (resultState->columns[i] != NONE) {
+		combinedColumns[i] = resultState->columns[i];
+		continue;
+	  }
+
+	  // copy in data from initialState, if it wasn't moved
+	  if (
+		initialState->columns[i] == LEFT_HEEL ||
+		initialState->columns[i] == RIGHT_HEEL
+	  ) {
+		if (!resultState->didTheFootMove[initialState->columns[i]]) {
+		  combinedColumns[i] = initialState->columns[i];
+		}
+	  } else if (initialState->columns[i] == LEFT_TOE) {
+		if (
+		  !resultState->didTheFootMove[LEFT_TOE] &&
+		  !resultState->didTheFootMove[LEFT_HEEL]
+		) {
+		  combinedColumns[i] = initialState->columns[i];
+		}
+	  } else if (initialState->columns[i] == RIGHT_TOE) {
+		if (
+		  !resultState->didTheFootMove[RIGHT_TOE] &&
+		  !resultState->didTheFootMove[RIGHT_HEEL]
+		) {
+		  combinedColumns[i] = initialState->columns[i];
+		}
+	  }
+	}
+}
+
+// Calculate the cost of avoiding a mine before the current step
+// If a mine occurred just before a step, add to the cost
+// ex: 00M0
+//     0010 <- add cost
+//
+//     00M0
+//     0100 <- no cost
+float StepParityCost::calcMineCost(State * initialState, State * resultState, Row &row, std::vector<StepParity::Foot>& combinedColumns, int columnCount)
+{
+	float cost = 0;
+
+	for (int i = 0; i < columnCount; i++) {
+		if (combinedColumns[i] != NONE && row.mines[i] != 0) {
+			cost += MINE;
+			break;
+	  	}
+	}
+	return cost;
+}
+
+// Calculate a cost from having to switch feet in the middle of a hold.
+// Multiply the HOLDSWITCH cost by the distance that the "intial" foot
+// that was holding the note had to travel to it's new position.
+// If the initial foot doesn't move anywhere, then don't mulitply it by anything.
+float StepParityCost::calcHoldSwitchCost(State * initialState, State * resultState, Row &row, std::vector<StepParity::Foot> & combinedColumns, int columnCount)
+{
+	float cost = 0;
+	for (int c = 0; c < columnCount; c++)
+	{
+		if (row.holds[c].type == TapNoteType_Empty)
+			continue;
+		if (
+			((combinedColumns[c] == LEFT_HEEL ||
+			  combinedColumns[c] == LEFT_TOE) &&
+			 initialState->columns[c] != LEFT_TOE &&
+			 initialState->columns[c] != LEFT_HEEL) ||
+			((combinedColumns[c] == RIGHT_HEEL ||
+			  combinedColumns[c] == RIGHT_TOE) &&
+			 initialState->columns[c] != RIGHT_TOE &&
+			 initialState->columns[c] != RIGHT_HEEL)) {
+		int previousFoot =initialState->whereTheFeetAre[combinedColumns[c]];
+		cost +=
+		  HOLDSWITCH *
+		  (previousFoot == -1
+			? 1
+			: sqrt(
+				getDistanceSq(layout[c], layout[previousFoot])
+			  ));
+	  }
+	}
+	return cost;
+}
+
+// Calculate the cost of tapping a bracket during a hold note
+//
+// ex: 0200
+//     0000
+//     1000	<- maybe bracketable, if left heel is holding Down arrow
+//     0300
+
+float StepParityCost::calcBracketTapCost(State * initialState, State * resultState, Row &row, int leftHeel, int leftToe, int rightHeel, int rightToe, float elapsedTime, int columnCount)
+{
+	// Small penalty for trying to jack a bracket during a hold
+	float cost = 0;
+	if (leftHeel != -1 && leftToe != -1)
+	{
+		float jackPenalty = 1;
+		if (
+			initialState->didTheFootMove[LEFT_HEEL] ||
+			initialState->didTheFootMove[LEFT_TOE])
+			jackPenalty = 1 / elapsedTime;
+		if (
+			row.holds[leftHeel].type != TapNoteType_Empty &&
+			row.holds[leftToe].type == TapNoteType_Empty) {
+		cost += BRACKETTAP * jackPenalty;
+	  }
+	  if (
+		row.holds[leftToe].type != TapNoteType_Empty &&
+		row.holds[leftHeel].type == TapNoteType_Empty
+	  ) {
+		cost += BRACKETTAP * jackPenalty;
+	  }
+	}
+
+	if (rightHeel != -1 && rightToe != -1) {
+	  float jackPenalty = 1;
+	  if (
+		initialState->didTheFootMove[RIGHT_TOE] ||
+		initialState->didTheFootMove[RIGHT_HEEL]
+	  )
+		jackPenalty = 1 / elapsedTime;
+
+	  if (
+		row.holds[rightHeel].type != TapNoteType_Empty &&
+		row.holds[rightToe].type == TapNoteType_Empty
+	  ) {
+		cost += BRACKETTAP * jackPenalty;
+	  }
+	  if (
+		row.holds[rightToe].type != TapNoteType_Empty &&
+		row.holds[rightHeel].type == TapNoteType_Empty
+	  ) {
+		cost += BRACKETTAP * jackPenalty;
+	  }
+	}
+	return cost;
+}
+
+// Calculate a cost for moving the same foot while the other
+// isn't on the pad.
+//
+float StepParityCost::calcMovingFootWhileOtherIsntOnPadCost(State * initialState, State * resultState, int columnCount)
+{
+	float cost = 0;
+	// Weighting for moving a foot while the other isn't on the pad (so marked doublesteps are less bad than this)
+	if (std::any_of(initialState->columns.begin(), initialState->columns.end(), [](Foot elem) { return elem != NONE;  }))
+	{
+		for (auto f : resultState->movedFeet)
+		{
+			switch (f)
+			{
+			case LEFT_HEEL:
+			case LEFT_TOE:
+				if (
+					!(
+						initialState->whereTheFeetAre[RIGHT_HEEL] != -1 ||
+						initialState->whereTheFeetAre[RIGHT_TOE] != -1))
+					cost += OTHER;
+				break;
+			case RIGHT_HEEL:
+			case RIGHT_TOE:
+				if (
+					!(
+						initialState->whereTheFeetAre[LEFT_HEEL] != -1 ||
+						initialState->whereTheFeetAre[LEFT_TOE] != -1))
+					cost += OTHER;
+				break;
+			default:
+				break;
+			}
+		}
+	}
+	return cost;
+}
+
+float StepParityCost::calcBracketJackCost(State * initialState, State * resultState, std::vector<Row> & rows, int rowIndex, bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, bool didJump, int columnCount)
+{
+	float cost = 0;
+	if (
+		movedLeft != movedRight &&
+		(movedLeft || movedRight) &&
+		isEmpty(resultState->holdFeet, columnCount) &&
+		!didJump)
+	{
+
+	  if (
+		jackedLeft &&
+		resultState->didTheFootMove[LEFT_HEEL] &&
+		resultState->didTheFootMove[LEFT_TOE]
+	  ) {
+		cost += BRACKETJACK;
+	  }
+
+	  if (
+		jackedRight &&
+		resultState->didTheFootMove[RIGHT_HEEL] &&
+		resultState->didTheFootMove[RIGHT_TOE]
+	  ) {
+		cost += BRACKETJACK;
+	  }
+	}
+	return cost;
+}
+
+float StepParityCost::calcDoublestepCost(State * initialState, State * resultState, std::vector<Row> & rows, int rowIndex, bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, bool didJump, int columnCount)
+{
+    float cost = 0;
+    if (
+        movedLeft != movedRight &&
+        (movedLeft || movedRight) &&
+        isEmpty(resultState->holdFeet, columnCount) &&
+        !didJump)
+    {
+        bool doublestepped = didDoubleStep(initialState, resultState, rows, rowIndex, movedLeft, jackedLeft, movedRight, jackedRight, columnCount);
+        
+        if (doublestepped) {
+            cost += DOUBLESTEP;
+        }
+    }
+    return cost;
+
+}
+float StepParityCost::calcJumpCost(Row & row, bool movedLeft, bool movedRight, float elapsedTime, int columnCount)
+{
+	float cost = 0;
+	if (
+		movedLeft &&
+		movedRight &&
+		std::count_if(row.notes.begin(), row.notes.end(), [](StepParity::IntermediateNoteData note)
+					  { return note.type != TapNoteType_Empty; }) >= 2)
+	{
+		cost += JUMP / elapsedTime;
+	}
+
+	return cost;
+}
+
+float StepParityCost::calcMissedFootswitchCost(Row & row, bool jackedLeft, bool jackedRight, int columnCount)
+{
+	float cost = 0;
+	if (
+		(jackedLeft || jackedRight) &&
+		(std::any_of(row.mines.begin(), row.mines.end(), [](int mine)
+					 { return mine != 0; }) ||
+		 std::any_of(row.fakeMines.begin(), row.fakeMines.end(), [](int mine)
+					 { return mine != 0; })))
+	{
+		cost += MISSED_FOOTSWITCH;
+	}
+
+	return cost;
+}
+
+float StepParityCost::calcFacingCosts(State * initialState, State * resultState, std::vector<StepParity::Foot> & combinedColumns, int columnCount)
+{
+
+	float cost = 0;
+
+	float endLeftHeel = -1;
+	float endLeftToe = -1;
+	float endRightHeel = -1;
+	float endRightToe = -1;
+
+	for (int i = 0; i < columnCount; i++) {
+	  switch (combinedColumns[i]) {
+		case NONE:
+		  break;
+		case LEFT_HEEL:
+		  endLeftHeel = i;
+		  break;
+		case LEFT_TOE:
+		  endLeftToe = i;
+		  break;
+		case RIGHT_HEEL:
+		  endRightHeel = i;
+		  break;
+		case RIGHT_TOE:
+		  endRightToe = i;
+		default:
+		  break;
+	  }
+	}
+
+	if (endLeftToe == -1) endLeftToe = endLeftHeel;
+	if (endRightToe == -1) endRightToe = endRightHeel;
+
+	// facing backwards gives a bit of bad weight (scaled heavily the further back you angle, so crossovers aren't Too bad; less bad than doublesteps)
+	float heelFacing =
+	  endLeftHeel != -1 && endRightHeel != -1
+		? getXDifference(endLeftHeel, endRightHeel)
+		: 0;
+	float toeFacing =
+	  endLeftToe != -1 && endRightToe != -1
+		? getXDifference(endLeftToe, endRightToe)
+		: 0;
+	float leftFacing =
+	  endLeftHeel != -1 && endLeftToe != -1
+		? getYDifference(endLeftHeel, endLeftToe)
+		: 0;
+	float rightFacing =
+	  endRightHeel != -1 && endRightToe != -1
+		? getYDifference(endRightHeel, endRightToe)
+		: 0;
+
+
+	float heelFacingPenalty = pow(-1 * std::min(heelFacing, 0.0f), 1.8) * 100;
+	float toesFacingPenalty = pow(-1 * std::min(toeFacing, 0.0f), 1.8) * 100;
+	float leftFacingPenalty = pow(-1 * std::min(leftFacing, 0.0f), 1.8) * 100;
+	float rightFacingPenalty = pow(-1 * std::min(rightFacing, 0.0f), 1.8) * 100;
+
+
+	if (heelFacingPenalty > 0)
+		cost += heelFacingPenalty * FACING;
+	if (toesFacingPenalty > 0) 
+		cost += toesFacingPenalty * FACING;
+	if (leftFacingPenalty > 0) 
+		cost += leftFacingPenalty * FACING;
+	if (rightFacingPenalty > 0) 
+		cost += rightFacingPenalty * FACING;
+
+	return cost;
+}
+
+float StepParityCost::calcSpinCosts(State * initialState, State * resultState, std::vector<StepParity::Foot> & combinedColumns, int columnCount)
+{
+    float cost = 0;
+    
+    float endLeftHeel = -1;
+    float endLeftToe = -1;
+    float endRightHeel = -1;
+    float endRightToe = -1;
+
+    for (int i = 0; i < columnCount; i++) {
+      switch (combinedColumns[i]) {
+        case NONE:
+          break;
+        case LEFT_HEEL:
+          endLeftHeel = i;
+          break;
+        case LEFT_TOE:
+          endLeftToe = i;
+          break;
+        case RIGHT_HEEL:
+          endRightHeel = i;
+          break;
+        case RIGHT_TOE:
+          endRightToe = i;
+        default:
+          break;
+      }
+    }
+
+    if (endLeftToe == -1) endLeftToe = endLeftHeel;
+    if (endRightToe == -1) endRightToe = endRightHeel;
+    
+    // spin
+    StagePoint previousLeftPos = averagePoint(
+     initialState->whereTheFeetAre[LEFT_HEEL],
+     initialState->whereTheFeetAre[LEFT_TOE]
+    );
+    StagePoint previousRightPos = averagePoint(
+     initialState->whereTheFeetAre[RIGHT_HEEL],
+     initialState->whereTheFeetAre[RIGHT_TOE]
+    );
+    StagePoint leftPos = averagePoint(endLeftHeel, endLeftToe);
+    StagePoint rightPos = averagePoint(endRightHeel, endRightToe);
+
+    if (
+      rightPos.x < leftPos.x &&
+      previousRightPos.x < previousLeftPos.x &&
+      rightPos.y < leftPos.y &&
+      previousRightPos.y > previousLeftPos.y
+    ) {
+      cost += SPIN;
+    }
+    if (
+      rightPos.x < leftPos.x &&
+      previousRightPos.x < previousLeftPos.x &&
+      rightPos.y > leftPos.y &&
+      previousRightPos.y < previousLeftPos.y
+    ) {
+      cost += SPIN;
+    }
+    return cost;
+}
+
+// Footswitches are harder the slower they are.
+// Add a penalty when they get slower than 8ths at 120bpm (0.25 seconds)
+float StepParityCost::caclFootswitchCost(State * initialState, State * resultState, Row & row, std::vector<StepParity::Foot> & combinedColumns, float elapsedTime, int columnCount)
+{
+	float cost = 0;
+	// ignore footswitch with 24 or less distance (8th note); penalise slower footswitches based on distance
+	if (elapsedTime >= 0.25) {
+		// footswitching has no penalty if there's a mine nearby
+	if (
+		std::all_of(row.mines.begin(), row.mines.end(), [](int mine)
+					{ return mine == 0; }) &&
+		std::all_of(row.fakeMines.begin(), row.fakeMines.end(), [](int mine)
+					{ return mine == 0; }))
+	{
+		float timeScaled = elapsedTime - 0.25;
+
+		for (int i = 0; i < columnCount; i++)
+		{
+			if (
+				initialState->columns[i] == NONE ||
+				resultState->columns[i] == NONE)
+				continue;
+
+			if (
+				initialState->columns[i] != resultState->columns[i] &&
+				!resultState->didTheFootMove[initialState->columns[i]])
+			{
+				cost += pow(timeScaled / 2.0f, 2) * FOOTSWITCH;
+				break;
+			}
+		}
+	  }
+	}
+
+	  return cost;
+}
+
+// TODO: This doesn't work for doubles, since it's only checking P1 left and P1 right
+float StepParityCost::calcSideswitchCost(State * initialState, State * resultState, int columnCount)
+{
+	float cost = 0;
+	if (
+		initialState->columns[0] != resultState->columns[0] &&
+		resultState->columns[0] != NONE &&
+		initialState->columns[0] != NONE &&
+		!resultState->didTheFootMove[initialState->columns[0]])
+	{
+		cost += SIDESWITCH;
+	}
+
+	if (
+	  initialState->columns[3] != resultState->columns[3] &&
+	  resultState->columns[3] != NONE &&
+	  initialState->columns[3] != NONE &&
+	  !resultState->didTheFootMove[initialState->columns[3]]
+	) {
+	  cost += SIDESWITCH;
+	}
+	return cost;
+}
+
+// Jacks are harder to do the faster they are.
+// Add a penalty when they get faster than 16ths at 150bpm (0.1 seconds)
+float StepParityCost::calcJackCost(bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, float elapsedTime, int columnCount)
+{
+	float cost = 0;
+	// weighting for jacking two notes too close to eachother
+	if (elapsedTime < JACK_THRESHOLD && movedLeft != movedRight) {
+	  float timeScaled = JACK_THRESHOLD - elapsedTime;
+	  if (jackedLeft || jackedRight) {
+		cost += (1 / timeScaled - 1 / JACK_THRESHOLD) * JACK;
+	  }
+	}
+
+	return cost;
+}
+
+float StepParityCost::calcBigMovementsQuicklyCost(State * initialState, State * resultState, float elapsedTime, int columnCount)
+{
+	float cost = 0;
+	for (StepParity::Foot foot : resultState->movedFeet)
+	{
+		if(foot == NONE)
+			continue;
+		int idxFoot = initialState->whereTheFeetAre[foot];
+		if (idxFoot == -1)
+			continue;
+		cost +=
+			(sqrt(
+				 getDistanceSq(
+					 layout[idxFoot],
+					 layout[resultState->whereTheFeetAre[foot]])) *
+			 DISTANCE) /
+			elapsedTime;
+	}
+
+	return cost;
+}
+
+// Are we trying to bracket a column that the other foot was just on,
+// or are we trying to hit a note that the other foot was just bracketing?
+
+float StepParityCost::calcCrowdedBracketCost(State * initialState, State * resultState, float elapsedTime, int columnCount)
+{
+    float cost = 0;
+    
+    bool resultLeftBracket = resultState->whereTheFeetAre[LEFT_HEEL] > -1 && resultState->whereTheFeetAre[LEFT_TOE] > -1;
+    bool resultRightBracket = resultState->whereTheFeetAre[RIGHT_HEEL] > -1 && resultState->whereTheFeetAre[RIGHT_TOE] > -1;
+    
+    bool initialLeftBracket = initialState->whereTheFeetAre[LEFT_HEEL] > -1 && initialState->whereTheFeetAre[LEFT_TOE] > -1;
+    bool initialRightBracket = initialState->whereTheFeetAre[RIGHT_HEEL] > -1 && initialState->whereTheFeetAre[RIGHT_TOE] > -1;
+    
+    // if we're trying to bracket with left foot, does it overlap the right foot
+    // in previous state?
+    if(
+       (resultLeftBracket)
+       && (
+           initialState->columns[resultState->whereTheFeetAre[LEFT_HEEL]] == RIGHT_HEEL ||
+           initialState->columns[resultState->whereTheFeetAre[LEFT_HEEL]] == RIGHT_TOE ||
+           initialState->columns[resultState->whereTheFeetAre[LEFT_TOE]] == RIGHT_HEEL ||
+           initialState->columns[resultState->whereTheFeetAre[LEFT_TOE]] == RIGHT_TOE
+           )
+       )
+    {
+        cost += CROWDED_BRACKET / elapsedTime;
+    }
+    else if(initialLeftBracket
+        && (
+            resultState->columns[initialState->whereTheFeetAre[LEFT_HEEL]] == RIGHT_HEEL ||
+            resultState->columns[initialState->whereTheFeetAre[LEFT_HEEL]] == RIGHT_TOE ||
+            resultState->columns[initialState->whereTheFeetAre[LEFT_TOE]] == RIGHT_HEEL ||
+            resultState->columns[initialState->whereTheFeetAre[LEFT_TOE]] == RIGHT_TOE
+            )
+        )
+    {
+        cost += CROWDED_BRACKET / elapsedTime;
+    }
+    
+    // and if we're trying to bracket with right foot, does it overlap the left ?
+    if((resultRightBracket )
+       && (
+           initialState->columns[resultState->whereTheFeetAre[RIGHT_HEEL]] == LEFT_HEEL ||
+           initialState->columns[resultState->whereTheFeetAre[RIGHT_HEEL]] == LEFT_TOE ||
+           initialState->columns[resultState->whereTheFeetAre[RIGHT_TOE]] == LEFT_HEEL ||
+           initialState->columns[resultState->whereTheFeetAre[RIGHT_TOE]] == LEFT_TOE
+           )
+       )
+    {
+        cost += CROWDED_BRACKET / elapsedTime;
+    }
+    else if( initialRightBracket
+        && (
+            resultState->columns[initialState->whereTheFeetAre[RIGHT_HEEL]] == LEFT_HEEL ||
+            resultState->columns[initialState->whereTheFeetAre[RIGHT_HEEL]] == LEFT_TOE ||
+            resultState->columns[initialState->whereTheFeetAre[RIGHT_TOE]] == LEFT_HEEL ||
+            resultState->columns[initialState->whereTheFeetAre[RIGHT_TOE]] == LEFT_TOE
+            )
+        )
+    {
+        cost += CROWDED_BRACKET / elapsedTime;
+    }
+    
+    return cost;
+}
+
+
+bool StepParityCost::didDoubleStep(State * initialState, State * resultState, std::vector<Row> & rows, int rowIndex, bool movedLeft, bool jackedLeft, bool movedRight, bool jackedRight, int columnCount)
+{
+	Row &row = rows[rowIndex];
+	bool doublestepped = false;
+	if (
+		movedLeft &&
+		!jackedLeft &&
+		((initialState->didTheFootMove[LEFT_HEEL] &&
+		  !initialState->isTheFootHolding[LEFT_HEEL]) ||
+		 (initialState->didTheFootMove[LEFT_TOE] &&
+		  !initialState->isTheFootHolding[LEFT_TOE])))
+	{
+		doublestepped = true;
+	}
+	  if (
+		movedRight &&
+		!jackedRight &&
+		((initialState->didTheFootMove[RIGHT_HEEL] &&
+		  !initialState->isTheFootHolding[RIGHT_HEEL]) ||
+		  (initialState->didTheFootMove[RIGHT_TOE] &&
+			!initialState->isTheFootHolding[RIGHT_TOE]))
+	  )
+		doublestepped = true;
+
+
+	  if (rowIndex - 1 > -1)
+	  {
+	  	StepParity::Row &lastRow = rows[rowIndex - 1];
+		for (StepParity::IntermediateNoteData hold: lastRow.holds) {
+		  if (hold.type == TapNoteType_Empty) continue;
+		  float endBeat = row.beat;
+		  float startBeat = lastRow.beat;
+		  // if a hold tail extends past the last row & ends in between, we can doublestep
+		  if (
+			hold.beat + hold.hold_length > startBeat &&
+			hold.beat + hold.hold_length < endBeat
+		  )
+			doublestepped = false;
+		  // if the hold tail extends past this row, we can doublestep
+		  if (hold.beat + hold.hold_length >= endBeat) doublestepped = false;
+		}
+	  }
+	  return doublestepped;
+}
+
+bool StepParityCost::didJackLeft(State * initialState, State * resultState, int leftHeel, int leftToe, bool movedLeft, bool didJump, int columnCount)
+{
+	bool jackedLeft = false;
+	if(!didJump && movedLeft)
+	{
+		
+			if ( leftHeel > -1 &&
+			initialState->columns[leftHeel] == LEFT_HEEL &&
+			!resultState->isTheFootHolding[LEFT_HEEL] &&
+			((initialState->didTheFootMove[LEFT_HEEL] &&
+				!initialState->isTheFootHolding[LEFT_HEEL]) ||
+				(initialState->didTheFootMove[LEFT_TOE] &&
+				!initialState->isTheFootHolding[LEFT_TOE]))
+				) {
+				jackedLeft = true;
+			}
+			if (
+				leftToe > -1 &&
+			initialState->columns[leftToe] == LEFT_TOE &&
+			!resultState->isTheFootHolding[LEFT_TOE] &&
+			((initialState->didTheFootMove[LEFT_HEEL] &&
+				!initialState->isTheFootHolding[LEFT_HEEL]) ||
+				(initialState->didTheFootMove[LEFT_TOE] &&
+				!initialState->isTheFootHolding[LEFT_TOE]))
+				){
+					jackedLeft = true;
+				}
+		
+	}
+	return jackedLeft;
+}
+
+bool StepParityCost::didJackRight(State * initialState, State * resultState, int rightHeel, int rightToe, bool movedRight, bool didJump, int columnCount)
+{
+	bool jackedRight = false;
+	if(!didJump && movedRight)
+	{
+		if ( rightHeel > -1 &&
+		  initialState->columns[rightHeel] == RIGHT_HEEL &&
+		  !resultState->isTheFootHolding[RIGHT_HEEL] &&
+		  ((initialState->didTheFootMove[RIGHT_HEEL] &&
+			!initialState->isTheFootHolding[RIGHT_HEEL]) ||
+			(initialState->didTheFootMove[RIGHT_TOE] &&
+			  !initialState->isTheFootHolding[RIGHT_TOE]))
+			) {
+				jackedRight = true;
+			}
+		if ( rightToe > -1 &&
+		  initialState->columns[rightToe] == RIGHT_TOE &&
+		  !resultState->isTheFootHolding[RIGHT_TOE] &&
+		  ((initialState->didTheFootMove[RIGHT_HEEL] &&
+			!initialState->isTheFootHolding[RIGHT_HEEL]) ||
+			(initialState->didTheFootMove[RIGHT_TOE] &&
+			  !initialState->isTheFootHolding[RIGHT_TOE]))
+			) {
+				jackedRight = true;
+			}
+	}
+	return jackedRight;
+}
+
+
+float StepParityCost::getDistanceSq(StepParity::StagePoint p1, StepParity::StagePoint p2)
+{
+	return (p1.y - p2.y) * (p1.y - p2.y) + (p1.x - p2.x) * (p1.x - p2.x);
+}
+
+float StepParityCost::getPlayerAngle(StepParity::StagePoint left, StepParity::StagePoint right)
+{
+	float x1 = right.x - left.x;
+	float y1 = right.y - left.y;
+	float x2 = 1;
+	float y2 = 0;
+	float dot = x1 * x2 + y1 * y2;
+	float det = x1 * y2 - y1 * x2;
+	return atan2f(det, dot);
+}
+
+
+
+
+float StepParityCost::getXDifference(int leftIndex, int rightIndex) {
+	if (leftIndex == rightIndex) return 0;
+	float dx = layout[rightIndex].x - layout[leftIndex].x;
+	float dy = layout[rightIndex].y - layout[leftIndex].y;
+
+	float distance = sqrt(dx * dx + dy * dy);
+	dx /= distance;
+
+	bool negative = dx <= 0;
+
+	dx = pow(dx, 4);
+
+	if (negative) dx = -dx;
+
+	return dx;
+  }
+
+  float StepParityCost::getYDifference(int leftIndex, int rightIndex) {
+	if (leftIndex == rightIndex) return 0;
+	float dx = layout[rightIndex].x - layout[leftIndex].x;
+	float dy = layout[rightIndex].y - layout[leftIndex].y;
+
+	float distance = sqrt(dx * dx + dy * dy);
+	dy /= distance;
+
+	bool negative = dy <= 0;
+
+	dy = pow(dy, 4);
+
+	if (negative) dy = -dy;
+
+	return dy;
+  }
+
+StagePoint StepParityCost::averagePoint(int leftIndex, int rightIndex) {
+	if (leftIndex == -1 && rightIndex == -1) return { 0,0 };
+	if (leftIndex == -1) return layout[rightIndex];
+	if (rightIndex == -1) return layout[leftIndex];
+	return {
+	  (layout[leftIndex].x + layout[rightIndex].x) / 2.0f,
+	  (layout[leftIndex].y + layout[rightIndex].y) / 2.0f,
+	};
+  }

--- a/src/StepParityCost.h
+++ b/src/StepParityCost.h
@@ -50,12 +50,11 @@ namespace StepParity
 		/// @param rows 
 		/// @param rowIndex The index of the row represented by resultState
 		/// @return The computed cost
-		float getActionCost(State * initialState, State * resultState, std::vector<Row> &rows, int rowIndex);
+		float getActionCost(State * initialState, State * resultState, std::vector<Row> &rows, int rowIndex, float elapsedTime);
 
 	private:
-		void mergeInitialAndResultPosition(State * initialState, State * resultState, std::vector<StepParity::Foot> &combinedColumns, int columnCount);
-		float calcMineCost(State * initialState, State * resultState, Row &row, std::vector<StepParity::Foot> &combinedColumns, int columnCount);
-		float calcHoldSwitchCost(State * initialState, State * resultState, Row &row, std::vector<StepParity::Foot> &combinedColumns, int columnCount);
+		float calcMineCost(State * initialState, State * resultState, Row &row, int columnCount);
+		float calcHoldSwitchCost(State * initialState, State * resultState, Row &row, int columnCount);
 		float calcBracketTapCost(State * initialState, State * resultState, Row &row, int leftHeel, int leftToe, int rightHeel, int rightToe, float elapsedTime, int columnCount);
 		float calcMovingFootWhileOtherIsntOnPadCost(State * initialState, State * resultState, int columnCount);
 		float calcBracketJackCost(State * initialState, State * resultState, std::vector<Row> &rows, int rowIndex, bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, bool didJump, int columnCount);
@@ -64,9 +63,9 @@ namespace StepParity
 		float calcSlowBracketCost(Row & row, bool movedLeft, bool movedRight, float elapsedTime);
 		float calcTwistedFootCost(State * resultState);
 		float calcMissedFootswitchCost(Row &row, bool jackedLeft, bool jackedRight, int columnCount);
-		float calcFacingCosts(State * initialState, State * resultState, std::vector<StepParity::Foot> &combinedColumns, int columnCount);
-		float calcSpinCosts(State * initialState, State * resultState, std::vector<StepParity::Foot> & combinedColumns, int columnCount);
-		float caclFootswitchCost(State * initialState, State * resultState, Row &row, std::vector<StepParity::Foot> &combinedColumns, float elapsedTime, int columnCount);
+		float calcFacingCosts(State * initialState, State * resultState, int columnCount);
+		float calcSpinCosts(State * initialState, State * resultState, int columnCount);
+		float caclFootswitchCost(State * initialState, State * resultState, Row &row, float elapsedTime, int columnCount);
 		float calcSideswitchCost(State * initialState, State * resultState, int columnCount);
 		float calcJackCost(bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, float elapsedTime, int columnCount);
 		float calcBigMovementsQuicklyCost(State * initialState, State * resultState, float elapsedTime, int columnCount);

--- a/src/StepParityCost.h
+++ b/src/StepParityCost.h
@@ -11,21 +11,34 @@ namespace StepParity
 	const int DOUBLESTEP= 850;
 	const int BRACKETJACK= 20;
 	const int JACK= 30;
-	const int JUMP= 30;
+	const int JUMP= 0;
+	const int SLOW_BRACKET=300;
+	const int TWISTED_FOOT=100000;
 	const int BRACKETTAP= 400;
 	const int HOLDSWITCH= 55;
 	const int MINE= 10000;
-	const int FOOTSWITCH= 5000;
+	const int FOOTSWITCH= 325;
 	const int MISSED_FOOTSWITCH= 500;
 	const int FACING= 2;
 	const int DISTANCE= 6;
 	const int SPIN= 1000;
 	const int SIDESWITCH= 130;
-    const int CROWDED_BRACKET = 40;
-    const int OTHER = 500;
+    const int CROWDED_BRACKET = 0;
+    const int OTHER = 0;
     
-    const float JACK_THRESHOLD = 0.1;
-    
+	// 0.1 = 1/16th note at 150bpm. Jacks quicker than this are harder.
+	// Above this speed, footswitches should be prioritized
+	const float JACK_THRESHOLD = 0.1;
+	// 0.15 = 1/8th at 200bpm, or 3/16th at 150bpm. Below this speed, jumps should be prioritized
+	const float SLOW_BRACKET_THRESHOLD = 0.15;
+	
+	// 0.2 = 1/8th at 150bpm. Footswitches slower than this are harder.
+	// Below this speed, jacks should be prioritized
+	const float SLOW_FOOTSWITCH_THRESHOLD = 0.2;
+	// 0.4 = 1/4th at 150bpm. Once a footswitch gets slow enough, though,
+	// just ignore it.
+	const float SLOW_FOOTSWITCH_IGNORE = 0.4;
+	
 	class StepParityCost
 	{
 	private:
@@ -54,6 +67,8 @@ namespace StepParity
 		float calcBracketJackCost(State * initialState, State * resultState, std::vector<Row> &rows, int rowIndex, bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, bool didJump, int columnCount);
         float calcDoublestepCost(State * initialState, State * resultState, std::vector<Row> & rows, int rowIndex, bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, bool didJump, int columnCount);
 		float calcJumpCost(Row &row, bool movedLeft, bool movedRight, float elapsedTime, int columnCount);
+		float calcSlowBracketCost(Row & row, bool movedLeft, bool movedRight, float elapsedTime);
+		float calcTwistedFootCost(State * resultState);
 		float calcMissedFootswitchCost(Row &row, bool jackedLeft, bool jackedRight, int columnCount);
 		float calcFacingCosts(State * initialState, State * resultState, std::vector<StepParity::Foot> &combinedColumns, int columnCount);
         float calcSpinCosts(State * initialState, State * resultState, std::vector<StepParity::Foot> & combinedColumns, int columnCount);

--- a/src/StepParityCost.h
+++ b/src/StepParityCost.h
@@ -50,7 +50,7 @@ namespace StepParity
 		/// @param rows 
 		/// @param rowIndex The index of the row represented by resultState
 		/// @return The computed cost
-		float* getActionCost(State * initialState, State * resultState, std::vector<Row> &rows, int rowIndex);
+		float getActionCost(State * initialState, State * resultState, std::vector<Row> &rows, int rowIndex);
 
 	private:
 		void mergeInitialAndResultPosition(State * initialState, State * resultState, std::vector<StepParity::Foot> &combinedColumns, int columnCount);

--- a/src/StepParityCost.h
+++ b/src/StepParityCost.h
@@ -1,0 +1,81 @@
+#ifndef STEP_PARITY_COST_H
+#define STEP_PARITY_COST_H
+
+#include "GameConstantsAndTypes.h"
+#include "StepParityDatastructs.h"
+
+namespace StepParity
+{
+	
+   
+	const int DOUBLESTEP= 850;
+	const int BRACKETJACK= 20;
+	const int JACK= 30;
+	const int JUMP= 30;
+	const int BRACKETTAP= 400;
+	const int HOLDSWITCH= 55;
+	const int MINE= 10000;
+	const int FOOTSWITCH= 5000;
+	const int MISSED_FOOTSWITCH= 500;
+	const int FACING= 2;
+	const int DISTANCE= 6;
+	const int SPIN= 1000;
+	const int SIDESWITCH= 130;
+    const int CROWDED_BRACKET = 40;
+    const int OTHER = 500;
+    
+    const float JACK_THRESHOLD = 0.1;
+    
+	class StepParityCost
+	{
+	private:
+		StageLayout layout;
+
+	public:
+		StepParityCost(StageLayout _layout)
+		{
+			layout = _layout;
+		}
+
+		/// @brief Computes and returns a cost value for the player moving from initialState to resultState.
+		/// @param initialState The starting position of the player
+		/// @param resultState The end position of the player
+		/// @param rows 
+		/// @param rowIndex The index of the row represented by resultState
+		/// @return The computed cost
+		float* getActionCost(State * initialState, State * resultState, std::vector<Row> &rows, int rowIndex);
+
+	private:
+		void mergeInitialAndResultPosition(State * initialState, State * resultState, std::vector<StepParity::Foot> &combinedColumns, int columnCount);
+		float calcMineCost(State * initialState, State * resultState, Row &row, std::vector<StepParity::Foot> &combinedColumns, int columnCount);
+		float calcHoldSwitchCost(State * initialState, State * resultState, Row &row, std::vector<StepParity::Foot> &combinedColumns, int columnCount);
+		float calcBracketTapCost(State * initialState, State * resultState, Row &row, int leftHeel, int leftToe, int rightHeel, int rightToe, float elapsedTime, int columnCount);
+		float calcMovingFootWhileOtherIsntOnPadCost(State * initialState, State * resultState, int columnCount);
+		float calcBracketJackCost(State * initialState, State * resultState, std::vector<Row> &rows, int rowIndex, bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, bool didJump, int columnCount);
+        float calcDoublestepCost(State * initialState, State * resultState, std::vector<Row> & rows, int rowIndex, bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, bool didJump, int columnCount);
+		float calcJumpCost(Row &row, bool movedLeft, bool movedRight, float elapsedTime, int columnCount);
+		float calcMissedFootswitchCost(Row &row, bool jackedLeft, bool jackedRight, int columnCount);
+		float calcFacingCosts(State * initialState, State * resultState, std::vector<StepParity::Foot> &combinedColumns, int columnCount);
+        float calcSpinCosts(State * initialState, State * resultState, std::vector<StepParity::Foot> & combinedColumns, int columnCount);
+		float caclFootswitchCost(State * initialState, State * resultState, Row &row, std::vector<StepParity::Foot> &combinedColumns, float elapsedTime, int columnCount);
+		float calcSideswitchCost(State * initialState, State * resultState, int columnCount);
+		float calcJackCost(bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, float elapsedTime, int columnCount);
+		float calcBigMovementsQuicklyCost(State * initialState, State * resultState, float elapsedTime, int columnCount);
+        float calcCrowdedBracketCost(State * initialState, State * resultState, float elapsedTime, int columnCount);
+        
+		bool didDoubleStep(State * initialState, State * resultState, std::vector<Row> &rows, int rowIndex, bool movedLeft, bool jackedLeft, bool movedRight, bool jackedRight, int columnCount);
+		bool didJackLeft(State * initialState, State * resultState, int leftHeel, int leftToe, bool movedLeft, bool didJump, int columnCount);
+		bool didJackRight(State * initialState, State * resultState, int rightHeel, int rightToe, bool movedRight, bool didJump,int columnCount);
+
+		float getDistanceSq(StepParity::StagePoint p1, StepParity::StagePoint p2);
+		float getPlayerAngle(StepParity::StagePoint left, StepParity::StagePoint right);
+
+		float getXDifference(int leftIndex, int rightIndex);
+		float getYDifference(int leftIndex, int rightIndex);
+		StagePoint averagePoint(int leftIndex, int rightIndex);
+
+	};
+};
+
+#endif
+

--- a/src/StepParityCost.h
+++ b/src/StepParityCost.h
@@ -45,9 +45,7 @@ namespace StepParity
 		StageLayout layout;
 
 	public:
-		StepParityCost(StageLayout _layout)
-		{
-			layout = _layout;
+		StepParityCost(const StageLayout& _layout): layout(_layout){
 		}
 
 		/// @brief Computes and returns a cost value for the player moving from initialState to resultState.
@@ -81,14 +79,6 @@ namespace StepParity
 		bool didDoubleStep(State * initialState, State * resultState, std::vector<Row> &rows, int rowIndex, bool movedLeft, bool jackedLeft, bool movedRight, bool jackedRight, int columnCount);
 		bool didJackLeft(State * initialState, State * resultState, int leftHeel, int leftToe, bool movedLeft, bool didJump, int columnCount);
 		bool didJackRight(State * initialState, State * resultState, int rightHeel, int rightToe, bool movedRight, bool didJump,int columnCount);
-
-		float getDistanceSq(StepParity::StagePoint p1, StepParity::StagePoint p2);
-		float getPlayerAngle(StepParity::StagePoint left, StepParity::StagePoint right);
-
-		float getXDifference(int leftIndex, int rightIndex);
-		float getYDifference(int leftIndex, int rightIndex);
-		StagePoint averagePoint(int leftIndex, int rightIndex);
-
 	};
 };
 

--- a/src/StepParityCost.h
+++ b/src/StepParityCost.h
@@ -6,8 +6,6 @@
 
 namespace StepParity
 {
-	
-   
 	const int DOUBLESTEP= 850;
 	const int BRACKETJACK= 20;
 	const int JACK= 30;
@@ -23,15 +21,14 @@ namespace StepParity
 	const int DISTANCE= 6;
 	const int SPIN= 1000;
 	const int SIDESWITCH= 130;
-    const int CROWDED_BRACKET = 0;
-    const int OTHER = 0;
-    
+	const int CROWDED_BRACKET = 0;
+	const int OTHER = 0;
+
 	// 0.1 = 1/16th note at 150bpm. Jacks quicker than this are harder.
 	// Above this speed, footswitches should be prioritized
 	const float JACK_THRESHOLD = 0.1;
 	// 0.15 = 1/8th at 200bpm, or 3/16th at 150bpm. Below this speed, jumps should be prioritized
 	const float SLOW_BRACKET_THRESHOLD = 0.15;
-	
 	// 0.2 = 1/8th at 150bpm. Footswitches slower than this are harder.
 	// Below this speed, jacks should be prioritized
 	const float SLOW_FOOTSWITCH_THRESHOLD = 0.2;
@@ -45,8 +42,7 @@ namespace StepParity
 		StageLayout layout;
 
 	public:
-		StepParityCost(const StageLayout& _layout): layout(_layout){
-		}
+		StepParityCost(const StageLayout& _layout): layout(_layout) {}
 
 		/// @brief Computes and returns a cost value for the player moving from initialState to resultState.
 		/// @param initialState The starting position of the player
@@ -63,18 +59,18 @@ namespace StepParity
 		float calcBracketTapCost(State * initialState, State * resultState, Row &row, int leftHeel, int leftToe, int rightHeel, int rightToe, float elapsedTime, int columnCount);
 		float calcMovingFootWhileOtherIsntOnPadCost(State * initialState, State * resultState, int columnCount);
 		float calcBracketJackCost(State * initialState, State * resultState, std::vector<Row> &rows, int rowIndex, bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, bool didJump, int columnCount);
-        float calcDoublestepCost(State * initialState, State * resultState, std::vector<Row> & rows, int rowIndex, bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, bool didJump, int columnCount);
+		float calcDoublestepCost(State * initialState, State * resultState, std::vector<Row> & rows, int rowIndex, bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, bool didJump, int columnCount);
 		float calcJumpCost(Row &row, bool movedLeft, bool movedRight, float elapsedTime, int columnCount);
 		float calcSlowBracketCost(Row & row, bool movedLeft, bool movedRight, float elapsedTime);
 		float calcTwistedFootCost(State * resultState);
 		float calcMissedFootswitchCost(Row &row, bool jackedLeft, bool jackedRight, int columnCount);
 		float calcFacingCosts(State * initialState, State * resultState, std::vector<StepParity::Foot> &combinedColumns, int columnCount);
-        float calcSpinCosts(State * initialState, State * resultState, std::vector<StepParity::Foot> & combinedColumns, int columnCount);
+		float calcSpinCosts(State * initialState, State * resultState, std::vector<StepParity::Foot> & combinedColumns, int columnCount);
 		float caclFootswitchCost(State * initialState, State * resultState, Row &row, std::vector<StepParity::Foot> &combinedColumns, float elapsedTime, int columnCount);
 		float calcSideswitchCost(State * initialState, State * resultState, int columnCount);
 		float calcJackCost(bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, float elapsedTime, int columnCount);
 		float calcBigMovementsQuicklyCost(State * initialState, State * resultState, float elapsedTime, int columnCount);
-        float calcCrowdedBracketCost(State * initialState, State * resultState, float elapsedTime, int columnCount);
+		float calcCrowdedBracketCost(State * initialState, State * resultState, float elapsedTime, int columnCount);
         
 		bool didDoubleStep(State * initialState, State * resultState, std::vector<Row> &rows, int rowIndex, bool movedLeft, bool jackedLeft, bool movedRight, bool jackedRight, int columnCount);
 		bool didJackLeft(State * initialState, State * resultState, int leftHeel, int leftToe, bool movedLeft, bool didJump, int columnCount);

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -1,0 +1,250 @@
+#include "global.h"
+#include "StepParityDatastructs.h"
+
+using namespace StepParity;
+
+
+//
+// Graph/Node methods
+//
+int calculateVectorHash(const std::vector<Foot> &vec)
+{
+	int value = 0;
+	for(Foot f : vec)
+	{
+		value *= 5;
+		value += f;
+	}
+	return value;
+}
+
+bool State::operator==(const State &other) const
+{
+   return rowIndex == other.rowIndex &&
+   columns == other.columns &&
+   movedFeet == other.movedFeet &&
+   holdFeet == other.holdFeet;
+}
+
+bool State::operator<(const State &other) const
+{
+
+	if(rowIndex != other.rowIndex) {
+		return rowIndex < other.rowIndex;
+	}
+	if(columnsHash != other.columnsHash) {
+		return columnsHash < other.columnsHash;
+	}
+	if(movedFeetHash != other.movedFeetHash) {
+		return movedFeetHash < other.movedFeetHash;
+	}
+	if(holdFeetHash != other.holdFeetHash) {
+		return holdFeetHash < other.holdFeetHash;
+	}
+	return false;
+}
+
+void State::calculateHashes()
+{
+	columnsHash = calculateVectorHash(columns);
+	movedFeetHash = calculateVectorHash(movedFeet);
+	holdFeetHash = calculateVectorHash(holdFeet);
+}
+
+StepParityNode * StepParityGraph::addOrGetExistingNode(const State &state)
+{
+	// this is silly, but the start node has a rowIndex of -1
+	// which doesn't work as an array index.
+	int rowIndex = state.rowIndex + 1; 
+	while (static_cast<int>(stateNodeMap.size()) <= rowIndex)
+	{
+		stateNodeMap.push_back(std::map<State, StepParityNode *, StateComparator>());
+	}
+	
+	if(stateNodeMap[rowIndex].find(state) == stateNodeMap[rowIndex].end())
+	{
+		StepParityNode* newNode = new StepParityNode(state);
+        newNode->id = int(nodes.size());
+        nodes.push_back(newNode);
+        newNode->state.idx = int(states.size());
+        states.push_back(&(newNode->state));
+		stateNodeMap[rowIndex][state] = newNode;
+	}
+
+	return stateNodeMap[rowIndex][state];
+}
+
+
+//
+// Json methods
+//
+
+
+template<typename Container>
+Json::Value FeetToJson(const Container& feets, bool useStrings)
+{
+	Json::Value root;
+	for(Foot f: feets)
+	{
+		if(useStrings)
+		{
+			root.append(FEET_LABELS[static_cast<int>(f)]);
+		}
+		else
+		{
+			root.append(static_cast<int>(f));
+		}
+	}
+	return root;
+}
+
+Json::Value State::ToJson(bool useStrings)
+{
+	Json::Value root;
+	Json::Value jsonColumns = FeetToJson(columns, useStrings);
+	Json::Value jsonMovedFeet = FeetToJson(movedFeet, useStrings);
+	Json::Value jsonHoldFeet = FeetToJson(holdFeet, useStrings);
+    
+    root["idx"] = idx;
+    root["columns"] = jsonColumns;
+	root["movedFeet"] = jsonMovedFeet;
+	root["holdFeet"] = jsonHoldFeet;
+	root["second"] = second;
+	root["rowIndex"] = rowIndex;
+	return root;
+}
+
+Json::Value IntermediateNoteData::ToJson(bool useStrings)
+{
+	Json::Value root;
+	if(useStrings)
+	{
+		root["type"] = TapNoteTypeShortNames[static_cast<int>(type)];
+		root["subtype"] = TapNoteSubTypeShortNames[static_cast<int>(subtype)];
+		root["parity"] = FEET_LABELS[static_cast<int>(parity)];
+		
+	}
+	else
+	{
+		root["type"] = static_cast<int>(type);
+		root["subtype"] = static_cast<int>(subtype);
+		root["parity"] = static_cast<int>(parity);
+	}
+	root["col"] = col;
+	root["row"] = row;
+	root["beat"] = beat;
+	root["hold"] = hold_length;
+	root["warped"] = warped;
+	root["fake"] = fake;
+	root["second"] = second;
+	return root;
+}
+
+Json::Value Row::ToJson(bool useStrings)
+{
+	Json::Value root;
+	Json::Value jsonNotes;
+	Json::Value jsonHolds;
+	Json::Value jsonHoldTails;
+	Json::Value jsonMines;
+	Json::Value jsonFakeMines;
+
+	for (IntermediateNoteData n : notes) { jsonNotes.append(n.ToJson(useStrings)); }
+	for (IntermediateNoteData n : holds) { jsonHolds.append(n.ToJson(useStrings)); }
+	for (int t : holdTails) { jsonHoldTails.append(t); }
+	for (int m : mines) { jsonMines.append(m); }
+	for (int f : fakeMines) { jsonFakeMines.append(f); }
+
+	root["notes"] = jsonNotes;
+	root["holds"] = jsonHolds;
+	root["hold_tails"] = jsonHoldTails;
+	root["mines"] = jsonMines;
+	root["fake_mines"] = jsonFakeMines;
+	root["second"] = second;
+	root["beat"] = beat;
+
+	return root;
+}
+
+Json::Value StepParityNode::ToJson()
+{
+	Json::Value root;
+	Json::Value jsonNeighbors;
+
+	for (auto it = neighbors.begin(); it != neighbors.end(); it++)
+	{
+		Json::Value n;
+		n["id"] = it->first->id;
+        Json::Value jsonCosts;
+        float * costs = it->second;
+        for(int i = 0; i < NUM_Cost; i++)
+        {
+            jsonCosts[COST_LABELS[i]] = costs[i];
+        }
+        n["costs"] = jsonCosts;
+		jsonNeighbors.append(n);
+	}
+	root["id"] = id;
+    root["stateIdx"] = state.idx;
+	root["neighbors"] = jsonNeighbors;
+	return root;
+}
+
+
+Json::Value Row::ToJsonRows(const std::vector<Row> & rows, bool useStrings)
+{
+	Json::Value root;
+	for(Row row: rows)
+	{
+		root.append(row.ToJson(useStrings));
+	}
+	return root;
+}
+
+Json::Value Row::ParityRowsJson(const std::vector<Row> & rows)
+{
+	Json::Value root;
+	for(Row row: rows)
+	{
+		Json::Value pr;
+		for(IntermediateNoteData note: row.notes)
+		{
+			pr.append(static_cast<int>(note.parity));
+		}
+		root.append(pr);
+	}
+	return root;
+}
+
+
+Json::Value StepParityGraph::ToJson()
+{
+    Json::Value jsonNodes;
+	for(auto node: nodes)
+	{
+        jsonNodes.append(node->ToJson());
+	}
+    Json::Value jsonStates;
+    for(auto state: states)
+    {
+        jsonStates.append(state->ToJson(false));
+    }
+    
+    Json::Value root;
+    root["nodes"] = jsonNodes;
+    root["states"] = jsonStates;
+	return root;
+}
+
+Json::Value StepParityGraph::NodeStateJson()
+{
+	Json::Value root;
+	for(auto node: nodes)
+	{
+		Json::Value nodeJson;
+		nodeJson["id"] = node->id;
+		nodeJson["state"] = node->state.ToJson(false);
+		root.append(nodeJson);
+	}
+	return root;
+}

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -273,12 +273,8 @@ Json::Value StepParityNode::ToJson()
 		Json::Value n;
 		n["id"] = it->first->id;
 		Json::Value jsonCosts;
-		float * costs = it->second;
-		for(int i = 0; i < NUM_Cost; i++)
-		{
-			jsonCosts[COST_LABELS[i]] = costs[i];
-		}
-		n["costs"] = jsonCosts;
+		float cost = it->second;
+		n["cost"] = cost;
 		jsonNeighbors.append(n);
 	}
 	root["id"] = id;

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -61,10 +61,10 @@ StepParityNode * StepParityGraph::addOrGetExistingNode(const State &state)
 	if(stateNodeMap[rowIndex].find(state) == stateNodeMap[rowIndex].end())
 	{
 		StepParityNode* newNode = new StepParityNode(state);
-        newNode->id = int(nodes.size());
-        nodes.push_back(newNode);
-        newNode->state.idx = int(states.size());
-        states.push_back(&(newNode->state));
+		newNode->id = int(nodes.size());
+		nodes.push_back(newNode);
+		newNode->state.idx = int(states.size());
+		states.push_back(&(newNode->state));
 		stateNodeMap[rowIndex][state] = newNode;
 	}
 
@@ -314,7 +314,7 @@ Json::Value Row::ParityRowsJson(const std::vector<Row> & rows)
 
 Json::Value StepParityGraph::ToJson()
 {
-    Json::Value jsonNodes;
+	Json::Value jsonNodes;
 	for(auto node: nodes)
 	{
 		jsonNodes.append(node->ToJson());

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -170,6 +170,23 @@ float StageLayout::getPlayerAngle(StepParity::StagePoint left, StepParity::Stage
 }
 
 //
+// Row
+//
+
+void Row::setFootPlacement(const std::vector<Foot> & footPlacement)
+{
+	for (int c = 0; c < columnCount; c++) {
+		if(notes[c].type != TapNoteType_Empty) {
+			notes[c].parity = footPlacement[c];
+			columns[c] = footPlacement[c];
+			whereTheFeetAre[footPlacement[c]] = c;
+			noteCount += 1;
+		}
+	}
+}
+
+
+//
 // Json methods
 //
 

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -3,72 +3,13 @@
 
 using namespace StepParity;
 
-// Graph/Node methods
-int calculateVectorHash(const std::vector<Foot> &vec)
-{
-	int value = 0;
-	for(Foot f : vec)
-	{
-		value *= 5;
-		value += f;
-	}
-	return value;
-}
 
 bool State::operator==(const State &other) const
 {
-   return rowIndex == other.rowIndex &&
-   columns == other.columns &&
+   return columns == other.columns &&
+	combinedColumns == other.combinedColumns &&
    movedFeet == other.movedFeet &&
    holdFeet == other.holdFeet;
-}
-
-bool State::operator<(const State &other) const
-{
-
-	if(rowIndex != other.rowIndex) {
-		return rowIndex < other.rowIndex;
-	}
-	if(columnsHash != other.columnsHash) {
-		return columnsHash < other.columnsHash;
-	}
-	if(movedFeetHash != other.movedFeetHash) {
-		return movedFeetHash < other.movedFeetHash;
-	}
-	if(holdFeetHash != other.holdFeetHash) {
-		return holdFeetHash < other.holdFeetHash;
-	}
-	return false;
-}
-
-void State::calculateHashes()
-{
-	columnsHash = calculateVectorHash(columns);
-	movedFeetHash = calculateVectorHash(movedFeet);
-	holdFeetHash = calculateVectorHash(holdFeet);
-}
-
-StepParityNode * StepParityGraph::addOrGetExistingNode(const State &state)
-{
-	// This is silly, but the start node has a rowIndex of -1
-	// which doesn't work as an array index.
-	int rowIndex = state.rowIndex + 1; 
-	while (static_cast<int>(stateNodeMap.size()) <= rowIndex)
-	{
-		stateNodeMap.push_back(std::map<State, StepParityNode *, StateComparator>());
-	}
-	
-	if(stateNodeMap[rowIndex].find(state) == stateNodeMap[rowIndex].end())
-	{
-		StepParityNode* newNode = new StepParityNode(state);
-		newNode->id = int(nodes.size());
-		nodes.push_back(newNode);
-		newNode->state.idx = int(states.size());
-		states.push_back(&(newNode->state));
-		stateNodeMap[rowIndex][state] = newNode;
-	}
-
-	return stateNodeMap[rowIndex][state];
 }
 
 // StageLayout
@@ -176,166 +117,22 @@ void Row::setFootPlacement(const std::vector<Foot> & footPlacement)
 	}
 }
 
-// Json methods
-template<typename Container>
-Json::Value FeetToJson(const Container& feets, bool useStrings)
+bool Row::operator==(const Row& other) const
 {
-	Json::Value root;
-	for(Foot f: feets)
-	{
-		if(useStrings)
-		{
-			root.append(FEET_LABELS[static_cast<int>(f)]);
-		}
-		else
-		{
-			root.append(static_cast<int>(f));
-		}
-	}
-	return root;
+	return second == other.second &&
+	beat == other.beat &&
+	rowIndex == other.rowIndex &&
+	columnCount == other.columnCount &&
+	noteCount == other.noteCount &&
+	holdTails == other.holdTails &&
+	mines == other.mines &&
+	fakeMines == other.fakeMines &&
+	columns == other.columns &&
+	whereTheFeetAre == other.whereTheFeetAre;
+	
 }
 
-Json::Value State::ToJson(bool useStrings)
+bool Row::operator!=(const Row& other) const
 {
-	Json::Value root;
-	Json::Value jsonColumns = FeetToJson(columns, useStrings);
-	Json::Value jsonMovedFeet = FeetToJson(movedFeet, useStrings);
-	Json::Value jsonHoldFeet = FeetToJson(holdFeet, useStrings);
-
-	root["idx"] = idx;
-	root["columns"] = jsonColumns;
-	root["movedFeet"] = jsonMovedFeet;
-	root["holdFeet"] = jsonHoldFeet;
-	root["second"] = second;
-	root["rowIndex"] = rowIndex;
-	return root;
-}
-
-Json::Value IntermediateNoteData::ToJson(bool useStrings)
-{
-	Json::Value root;
-	if(useStrings)
-	{
-		root["type"] = TapNoteTypeShortNames[static_cast<int>(type)];
-		root["subtype"] = TapNoteSubTypeShortNames[static_cast<int>(subtype)];
-		root["parity"] = FEET_LABELS[static_cast<int>(parity)];
-		
-	}
-	else
-	{
-		root["type"] = static_cast<int>(type);
-		root["subtype"] = static_cast<int>(subtype);
-		root["parity"] = static_cast<int>(parity);
-	}
-	root["col"] = col;
-	root["row"] = row;
-	root["beat"] = beat;
-	root["hold"] = hold_length;
-	root["warped"] = warped;
-	root["fake"] = fake;
-	root["second"] = second;
-	return root;
-}
-
-Json::Value Row::ToJson(bool useStrings)
-{
-	Json::Value root;
-	Json::Value jsonNotes;
-	Json::Value jsonHolds;
-	Json::Value jsonHoldTails;
-	Json::Value jsonMines;
-	Json::Value jsonFakeMines;
-
-	for (IntermediateNoteData n : notes) { jsonNotes.append(n.ToJson(useStrings)); }
-	for (IntermediateNoteData n : holds) { jsonHolds.append(n.ToJson(useStrings)); }
-	for (int t : holdTails) { jsonHoldTails.append(t); }
-	for (int m : mines) { jsonMines.append(m); }
-	for (int f : fakeMines) { jsonFakeMines.append(f); }
-
-	root["notes"] = jsonNotes;
-	root["holds"] = jsonHolds;
-	root["hold_tails"] = jsonHoldTails;
-	root["mines"] = jsonMines;
-	root["fake_mines"] = jsonFakeMines;
-	root["second"] = second;
-	root["beat"] = beat;
-
-	return root;
-}
-
-Json::Value StepParityNode::ToJson()
-{
-	Json::Value root;
-	Json::Value jsonNeighbors;
-
-	for (auto it = neighbors.begin(); it != neighbors.end(); it++)
-	{
-		Json::Value n;
-		n["id"] = it->first->id;
-		Json::Value jsonCosts;
-		float cost = it->second;
-		n["cost"] = cost;
-		jsonNeighbors.append(n);
-	}
-	root["id"] = id;
-	root["stateIdx"] = state.idx;
-	root["neighbors"] = jsonNeighbors;
-	return root;
-}
-
-Json::Value Row::ToJsonRows(const std::vector<Row> & rows, bool useStrings)
-{
-	Json::Value root;
-	for(Row row: rows)
-	{
-		root.append(row.ToJson(useStrings));
-	}
-	return root;
-}
-
-Json::Value Row::ParityRowsJson(const std::vector<Row> & rows)
-{
-	Json::Value root;
-	for(Row row: rows)
-	{
-		Json::Value pr;
-		for(IntermediateNoteData note: row.notes)
-		{
-			pr.append(static_cast<int>(note.parity));
-		}
-		root.append(pr);
-	}
-	return root;
-}
-
-Json::Value StepParityGraph::ToJson()
-{
-	Json::Value jsonNodes;
-	for(auto node: nodes)
-	{
-		jsonNodes.append(node->ToJson());
-	}
-	Json::Value jsonStates;
-	for(auto state: states)
-	{
-		jsonStates.append(state->ToJson(false));
-	}
-
-	Json::Value root;
-	root["nodes"] = jsonNodes;
-	root["states"] = jsonStates;
-	return root;
-}
-
-Json::Value StepParityGraph::NodeStateJson()
-{
-	Json::Value root;
-	for(auto node: nodes)
-	{
-		Json::Value nodeJson;
-		nodeJson["id"] = node->id;
-		nodeJson["state"] = node->state.ToJson(false);
-		root.append(nodeJson);
-	}
-	return root;
+	return !operator==(other);
 }

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -74,6 +74,100 @@ StepParityNode * StepParityGraph::addOrGetExistingNode(const State &state)
 	return stateNodeMap[rowIndex][state];
 }
 
+//
+// StageLayout
+//
+
+bool StageLayout::bracketCheck(int column1, int column2)
+{
+	StagePoint p1 = columns[column1];
+	StagePoint p2 = columns[column2];
+	return getDistanceSq(p1, p2) <= 2;
+}
+
+bool StageLayout::isSideArrow(int column)
+{
+	return std::find(sideArrows.begin(), sideArrows.end(), column) != sideArrows.end();
+}
+
+bool StageLayout::isUpArrow(int column)
+{
+	return std::find(upArrows.begin(), upArrows.end(), column) != upArrows.end();
+}
+
+bool StageLayout::isDownArrow(int column)
+{
+	return std::find(downArrows.begin(), downArrows.end(), column) != downArrows.end();
+}
+
+float StageLayout::getDistanceSq(int c1, int c2)
+{
+	return getDistanceSq(columns[c1], columns[c2]);
+}
+
+float StageLayout::getDistanceSq(StepParity::StagePoint p1, StepParity::StagePoint p2)
+{
+	return (p1.y - p2.y) * (p1.y - p2.y) + (p1.x - p2.x) * (p1.x - p2.x);
+}
+
+float StageLayout::getXDifference(int leftIndex, int rightIndex) {
+	if (leftIndex == rightIndex) return 0;
+	float dx = columns[rightIndex].x - columns[leftIndex].x;
+	float dy = columns[rightIndex].y - columns[leftIndex].y;
+
+	float distance = sqrt(dx * dx + dy * dy);
+	dx /= distance;
+
+	bool negative = dx <= 0;
+
+	dx = pow(dx, 4);
+
+	if (negative) dx = -dx;
+
+	return dx;
+}
+
+float StageLayout::getYDifference(int leftIndex, int rightIndex) {
+	if (leftIndex == rightIndex) return 0;
+	float dx = columns[rightIndex].x - columns[leftIndex].x;
+	float dy = columns[rightIndex].y - columns[leftIndex].y;
+
+	float distance = sqrt(dx * dx + dy * dy);
+	dy /= distance;
+
+	bool negative = dy <= 0;
+
+	dy = pow(dy, 4);
+
+	if (negative) dy = -dy;
+
+	return dy;
+}
+
+StagePoint StageLayout::averagePoint(int leftIndex, int rightIndex) {
+	if (leftIndex == -1 && rightIndex == -1) return { 0,0 };
+	if (leftIndex == -1) return columns[rightIndex];
+	if (rightIndex == -1) return columns[leftIndex];
+	return {
+	  (columns[leftIndex].x + columns[rightIndex].x) / 2.0f,
+	  (columns[leftIndex].y + columns[rightIndex].y) / 2.0f,
+	};
+}
+
+float StageLayout::getPlayerAngle(int c1, int c2)
+{
+	return getPlayerAngle(columns[c1], columns[c2]);
+}
+float StageLayout::getPlayerAngle(StepParity::StagePoint left, StepParity::StagePoint right)
+{
+	float x1 = right.x - left.x;
+	float y1 = right.y - left.y;
+	float x2 = 1;
+	float y2 = 0;
+	float dot = x1 * x2 + y1 * y2;
+	float det = x1 * y2 - y1 * x2;
+	return atan2f(det, dot);
+}
 
 //
 // Json methods

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -3,10 +3,7 @@
 
 using namespace StepParity;
 
-
-//
 // Graph/Node methods
-//
 int calculateVectorHash(const std::vector<Foot> &vec)
 {
 	int value = 0;
@@ -53,7 +50,7 @@ void State::calculateHashes()
 
 StepParityNode * StepParityGraph::addOrGetExistingNode(const State &state)
 {
-	// this is silly, but the start node has a rowIndex of -1
+	// This is silly, but the start node has a rowIndex of -1
 	// which doesn't work as an array index.
 	int rowIndex = state.rowIndex + 1; 
 	while (static_cast<int>(stateNodeMap.size()) <= rowIndex)
@@ -74,10 +71,7 @@ StepParityNode * StepParityGraph::addOrGetExistingNode(const State &state)
 	return stateNodeMap[rowIndex][state];
 }
 
-//
 // StageLayout
-//
-
 bool StageLayout::bracketCheck(int column1, int column2)
 {
 	StagePoint p1 = columns[column1];
@@ -169,10 +163,7 @@ float StageLayout::getPlayerAngle(StepParity::StagePoint left, StepParity::Stage
 	return atan2f(det, dot);
 }
 
-//
 // Row
-//
-
 void Row::setFootPlacement(const std::vector<Foot> & footPlacement)
 {
 	for (int c = 0; c < columnCount; c++) {
@@ -185,12 +176,7 @@ void Row::setFootPlacement(const std::vector<Foot> & footPlacement)
 	}
 }
 
-
-//
 // Json methods
-//
-
-
 template<typename Container>
 Json::Value FeetToJson(const Container& feets, bool useStrings)
 {
@@ -215,9 +201,9 @@ Json::Value State::ToJson(bool useStrings)
 	Json::Value jsonColumns = FeetToJson(columns, useStrings);
 	Json::Value jsonMovedFeet = FeetToJson(movedFeet, useStrings);
 	Json::Value jsonHoldFeet = FeetToJson(holdFeet, useStrings);
-    
-    root["idx"] = idx;
-    root["columns"] = jsonColumns;
+
+	root["idx"] = idx;
+	root["columns"] = jsonColumns;
 	root["movedFeet"] = jsonMovedFeet;
 	root["holdFeet"] = jsonHoldFeet;
 	root["second"] = second;
@@ -286,21 +272,20 @@ Json::Value StepParityNode::ToJson()
 	{
 		Json::Value n;
 		n["id"] = it->first->id;
-        Json::Value jsonCosts;
-        float * costs = it->second;
-        for(int i = 0; i < NUM_Cost; i++)
-        {
-            jsonCosts[COST_LABELS[i]] = costs[i];
-        }
-        n["costs"] = jsonCosts;
+		Json::Value jsonCosts;
+		float * costs = it->second;
+		for(int i = 0; i < NUM_Cost; i++)
+		{
+			jsonCosts[COST_LABELS[i]] = costs[i];
+		}
+		n["costs"] = jsonCosts;
 		jsonNeighbors.append(n);
 	}
 	root["id"] = id;
-    root["stateIdx"] = state.idx;
+	root["stateIdx"] = state.idx;
 	root["neighbors"] = jsonNeighbors;
 	return root;
 }
-
 
 Json::Value Row::ToJsonRows(const std::vector<Row> & rows, bool useStrings)
 {
@@ -327,23 +312,22 @@ Json::Value Row::ParityRowsJson(const std::vector<Row> & rows)
 	return root;
 }
 
-
 Json::Value StepParityGraph::ToJson()
 {
     Json::Value jsonNodes;
 	for(auto node: nodes)
 	{
-        jsonNodes.append(node->ToJson());
+		jsonNodes.append(node->ToJson());
 	}
-    Json::Value jsonStates;
-    for(auto state: states)
-    {
-        jsonStates.append(state->ToJson(false));
-    }
-    
-    Json::Value root;
-    root["nodes"] = jsonNodes;
-    root["states"] = jsonStates;
+	Json::Value jsonStates;
+	for(auto state: states)
+	{
+		jsonStates.append(state->ToJson(false));
+	}
+
+	Json::Value root;
+	root["nodes"] = jsonNodes;
+	root["states"] = jsonStates;
 	return root;
 }
 

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -8,7 +8,6 @@
 #include <queue>
 #include <unordered_map>
 
-
 namespace StepParity {
 
 	const float CLM_SECOND_INVALID = -1;
@@ -33,48 +32,48 @@ namespace StepParity {
 	const RString TapNoteTypeShortNames[] = { "Empty", "Tap",  "Mine",  "Attack", "AutoKeySound", "Fake", "", "" };
 	const RString TapNoteSubTypeShortNames[] = { "Hold", "Roll", "", "" };	
 
-    enum Cost
-    {
-        COST_DOUBLESTEP = 0,
-        COST_BRACKETJACK,
-        COST_JACK,
-        COST_JUMP,
+	enum Cost
+	{
+		COST_DOUBLESTEP = 0,
+		COST_BRACKETJACK,
+		COST_JACK,
+		COST_JUMP,
 		COST_SLOW_BRACKET,
 		COST_TWISTED_FOOT,
-        COST_BRACKETTAP,
-        COST_HOLDSWITCH,
-        COST_MINE,
-        COST_FOOTSWITCH,
-        COST_MISSED_FOOTSWITCH,
-        COST_FACING,
-        COST_DISTANCE,
-        COST_SPIN,
-        COST_SIDESWITCH,
-        COST_CROWDED_BRACKET ,
-        COST_OTHER,
-        COST_TOTAL,
-        NUM_Cost
-    };
-    const RString COST_LABELS[] = {
-        "DOUBLESTEP",
-        "BRACKETJACK",
-        "JACK",
-        "JUMP",
+		COST_BRACKETTAP,
+		COST_HOLDSWITCH,
+		COST_MINE,
+		COST_FOOTSWITCH,
+		COST_MISSED_FOOTSWITCH,
+		COST_FACING,
+		COST_DISTANCE,
+		COST_SPIN,
+		COST_SIDESWITCH,
+		COST_CROWDED_BRACKET ,
+		COST_OTHER,
+		COST_TOTAL,
+		NUM_Cost
+	};
+	const RString COST_LABELS[] = {
+		"DOUBLESTEP",
+		"BRACKETJACK",
+		"JACK",
+		"JUMP",
 		"SLOW_BRACKET",
 		"TWISTED_FOOT",
-        "BRACKETTAP",
-        "HOLDSWITCH",
-        "MINE",
-        "FOOTSWITCH",
-        "MISSED_FOOTSWITCH",
-        "FACING",
-        "DISTANCE",
-        "SPIN",
-        "SIDESWITCH",
-        "CROWDED_BRACKET",
-        "OTHER",
-        "TOTAL"
-    };
+		"BRACKETTAP",
+		"HOLDSWITCH",
+		"MINE",
+		"FOOTSWITCH",
+		"MISSED_FOOTSWITCH",
+		"FACING",
+		"DISTANCE",
+		"SPIN",
+		"SIDESWITCH",
+		"CROWDED_BRACKET",
+		"OTHER",
+		"TOTAL"
+	};
     
 	struct StagePoint {
 		float x;
@@ -91,12 +90,11 @@ namespace StepParity {
 		std::vector<int> downArrows;
 		std::vector<int> sideArrows;
 		
-		
 		StageLayout(StepsType t,
 					 const std::vector<StagePoint>& c,
 					 const std::vector<int> & u,
 					 const std::vector<int> & d,
-					 const std::vector<int> & s) :type(t), columns(c), upArrows(u), downArrows(d), sideArrows(s) {
+					 const std::vector<int> & s) : type(t), columns(c), upArrows(u), downArrows(d), sideArrows(s) {
 			this->columnCount = static_cast<int>(this->columns.size());
 		}
 		
@@ -126,11 +124,11 @@ namespace StepParity {
 		FootPlacement holdFeet;  // Any feet that stayed in place due to a hold/roll note.
 		float second;			 // The time of the song represented by this state
 		int rowIndex;			 // The index of the row represented by this state
-        int idx;
-        
-        int whereTheFeetAre[NUM_Foot]; // the inverse of columns
-        bool didTheFootMove[NUM_Foot]; // the inverse of movedFeet
-        bool isTheFootHolding[NUM_Foot]; //inverse of holdFeet
+		int idx;
+
+		int whereTheFeetAre[NUM_Foot]; // the inverse of columns
+		bool didTheFootMove[NUM_Foot]; // the inverse of movedFeet
+		bool isTheFootHolding[NUM_Foot]; //inverse of holdFeet
 		// These hashes are used in operator<() to speed up the comparison of the vectors.
 		// Their values are computed by calculateHashes(), which is used in StepParityGenerator::buildStateGraph().
 		int columnsHash = 0;
@@ -149,13 +147,13 @@ namespace StepParity {
 			holdFeet = FootPlacement(columnCount, NONE);
 			second = 0;
 			rowIndex = 0;
-            idx = -1;
-            for(int i = 0; i < NUM_Foot; i++)
-            {
-                whereTheFeetAre[i] = -1;
-                didTheFootMove[i] = false;
-                isTheFootHolding[i] = false;
-            }
+			idx = -1;
+			for(int i = 0; i < NUM_Foot; i++)
+			{
+				whereTheFeetAre[i] = -1;
+				didTheFootMove[i] = false;
+				isTheFootHolding[i] = false;
+			}
 		}
 		
 		Json::Value ToJson(bool useStrings);
@@ -191,14 +189,17 @@ namespace StepParity {
 	/// This shouldn't be confused with the idea of "rows" elsewhere in SM. Here, we only use
 	/// these Rows to represent a row that isn't empty.
 	struct Row {
-
-		
-		std::vector<IntermediateNoteData> notes; // notes for the given row
-		std::vector<IntermediateNoteData> holds; // Any active hold notes, including ones that started before this row
-		std::set<int> holdTails;				 // Column index of any holds that end on this row
-		std::vector<float> mines;				 // If a mine occurred either on this row, or on a row on its own immediately
-												 // preceding this one, the time of when that mine occurred, indexed by column.
-		std::vector<float> fakeMines;			 // The same thing, but for fake mines
+		// notes for the given row
+		std::vector<IntermediateNoteData> notes;
+		// Any active hold notes, including ones that started before this row
+		std::vector<IntermediateNoteData> holds;
+		// Column index of any holds that end on this row
+		std::set<int> holdTails;
+		// If a mine occurred either on this row, or on a row on its own immediately
+		// preceding this one, the time of when that mine occurred, indexed by column.
+		std::vector<float> mines;
+		// The same thing, but for fake mines
+		std::vector<float> fakeMines;
 
 		FootPlacement columns;
 		std::vector<int> whereTheFeetAre;
@@ -235,24 +236,30 @@ namespace StepParity {
 	/// @brief A counter used while creating rows
 	struct RowCounter
 	{
-		std::vector<IntermediateNoteData> notes; 		// Notes for the "current" row being generated
-		std::vector<IntermediateNoteData> activeHolds;	// Any holds that are active for the current row
+		// Notes for the "current" row being generated
+		std::vector<IntermediateNoteData> notes;
+		// Any holds that are active for the current row
+		std::vector<IntermediateNoteData> activeHolds;
 		float lastColumnSecond = CLM_SECOND_INVALID;
 		float lastColumnBeat = CLM_SECOND_INVALID;
 
-		std::vector<float> mines;						// The time at which a mine occurred for the current row,
-														// indexed by column
-		std::vector<float> fakeMines;					// The time at which a fake mine occurred for the current row,
-														// indexed by column
-		
-		std::vector<float> nextMines;					// The time at which a mine occurred in the _previous_ row,
-														// indexed by column
-		std::vector<float> nextFakeMines;				// The time at which a fake mine occurred in the _previous_ row,
-														// indexed by column
-		int noteCount = 0;								// number of "notes" added to the counter for the current row.
+		// The time at which a mine occurred for the current row,
+		// indexed by column
+		std::vector<float> mines;
+		// The time at which a fake mine occurred for the current row,
+		// indexed by column
+		std::vector<float> fakeMines;
+
+		// The time at which a mine occurred in the _previous_ row,
+		// indexed by column
+		std::vector<float> nextMines;
+		// The time at which a fake mine occurred in the _previous_ row,
+		// indexed by column
+		std::vector<float> nextFakeMines;
+		// number of "notes" added to the counter for the current row.
+		int noteCount = 0;
 		RowCounter(int columnCount)
 		{
-
 			notes = std::vector<IntermediateNoteData>(columnCount);
 			activeHolds = std::vector<IntermediateNoteData>(columnCount);
 			mines = std::vector<float>(columnCount, 0);
@@ -270,10 +277,12 @@ namespace StepParity {
 	/// following row of the step chart.
 	struct StepParityNode
 	{
-		int id = 0;	// The index of this node in its graph
+		// The index of this node in its graph
+		int id = 0;
 		State state;
 
-		std::unordered_map<StepParityNode *, float*> neighbors; // Connections to, and the cost of moving to, the connected nodes
+		// Connections to, and the cost of moving to, the connected nodes
+		std::unordered_map<StepParityNode *, float*> neighbors;
 		
 		~StepParityNode()
 		{
@@ -313,17 +322,18 @@ namespace StepParity {
 		std::vector<std::map<State, StepParityNode *, StateComparator>> stateNodeMap;
 
 	public:
-		StepParityNode * startNode;	// This represents the very start of the song, before any notes
-		StepParityNode *endNode;	// This represents the end of the song, after all of the notes
+		// This represents the very start of the song, before any notes
+		StepParityNode * startNode;
+		// This represents the end of the song, after all of the notes
+		StepParityNode *endNode;
 
 		~StepParityGraph()
 		{
-            states.clear();
+			states.clear();
 			for(StepParityNode * node: nodes)
 			{
 				delete node;
 			}
-            
 		}
 
 		/// @brief Returns a pointer to a StepParityNode that represents the given state within the graph.
@@ -332,7 +342,8 @@ namespace StepParity {
 		/// @return
 		StepParityNode *addOrGetExistingNode(const State &state);
 
-		void addEdge(StepParityNode* from, StepParityNode* to, float* costs) {
+		void addEdge(StepParityNode* from, StepParityNode* to, float* costs)
+		{
 			from->neighbors[to] = costs;
 		}
 
@@ -348,8 +359,6 @@ namespace StepParity {
 			return nodes[index];
 		}
 	};
-
-
 };
 
 #endif

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -60,6 +60,8 @@ namespace StepParity {
         "BRACKETJACK",
         "JACK",
         "JUMP",
+		"SLOW_BRACKET",
+		"TWISTED_FOOT",
         "BRACKETTAP",
         "HOLDSWITCH",
         "MINE",
@@ -198,11 +200,14 @@ namespace StepParity {
 												 // preceding this one, the time of when that mine occurred, indexed by column.
 		std::vector<float> fakeMines;			 // The same thing, but for fake mines
 
+		FootPlacement columns;
+		std::vector<int> whereTheFeetAre;
+		
 		float second = 0;
 		float beat = 0;
 		int rowIndex = 0;
 		int columnCount = 0;
-
+		int noteCount = 0;
 		Row()
 		{
 			Row(0);
@@ -216,10 +221,11 @@ namespace StepParity {
 			holdTails.clear();
 			mines = std::vector<float>(columnCount, 0);
 			fakeMines = std::vector<float>(columnCount, 0);
-			second = 0;
-			beat = 0;
-			rowIndex = 0;
+			columns = std::vector<StepParity::Foot>(columnCount, StepParity::NONE);
+			whereTheFeetAre = std::vector<int>(StepParity::NUM_Foot, -1);
 		}
+		
+		void setFootPlacement(const std::vector<Foot> & footPlacement);
 
 		Json::Value ToJson(bool useStrings);
 		static Json::Value ToJsonRows(const std::vector<Row> & rows, bool useStrings);

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -1,0 +1,307 @@
+#ifndef STEP_PARITY_DATASTRUCTS_H
+#define STEP_PARITY_DATASTRUCTS_H
+
+#include "GameConstantsAndTypes.h"
+#include "NoteData.h"
+#include "json/json.h"
+#include "JsonUtil.h"
+#include <queue>
+#include <unordered_map>
+
+
+namespace StepParity {
+
+	const float CLM_SECOND_INVALID = -1;
+
+	enum Foot
+	{
+		NONE = 0,
+		LEFT_HEEL,
+		LEFT_TOE,
+		RIGHT_HEEL,
+		RIGHT_TOE,
+		NUM_Foot
+	};
+
+	const std::vector<StepParity::Foot> FEET = {LEFT_HEEL, LEFT_TOE, RIGHT_HEEL, RIGHT_TOE};
+	const RString FEET_LABELS[] = {"N", "L", "l", "R", "r", "5??", "6??"};
+	const RString TapNoteTypeShortNames[] = { "Empty", "Tap",  "Mine",  "Attack", "AutoKeySound", "Fake", "", "" };
+	const RString TapNoteSubTypeShortNames[] = { "Hold", "Roll", "", "" };	
+
+    enum Cost
+    {
+        COST_DOUBLESTEP = 0,
+        COST_BRACKETJACK,
+        COST_JACK,
+        COST_JUMP,
+        COST_BRACKETTAP,
+        COST_HOLDSWITCH,
+        COST_MINE,
+        COST_FOOTSWITCH,
+        COST_MISSED_FOOTSWITCH,
+        COST_FACING,
+        COST_DISTANCE,
+        COST_SPIN,
+        COST_SIDESWITCH,
+        COST_CROWDED_BRACKET ,
+        COST_OTHER,
+        COST_TOTAL,
+        NUM_Cost
+    };
+    const RString COST_LABELS[] = {
+        "DOUBLESTEP",
+        "BRACKETJACK",
+        "JACK",
+        "JUMP",
+        "BRACKETTAP",
+        "HOLDSWITCH",
+        "MINE",
+        "FOOTSWITCH",
+        "MISSED_FOOTSWITCH",
+        "FACING",
+        "DISTANCE",
+        "SPIN",
+        "SIDESWITCH",
+        "CROWDED_BRACKET",
+        "OTHER",
+        "TOTAL"
+    };
+    
+    
+    
+	struct StagePoint {
+		float x;
+		float y;
+	};
+
+	/// @brief A vector of StagePoints, which represents the 
+	/// relative position of each arrow on the dance stage. 
+	typedef std::vector<StagePoint> StageLayout;
+
+	/// @brief A vector of Foot values, which represents the player's
+	/// foot placement on the dance stage.
+	typedef std::vector<Foot> FootPlacement;
+
+	/// @brief Represents a specific possible state of the player's position
+	/// for a given row of the step chart.
+	struct State {
+		FootPlacement columns;	 // The position of the player
+		FootPlacement movedFeet; // Any feet that have moved from the previous state to this one
+		FootPlacement holdFeet;  // Any feet that stayed in place due to a hold/roll note.
+		float second;			 // The time of the song represented by this state
+		int rowIndex;			 // The index of the row represented by this state
+        int idx;
+        
+        int whereTheFeetAre[NUM_Foot]; // the inverse of columns
+        bool didTheFootMove[NUM_Foot]; // the inverse of movedFeet
+        bool isTheFootHolding[NUM_Foot]; //inverse of holdFeet
+        
+		// These hashes are used in operator<() to speed up the comparison of the vectors.
+		// Their values are computed by calculateHashes(), which is used in StepParityGenerator::buildStateGraph().
+		int columnsHash = 0;
+		int movedFeetHash = 0;
+		int holdFeetHash = 0;
+		
+		State()
+		{
+			State(4);
+		}
+		
+		State(int columnCount)
+		{
+			columns = FootPlacement(columnCount, NONE);
+			movedFeet = FootPlacement(columnCount, NONE);
+			holdFeet = FootPlacement(columnCount, NONE);
+			second = 0;
+			rowIndex = 0;
+            idx = -1;
+            for(int i = 0; i < NUM_Foot; i++)
+            {
+                whereTheFeetAre[i] = -1;
+                didTheFootMove[i] = false;
+                isTheFootHolding[i] = false;
+            }
+		}
+		
+		Json::Value ToJson(bool useStrings);
+		
+		bool operator==(const State& other) const;		
+		bool operator<(const State& other) const;
+		
+		void calculateHashes();
+	};
+
+	/// @brief A convenience struct used to encapsulate data from NoteData in an 
+	/// easier to work with format.
+	struct IntermediateNoteData {
+		TapNoteType type = TapNoteType_Empty; 	// type of the note
+		TapNoteSubType subtype = TapNoteSubType_Invalid;
+		int col = 0;			// column/track number
+		int row = 0;			// row on which the note occurs
+		float beat = 0;			// beat on which the note occurs
+		float hold_length = 0;	// If type is TapNoteType_HoldTail, length of hold, in beats
+
+		bool warped = false;		// Is this note warped?
+		bool fake = false;			// Is this note fake (besides being TapNoteType_Fake)?
+		float second = false;		// time into the song on which the note occurs
+
+		Foot parity = NONE; 		// Which foot (and which part of the foot) will most likely be used
+		Json::Value ToJson(bool useStrings);
+	};
+
+
+	/// @brief A slightly complicated structure to encapsulate all of the data for a given 
+	/// row of a step chart.
+	/// 'notes' and 'holds' will always have 'columnCount' entries. "Empty" columns will have a type of TapNoteType_Empty.
+	/// This shouldn't be confused with the idea of "rows" elsewhere in SM. Here, we only use
+	/// these Rows to represent a row that isn't empty.
+	struct Row {
+
+		
+		std::vector<IntermediateNoteData> notes; // notes for the given row
+		std::vector<IntermediateNoteData> holds; // Any active hold notes, including ones that started before this row
+		std::set<int> holdTails;				 // Column index of any holds that end on this row
+		std::vector<float> mines;				 // If a mine occurred either on this row, or on a row on its own immediately
+												 // preceding this one, the time of when that mine occurred, indexed by column.
+		std::vector<float> fakeMines;			 // The same thing, but for fake mines
+
+		float second = 0;
+		float beat = 0;
+		int rowIndex = 0;
+		int columnCount = 0;
+
+		Row()
+		{
+			Row(0);
+		}
+		
+		Row(int _columnCount)
+		{
+			columnCount = _columnCount;
+			notes = std::vector<IntermediateNoteData>(columnCount);
+			holds = std::vector<IntermediateNoteData>(columnCount);
+			holdTails.clear();
+			mines = std::vector<float>(columnCount, 0);
+			fakeMines = std::vector<float>(columnCount, 0);
+			second = 0;
+			beat = 0;
+			rowIndex = 0;
+		}
+
+		Json::Value ToJson(bool useStrings);
+		static Json::Value ToJsonRows(const std::vector<Row> & rows, bool useStrings);
+		static Json::Value ParityRowsJson(const std::vector<Row> & rows);
+	};
+
+	/// @brief A counter used while creating rows
+	struct RowCounter
+	{
+		std::vector<IntermediateNoteData> notes; 		// Notes for the "current" row being generated
+		std::vector<IntermediateNoteData> activeHolds;	// Any holds that are active for the current row
+		float lastColumnSecond = CLM_SECOND_INVALID;
+		float lastColumnBeat = CLM_SECOND_INVALID;
+
+		std::vector<float> mines;						// The time at which a mine occurred for the current row,
+														// indexed by column
+		std::vector<float> fakeMines;					// The time at which a fake mine occurred for the current row,
+														// indexed by column
+		
+		std::vector<float> nextMines;					// The time at which a mine occurred in the _previous_ row,
+														// indexed by column
+		std::vector<float> nextFakeMines;				// The time at which a fake mine occurred in the _previous_ row,
+														// indexed by column
+		int noteCount = 0;								// number of "notes" added to the counter for the current row.
+		RowCounter(int columnCount)
+		{
+
+			notes = std::vector<IntermediateNoteData>(columnCount);
+			activeHolds = std::vector<IntermediateNoteData>(columnCount);
+			mines = std::vector<float>(columnCount, 0);
+			fakeMines = std::vector<float>(columnCount, 0);
+			nextMines = std::vector<float>(columnCount, 0);
+			nextFakeMines = std::vector<float>(columnCount, 0);
+
+			lastColumnSecond = CLM_SECOND_INVALID;
+			lastColumnBeat = CLM_SECOND_INVALID;
+		}
+	};
+
+	/// @brief A node within a StepParityGraph.
+	/// Represents a given state, and its connections to the states in the
+	/// following row of the step chart.
+	struct StepParityNode
+	{
+		int id = 0;	// The index of this node in its graph
+		State state;
+
+		std::unordered_map<StepParityNode *, float*> neighbors; // Connections to, and the cost of moving to, the connected nodes
+		StepParityNode(const State &_state)
+		{
+			state = _state;
+		}
+
+		Json::Value ToJson();
+		
+		int neighborCount()
+		{
+			return static_cast<int>(neighbors.size());
+		}
+	};
+
+	/// @brief A comparator, needed in order use State objects as the key in a std::map.
+	struct StateComparator
+	{
+		bool operator()(const State& lhs, const State& rhs) const {
+			return lhs < rhs;
+		}
+	};
+	
+	/// @brief A graph, representing all of the possible states for a step chart.
+	class StepParityGraph
+	{
+	private:
+		std::vector<StepParityNode *> nodes;
+        std::vector<State *> states;
+		std::vector<std::map<State, StepParityNode *, StateComparator>> stateNodeMap;
+
+	public:
+		StepParityNode * startNode;	// This represents the very start of the song, before any notes
+		StepParityNode *endNode;	// This represents the end of the song, after all of the notes
+
+		~StepParityGraph()
+		{
+            states.clear();
+			for(StepParityNode * node: nodes)
+			{
+				delete node;
+			}
+            
+		}
+
+		/// @brief Returns a pointer to a StepParityNode that represents the given state within the graph.
+		/// If a node already exists, it is returned, otherwise a new one is created and added to the graph.
+		/// @param state 
+		/// @return
+		StepParityNode *addOrGetExistingNode(const State &state);
+
+		void addEdge(StepParityNode* from, StepParityNode* to, float* costs) {
+			from->neighbors[to] = costs;
+		}
+
+		int nodeCount() const
+		{
+			return static_cast<int>(nodes.size());
+		}
+		
+		Json::Value ToJson();
+		Json::Value NodeStateJson();
+		StepParityNode *operator[](int index) const
+		{
+			return nodes[index];
+		}
+	};
+
+
+};
+
+#endif

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -24,6 +24,11 @@ namespace StepParity {
 	};
 
 	const std::vector<StepParity::Foot> FEET = {LEFT_HEEL, LEFT_TOE, RIGHT_HEEL, RIGHT_TOE};
+	// A map for getting the other part of the foot, when you don't actually care
+	// what part it is.
+	// OTHER_PART_OF_FOOT[LEFT_HEEL] == LEFT_TOE
+	const std::vector<StepParity::Foot> OTHER_PART_OF_FOOT = {NONE, LEFT_TOE, LEFT_HEEL, RIGHT_TOE, RIGHT_HEEL};
+	
 	const RString FEET_LABELS[] = {"N", "L", "l", "R", "r", "5??", "6??"};
 	const RString TapNoteTypeShortNames[] = { "Empty", "Tap",  "Mine",  "Attack", "AutoKeySound", "Fake", "", "" };
 	const RString TapNoteSubTypeShortNames[] = { "Hold", "Roll", "", "" };	

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -282,14 +282,10 @@ namespace StepParity {
 		State state;
 
 		// Connections to, and the cost of moving to, the connected nodes
-		std::unordered_map<StepParityNode *, float*> neighbors;
+		std::unordered_map<StepParityNode *, float> neighbors;
 		
 		~StepParityNode()
 		{
-			for(auto neighbor: neighbors)
-			{
-				delete[] neighbor.second;
-			}
 			neighbors.clear();
 		}
 		StepParityNode(const State &_state)
@@ -342,9 +338,9 @@ namespace StepParity {
 		/// @return
 		StepParityNode *addOrGetExistingNode(const State &state);
 
-		void addEdge(StepParityNode* from, StepParityNode* to, float* costs)
+		void addEdge(StepParityNode* from, StepParityNode* to, float cost)
 		{
-			from->neighbors[to] = costs;
+			from->neighbors[to] = cost;
 		}
 
 		int nodeCount() const

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -74,16 +74,43 @@ namespace StepParity {
         "TOTAL"
     };
     
-    
-    
 	struct StagePoint {
 		float x;
 		float y;
 	};
-
-	/// @brief A vector of StagePoints, which represents the 
-	/// relative position of each arrow on the dance stage. 
-	typedef std::vector<StagePoint> StageLayout;
+	
+	// StageLayout represents the relative position of each panel on the dance stage,
+	// and provides some basic math function
+	struct StageLayout {
+		StepsType type;
+		int columnCount;
+		std::vector<StagePoint> columns;
+		std::vector<int> upArrows;
+		std::vector<int> downArrows;
+		std::vector<int> sideArrows;
+		
+		
+		StageLayout(StepsType t,
+					 const std::vector<StagePoint>& c,
+					 const std::vector<int> & u,
+					 const std::vector<int> & d,
+					 const std::vector<int> & s) :type(t), columns(c), upArrows(u), downArrows(d), sideArrows(s) {
+			this->columnCount = static_cast<int>(this->columns.size());
+		}
+		
+		
+		bool bracketCheck(int column1, int column2);
+		bool isSideArrow(int column);
+		bool isUpArrow(int column);
+		bool isDownArrow(int column);
+		float getDistanceSq(int c1, int c2);
+		float getDistanceSq(StagePoint p1, StagePoint p2);
+		float getXDifference(int leftIndex, int rightIndex);
+		float getYDifference(int leftIndex, int rightIndex);
+		StagePoint averagePoint(int leftIndex, int rightIndex);
+		float getPlayerAngle(int c1, int c2);
+		float getPlayerAngle(StepParity::StagePoint left, StepParity::StagePoint right);
+	};
 
 	/// @brief A vector of Foot values, which represents the player's
 	/// foot placement on the dance stage.

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -102,7 +102,6 @@ namespace StepParity {
         int whereTheFeetAre[NUM_Foot]; // the inverse of columns
         bool didTheFootMove[NUM_Foot]; // the inverse of movedFeet
         bool isTheFootHolding[NUM_Foot]; //inverse of holdFeet
-        
 		// These hashes are used in operator<() to speed up the comparison of the vectors.
 		// Their values are computed by calculateHashes(), which is used in StepParityGenerator::buildStateGraph().
 		int columnsHash = 0;
@@ -242,6 +241,15 @@ namespace StepParity {
 		State state;
 
 		std::unordered_map<StepParityNode *, float*> neighbors; // Connections to, and the cost of moving to, the connected nodes
+		
+		~StepParityNode()
+		{
+			for(auto neighbor: neighbors)
+			{
+				delete[] neighbor.second;
+			}
+			neighbors.clear();
+		}
 		StepParityNode(const State &_state)
 		{
 			state = _state;

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -39,6 +39,8 @@ namespace StepParity {
         COST_BRACKETJACK,
         COST_JACK,
         COST_JUMP,
+		COST_SLOW_BRACKET,
+		COST_TWISTED_FOOT,
         COST_BRACKETTAP,
         COST_HOLDSWITCH,
         COST_MINE,

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -33,11 +33,7 @@ void StepParityGenerator::analyzeGraph() {
 	for (unsigned long i = 0; i < rows.size(); i++)
 	{
 		StepParityNode *node = graph[nodes_for_rows[i]];
-		for (int j = 0; j < rows[i].columnCount; j++) {
-			if(rows[i].notes[j].type != TapNoteType_Empty) {
-				rows[i].notes[j].parity = node->state.columns[j];
-			}
-		}
+		rows[i].setFootPlacement(node->state.columns);
 	}
 }
 

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -28,8 +28,8 @@ void StepParityGenerator::analyzeGraph() {
 
 	for (unsigned long i = 0; i < rows.size(); i++)
 	{
-		StepParityNode *node = graph[nodes_for_rows[i]];
-		rows[i].setFootPlacement(node->state.columns);
+		StepParityNode *node = nodes[nodes_for_rows[i]];
+		rows[i].setFootPlacement(node->state->combinedColumns);
 	}
 }
 
@@ -37,87 +37,93 @@ void StepParityGenerator::buildStateGraph()
 {
 	// The first node of the graph is beginningState, which represents the time before
 	// the first note (and so it's roIndex is considered -1)
-	State beginningState(columnCount);
-	beginningState.rowIndex = -1;
-	beginningState.second = rows[0].second - 1;
-	StepParityNode *startNode = graph.addOrGetExistingNode(beginningState);
-
-	graph.startNode = startNode;
-
-	std::queue<State> previousStates;
-	previousStates.push(beginningState);
+	beginningState = new State(columnCount);
+	startNode = addNode(beginningState, rows[0].second - 1, -1);
+	
+	std::queue<StepParityNode *> previousNodes;
+	previousNodes.push(startNode);
 	StepParityCost costCalculator(layout);
 
 	for (unsigned long i = 0; i < rows.size(); i++)
 	{
-		std::vector<State> uniqueStates;
+		std::vector<StepParityNode *> resultNodes;
 		Row &row = rows[i];
 		std::vector<FootPlacement> *PermuteFootPlacements = getFootPlacementPermutations(row);
-		while (!previousStates.empty())
+		while (!previousNodes.empty())
 		{
-			State state = previousStates.front();
-			StepParityNode *initialNode = graph.addOrGetExistingNode(state);
-
+			StepParityNode *initialNode = previousNodes.front();
+			float elapsedTime = row.second - initialNode->second;
 			for(auto it = PermuteFootPlacements->begin(); it != PermuteFootPlacements->end(); it++)
 			{
-				State resultState = initResultState(state, row, *it);
-				float cost = costCalculator.getActionCost(&state, &resultState, rows, i);
-				resultState.calculateHashes();
-				StepParityNode *resultNode = graph.addOrGetExistingNode(resultState);
-				graph.addEdge(initialNode, resultNode, cost);
-				if(std::find(uniqueStates.begin(), uniqueStates.end(), resultState) == uniqueStates.end())
-				{
-					uniqueStates.push_back(resultState);
-				}
+				State * resultState = initResultState(initialNode->state, row, *it);
+				
+				float cost = costCalculator.getActionCost(initialNode->state, resultState, rows, i, elapsedTime);
+				addStateToGraph(resultState, initialNode, row, resultNodes, cost);
+				
 			}
-			previousStates.pop();
+			previousNodes.pop();
 		}
 		
-		for (State s : uniqueStates)
+		for (StepParityNode * n : resultNodes)
 		{
-			previousStates.push(s);
+			previousNodes.push(n);
 		}
 	}
 	
 	// at this point, previousStates holds all of the states for the very last row,
 	// which just get connected to the endState
-	State endState(columnCount);
-	endState.rowIndex = rows.size();
-	endState.second = rows[rows.size() - 1].second + 1;
-	StepParityNode *endNode = graph.addOrGetExistingNode(endState);
-	graph.endNode = endNode;
-	while(!previousStates.empty())
+	endingState = new State(columnCount);
+	endNode = addNode(endingState, rows[rows.size() - 1].second + 1, rows.size());
+	
+	while(!previousNodes.empty())
 	{
-		State state = previousStates.front();
-		StepParityNode *node = graph.addOrGetExistingNode(state);
-		graph.addEdge(node, endNode, 0);
-		previousStates.pop();
+		StepParityNode *node = previousNodes.front();
+		addEdge(node, endNode, 0);
+		previousNodes.pop();
 	}
 }
 
-State StepParityGenerator::initResultState(State &initialState, Row &row, const FootPlacement &columns)
+void StepParityGenerator::addStateToGraph(State * resultState, StepParityNode * initialNode, Row & row, std::vector<StepParityNode *> &existingNodesForThisRow, float cost)
 {
-	State resultState(row.columnCount);
-	resultState.columns = columns;
-	resultState.rowIndex = row.rowIndex;
+	
+	for(StepParityNode * existingNode : existingNodesForThisRow)
+	{
+		if(existingNode->state == resultState)
+		{
+			addEdge(initialNode, existingNode, cost);
+			return;
+		}
+	}
+	StepParityNode *resultNode = addNode(resultState, row.second, row.rowIndex);
+	addEdge(initialNode, resultNode, cost);
+	existingNodesForThisRow.push_back(resultNode);
+}
+
+
+State * StepParityGenerator::initResultState(State * initialState, Row &row, const FootPlacement &columns)
+{
+	State * resultState = new State(row.columnCount);
+	resultState->columns = columns;
+	
+	
 	// I tried to condense this, but kept getting the logic messed up
 	for (unsigned long i = 0; i < columns.size(); i++)
 	{
 		if(columns[i] == NONE) {
 			continue;
 		}
-		resultState.whereTheFeetAre[columns[i]] = i;
+		resultState->whatNoteTheFootIsHitting[columns[i]] = i;
 
 		if(row.holds[i].type == TapNoteType_Empty)
 		{
-			resultState.movedFeet[i] = columns[i];
-			resultState.didTheFootMove[columns[i]] = true;
+			resultState->movedFeet[i] = columns[i];
+			resultState->didTheFootMove[columns[i]] = true;
 			continue;
 		}
-		if(initialState.columns[i] != columns[i])
+		if(initialState->combinedColumns[i] != columns[i])
 		{
-			resultState.movedFeet[i] = columns[i];
-			resultState.didTheFootMove[columns[i]] = true;
+			resultState->movedFeet[i] = columns[i];
+			resultState->didTheFootMove[columns[i]] = true;
 		}
 	}
 
@@ -129,13 +135,86 @@ State StepParityGenerator::initResultState(State &initialState, Row &row, const 
 
 		if(row.holds[i].type != TapNoteType_Empty)
 		{
-			resultState.holdFeet[i] = columns[i];
-			resultState.isTheFootHolding[columns[i]] = true;
+			resultState->holdFeet[i] = columns[i];
+			resultState->isTheFootHolding[columns[i]] = true;
 		}
 	}
-	resultState.second = row.second;
+	
+	mergeInitialAndResultPosition(initialState, resultState, (int)columns.size());
+	
+	std::uint64_t stateHash = getStateCacheKey(resultState);
+	
+	auto maybeState = stateCache.find(stateHash);
+	
+	if(maybeState != stateCache.end())
+	{
+		State* cachedState = maybeState->second;
+		delete resultState;
+		return maybeState->second;
+	}
+	
+	stateCache.insert({stateHash, resultState});
+	
 	return resultState;
 }
+
+// This merges the `columns` properties of initialState and resultState, which
+// fully represents the player's position on the dance stage.
+// For example:
+// initialState.combinedColumns = [L,0,0,R]
+// resultState.columns = [0,L,0,0]
+// combinedColumns = [0,L,0,R]
+// This eventually gets saved back to resultState
+void StepParityGenerator::mergeInitialAndResultPosition(State * initialState, State * resultState, int columnCount)
+{
+	// Merge initial + result position
+	for (int i = 0; i < columnCount; i++) {
+	  	  // copy in data from resultState over the top which overrides it, as long as it's not nothing
+	  	  if (resultState->columns[i] != NONE) {
+		  	  resultState->combinedColumns[i] = resultState->columns[i];
+		continue;
+	  	  }
+
+	  	  // copy in data from initialState, if it wasn't moved
+	  	  if (
+		initialState->combinedColumns[i] == LEFT_HEEL ||
+		initialState->combinedColumns[i] == RIGHT_HEEL
+	  	  ) {
+		if (!resultState->didTheFootMove[initialState->combinedColumns[i]]) {
+			resultState->combinedColumns[i] = initialState->combinedColumns[i];
+		}
+	  	  } else if (initialState->combinedColumns[i] == LEFT_TOE) {
+		if (
+		  	  !resultState->didTheFootMove[LEFT_TOE] &&
+		  	  !resultState->didTheFootMove[LEFT_HEEL]
+		) {
+			resultState->combinedColumns[i] = initialState->combinedColumns[i];
+		}
+	  	  } else if (initialState->combinedColumns[i] == RIGHT_TOE) {
+		if (
+		  	  !resultState->didTheFootMove[RIGHT_TOE] &&
+		  	  !resultState->didTheFootMove[RIGHT_HEEL]
+		) {
+			resultState->combinedColumns[i] = initialState->combinedColumns[i];
+		}
+	  	  }
+	}
+	
+	for(int i = 0; i < columnCount; i++)
+	{
+		if(resultState->combinedColumns[i] != NONE)
+		{
+			resultState->whereTheFeetAre[resultState->combinedColumns[i]] = i;
+		}
+	}
+}
+
+// For the given row, generate all of the possible foot placements
+// (even if they're not physically possible)
+//
+// We cache this data and return a pointer for two reasons:
+// - It takes a long time to generate the permutations
+// - We end up generating a lot of redundant data, so caching it saves memory
 
 std::vector<FootPlacement>* StepParityGenerator::getFootPlacementPermutations(const Row &row)
 {
@@ -151,15 +230,18 @@ std::vector<FootPlacement>* StepParityGenerator::getFootPlacementPermutations(co
 	return &permuteCache[cacheKey];
 }
 
-
+// Recursively generate each permutation for the given row.
 std::vector<FootPlacement> StepParityGenerator::PermuteFootPlacements(const Row &row, FootPlacement columns, unsigned long column)
 {
+	// If column >= columns.size(), we've reached the end of the row.
+	// Perform some final validation before returning the contents of columns
 	if (column >= columns.size())
 	{
-		int leftHeelIndex = -1;
-		int leftToeIndex = -1;
-		int rightHeelIndex = -1;
-		int rightToeIndex = -1;
+		int leftHeelIndex = StepParity::INVALID_COLUMN;
+		int leftToeIndex = StepParity::INVALID_COLUMN;
+		int rightHeelIndex = StepParity::INVALID_COLUMN;
+		int rightToeIndex = StepParity::INVALID_COLUMN;
+		
 		for (unsigned long i = 0; i < columns.size(); i++)
 		{
 			if (columns[i] == NONE)
@@ -183,20 +265,24 @@ std::vector<FootPlacement> StepParityGenerator::PermuteFootPlacements(const Row 
 				rightToeIndex = i;
 			}
 		}
+		
+		// Filter out actually invalid combinations:
+		// - We don't want permutations where the toe is on an arrow, but not the heel
+		// - We don't want impossible brackets (eg you can't bracket up and down)
 		if (
-			(leftHeelIndex == -1 && leftToeIndex != -1) ||
-			(rightHeelIndex == -1 && rightToeIndex != -1))
+			(leftHeelIndex == StepParity::INVALID_COLUMN && leftToeIndex != StepParity::INVALID_COLUMN) ||
+			(rightHeelIndex == StepParity::INVALID_COLUMN && rightToeIndex != StepParity::INVALID_COLUMN))
 		{
 			return std::vector<FootPlacement>();
 		}
-		if (leftHeelIndex != -1 && leftToeIndex != -1)
+		if (leftHeelIndex != StepParity::INVALID_COLUMN && leftToeIndex != StepParity::INVALID_COLUMN)
 		{
 			if (!layout.bracketCheck(leftHeelIndex, leftToeIndex))
 			{
 				return std::vector<FootPlacement>();
 			}
 		}
-		if (rightHeelIndex != -1 && rightToeIndex != -1)
+		if (rightHeelIndex != StepParity::INVALID_COLUMN && rightToeIndex != StepParity::INVALID_COLUMN)
 		{
 			if (!layout.bracketCheck(rightHeelIndex, rightToeIndex))
 			{
@@ -206,11 +292,18 @@ std::vector<FootPlacement> StepParityGenerator::PermuteFootPlacements(const Row 
 		return {columns};
 	}
 
+	// If this column has a valid tap/hold head, or is actively holding a note,
+	// iterate through values of StepParity::Foot. For each foot part, check that
+	// it's not already present in columns, and if not, create a copy of columns,
+	// and set the current foot part to the current column.
+	// Then pass it to PermuteFootPlacements() and increment the column index.
+	// Collect each permutationm, and then return all of them.
+	
 	std::vector<FootPlacement> permutations;
 	if (row.notes[column].type != TapNoteType_Empty  ||
 			row.holds[column].type != TapNoteType_Empty)
 	{
-	  for (StepParity::Foot foot: FEET) {
+	  	  for (StepParity::Foot foot: FEET) {
 		if(std::find(columns.begin(), columns.end(), foot) != columns.end())
 		{
 			continue;
@@ -221,24 +314,27 @@ std::vector<FootPlacement> StepParityGenerator::PermuteFootPlacements(const Row 
 		newColumns[column] = foot;
 		std::vector<FootPlacement> p = PermuteFootPlacements(row, newColumns, column + 1);
 		permutations.insert(permutations.end(), p.begin(), p.end());
-	  }
-	  return permutations;
+	  	  }
+	  	  return permutations;
 	}
+	// If the current column doesn't have any taps or holds,
+	// then we don't need to generate any permutations for it.
+	// Return the contents of calling PermuteFootPlacements() for the next column.
 	return PermuteFootPlacements(row, columns, column + 1);
 }
 
 std::vector<int> StepParityGenerator::computeCheapestPath()
 {
-	int start = graph.startNode->id;
-	int end = graph.endNode->id;
+	int start = startNode->id;
+	int end = endNode->id;
 	std::vector<int> shortest_path;
-	std::vector<float> cost(graph.nodeCount(), FLT_MAX);
-	std::vector<int> predecessor(graph.nodeCount(), -1);
+	std::vector<float> cost(nodes.size(), FLT_MAX);
+	std::vector<int> predecessor(nodes.size(), -1);
 
 	cost[start] = 0;
 	for (int i = start; i <= end; i++)
 	{
-		StepParityNode *node = graph[i];
+		StepParityNode *node = nodes[i];
 		for(auto neighbor: node->neighbors)
 		{
 			int neighbor_id = neighbor.first->id;
@@ -472,15 +568,42 @@ int StepParityGenerator::getPermuteCacheKey(const Row &row)
 	return key;
 }
 
-Json::Value StepParityGenerator::SMEditorParityJson()
+std::uint64_t StepParityGenerator::getStateCacheKey(State * state)
 {
-	Json::Value root;
-	
-	for (unsigned long i = 0; i < nodes_for_rows.size(); i++)
+	std::uint64_t value = 0;
+	const std::uint64_t prime = 31;
+	for(Foot f : state->columns)
 	{
-		StepParityNode *node = graph[nodes_for_rows[i]];
-		root.append(node->state.ToJson(false));
+		value *= prime;
+		value += f;
 	}
-	
-	return root;
+	for(Foot f : state->combinedColumns)
+	{
+		value *= prime;
+		value += f;
+	}
+	for(Foot f : state->movedFeet)
+	{
+		value *= prime;
+		value += f;
+	}
+	for(Foot f : state->holdFeet)
+	{
+		value *= prime;
+		value += f;
+	}
+	return value;
+}
+
+StepParityNode * StepParityGenerator::addNode(State *state, float second, int rowIndex)
+{
+	StepParityNode * newNode = new StepParityNode(state, second, rowIndex);
+	newNode->id = int(nodes.size());
+	nodes.push_back(newNode);
+	return newNode;
+}
+
+void StepParityGenerator::addEdge(StepParityNode* from, StepParityNode* to, float cost)
+{
+	from->neighbors[to] = cost;
 }

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -5,10 +5,7 @@
 #include "TechCounts.h"
 #include "GameState.h"
 
-
 using namespace StepParity;
-
-
 
 void StepParityGenerator::analyzeNoteData(const NoteData &in)
 {	
@@ -25,7 +22,6 @@ void StepParityGenerator::analyzeNoteData(const NoteData &in)
 	analyzeGraph();
 }
 
-
 void StepParityGenerator::analyzeGraph() {
 	nodes_for_rows = computeCheapestPath();
 	ASSERT_M(nodes_for_rows.size() == rows.size(), "nodes_for_rows should be the same length as rows!");
@@ -36,7 +32,6 @@ void StepParityGenerator::analyzeGraph() {
 		rows[i].setFootPlacement(node->state.columns);
 	}
 }
-
 
 void StepParityGenerator::buildStateGraph()
 {
@@ -95,16 +90,15 @@ void StepParityGenerator::buildStateGraph()
 	{
 		State state = previousStates.front();
 		StepParityNode *node = graph.addOrGetExistingNode(state);
-        float * emptyCosts = new float[NUM_Cost];
-        for(int i = 0; i < NUM_Cost; i++)
-        {
-            emptyCosts[i] = 0;
-        }
+		float * emptyCosts = new float[NUM_Cost];
+		for(int i = 0; i < NUM_Cost; i++)
+		{
+			emptyCosts[i] = 0;
+		}
 		graph.addEdge(node, endNode, emptyCosts);
 		previousStates.pop();
 	}
 }
-
 
 State StepParityGenerator::initResultState(State &initialState, Row &row, const FootPlacement &columns)
 {
@@ -117,18 +111,18 @@ State StepParityGenerator::initResultState(State &initialState, Row &row, const 
 		if(columns[i] == NONE) {
 			continue;
 		}
-        resultState.whereTheFeetAre[columns[i]] = i;
-        
+		resultState.whereTheFeetAre[columns[i]] = i;
+
 		if(row.holds[i].type == TapNoteType_Empty)
 		{
 			resultState.movedFeet[i] = columns[i];
-            resultState.didTheFootMove[columns[i]] = true;
+			resultState.didTheFootMove[columns[i]] = true;
 			continue;
 		}
 		if(initialState.columns[i] != columns[i])
 		{
 			resultState.movedFeet[i] = columns[i];
-            resultState.didTheFootMove[columns[i]] = true;
+			resultState.didTheFootMove[columns[i]] = true;
 		}
 	}
 
@@ -141,13 +135,12 @@ State StepParityGenerator::initResultState(State &initialState, Row &row, const 
 		if(row.holds[i].type != TapNoteType_Empty)
 		{
 			resultState.holdFeet[i] = columns[i];
-            resultState.isTheFootHolding[columns[i]] = true;
+			resultState.isTheFootHolding[columns[i]] = true;
 		}
 	}
 	resultState.second = row.second;
 	return resultState;
 }
-
 
 std::vector<FootPlacement>* StepParityGenerator::getFootPlacementPermutations(const Row &row)
 {
@@ -175,15 +168,25 @@ std::vector<FootPlacement> StepParityGenerator::PermuteFootPlacements(const Row 
 		for (unsigned long i = 0; i < columns.size(); i++)
 		{
 			if (columns[i] == NONE)
+			{
 				continue;
+			}
 			if (columns[i] == LEFT_HEEL)
+			{
 				leftHeelIndex = i;
+			}
 			if (columns[i] == LEFT_TOE)
+			{
 				leftToeIndex = i;
+			}
 			if (columns[i] == RIGHT_HEEL)
+			{
 				rightHeelIndex = i;
+			}
 			if (columns[i] == RIGHT_TOE)
+			{
 				rightToeIndex = i;
+			}
 		}
 		if (
 			(leftHeelIndex == -1 && leftToeIndex != -1) ||
@@ -194,19 +197,24 @@ std::vector<FootPlacement> StepParityGenerator::PermuteFootPlacements(const Row 
 		if (leftHeelIndex != -1 && leftToeIndex != -1)
 		{
 			if (!layout.bracketCheck(leftHeelIndex, leftToeIndex))
+			{
 				return std::vector<FootPlacement>();
+			}
 		}
 		if (rightHeelIndex != -1 && rightToeIndex != -1)
 		{
 			if (!layout.bracketCheck(rightHeelIndex, rightToeIndex))
+			{
 				return std::vector<FootPlacement>();
+			}
 		}
 		return {columns};
 	}
 
 	std::vector<FootPlacement> permutations;
-	if (row.notes[column].type != TapNoteType_Empty  || row.holds[column].type != TapNoteType_Empty) {
-		
+	if (row.notes[column].type != TapNoteType_Empty  ||
+			row.holds[column].type != TapNoteType_Empty)
+	{
 	  for (StepParity::Foot foot: FEET) {
 		if(std::find(columns.begin(), columns.end(), foot) != columns.end())
 		{
@@ -224,7 +232,6 @@ std::vector<FootPlacement> StepParityGenerator::PermuteFootPlacements(const Row 
 	return PermuteFootPlacements(row, columns, column + 1);
 }
 
-
 std::vector<int> StepParityGenerator::computeCheapestPath()
 {
 	int start = graph.startNode->id;
@@ -241,7 +248,6 @@ std::vector<int> StepParityGenerator::computeCheapestPath()
 		{
 			int neighbor_id = neighbor.first->id;
 			float weight = neighbor.second[COST_TOTAL];
-//            printf("computeCheapestPath:: weight = %f", weight);
 			if(cost[i] + weight < cost[neighbor_id])
 			{
 				cost[neighbor_id] = cost[i] + weight;
@@ -264,8 +270,8 @@ std::vector<int> StepParityGenerator::computeCheapestPath()
 	return shortest_path;
 }
 
-
-void StepParityGenerator::CreateIntermediateNoteData(const NoteData &in, std::vector<IntermediateNoteData> &out)
+void StepParityGenerator::CreateIntermediateNoteData(
+		const NoteData &in, std::vector<IntermediateNoteData> &out)
 {
 	TimingData *timing = GAMESTATE->GetProcessedTimingData();
 	int columnCount = in.GetNumTracks();
@@ -302,7 +308,6 @@ void StepParityGenerator::CreateIntermediateNoteData(const NoteData &in, std::ve
 	out.assign(notes.begin(), notes.end());
 }
 
-
 void StepParityGenerator::CreateRows(const NoteData &in)
 {	
 	TimingData *timing = GAMESTATE->GetProcessedTimingData();
@@ -332,7 +337,6 @@ void StepParityGenerator::CreateRows(const NoteData &in)
 			// before checking whether or not this note represens a new row.
 			// But we only want to create a new Row if it has at least one note.
 			// So probably something like
-			
 			/*
 			 
 			 for(note of notes)
@@ -349,7 +353,6 @@ void StepParityGenerator::CreateRows(const NoteData &in)
 				check if note is a mine or fake mine
 				if note is fake continue
 				put note into counter.notes
-				
 			 }
 			 */
 			if (note.second == counter.lastColumnSecond && rows.size() > 0)
@@ -384,14 +387,13 @@ void StepParityGenerator::CreateRows(const NoteData &in)
 
 		if (counter.lastColumnSecond != note.second)
 		{
-
-			// we're past the previous row, so save all of the previous row's data
+			// We're past the previous row, so save all of the previous row's data.
 			if (counter.lastColumnSecond != CLM_SECOND_INVALID)
 			{
 				AddRow(counter);
 			}
 
-			// Move mines and fakeMines to "next", and reset counters
+			// Move mines and fakeMines to "next", and reset counters.
 			counter.lastColumnSecond = note.second;
 			counter.lastColumnBeat = note.beat;
 			counter.nextMines.assign(counter.mines.begin(), counter.mines.end());
@@ -400,7 +402,7 @@ void StepParityGenerator::CreateRows(const NoteData &in)
 			counter.mines = std::vector<float>(columnCount);
 			counter.fakeMines = std::vector<float>(columnCount);
 
-			// reset any now-inactive holds to empty values
+			// Reset any now-inactive holds to empty values.
 			for (int c = 0; c < columnCount; c++)
 			{
 				if (counter.activeHolds[c].type == TapNoteType_Empty || note.beat > counter.activeHolds[c].beat + counter.activeHolds[c].hold_length)

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -61,10 +61,10 @@ void StepParityGenerator::buildStateGraph()
 			for(auto it = PermuteFootPlacements->begin(); it != PermuteFootPlacements->end(); it++)
 			{
 				State resultState = initResultState(state, row, *it);
-				float* costs = costCalculator.getActionCost(&state, &resultState, rows, i);
+				float cost = costCalculator.getActionCost(&state, &resultState, rows, i);
 				resultState.calculateHashes();
 				StepParityNode *resultNode = graph.addOrGetExistingNode(resultState);
-				graph.addEdge(initialNode, resultNode, costs);
+				graph.addEdge(initialNode, resultNode, cost);
 				if(std::find(uniqueStates.begin(), uniqueStates.end(), resultState) == uniqueStates.end())
 				{
 					uniqueStates.push_back(resultState);
@@ -90,12 +90,7 @@ void StepParityGenerator::buildStateGraph()
 	{
 		State state = previousStates.front();
 		StepParityNode *node = graph.addOrGetExistingNode(state);
-		float * emptyCosts = new float[NUM_Cost];
-		for(int i = 0; i < NUM_Cost; i++)
-		{
-			emptyCosts[i] = 0;
-		}
-		graph.addEdge(node, endNode, emptyCosts);
+		graph.addEdge(node, endNode, 0);
 		previousStates.pop();
 	}
 }
@@ -247,7 +242,7 @@ std::vector<int> StepParityGenerator::computeCheapestPath()
 		for(auto neighbor: node->neighbors)
 		{
 			int neighbor_id = neighbor.first->id;
-			float weight = neighbor.second[COST_TOTAL];
+			float weight = neighbor.second;
 			if(cost[i] + weight < cost[neighbor_id])
 			{
 				cost[neighbor_id] = cost[i] + weight;

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -108,13 +108,36 @@ void StepParityGenerator::addStateToGraph(State * resultState, StepParityNode * 
 
 State * StepParityGenerator::initResultState(State * initialState, Row &row, const FootPlacement &columns)
 {
-	State * resultState = new State(row.columnCount);
-	resultState->columns = columns;
+	if(tmpState == nullptr)
+	{
+		tmpState = new State(row.columnCount);
+	}
 	
+	State * resultState = tmpState;
 	
+
+	// reset resultState
+	
+	for(int i = 0; i < NUM_Foot; i++)
+	{
+		resultState->whereTheFeetAre[i] = INVALID_COLUMN;
+		resultState->whatNoteTheFootIsHitting[i] = INVALID_COLUMN;
+		resultState->didTheFootMove[i] = false;
+		resultState->isTheFootHolding[i] = false;
+	}
+	
+	for (unsigned long i = 0; i < columns.size(); i++)
+	{
+		resultState->columns[i] = NONE;
+		resultState->combinedColumns[i] = NONE;
+		resultState->movedFeet[i] = NONE;
+		resultState->holdFeet[i] = NONE;
+	}
+		
 	// I tried to condense this, but kept getting the logic messed up
 	for (unsigned long i = 0; i < columns.size(); i++)
 	{
+		resultState->columns[i] = columns[i];
 		if(columns[i] == NONE) {
 			continue;
 		}
@@ -155,12 +178,11 @@ State * StepParityGenerator::initResultState(State * initialState, Row &row, con
 	if(maybeState != stateCache.end())
 	{
 		State* cachedState = maybeState->second;
-		delete resultState;
 		return maybeState->second;
 	}
 	
 	stateCache.insert({stateHash, resultState});
-	
+	tmpState = nullptr;
 	return resultState;
 }
 

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -5,40 +5,13 @@
 #include "TechCounts.h"
 #include "GameState.h"
 
-// Generates foot parity given notedata
-// Original algorithm by Jewel, polished by tillvit, then ported to C++
 
 using namespace StepParity;
 
-const std::map<StepsType, StageLayout> Layouts = {
-    {StepsType_dance_single, {
-        {0, 1},  // Left
-        {1, 0},  // Down
-        {1, 2},  // Up
-        {2, 1}   // Right
-    }},
-    {StepsType_dance_double, {
-        {0, 1},  // P1 Left
-        {1, 0},  // P1 Down
-        {1, 2},  // P1 Up
-        {2, 1},  // P1 Right
-        
-        {3, 1},  // P2 Left
-        {4, 0},  // P2 Down
-        {4, 2},  // P2 Up
-        {5, 1}   // P2 Right
-    }}
-	};
 
-void StepParityGenerator::analyzeNoteData(const NoteData &in, StepsType stepsType)
+
+void StepParityGenerator::analyzeNoteData(const NoteData &in)
 {	
-	if(Layouts.find(stepsType) == Layouts.end())
-	{
-		LOG->Warn("Tried to call StepParityGenerator::analyze with an unsupported StepsType %s", StepsTypeToString(stepsType).c_str());
-		return;
-	}
-
-	layout = Layouts.at(stepsType);
 	columnCount = in.GetNumTracks();
 	
 	CreateRows(in);
@@ -224,12 +197,12 @@ std::vector<FootPlacement> StepParityGenerator::PermuteFootPlacements(const Row 
 		}
 		if (leftHeelIndex != -1 && leftToeIndex != -1)
 		{
-			if (!bracketCheck(leftHeelIndex, leftToeIndex))
+			if (!layout.bracketCheck(leftHeelIndex, leftToeIndex))
 				return std::vector<FootPlacement>();
 		}
 		if (rightHeelIndex != -1 && rightToeIndex != -1)
 		{
-			if (!bracketCheck(rightHeelIndex, rightToeIndex))
+			if (!layout.bracketCheck(rightHeelIndex, rightToeIndex))
 				return std::vector<FootPlacement>();
 		}
 		return {columns};
@@ -517,16 +490,4 @@ Json::Value StepParityGenerator::SMEditorParityJson()
 	}
 	
 	return root;
-}
-
-bool StepParityGenerator::bracketCheck(int column1, int column2)
-{
-	StagePoint p1 = layout[column1];
-	StagePoint p2 = layout[column2];
-	return getDistanceSq(p1, p2) <= 2;
-}
-
-float StepParityGenerator::getDistanceSq(StepParity::StagePoint p1, StepParity::StagePoint p2)
-{
-	return (p1.y - p2.y) * (p1.y - p2.y) + (p1.x - p2.x) * (p1.x - p2.x);
 }

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -1,0 +1,532 @@
+#include "global.h"
+#include "StepParityGenerator.h"
+#include "StepParityCost.h"
+#include "NoteData.h"
+#include "TechCounts.h"
+#include "GameState.h"
+
+// Generates foot parity given notedata
+// Original algorithm by Jewel, polished by tillvit, then ported to C++
+
+using namespace StepParity;
+
+const std::map<StepsType, StageLayout> Layouts = {
+    {StepsType_dance_single, {
+        {0, 1},  // Left
+        {1, 0},  // Down
+        {1, 2},  // Up
+        {2, 1}   // Right
+    }},
+    {StepsType_dance_double, {
+        {0, 1},  // P1 Left
+        {1, 0},  // P1 Down
+        {1, 2},  // P1 Up
+        {2, 1},  // P1 Right
+        
+        {3, 1},  // P2 Left
+        {4, 0},  // P2 Down
+        {4, 2},  // P2 Up
+        {5, 1}   // P2 Right
+    }}
+	};
+
+void StepParityGenerator::analyzeNoteData(const NoteData &in, StepsType stepsType)
+{	
+	if(Layouts.find(stepsType) == Layouts.end())
+	{
+		LOG->Warn("Tried to call StepParityGenerator::analyze with an unsupported StepsType %s", StepsTypeToString(stepsType).c_str());
+		return;
+	}
+
+	layout = Layouts.at(stepsType);
+	columnCount = in.GetNumTracks();
+	
+	CreateRows(in);
+
+	if(rows.size() == 0)
+	{
+		LOG->Trace("StepParityGenerator::analyze no rows, bailing out");
+		return;
+	}
+	buildStateGraph();
+	analyzeGraph();
+}
+
+
+void StepParityGenerator::analyzeGraph() {
+	nodes_for_rows = computeCheapestPath();
+	ASSERT_M(nodes_for_rows.size() == rows.size(), "nodes_for_rows should be the same length as rows!");
+
+	for (unsigned long i = 0; i < rows.size(); i++)
+	{
+		StepParityNode *node = graph[nodes_for_rows[i]];
+		for (int j = 0; j < rows[i].columnCount; j++) {
+			if(rows[i].notes[j].type != TapNoteType_Empty) {
+				rows[i].notes[j].parity = node->state.columns[j];
+			}
+		}
+	}
+}
+
+
+void StepParityGenerator::buildStateGraph()
+{
+	// The first node of the graph is beginningState, which represents the time before
+	// the first note (and so it's roIndex is considered -1)
+	State beginningState(columnCount);
+	beginningState.rowIndex = -1;
+	beginningState.second = rows[0].second - 1;
+	StepParityNode *startNode = graph.addOrGetExistingNode(beginningState);
+
+	graph.startNode = startNode;
+
+	std::queue<State> previousStates;
+	previousStates.push(beginningState);
+	StepParityCost costCalculator(layout);
+
+	for (unsigned long i = 0; i < rows.size(); i++)
+	{
+		std::vector<State> uniqueStates;
+		Row &row = rows[i];
+		std::vector<FootPlacement> *PermuteFootPlacements = getFootPlacementPermutations(row);
+		while (!previousStates.empty())
+		{
+			State state = previousStates.front();
+			StepParityNode *initialNode = graph.addOrGetExistingNode(state);
+
+			for(auto it = PermuteFootPlacements->begin(); it != PermuteFootPlacements->end(); it++)
+			{
+				State resultState = initResultState(state, row, *it);
+				float* costs = costCalculator.getActionCost(&state, &resultState, rows, i);
+				resultState.calculateHashes();
+				StepParityNode *resultNode = graph.addOrGetExistingNode(resultState);
+				graph.addEdge(initialNode, resultNode, costs);
+				if(std::find(uniqueStates.begin(), uniqueStates.end(), resultState) == uniqueStates.end())
+				{
+					uniqueStates.push_back(resultState);
+				}
+			}
+			previousStates.pop();
+		}
+		
+		for (State s : uniqueStates)
+		{
+			previousStates.push(s);
+		}
+	}
+	
+	// at this point, previousStates holds all of the states for the very last row,
+	// which just get connected to the endState
+	State endState(columnCount);
+	endState.rowIndex = rows.size();
+	endState.second = rows[rows.size() - 1].second + 1;
+	StepParityNode *endNode = graph.addOrGetExistingNode(endState);
+	graph.endNode = endNode;
+	while(!previousStates.empty())
+	{
+		State state = previousStates.front();
+		StepParityNode *node = graph.addOrGetExistingNode(state);
+        float * emptyCosts = new float[NUM_Cost];
+        for(int i = 0; i < NUM_Cost; i++)
+        {
+            emptyCosts[i] = 0;
+        }
+		graph.addEdge(node, endNode, emptyCosts);
+		previousStates.pop();
+	}
+}
+
+
+State StepParityGenerator::initResultState(State &initialState, Row &row, const FootPlacement &columns)
+{
+	State resultState(row.columnCount);
+	resultState.columns = columns;
+	resultState.rowIndex = row.rowIndex;
+	// I tried to condense this, but kept getting the logic messed up
+	for (unsigned long i = 0; i < columns.size(); i++)
+	{
+		if(columns[i] == NONE) {
+			continue;
+		}
+        resultState.whereTheFeetAre[columns[i]] = i;
+        
+		if(row.holds[i].type == TapNoteType_Empty)
+		{
+			resultState.movedFeet[i] = columns[i];
+            resultState.didTheFootMove[columns[i]] = true;
+			continue;
+		}
+		if(initialState.columns[i] != columns[i])
+		{
+			resultState.movedFeet[i] = columns[i];
+            resultState.didTheFootMove[columns[i]] = true;
+		}
+	}
+
+	for (unsigned long i = 0; i < columns.size(); i++)
+	{
+		if(columns[i] == NONE) {
+			continue;
+		}
+
+		if(row.holds[i].type != TapNoteType_Empty)
+		{
+			resultState.holdFeet[i] = columns[i];
+            resultState.isTheFootHolding[columns[i]] = true;
+		}
+	}
+	resultState.second = row.second;
+	return resultState;
+}
+
+
+std::vector<FootPlacement>* StepParityGenerator::getFootPlacementPermutations(const Row &row)
+{
+	int cacheKey = getPermuteCacheKey(row);	
+	auto maybePermuteFootPlacements = permuteCache.find(cacheKey);
+	
+	if (maybePermuteFootPlacements == permuteCache.end())
+	{
+		FootPlacement blankColumns(row.columnCount, NONE);
+		std::vector<FootPlacement> computedPermutations = PermuteFootPlacements(row, blankColumns, 0);
+		permuteCache[cacheKey] = std::move(computedPermutations);
+	}
+	return &permuteCache[cacheKey];
+}
+
+
+std::vector<FootPlacement> StepParityGenerator::PermuteFootPlacements(const Row &row, FootPlacement columns, unsigned long column)
+{
+	if (column >= columns.size())
+	{
+		int leftHeelIndex = -1;
+		int leftToeIndex = -1;
+		int rightHeelIndex = -1;
+		int rightToeIndex = -1;
+		for (unsigned long i = 0; i < columns.size(); i++)
+		{
+			if (columns[i] == NONE)
+				continue;
+			if (columns[i] == LEFT_HEEL)
+				leftHeelIndex = i;
+			if (columns[i] == LEFT_TOE)
+				leftToeIndex = i;
+			if (columns[i] == RIGHT_HEEL)
+				rightHeelIndex = i;
+			if (columns[i] == RIGHT_TOE)
+				rightToeIndex = i;
+		}
+		if (
+			(leftHeelIndex == -1 && leftToeIndex != -1) ||
+			(rightHeelIndex == -1 && rightToeIndex != -1))
+		{
+			return std::vector<FootPlacement>();
+		}
+		if (leftHeelIndex != -1 && leftToeIndex != -1)
+		{
+			if (!bracketCheck(leftHeelIndex, leftToeIndex))
+				return std::vector<FootPlacement>();
+		}
+		if (rightHeelIndex != -1 && rightToeIndex != -1)
+		{
+			if (!bracketCheck(rightHeelIndex, rightToeIndex))
+				return std::vector<FootPlacement>();
+		}
+		return {columns};
+	}
+
+	std::vector<FootPlacement> permutations;
+	if (row.notes[column].type != TapNoteType_Empty  || row.holds[column].type != TapNoteType_Empty) {
+		
+	  for (StepParity::Foot foot: FEET) {
+		if(std::find(columns.begin(), columns.end(), foot) != columns.end())
+		{
+			continue;
+		}
+
+		FootPlacement newColumns = columns;
+
+		newColumns[column] = foot;
+		std::vector<FootPlacement> p = PermuteFootPlacements(row, newColumns, column + 1);
+		permutations.insert(permutations.end(), p.begin(), p.end());
+	  }
+	  return permutations;
+	}
+	return PermuteFootPlacements(row, columns, column + 1);
+}
+
+
+std::vector<int> StepParityGenerator::computeCheapestPath()
+{
+	int start = graph.startNode->id;
+	int end = graph.endNode->id;
+	std::vector<int> shortest_path;
+	std::vector<float> cost(graph.nodeCount(), FLT_MAX);
+	std::vector<int> predecessor(graph.nodeCount(), -1);
+
+	cost[start] = 0;
+	for (int i = start; i <= end; i++)
+	{
+		StepParityNode *node = graph[i];
+		for(auto neighbor: node->neighbors)
+		{
+			int neighbor_id = neighbor.first->id;
+			float weight = neighbor.second[COST_TOTAL];
+//            printf("computeCheapestPath:: weight = %f", weight);
+			if(cost[i] + weight < cost[neighbor_id])
+			{
+				cost[neighbor_id] = cost[i] + weight;
+				predecessor[neighbor_id] = i;
+			}
+		}
+	}
+
+	int current_node = end;
+	while(current_node != start)
+	{
+		ASSERT_M(current_node != -1, "WHOA");
+		if(current_node != end)
+		{
+			shortest_path.push_back(current_node);
+		}
+		current_node = predecessor[current_node];
+	}
+	std::reverse(shortest_path.begin(), shortest_path.end());
+	return shortest_path;
+}
+
+
+void StepParityGenerator::CreateIntermediateNoteData(const NoteData &in, std::vector<IntermediateNoteData> &out)
+{
+	TimingData *timing = GAMESTATE->GetProcessedTimingData();
+	int columnCount = in.GetNumTracks();
+
+	NoteData::all_tracks_const_iterator curr_note = in.GetTapNoteRangeAllTracks(0, MAX_NOTE_ROW);
+
+	std::vector<IntermediateNoteData> notes;
+
+	for (; !curr_note.IsAtEnd(); ++curr_note)
+	{
+		IntermediateNoteData note;
+		note.type = curr_note->type;
+		note.subtype = curr_note->subType;
+		note.col = curr_note.Track();
+
+		note.row = curr_note.Row();
+		note.beat = NoteRowToBeat(curr_note.Row());
+		note.second = timing->GetElapsedTimeFromBeat(note.beat);
+
+		note.fake = note.type == TapNoteType_Fake || timing->IsFakeAtBeat(note.row);
+		note.warped = timing->IsWarpAtRow(note.row);
+
+		if (note.type == TapNoteType_HoldHead)
+		{
+			note.hold_length = NoteRowToBeat(curr_note->iDuration);
+		}
+		else
+		{
+			note.hold_length = -1;
+		}
+
+		notes.push_back(note);
+	}
+	out.assign(notes.begin(), notes.end());
+}
+
+
+void StepParityGenerator::CreateRows(const NoteData &in)
+{	
+	TimingData *timing = GAMESTATE->GetProcessedTimingData();
+	int columnCount = in.GetNumTracks();
+
+	RowCounter counter = RowCounter(columnCount);
+
+	std::vector<IntermediateNoteData> noteData;
+
+	CreateIntermediateNoteData(in, noteData);
+
+	for (IntermediateNoteData note : noteData)
+	{
+		if (note.type == TapNoteType_Empty)
+		{
+			continue;
+		}
+
+		if (note.type == TapNoteType_Mine)
+		{
+			// If this mine occurs on the same row as everything else that's been counted
+			// (in other words, if this note doesn't represent the start of a new row),
+			// and this isn't the very first row, put it in nextMines??
+			// I honestly don't know why this works the way it does, it all feels
+			// really backwards to me.
+			// I think the complication comes from the fact that this is getting handled
+			// before checking whether or not this note represens a new row.
+			// But we only want to create a new Row if it has at least one note.
+			// So probably something like
+			
+			/*
+			 
+			 for(note of notes)
+			 {
+				if(note is empty note)
+				 {
+					continue
+				 }
+				if(note is on new row and counter has at least one note)
+				{
+					create new row
+					reset counter
+				}
+				check if note is a mine or fake mine
+				if note is fake continue
+				put note into counter.notes
+				
+			 }
+			 */
+			if (note.second == counter.lastColumnSecond && rows.size() > 0)
+			{
+				if (note.fake)
+				{
+					counter.nextFakeMines[note.col] = note.second;
+				}
+				else
+				{
+					counter.nextMines[note.col] = note.second;
+				}
+			}
+			else
+			{
+				if (note.fake)
+				{
+					counter.fakeMines[note.col] = note.second;
+				}
+				else
+				{
+					counter.mines[note.col] = note.second;
+				}
+			}
+			continue;
+		}
+
+		if (note.fake)
+		{
+			continue;
+		}
+
+		if (counter.lastColumnSecond != note.second)
+		{
+
+			// we're past the previous row, so save all of the previous row's data
+			if (counter.lastColumnSecond != CLM_SECOND_INVALID)
+			{
+				AddRow(counter);
+			}
+
+			// Move mines and fakeMines to "next", and reset counters
+			counter.lastColumnSecond = note.second;
+			counter.lastColumnBeat = note.beat;
+			counter.nextMines.assign(counter.mines.begin(), counter.mines.end());
+			counter.nextFakeMines.assign(counter.fakeMines.begin(), counter.fakeMines.end());
+			counter.notes = std::vector<IntermediateNoteData>(columnCount);
+			counter.mines = std::vector<float>(columnCount);
+			counter.fakeMines = std::vector<float>(columnCount);
+
+			// reset any now-inactive holds to empty values
+			for (int c = 0; c < columnCount; c++)
+			{
+				if (counter.activeHolds[c].type == TapNoteType_Empty || note.beat > counter.activeHolds[c].beat + counter.activeHolds[c].hold_length)
+				{
+					counter.activeHolds[c] = IntermediateNoteData();
+				}
+			}
+		}
+
+		counter.notes[note.col] = note;
+		if (note.type == TapNoteType_HoldHead)
+		{
+			counter.activeHolds[note.col] = note;
+		}
+	}
+
+	AddRow(counter);
+}
+
+void StepParityGenerator::AddRow(RowCounter &counter)
+{
+	Row newRow = CreateRow(counter);
+	newRow.rowIndex = rows.size();
+	rows.push_back(newRow);
+}
+
+Row StepParityGenerator::CreateRow(RowCounter &counter)
+{
+	Row row = Row(columnCount);
+	row.notes.assign(counter.notes.begin(), counter.notes.end());
+	row.mines.assign(counter.nextMines.begin(), counter.nextMines.end());
+	row.fakeMines.assign(counter.nextFakeMines.begin(), counter.nextFakeMines.end());
+	row.second = counter.lastColumnSecond;
+	row.beat = counter.lastColumnBeat;
+
+	for (int c = 0; c < columnCount; c++)
+	{
+		// save any active holds
+		if (counter.activeHolds[c].type == TapNoteType_Empty || counter.activeHolds[c].second >= counter.lastColumnSecond)
+		{
+			row.holds[c] = IntermediateNoteData();
+		}
+		else
+		{
+			row.holds[c] = counter.activeHolds[c];
+		}
+
+		// save any hold tails
+
+		if (counter.activeHolds[c].type != TapNoteType_Empty)
+		{
+			if (abs(counter.activeHolds[c].beat + counter.activeHolds[c].hold_length - counter.lastColumnBeat) < 0.0005)
+			{
+				row.holdTails.insert(c);
+			}
+		}
+	}
+	return row;
+}
+
+int StepParityGenerator::getPermuteCacheKey(const Row &row)
+{
+	int key = 0;
+
+	for (unsigned long i = 0; i < row.notes.size() && i < row.holds.size(); i++)
+	{
+		if(row.notes[i].type != TapNoteType_Empty || row.holds[i].type != TapNoteType_Empty)
+		{
+			key += pow(2, i);
+		}
+	}
+	return key;
+}
+
+Json::Value StepParityGenerator::SMEditorParityJson()
+{
+	Json::Value root;
+	
+	for (unsigned long i = 0; i < nodes_for_rows.size(); i++)
+	{
+		StepParityNode *node = graph[nodes_for_rows[i]];
+		root.append(node->state.ToJson(false));
+	}
+	
+	return root;
+}
+
+bool StepParityGenerator::bracketCheck(int column1, int column2)
+{
+	StagePoint p1 = layout[column1];
+	StagePoint p2 = layout[column2];
+	return getDistanceSq(p1, p2) <= 2;
+}
+
+float StepParityGenerator::getDistanceSq(StepParity::StagePoint p1, StepParity::StagePoint p2)
+{
+	return (p1.y - p2.y) * (p1.y - p2.y) + (p1.x - p2.x) * (p1.x - p2.x);
+}

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -16,7 +16,7 @@ bool StepParityGenerator::analyzeNoteData(const NoteData &in)
 	if(rows.size() == 0)
 	{
 		LOG->Trace("StepParityGenerator::analyze no rows, bailing out");
-		return;
+		return false;
 	}
 	buildStateGraph();
 	return analyzeGraph();

--- a/src/StepParityGenerator.h
+++ b/src/StepParityGenerator.h
@@ -41,7 +41,7 @@ namespace StepParity {
 		StepParity::StepParityNode * startNode = nullptr;
 		StepParity::State * endingState = nullptr;
 		StepParity::StepParityNode * endNode = nullptr;
-		
+		StepParity::State * tmpState = nullptr;
 	public:
 		std::unordered_map <std::uint64_t, StepParity::State*> stateCache;
 		std::vector<StepParity::StepParityNode*> nodes;
@@ -71,6 +71,10 @@ namespace StepParity {
 			if(endingState != nullptr)
 			{
 				delete endingState;
+			}
+			if(tmpState != nullptr)
+			{
+				delete tmpState;
 			}
 		}
 		/// @brief Analyzes the given NoteData to generate a vector of StepParity::Rows, with each step annotated with

--- a/src/StepParityGenerator.h
+++ b/src/StepParityGenerator.h
@@ -16,7 +16,7 @@ namespace StepParity {
 			{1, 0},  // Down
 			{1, 2},  // Up
 			{2, 1}   // Right
-		}, {2}, {1}, {0,3})},
+		}, {2}, {1}, {0, 3})},
 		{StepsType_dance_double, StageLayout(StepsType_dance_double, {
 			{0, 1},  // P1 Left
 			{1, 0},  // P1 Down
@@ -27,7 +27,7 @@ namespace StepParity {
 			{4, 0},  // P2 Down
 			{4, 2},  // P2 Up
 			{5, 1}   // P2 Right
-		}, {26}, {1,5}, {0,3,4,7})}
+		}, {2, 6}, {1, 5}, {0, 3, 4, 7})}
 	};
 	
 	/// @brief This class handles most of the work for generating step parities for a step chart.

--- a/src/StepParityGenerator.h
+++ b/src/StepParityGenerator.h
@@ -1,0 +1,85 @@
+#ifndef STEP_PARITY_GENERATOR_H
+#define STEP_PARITY_GENERATOR_H
+
+#include "GameConstantsAndTypes.h"
+#include "NoteData.h"
+#include "StepParityDatastructs.h"
+#include <queue>
+#include <unordered_map>
+#include "json/json.h"
+
+namespace StepParity {
+	
+	/// @brief This class handles most of the work for generating step parities for a step chart.
+	class StepParityGenerator 
+	{
+	private:
+		StageLayout layout;
+		std::map < int, std::vector<std::vector<StepParity::Foot>>> permuteCache;
+
+	public:
+		StepParityGraph graph;
+		std::vector<Row> rows;
+		std::vector<int> nodes_for_rows;
+		int columnCount;
+		
+		/// @brief Analyzes the given NoteData to generate a vector of StepParity::Rows, with each step annotated with
+		/// a foot placement.
+		/// @param in The NoteData to analyze
+		/// @param stepsTypeStr StepsType, currently only supports "dance-single"
+		void analyzeNoteData(const NoteData &in, StepsType stepsType);
+
+		/// @brief Analyzes the given graph to find the least costly path from the beginnning to the end of the stepchart.
+		/// Sets the `parity` for the relevant notes of each row in rows.
+		void analyzeGraph();
+
+		/// @brief Generates a StepParityGraph from the given vector of Rows.
+		/// The graph inserts two additional nodes: one that represent the beginning of the song, before the first note,
+		/// and one that represents the end of the song, after the final note.
+		void buildStateGraph();
+
+		/// @brief Creates a new State, which is the result of moving from the given initialState
+		/// to the steps of the given row with the given foot placements in columns.
+		/// @param initialState The state of the player prior to the next row
+		/// @param row The next row for the resulting state
+		/// @param columns The foot placement for the resulting state
+		/// @return The resulting state
+		State initResultState(State &initialState, Row &row, const FootPlacement &columns);
+
+		/// @brief Returns a pointer to a vector of foot possible foot placements for the given row.
+		/// Utilizes the permuteCache to re-use vectors. The returned pointer points to a vector within the permuteCache.
+		/// @param row The row to calculate foot placement permutations for.
+		/// @return A pointer to a vector of foot placements.
+		std::vector<FootPlacement>* getFootPlacementPermutations(const Row &row);
+
+		/// @brief A recursive function that generates a vector of possible foot placements for the given row.
+		/// This function should not be used directly, instead use getFootPlacementPermutations().
+		/// @param row
+		/// @param columns
+		/// @param column
+		/// @return
+		std::vector<FootPlacement> PermuteFootPlacements(const Row &row, FootPlacement columns, unsigned long column);
+
+		/// @brief Computes the "cheapest" path through the given graph.
+		/// This relies on the fact that the nodes stored in the graph are topologically sorted (that is, all
+		/// of the nodes are ordered in such a way that each node comes before all the nodes it points to.)
+		/// This allows us to find the cheapest path in a single pass.
+		/// The resulting path includes one node for each row of the stepchart represented by the graph.
+		/// Returns a vector of node indices, which can be mapped back to the cheapest state for each row.
+		/// @return A vector of node indices, making up the cheapest path through the step chart.
+		std::vector<int> computeCheapestPath();
+		
+		/// @brief Converts NoteData into an intermediate form that's a little more convenient
+		/// to work with when creating rows.
+		void CreateIntermediateNoteData(const NoteData &in, std::vector<IntermediateNoteData> &out);
+		void CreateRows(const NoteData &in);
+		void AddRow(RowCounter &counter);
+		Row CreateRow(RowCounter &counter);
+		int getPermuteCacheKey(const Row &row);
+		bool bracketCheck(int column1, int column2);
+		float getDistanceSq(StepParity::StagePoint p1, StepParity::StagePoint p2);
+		Json::Value SMEditorParityJson();
+	};
+};
+
+#endif

--- a/src/StepParityGenerator.h
+++ b/src/StepParityGenerator.h
@@ -10,6 +10,26 @@
 
 namespace StepParity {
 	
+	const std::map<StepsType, StageLayout> Layouts = {
+		{StepsType_dance_single, StageLayout(StepsType_dance_single, {
+			{0, 1},  // Left
+			{1, 0},  // Down
+			{1, 2},  // Up
+			{2, 1}   // Right
+		}, {2}, {1}, {0,3})},
+		{StepsType_dance_double, StageLayout(StepsType_dance_double, {
+			{0, 1},  // P1 Left
+			{1, 0},  // P1 Down
+			{1, 2},  // P1 Up
+			{2, 1},  // P1 Right
+			
+			{3, 1},  // P2 Left
+			{4, 0},  // P2 Down
+			{4, 2},  // P2 Up
+			{5, 1}   // P2 Right
+		}, {26}, {1,5}, {0,3,4,7})}
+	};
+	
 	/// @brief This class handles most of the work for generating step parities for a step chart.
 	class StepParityGenerator 
 	{
@@ -23,11 +43,12 @@ namespace StepParity {
 		std::vector<int> nodes_for_rows;
 		int columnCount;
 		
+		StepParityGenerator(const StageLayout & l) : layout(l) {
+		}
 		/// @brief Analyzes the given NoteData to generate a vector of StepParity::Rows, with each step annotated with
 		/// a foot placement.
 		/// @param in The NoteData to analyze
-		/// @param stepsTypeStr StepsType, currently only supports "dance-single"
-		void analyzeNoteData(const NoteData &in, StepsType stepsType);
+		void analyzeNoteData(const NoteData &in);
 
 		/// @brief Analyzes the given graph to find the least costly path from the beginnning to the end of the stepchart.
 		/// Sets the `parity` for the relevant notes of each row in rows.

--- a/src/StepParityGenerator.h
+++ b/src/StepParityGenerator.h
@@ -36,14 +36,15 @@ namespace StepParity {
 	private:
 		StageLayout layout;
 		std::unordered_map < int, std::vector<std::vector<StepParity::Foot>>> permuteCache;
-		std::unordered_map <std::uint64_t, StepParity::State*> stateCache;
-		std::vector<StepParity::StepParityNode*> nodes;
+		
 		StepParity::State * beginningState = nullptr;
 		StepParity::StepParityNode * startNode = nullptr;
 		StepParity::State * endingState = nullptr;
 		StepParity::StepParityNode * endNode = nullptr;
 		
 	public:
+		std::unordered_map <std::uint64_t, StepParity::State*> stateCache;
+		std::vector<StepParity::StepParityNode*> nodes;
 		std::vector<Row> rows;
 		std::vector<int> nodes_for_rows;
 		int columnCount;
@@ -75,11 +76,13 @@ namespace StepParity {
 		/// @brief Analyzes the given NoteData to generate a vector of StepParity::Rows, with each step annotated with
 		/// a foot placement.
 		/// @param in The NoteData to analyze
-		void analyzeNoteData(const NoteData &in);
+		/// @return false if an error was encountered while analyzing the note data
+		bool analyzeNoteData(const NoteData &in);
 
 		/// @brief Analyzes the given graph to find the least costly path from the beginnning to the end of the stepchart.
 		/// Sets the `parity` for the relevant notes of each row in rows.
-		void analyzeGraph();
+		/// @return whether or not a valid graph was generated and analyzed
+		bool analyzeGraph();
 
 		/// @brief Generates a StepParityGraph from the given vector of Rows.
 		/// The graph inserts two additional nodes: one that represent the beginning of the song, before the first note,
@@ -108,8 +111,8 @@ namespace StepParity {
 		/// @param row
 		/// @param columns
 		/// @param column
-		/// @return
-		std::vector<FootPlacement> PermuteFootPlacements(const Row &row, FootPlacement columns, unsigned long column);
+		/// @param ignoreHolds
+		std::vector<FootPlacement> PermuteFootPlacements(const Row &row, FootPlacement columns, unsigned long column, bool ignoreHolds);
 
 		/// @brief Computes the "cheapest" path through the given graph.
 		/// This relies on the fact that the nodes stored in the graph are topologically sorted (that is, all

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -987,40 +987,6 @@ public:
 		return 1;
 	}
 
-	static int GetNPSPerMeasure(T *p, lua_State *L)
-	{
-		PlayerNumber pn = PLAYER_1;
-		if (!lua_isnil(L, 1)) {
-			pn = Enum::Check<PlayerNumber>(L, 1);
-		}
-		MeasureInfo &ts = const_cast<MeasureInfo &>(p->GetMeasureInfo(pn));
-		LuaHelpers::CreateTableFromArray(ts.npsPerMeasure, L);
-		return 1;
-	}
-
-	static int GetNotesPerMeasure(T *p, lua_State * L)
-	{
-		PlayerNumber pn = PLAYER_1;
-		if (!lua_isnil(L, 1)) {
-			pn = Enum::Check<PlayerNumber>(L, 1);
-		}
-		MeasureInfo &ts = const_cast<MeasureInfo &>(p->GetMeasureInfo(pn));
-		LuaHelpers::CreateTableFromArray(ts.notesPerMeasure, L);
-
-		return 1;
-	}
-
-	static int GetPeakNPS(T *p, lua_State *L)
-	{
-		PlayerNumber pn = PLAYER_1;
-		if (!lua_isnil(L, 1)) {
-			pn = Enum::Check<PlayerNumber>(L, 1);
-		}
-		MeasureInfo &ts = const_cast<MeasureInfo &>(p->GetMeasureInfo(pn));
-		lua_pushnumber(L, ts.peakNps);
-		return 1;
-	}
-
 	static int GetColumnCues(T *p, lua_State*L)
 	{
 		float minDuration = 1.5;

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -332,8 +332,7 @@ void Steps::CalculateRadarValues( float fMusicLengthSeconds )
 	this->GetNoteData( tempNoteData );
 
 	FOREACH_PlayerNumber(pn)
-		m_CachedRadarValues[pn]
-			.Zero();
+		m_CachedRadarValues[pn].Zero();
 
 	GAMESTATE->SetProcessedTimingData(this->GetTimingData());
 	if( tempNoteData.IsComposite() )
@@ -389,7 +388,7 @@ void Steps::CalculateTechCounts()
 		m_CachedTechCounts[pn]
 			.Zero();
 
-	
+
 	// If we don't have a valid layout for this StepsType, then don't even bother
 	if(StepParity::Layouts.find(this->m_StepsType) == StepParity::Layouts.end())
 	{
@@ -1045,8 +1044,8 @@ public:
 		ADD_METHOD( HasAttacks );
 		ADD_METHOD( GetRadarValues );
 		ADD_METHOD( GetTechCounts );
-		ADD_METHOD(CalculateTechCounts);
-		ADD_METHOD(GetTimingData);
+		ADD_METHOD( CalculateTechCounts );
+		ADD_METHOD( GetTimingData );
 		ADD_METHOD( GetChartName );
 		//ADD_METHOD( GetSMNoteData );
 		ADD_METHOD( GetStepsType );

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -389,16 +389,17 @@ void Steps::CalculateTechCounts()
 		m_CachedTechCounts[pn]
 			.Zero();
 
-	// For now, we're only supporting dance-single and dance-double
-	if(this->m_StepsType != StepsType_dance_single && this->m_StepsType != StepsType_dance_double)
+	
+	// If we don't have a valid layout for this StepsType, then don't even bother
+	if(StepParity::Layouts.find(this->m_StepsType) == StepParity::Layouts.end())
 	{
 		return;
 	}
-
+	StepParity::StageLayout layout = StepParity::Layouts.at(this->m_StepsType);
 	GAMESTATE->SetProcessedTimingData(this->GetTimingData());
-	StepParity::StepParityGenerator gen;
-	gen.analyzeNoteData(tempNoteData, this->m_StepsType);
-	TechCounts::CalculateTechCountsFromRows(gen.rows, m_CachedTechCounts[0]);
+	StepParity::StepParityGenerator gen = StepParity::StepParityGenerator(layout);
+	gen.analyzeNoteData(tempNoteData);
+	TechCounts::CalculateTechCountsFromRows(gen.rows, layout, m_CachedTechCounts[0]);
 	std::fill_n( m_CachedTechCounts + 1, NUM_PLAYERS-1, m_CachedTechCounts[0] );
 
 	GAMESTATE->SetProcessedTimingData(nullptr);

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -10,8 +10,8 @@
 #include "RageUtil_AutoPtr.h"
 #include "TimingData.h"
 #include "ColumnCues.h"
+#include "TechCounts.h"
 #include "MeasureInfo.h"
-
 #include <vector>
 
 
@@ -136,11 +136,15 @@ public:
 	RString GetChartKey();
 	void SetChartKey(const RString &k) { ChartKey = k; }
 
+	/** @brief Produces a chart that's reduced to it's smallest unique representable form. */
+	RString MinimizedChartString();
+
 	void ChangeFilenamesForCustomSong();
 
 	void SetLoadedFromProfile( ProfileSlot slot )	{ m_LoadedFromProfile = slot; }
 	void SetMeter( int meter );
 	void SetCachedRadarValues( const RadarValues v[NUM_PLAYERS] );
+	void SetCachedTechCounts(const TechCounts ts[NUM_PLAYERS]);
 	void SetCachedMeasureInfo(const MeasureInfo ms[NUM_PLAYERS]);
 	float PredictMeter() const;
 
@@ -164,7 +168,14 @@ public:
 	bool IsNoteDataEmpty() const;
 
 	void TidyUpData();
-	void CalculateRadarValues( float fMusicLengthSeconds );
+
+	/** @brief Convenience function to calculate Radar Values, Tech Stats, Measure Stats, and GrooveStats key.*/
+	void CalculateStepStats(float fMusicLengthSeconds);
+
+	void CalculateRadarValues (float fMusicLengthSeconds );
+
+	void CalculateTechCounts();
+	const TechCounts &GetTechCounts(PlayerNumber pn) const { return Real()->m_CachedTechCounts[pn]; }
 
 	void CalculateMeasureInfo();
 	const MeasureInfo &GetMeasureInfo(PlayerNumber pn) const { return Real()->m_CachedMeasureInfo[pn]; }
@@ -261,6 +272,10 @@ private:
 	/** @brief The radar values used for each player. */
 	RadarValues			m_CachedRadarValues[NUM_PLAYERS];
 	bool                m_bAreCachedRadarValuesJustLoaded;
+
+	/** @brief The tech stats used for each player */
+	mutable TechCounts m_CachedTechCounts[NUM_PLAYERS];
+	bool m_bAreCachedTechCountsValuesJustLoaded;
 
 	mutable MeasureInfo m_CachedMeasureInfo[NUM_PLAYERS];
 	bool m_bAreCachedMeasureInfoJustLoaded;

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -10,6 +10,7 @@
 #include "RageUtil_AutoPtr.h"
 #include "TimingData.h"
 #include "ColumnCues.h"
+#include "MeasureInfo.h"
 
 #include <vector>
 
@@ -140,6 +141,7 @@ public:
 	void SetLoadedFromProfile( ProfileSlot slot )	{ m_LoadedFromProfile = slot; }
 	void SetMeter( int meter );
 	void SetCachedRadarValues( const RadarValues v[NUM_PLAYERS] );
+	void SetCachedMeasureInfo(const MeasureInfo ms[NUM_PLAYERS]);
 	float PredictMeter() const;
 
 	unsigned GetHash() const;
@@ -163,6 +165,9 @@ public:
 
 	void TidyUpData();
 	void CalculateRadarValues( float fMusicLengthSeconds );
+
+	void CalculateMeasureInfo();
+	const MeasureInfo &GetMeasureInfo(PlayerNumber pn) const { return Real()->m_CachedMeasureInfo[pn]; }
 
 	/**
 	 * @brief The TimingData used by the Steps.
@@ -211,7 +216,7 @@ public:
 	{
 		return join(":", this->m_sAttackString);
 	}
-    
+
     std::vector<ColumnCue> GetColumnCues(float minDuration);
 
 private:
@@ -256,6 +261,10 @@ private:
 	/** @brief The radar values used for each player. */
 	RadarValues			m_CachedRadarValues[NUM_PLAYERS];
 	bool                m_bAreCachedRadarValuesJustLoaded;
+
+	mutable MeasureInfo m_CachedMeasureInfo[NUM_PLAYERS];
+	bool m_bAreCachedMeasureInfoJustLoaded;
+
 	/** @brief The name of the person who created the Steps. */
 	RString				m_sCredit;
 	/** @brief The name of the chart. */

--- a/src/TechCounts.cpp
+++ b/src/TechCounts.cpp
@@ -112,7 +112,7 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 		{
 			for (StepParity::Foot foot: StepParity::FEET)
 			{
-				if(currentRow.whereTheFeetAre[foot] == -1 || previousRow.whereTheFeetAre[foot] == -1)
+				if(currentRow.whereTheFeetAre[foot] == StepParity::INVALID_COLUMN || previousRow.whereTheFeetAre[foot] == StepParity::INVALID_COLUMN)
 				{
 					continue;
 				}
@@ -137,12 +137,12 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 		// Check for brackets
 		if(currentRow.noteCount >= 2)
 		{
-			if(currentRow.whereTheFeetAre[StepParity::LEFT_HEEL] != -1 && currentRow.whereTheFeetAre[StepParity::LEFT_TOE] != -1)
+			if(currentRow.whereTheFeetAre[StepParity::LEFT_HEEL] != StepParity::INVALID_COLUMN && currentRow.whereTheFeetAre[StepParity::LEFT_TOE] != StepParity::INVALID_COLUMN)
 			{
 				out[TechCountsCategory_Brackets] += 1;
 			}
 
-			if(currentRow.whereTheFeetAre[StepParity::RIGHT_HEEL] != -1 && currentRow.whereTheFeetAre[StepParity::RIGHT_TOE] != -1)
+			if(currentRow.whereTheFeetAre[StepParity::RIGHT_HEEL] != StepParity::INVALID_COLUMN && currentRow.whereTheFeetAre[StepParity::RIGHT_TOE] != StepParity::INVALID_COLUMN)
 			{
 				out[TechCountsCategory_Brackets] += 1;
 			}
@@ -197,7 +197,7 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 		//   - Was the right foot farther right than the left?
 		//     - If so, then this was a full crossover (like RDL, starting on right foot)
 		//     - otherwise, then this was probably a half crossover (like UDL, starting on right foot)
-		if(rightHeel != -1 && previousLeftHeel != -1 && previousRightHeel == -1)
+		if(rightHeel != StepParity::INVALID_COLUMN && previousLeftHeel != StepParity::INVALID_COLUMN && previousRightHeel == StepParity::INVALID_COLUMN)
 		{
 			StepParity::StagePoint leftPos = layout.averagePoint(previousLeftHeel, previousLeftToe);
 			StepParity::StagePoint rightPos = layout.averagePoint(rightHeel, rightToe);
@@ -209,7 +209,7 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 					const StepParity::Row & previousPreviousRow = rows[i - 2];
 					int previousPreviousRightHeel = previousPreviousRow.whereTheFeetAre[StepParity::RIGHT_HEEL];
 					
-					if(previousPreviousRightHeel != -1 && previousPreviousRightHeel != rightHeel)
+					if(previousPreviousRightHeel != StepParity::INVALID_COLUMN && previousPreviousRightHeel != rightHeel)
 					{
 						StepParity::StagePoint previousPreviousRightPos = layout.columns[previousPreviousRightHeel];
 						if(previousPreviousRightPos.x > leftPos.x)
@@ -231,7 +231,7 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 			}
 		}
 		// And check the same thing, starting with left foot
-		else if(leftHeel != -1 && previousRightHeel != -1 && previousLeftHeel == -1)
+		else if(leftHeel != StepParity::INVALID_COLUMN && previousRightHeel != StepParity::INVALID_COLUMN && previousLeftHeel == StepParity::INVALID_COLUMN)
 		{
 			StepParity::StagePoint leftPos = layout.averagePoint(leftHeel, leftToe);
 			StepParity::StagePoint rightPos = layout.averagePoint(previousRightHeel, previousRightToe);
@@ -241,9 +241,10 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 				if(i > 1)
 				{
 					const StepParity::Row & previousPreviousRow = rows[i - 2];
-					if(previousPreviousRow.whereTheFeetAre[StepParity::LEFT_HEEL] != leftHeel)
+					int previousPreviousLeftHeel = previousPreviousRow.whereTheFeetAre[StepParity::LEFT_HEEL];
+					if(previousPreviousLeftHeel != StepParity::INVALID_COLUMN && previousPreviousLeftHeel != leftHeel)
 					{
-						StepParity::StagePoint previousPreviousLeftPos = layout.columns[previousPreviousRow.whereTheFeetAre[StepParity::LEFT_HEEL]];
+						StepParity::StagePoint previousPreviousLeftPos = layout.columns[previousPreviousLeftHeel];
 						if(rightPos.x > previousPreviousLeftPos.x)
 						{
 							out[TechCountsCategory_FullCrossovers] += 1;

--- a/src/TechCounts.cpp
+++ b/src/TechCounts.cpp
@@ -8,7 +8,6 @@
 #include "GameState.h"
 #include "RageTimer.h"
 
-
 static const char *TechCountsCategoryNames[] = {
 	"Crossovers",
 	"HalfCrossovers",
@@ -26,7 +25,6 @@ XToString( TechCountsCategory );
 XToLocalizedString( TechCountsCategory );
 LuaFunction(TechCountsCategoryToLocalizedString, TechCountsCategoryToLocalizedString(Enum::Check<TechCountsCategory>(L, 1)) );
 LuaXType( TechCountsCategory );
-
 
 // 0.176 ~= 1/8th at 175bpm
 // Anything slower isn't counted as a jack
@@ -90,9 +88,7 @@ void TechCounts::FromString( RString sTechCounts )
 	{
 		(*this)[rc] = StringToFloat(saValues[rc]);
 	}
-
 }
-
 
 void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> &rows, StepParity::StageLayout & layout, TechCounts &out)
 {
@@ -103,17 +99,15 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 			
 		float elapsedTime = currentRow.second - previousRow.second;
 		
-		/*
-		Jacks are same arrow same foot
-		Doublestep is same foot on successive arrows
-		Brackets are jumps with one foot
+		// Jacks are same arrow same foot
+		// Doublestep is same foot on successive arrows
+		// Brackets are jumps with one foot
 
-		Footswitch is different foot on the up or down arrow
-		Sideswitch is footswitch on left or right arrow
-		Crossovers are left foot on right arrow or vice versa
-		*/
+		// Footswitch is different foot on the up or down arrow
+		// Sideswitch is footswitch on left or right arrow
+		// Crossovers are left foot on right arrow or vice versa
 
-		// check for jacks and doublesteps
+		// Check for jacks and doublesteps
 		if(currentRow.noteCount == 1 && previousRow.noteCount == 1)
 		{
 			for (StepParity::Foot foot: StepParity::FEET)
@@ -140,7 +134,7 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 			}
 		}
 
-		// check for brackets
+		// Check for brackets
 		if(currentRow.noteCount >= 2)
 		{
 			if(currentRow.whereTheFeetAre[StepParity::LEFT_HEEL] != -1 && currentRow.whereTheFeetAre[StepParity::LEFT_TOE] != -1)
@@ -183,7 +177,6 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 		}
 		
 		// Check for crossovers
-		
 		int leftHeel = currentRow.whereTheFeetAre[StepParity::LEFT_HEEL];
 		int leftToe = currentRow.whereTheFeetAre[StepParity::LEFT_TOE];
 		int rightHeel = currentRow.whereTheFeetAre[StepParity::RIGHT_HEEL];
@@ -235,7 +228,7 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 				}
 			}
 		}
-		// and check the same thing, starting with left foot
+		// And check the same thing, starting with left foot
 		else if(leftHeel != -1 && previousRightHeel != -1 && previousLeftHeel == -1)
 		{
 			StepParity::StagePoint leftPos = layout.averagePoint(leftHeel, leftToe);
@@ -287,12 +280,9 @@ bool TechCounts::isFootswitch(int c, const StepParity::Row & currentRow, const S
 }
 
 // lua start
-
 class LunaTechCounts: public Luna<TechCounts>
 {
 public:
-
-
 	static int GetValue( T* p, lua_State *L ) { lua_pushnumber( L, (*p)[Enum::Check<TechCountsCategory>(L, 1)] ); return 1; }
 
 	LunaTechCounts()

--- a/src/TechCounts.cpp
+++ b/src/TechCounts.cpp
@@ -1,0 +1,258 @@
+#include "global.h"
+#include "TechCounts.h"
+#include "NoteData.h"
+#include "RageLog.h"
+#include "LocalizedString.h"
+#include "LuaBinding.h"
+#include "TimingData.h"
+#include "GameState.h"
+#include "RageTimer.h"
+
+
+static const char *TechCountsCategoryNames[] = {
+	"Crossovers",
+	"Footswitches",
+	"Sideswitches",
+	"Jacks",
+	"Brackets",
+	"Doublesteps"
+};
+
+XToString( TechCountsCategory );
+XToLocalizedString( TechCountsCategory );
+LuaFunction(TechCountsCategoryToLocalizedString, TechCountsCategoryToLocalizedString(Enum::Check<TechCountsCategory>(L, 1)) );
+LuaXType( TechCountsCategory );
+
+
+// TechCounts methods
+
+TechCounts::TechCounts()
+{
+	MakeUnknown();
+}
+
+void TechCounts::MakeUnknown()
+{
+	FOREACH_ENUM( TechCountsCategory, rc )
+	{
+		(*this)[rc] = TECHCOUNTS_VAL_UNKNOWN;
+	}
+}
+
+void TechCounts::Zero()
+{
+	FOREACH_ENUM( TechCountsCategory, rc )
+	{
+		(*this)[rc] = 0;
+	}
+}
+
+RString TechCounts::ToString( int iMaxValues ) const
+{
+	if( iMaxValues == -1 )
+		iMaxValues = NUM_TechCountsCategory;
+	iMaxValues = std::min( iMaxValues, (int)NUM_TechCountsCategory );
+
+	std::vector<RString> asTechCounts;
+	for( int r=0; r < iMaxValues; r++ )
+	{
+		asTechCounts.push_back(ssprintf("%.3f", (*this)[r]));
+	}
+
+	return join( ",",asTechCounts );
+}
+
+void TechCounts::FromString( RString sTechCounts )
+{
+	std::vector<RString> saValues;
+	split( sTechCounts, ",", saValues, true );
+
+	if( saValues.size() != NUM_TechCountsCategory )
+	{
+		MakeUnknown();
+		return;
+	}
+
+	FOREACH_ENUM( RadarCategory, rc )
+	{
+		(*this)[rc] = StringToFloat(saValues[rc]);
+	}
+
+}
+
+void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> &rows, TechCounts &out)
+{
+	// arrays to hold the column for each Foot enum.
+	// A value of -1 means that Foot is not on any column
+	int previousFootPlacement[StepParity::NUM_Foot];
+	int currentFootPlacement[StepParity::NUM_Foot];
+
+	for (int f = 0; f < StepParity::NUM_Foot; f++)
+	{
+		previousFootPlacement[f] = -1;
+		currentFootPlacement[f] = -1;
+	}
+
+	// arrays to hold the foot placements for the current row and previos row.
+	// They're basically just so we don't have to reference currentRow.notes[c].parity everywhere
+	std::vector<StepParity::Foot> previousColumns(rows[0].columnCount, StepParity::NONE);
+	std::vector<StepParity::Foot> currentColumns(rows[0].columnCount, StepParity::NONE);
+	
+	for (unsigned long i = 1; i < rows.size(); i++)
+	{
+		const StepParity::Row &currentRow = rows[i];
+		int noteCount = 0;
+		
+		// copy the foot placement for the current row into currentColumns,
+		// and count up how many notes there are in this row
+		for (int c = 0; c < currentRow.columnCount; c++)
+		{
+			StepParity::Foot currFoot = currentRow.notes[c].parity;
+			TapNoteType currType = currentRow.notes[c].type;
+
+			// If this isn't either a tap or the beginning of a hold, skip it
+			if(currType != TapNoteType_Tap && currType != TapNoteType_HoldHead)
+			{
+				continue;
+			}
+
+			currentFootPlacement[currFoot] = c;
+			currentColumns[c] = currFoot;
+			noteCount += 1;
+		}
+
+		/*
+		Jacks are same arrow same foot
+		Doublestep is same foot on successive arrows
+		Brackets are jumps with one foot
+
+		Footswitch is different foot on the up or down arrow
+		Sideswitch is footswitch on left or right arrow
+		Crossovers are left foot on right arrow or vice versa
+		*/
+
+		// check for jacks and doublesteps
+		if(noteCount == 1)
+		{
+			for (StepParity::Foot foot: StepParity::FEET)
+			{
+				if(currentFootPlacement[foot] == -1 || previousFootPlacement[foot] == -1)
+				{
+					continue;
+				}
+				
+				if(previousFootPlacement[foot] == currentFootPlacement[foot])
+				{
+					out[TechCountsCategory_Jacks] += 1;
+				}
+				else
+				{
+					out[TechCountsCategory_Doublesteps] += 1;
+				}
+			}
+		}
+
+		// check for brackets
+		if(noteCount >= 2)
+		{
+			if(currentFootPlacement[StepParity::LEFT_HEEL] != -1 && currentFootPlacement[StepParity::LEFT_TOE] != -1)
+			{
+				out[TechCountsCategory_Brackets] += 1;
+			}
+
+			if(currentFootPlacement[StepParity::RIGHT_HEEL] != -1 && currentFootPlacement[StepParity::RIGHT_TOE] != -1)
+			{
+				out[TechCountsCategory_Brackets] += 1;
+			}
+		}
+
+		// Check for footswitches, sideswitches, and crossovers
+		for (int c = 0; c < currentRow.columnCount; c++)
+		{
+			if(currentColumns[c] == StepParity::NONE)
+			{
+				continue;
+			}
+
+			// this same column was stepped on in the previous row, but not by the same foot ==> footswitch or sideswitch
+			if(previousColumns[c] != StepParity::NONE && previousColumns[c] != currentColumns[c])
+			{
+				// this is assuming only 4-panel single
+				if(c == 0 || c == 3)
+				{
+					out[TechCountsCategory_Sideswitches] += 1;
+				}
+				else
+				{
+					out[TechCountsCategory_Footswitches] += 1;
+				}
+			}
+			// if the right foot is pressing the left arrow, or the left foot is pressing the right ==> crossover
+			else if(c == 0 && previousColumns[c] == StepParity::NONE &&
+					(currentColumns[c] == StepParity::RIGHT_HEEL || currentColumns[c] == StepParity::RIGHT_TOE))
+			{
+				out[TechCountsCategory_Crossovers] += 1;
+			}
+			else if(c == 3 && previousColumns[c] == StepParity::NONE &&
+					(currentColumns[c] == StepParity::LEFT_HEEL || currentColumns[c] == StepParity::LEFT_TOE))
+			{
+				out[TechCountsCategory_Crossovers] += 1;
+			}
+		}
+
+		// Move the values from currentFootPlacement to previousFootPlacement,
+		// and reset currentFootPlacement
+		for (int f = 0; f < StepParity::NUM_Foot; f++)
+		{
+			previousFootPlacement[f] = currentFootPlacement[f];
+			currentFootPlacement[f] = -1;
+		}
+		for (int c = 0; c < currentRow.columnCount; c++)
+		{
+			previousColumns[c] = currentColumns[c];
+			currentColumns[c] = StepParity::NONE;
+		}
+	}
+}
+
+// lua start
+
+class LunaTechCounts: public Luna<TechCounts>
+{
+public:
+
+
+	static int GetValue( T* p, lua_State *L ) { lua_pushnumber( L, (*p)[Enum::Check<TechCountsCategory>(L, 1)] ); return 1; }
+
+	LunaTechCounts()
+	{
+		ADD_METHOD( GetValue );
+	}
+};
+
+LUA_REGISTER_CLASS( TechCounts )
+
+/*
+ * (c) 2023 Michael Votaw
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */

--- a/src/TechCounts.cpp
+++ b/src/TechCounts.cpp
@@ -180,7 +180,10 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 			}
 
 			// this same column was stepped on in the previous row, but not by the same foot ==> footswitch or sideswitch
-			if(previousColumns[c] != StepParity::NONE && previousColumns[c] != currentColumns[c])
+			if(previousColumns[c] != StepParity::NONE 
+			   && previousColumns[c] != currentColumns[c]
+			   && StepParity::OTHER_PART_OF_FOOT[previousColumns[c]] != currentColumns[c]
+			   )
 			{
 				// this is assuming only 4-panel single
 				if(c == 0 || c == 3)

--- a/src/TechCounts.cpp
+++ b/src/TechCounts.cpp
@@ -23,7 +23,7 @@ XToLocalizedString( TechCountsCategory );
 LuaFunction(TechCountsCategoryToLocalizedString, TechCountsCategoryToLocalizedString(Enum::Check<TechCountsCategory>(L, 1)) );
 LuaXType( TechCountsCategory );
 
-
+const float JACK_CUTOFF = 0.176; // 170bpm 1/8th notes, anything slower isn't considered a jack
 // TechCounts methods
 
 TechCounts::TechCounts()
@@ -86,7 +86,7 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 	// A value of -1 means that Foot is not on any column
 	int previousFootPlacement[StepParity::NUM_Foot];
 	int currentFootPlacement[StepParity::NUM_Foot];
-
+	int previousNoteCount = 0;
 	for (int f = 0; f < StepParity::NUM_Foot; f++)
 	{
 		previousFootPlacement[f] = -1;
@@ -101,6 +101,8 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 	for (unsigned long i = 1; i < rows.size(); i++)
 	{
 		const StepParity::Row &currentRow = rows[i];
+		const StepParity::Row &previousRow = rows[i - 1];
+			
 		int noteCount = 0;
 		
 		// copy the foot placement for the current row into currentColumns,
@@ -143,7 +145,10 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 				
 				if(previousFootPlacement[foot] == currentFootPlacement[foot])
 				{
-					out[TechCountsCategory_Jacks] += 1;
+					if(previousNoteCount == 1 && currentRow.second - previousRow.second < JACK_CUTOFF)
+					{
+						out[TechCountsCategory_Jacks] += 1;
+					}
 				}
 				else
 				{
@@ -212,6 +217,8 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 			previousColumns[c] = currentColumns[c];
 			currentColumns[c] = StepParity::NONE;
 		}
+		
+		previousNoteCount = noteCount;
 	}
 }
 

--- a/src/TechCounts.cpp
+++ b/src/TechCounts.cpp
@@ -11,7 +11,9 @@
 
 static const char *TechCountsCategoryNames[] = {
 	"Crossovers",
-	"Footswitches",
+	"Total Footswitches",
+	"Up Footswitches",
+	"Down Footswitches",
 	"Sideswitches",
 	"Jacks",
 	"Brackets",
@@ -89,7 +91,7 @@ void TechCounts::FromString( RString sTechCounts )
 
 }
 
-void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> &rows, TechCounts &out)
+void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> &rows, StepParity::StageLayout & layout, TechCounts &out)
 {
 	// arrays to hold the column for each Foot enum.
 	// A value of -1 means that Foot is not on any column
@@ -200,13 +202,21 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 			   )
 			{
 				// this is assuming only 4-panel single
-				if(c == 0 || c == 3)
+				if(layout.isSideArrow(c))
 				{
 					out[TechCountsCategory_Sideswitches] += 1;
 				}
 				else
 				{
-					out[TechCountsCategory_Footswitches] += 1;
+					out[TechCountsCategory_TotalFootswitches] += 1;
+					if(layout.isUpArrow(c))
+					{
+						out[TechCountsCategory_UpFootswitches] += 1;
+					}
+					else if(layout.isDownArrow(c))
+					{
+						out[TechCountsCategory_DownFootswitches] += 1;
+					}
 				}
 			}
 			// if the right foot is pressing the left arrow, or the left foot is pressing the right ==> crossover

--- a/src/TechCounts.cpp
+++ b/src/TechCounts.cpp
@@ -189,8 +189,8 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 		
 		// Check for the following:
 		// - We moved the right foot on this row,
-		// - we moved the left foot on this row,
-		// - we didn't move the right foot on this row
+		// - we moved the left foot on the previous row,
+		// - we didn't move the right foot on the previous row
 		// - Is the position of the right foot farther left than the left foot
 		// - If so, check the row before the previous row for the following:
 		//   - Was the right foot on a difference position
@@ -207,9 +207,11 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 				if(i > 1)
 				{
 					const StepParity::Row & previousPreviousRow = rows[i - 2];
-					if(previousPreviousRow.whereTheFeetAre[StepParity::RIGHT_HEEL] != rightHeel)
+					int previousPreviousRightHeel = previousPreviousRow.whereTheFeetAre[StepParity::RIGHT_HEEL];
+					
+					if(previousPreviousRightHeel != -1 && previousPreviousRightHeel != rightHeel)
 					{
-						StepParity::StagePoint previousPreviousRightPos = layout.columns[previousPreviousRow.whereTheFeetAre[StepParity::RIGHT_HEEL]];
+						StepParity::StagePoint previousPreviousRightPos = layout.columns[previousPreviousRightHeel];
 						if(previousPreviousRightPos.x > leftPos.x)
 						{
 							out[TechCountsCategory_FullCrossovers] += 1;

--- a/src/TechCounts.cpp
+++ b/src/TechCounts.cpp
@@ -134,7 +134,7 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 		*/
 
 		// check for jacks and doublesteps
-		if(noteCount == 1)
+		if(noteCount == 1 && previousNoteCount == 1)
 		{
 			for (StepParity::Foot foot: StepParity::FEET)
 			{
@@ -145,7 +145,7 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 				
 				if(previousFootPlacement[foot] == currentFootPlacement[foot])
 				{
-					if(previousNoteCount == 1 && currentRow.second - previousRow.second < JACK_CUTOFF)
+					if(currentRow.second - previousRow.second < JACK_CUTOFF)
 					{
 						out[TechCountsCategory_Jacks] += 1;
 					}

--- a/src/TechCounts.h
+++ b/src/TechCounts.h
@@ -1,0 +1,110 @@
+#ifndef TECH_COUNTS_H
+#define TECH_COUNTS_H
+
+#include "GameConstantsAndTypes.h"
+#include "StepParityGenerator.h"
+class NoteData;
+
+
+/** @brief Unknown radar values are given a default value. */
+#define TECHCOUNTS_VAL_UNKNOWN -1
+
+enum TechCountsCategory
+{
+	TechCountsCategory_Crossovers = 0,
+	TechCountsCategory_Footswitches,
+	TechCountsCategory_Sideswitches,
+	TechCountsCategory_Jacks,
+	TechCountsCategory_Brackets,
+	TechCountsCategory_Doublesteps,
+	NUM_TechCountsCategory,
+	TechCountsCategory_Invalid
+};
+
+const RString& TechCountsCategoryToString( TechCountsCategory cat );
+/**
+ * @brief Turn the radar category into a proper localized string.
+ * @param cat the radar category.
+ * @return the localized string version of the radar category.
+ */
+const RString& TechCountsCategoryToLocalizedString( TechCountsCategory cat );
+LuaDeclareType( TechCountsCategory );
+
+struct lua_State;
+
+/** @brief Technical statistics */
+struct TechCounts
+{
+private:
+	float m_Values[NUM_TechCountsCategory];
+public:
+
+	float operator[](TechCountsCategory cat) const { return m_Values[cat]; }
+	float& operator[](TechCountsCategory cat) { return m_Values[cat]; }
+	float operator[](int cat) const { return m_Values[cat]; }
+	float& operator[](int cat) { return m_Values[cat]; }
+	TechCounts();
+	void MakeUnknown();
+	void Zero();
+
+	TechCounts& operator+=( const TechCounts& other )
+	{
+		FOREACH_ENUM( TechCountsCategory, tc )
+		{
+			(*this)[tc] += other[tc];
+		}
+		return *this;
+	}
+
+	bool operator==( const TechCounts& other ) const
+	{
+		FOREACH_ENUM( TechCountsCategory, tc )
+		{
+			if((*this)[tc] != other[tc])
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	bool operator!=( const TechCounts& other ) const
+	{
+		return !operator==( other );
+	}
+
+	RString ToString( int iMaxValues = -1 ) const; // default = all
+	void FromString( RString sValues );
+
+	void PushSelf( lua_State *L );
+	static void CalculateTechCountsFromRows(const std::vector<StepParity::Row> &rows, TechCounts &out);
+};
+
+#endif
+
+/**
+ * @file
+ * @author Michael Votaw (c) 2023
+ * @section LICENSE
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */

--- a/src/TechCounts.h
+++ b/src/TechCounts.h
@@ -12,7 +12,9 @@ class NoteData;
 enum TechCountsCategory
 {
 	TechCountsCategory_Crossovers = 0,
-	TechCountsCategory_TotalFootswitches,
+	TechCountsCategory_HalfCrossovers,
+	TechCountsCategory_FullCrossovers,
+	TechCountsCategory_Footswitches,
 	TechCountsCategory_UpFootswitches,
 	TechCountsCategory_DownFootswitches,
 	TechCountsCategory_Sideswitches,
@@ -80,6 +82,8 @@ public:
 
 	void PushSelf( lua_State *L );
 	static void CalculateTechCountsFromRows(const std::vector<StepParity::Row> &rows, StepParity::StageLayout & layout, TechCounts &out);
+private:
+	static bool isFootswitch(int c, const StepParity::Row & currentRow, const StepParity::Row & previousRow, float elapsedTime);
 };
 
 #endif

--- a/src/TechCounts.h
+++ b/src/TechCounts.h
@@ -3,8 +3,7 @@
 
 #include "GameConstantsAndTypes.h"
 #include "StepParityGenerator.h"
-class NoteData;
-
+#include "NoteData.h"
 
 /** @brief Unknown radar values are given a default value. */
 #define TECHCOUNTS_VAL_UNKNOWN -1

--- a/src/TechCounts.h
+++ b/src/TechCounts.h
@@ -12,7 +12,9 @@ class NoteData;
 enum TechCountsCategory
 {
 	TechCountsCategory_Crossovers = 0,
-	TechCountsCategory_Footswitches,
+	TechCountsCategory_TotalFootswitches,
+	TechCountsCategory_UpFootswitches,
+	TechCountsCategory_DownFootswitches,
 	TechCountsCategory_Sideswitches,
 	TechCountsCategory_Jacks,
 	TechCountsCategory_Brackets,
@@ -77,7 +79,7 @@ public:
 	void FromString( RString sValues );
 
 	void PushSelf( lua_State *L );
-	static void CalculateTechCountsFromRows(const std::vector<StepParity::Row> &rows, TechCounts &out);
+	static void CalculateTechCountsFromRows(const std::vector<StepParity::Row> &rows, StepParity::StageLayout & layout, TechCounts &out);
 };
 
 #endif


### PR DESCRIPTION
This moves calculating tech counts and measure info (peak NPS, data for nps chart) from SimplyLove to the game engine.
The bulk of this PR is the code for predicting player position and movement, in an attempt to better calculate the tech stats.

The main changes include:
- Replacing calls to `Steps::CalculateRadarValues` with `Steps::CalculateStepStats`, which is basically just a wrapper method so that we can call multiple calculation methods without having to update every file where it needs to be called
- Adding `#TECHCOUNTS` and `#MEASUREINFO` to cache files
- All of the StepParity* files for generating player movements
- Exposing the tech counts and measure info to themes throw Lua functions

Here's a spreadsheet comparing the resulting tech counts to those from SimplyLove:
https://docs.google.com/spreadsheets/d/1kX-lKumR-0Fy1mByjvliUq9i0cv_4BtZ02IjGD59Whw/edit?usp=sharing

I've done my best to comment anything that feels non-obvious (and there's a lot about this thing that feels non-obvious to me). Please let me know if anything doesn't make sense. I very much do not want to just add to the labyrinth that is the existing code base.

On a release build, it took an average of 0.02 seconds per chart to calculate the tech counts (run with packs from ITL 2022,23, and 24).

I think there might be a memory leak somewhere in StepParityGenerator or the StepParityGraph class, it probably has to do with a recent change to pass around the State structs as pointers.

Including a patch for `SL-ChartParser.lua` to load this data instead of calculating it in-theme. *Note* that this patch will break the GrooveStats integration (as those changes are in a different PR), so you'll want to disable that before testing these changes.
[tech-counts-patch.txt](https://github.com/user-attachments/files/16355861/tech-counts-patch.txt)

