### PR TITLE
Add DecodeNextFrame and DecodeMovie functions to populate the FrameBuffer.

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -73,6 +73,23 @@ public:
 	void GetFrame( RageSurface *pOut );
 	int DecodeFrame( float fTargetTime );
 
+	// Decode a single frame.  Return -2 on cancel, -1 on error, 0 on EOF, 1 if we have a frame.
+	int DecodeNextFrame();
+
+	// Decode the entire movie.
+	// If we let this decode as fast as possible, it could come at the expense
+	// of gameplay performance. Since dropping frames is undesirable, an
+	// artificial rate limit is introduced.
+	//
+	// Given that most movies will display at 30fps or 60fps, decoding at a
+	// speed of 1000fps should be more than sufficient to ensure we never
+	// run behind. This rate limiting is only needed in case itgmania is
+	// running on a low performance machine, or the movie is REALLY long.
+	//
+	// Returns 0 on success, -1 on fatal error, -2 on cancel.
+	int DecodeMovie();
+	bool IsCurrentFrameReady();
+
 	int GetWidth() const { return m_pStreamCodec->width; }
 	int GetHeight() const { return m_pStreamCodec->height; }
 

--- a/src/arch/MovieTexture/MovieTexture_Generic.h
+++ b/src/arch/MovieTexture/MovieTexture_Generic.h
@@ -28,6 +28,14 @@ public:
 	virtual void Close() = 0;
 	virtual void Rewind() = 0;
 
+	// Decode the next frame.
+	// Return 1 on success, 0 on EOF, -1 on fatal error, -2 on cancel.
+	virtual int DecodeNextFrame() = 0;
+	virtual int DecodeMovie() = 0;
+
+	// Returns true if the frame we want to display has been decoded already.
+	virtual bool IsCurrentFrameReady() = 0;
+
 	/*
 	 * Decode a frame.  Return 1 on success, 0 on EOF, -1 on fatal error.
 	 *
@@ -95,6 +103,10 @@ public:
 	virtual void Reload();
 
 	virtual void SetPosition( float fSeconds );
+
+	// UpdateMovie tells the MovieTexture to update the displayed frame based
+	// on fSeconds passed in. (e.g., 5.9 input means show the frame that should
+	// be displayed 5.9 seconds into the movie).
 	virtual void UpdateMovie( float fSeconds );
 	virtual void SetPlaybackRate( float fRate ) { m_fRate = fRate; }
 	void SetLooping( bool bLooping=true ) { m_bLoop = bLooping; }


### PR DESCRIPTION
This creates the last of the framework required for decoding movies with ffmpeg in the background. Using the functions created in the prior PR (https://github.com/itgmania/itgmania/pull/371), DecodeMovie will decode frames to the buffer until EoF. The decoding is rate limited to 1 frame / ms. This is to prevent extremely large movies from overwhelming the system by decoding as quickly as possible.

The intent is to call DecodeMovie in the `Init` function of the MovieTexture, which will be done in the following PR.

See,
* Previous Part: https://github.com/itgmania/itgmania/pull/371
* Full Context: https://github.com/itgmania/itgmania/pull/361