### PR TITLE
Create tests/Wallclock.h

### DIFF
--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -13,6 +13,7 @@
 #include "LightsManager.h" // for NUM_CabinetLight
 #include "ActorUtil.h"
 #include "Preference.h"
+#include "Wallclock.h"
 
 #include <cmath>
 #include <cstddef>
@@ -919,7 +920,7 @@ void Actor::UpdateInternal(float delta_time)
 		}
 		break;
 	case CLOCK_TIMER_GLOBAL:
-		generic_global_timer_update(RageTimer::GetUsecsSinceStart(), m_fEffectDelta, m_fSecsIntoEffect);
+		generic_global_timer_update(Wallclock::GetSystemTime(), m_fEffectDelta, m_fSecsIntoEffect);
 		break;
 	case CLOCK_BGM_BEAT:
 		generic_global_timer_update(g_fCurrentBGMBeat, m_fEffectDelta, m_fSecsIntoEffect);

--- a/src/ArrowEffects.cpp
+++ b/src/ArrowEffects.cpp
@@ -12,6 +12,7 @@
 #include "GameState.h"
 #include "Style.h"
 #include "ThemeMetric.h"
+#include "Wallclock.h"
 
 #include <cfloat>
 #include <cmath>
@@ -101,13 +102,13 @@ float ArrowEffects::GetTime()
 	{
 	    case ModTimerType_Default:
 	    case ModTimerType_Game:
-		return (RageTimer::GetTimeSinceStartFast()+offset)*mult;
+		return (Wallclock::FloatingPointTimeInSeconds()+offset)*mult;
 	    case ModTimerType_Beat:
 		return (GAMESTATE->m_Position.m_fSongBeatVisible+offset)*mult;
 	    case ModTimerType_Song:
 		return (GAMESTATE->m_Position.m_fMusicSeconds+offset)*mult;
 	    default:
-		return RageTimer::GetTimeSinceStartFast()+offset;
+		return Wallclock::FloatingPointTimeInSeconds()+offset;
 	}
 }
 
@@ -316,7 +317,7 @@ void ArrowEffects::Init(PlayerNumber pn)
 void ArrowEffects::Update()
 {
 	static float fLastTime = 0;
-	float fTime = RageTimer::GetTimeSinceStartFast();
+	float fTime = Wallclock::FloatingPointTimeInSeconds();
 
 	FOREACH_EnabledPlayer( pn )
 	{

--- a/src/BGAnimationLayer.cpp
+++ b/src/BGAnimationLayer.cpp
@@ -13,6 +13,7 @@
 #include "LuaManager.h"
 #include "AutoActor.h"
 #include "ThemeManager.h"
+#include "Wallclock.h"
 
 #include <cmath>
 
@@ -611,7 +612,7 @@ void BGAnimationLayer::UpdateInternal( float fDeltaTime )
 		break;
 	case TYPE_TILES:
 		{
-			float fSecs = RageTimer::GetTimeSinceStartFast();
+			float fSecs = Wallclock::FloatingPointTimeInSeconds();
 			float fTotalWidth = m_iNumTilesWide * m_fTilesSpacingX;
 			float fTotalHeight = m_iNumTilesHigh * m_fTilesSpacingY;
 

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -9,6 +9,7 @@
 #include "Font.h"
 #include "ActorUtil.h"
 #include "LuaBinding.h"
+#include "RandomSeed.h"
 
 #include <cmath>
 #include <cstddef>
@@ -330,16 +331,17 @@ void BitmapText::BuildChars()
 
 	if( m_bUsingDistortion )
 	{
-		int iSeed = std::lrint( RageTimer::GetTimeSinceStartFast()*500000.0f );
-		RandomGen rnd( iSeed );
+		int rnd1 = GetRandomInt();
+		int rnd2 = GetRandomInt();
+
 		for(unsigned int i= 0; i < m_aVertices.size(); i+=4)
 		{
-			float w= m_aVertices[i+2].p.x - m_aVertices[i].p.x;
-			float h= m_aVertices[i+2].p.y - m_aVertices[i].p.y;
+			float w = m_aVertices[i + 2].p.x - m_aVertices[i].p.x;
+			float h = m_aVertices[i + 2].p.y - m_aVertices[i].p.y;
 			for(unsigned int ioff= 0; ioff < 4; ++ioff)
 			{
-				m_aVertices[i+ioff].p.x += ((rnd()%9) / 8.0f - .5f) * m_fDistortion * w;
-				m_aVertices[i+ioff].p.y += ((rnd()%9) / 8.0f - .5f) * m_fDistortion * h;
+				m_aVertices[i+ioff].p.x += ((rnd1%9) / 8.0f - .5f) * m_fDistortion * w;
+				m_aVertices[i+ioff].p.y += ((rnd2%9) / 8.0f - .5f) * m_fDistortion * h;
 			}
 		}
 	}
@@ -711,7 +713,8 @@ void BitmapText::DrawPrimitives()
 		// render the diffuse pass
 		if( m_bRainbowScroll )
 		{
-			int color_index = int(RageTimer::GetTimeSinceStartFast() / 0.200) % RAINBOW_COLORS.size();
+			int iSeed = GetRandomInt();
+			int color_index = std::abs(iSeed);
 			for( unsigned i=0; i<m_aVertices.size(); i+=4 )
 			{
 				const RageColor color = RAINBOW_COLORS[color_index];
@@ -770,12 +773,12 @@ void BitmapText::DrawPrimitives()
 		std::vector<RageVector3> vGlyphJitter;
 		if( m_bJitter )
 		{
-			int iSeed = std::lrint( RageTimer::GetTimeSinceStartFast()*8 );
-			RandomGen rnd( iSeed );
+			float rnd1 = GetRandomFloat();
+			float rnd2 = GetRandomFloat();
 
 			for( unsigned i=0; i<m_aVertices.size(); i+=4 )
 			{
-				RageVector3 jitter( rnd()%2, rnd()%3, 0 );
+				RageVector3 jitter( rnd1, rnd2, 0 );
 				vGlyphJitter.push_back( jitter );
 
 				m_aVertices[i+0].p += jitter;	// top left

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -3,13 +3,21 @@
 #include "XmlFile.h"
 #include "FontManager.h"
 #include "RageLog.h"
-#include "RageTimer.h"
+//#include "RageTimer.h"
 #include "RageDisplay.h"
 #include "ThemeManager.h"
 #include "Font.h"
 #include "ActorUtil.h"
 #include "LuaBinding.h"
 #include "RandomSeed.h"
+
+/*   THIS CHANGE IS ONLY INCLUDED TO PROVIDE A FULLY WORKING PATCH
+ *     DEMONSTRATING A COMPLETE RAGETIMER REMOVAL.
+ *	 
+ *	 ALL CHANGES TO THIS FILE WILL BE REMOVED BEFORE THE PR IS MERGED.
+ *   
+ */
+
 
 #include <cmath>
 #include <cstddef>

--- a/src/CMakeData-singletons.cmake
+++ b/src/CMakeData-singletons.cmake
@@ -19,6 +19,7 @@ list(APPEND SMDATA_GLOBAL_SINGLETON_SRC
             "NoteSkinManager.cpp"
             "PrefsManager.cpp"
             "ProfileManager.cpp"
+            "RandomSeed.cpp"
             "ScreenManager.cpp"
             "SongManager.cpp"
             "StatsManager.cpp"
@@ -45,12 +46,13 @@ list(APPEND SMDATA_GLOBAL_SINGLETON_HPP
             "NoteSkinManager.h"
             "PrefsManager.h"
             "ProfileManager.h"
+            "RandomSeed.h"
             "ScreenManager.h"
             "SongManager.h"
             "StatsManager.h"
             "ThemeManager.h"
-            "UnlockManager.h")
-
+            "UnlockManager.h"
+            "Wallclock.h")
 source_group("Global Singletons"
              FILES
              ${SMDATA_GLOBAL_SINGLETON_SRC}

--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -281,7 +281,12 @@ void GameLoop::UpdateAllButDraw(bool bRunningFromVBLANK)
 	/* Important: Process input AFTER updating game logic, or input will be
 	* acting on song beat from last frame */
 	HandleInputEvents(fDeltaTime);
-
+/*   THIS CHANGE IS ONLY INCLUDED TO PROVIDE A FULLY WORKING PATCH
+ *     DEMONSTRATING A COMPLETE RAGETIMER REMOVAL.
+ *	 
+ *	 ALL CHANGES TO THIS FILE WILL BE REMOVED BEFORE THE PR IS MERGED.
+ *   
+ */
 	LIGHTSMAN->Update(fDeltaTime);
 }
 

--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -282,13 +282,8 @@ void GameLoop::UpdateAllButDraw(bool bRunningFromVBLANK)
 	* acting on song beat from last frame */
 	HandleInputEvents(fDeltaTime);
 
-	//bandaid for low max audio sample counter
-	SOUNDMAN->low_sample_count_workaround();
 	LIGHTSMAN->Update(fDeltaTime);
-
 }
-
-
 
 void GameLoop::RunGameLoop()
 {

--- a/src/Inventory.cpp
+++ b/src/Inventory.cpp
@@ -3,7 +3,7 @@
 #include "ThemeManager.h"
 #include "RageUtil.h"
 #include "GameState.h"
-#include "RageTimer.h"
+#include "Wallclock.h"
 #include "PrefsManager.h"
 #include "Song.h"
 #include "ScreenManager.h"
@@ -132,8 +132,8 @@ void Inventory::Update( float fDelta )
 		GAMESTATE->m_Position.m_fSongBeat < song.GetLastBeat() )
 	{
 		// every 1 seconds, try to use an item
-		int iLastSecond = (int)(RageTimer::GetTimeSinceStartFast() - fDelta);
-		int iThisSecond = (int)RageTimer::GetTimeSinceStartFast();
+		float iLastSecond = static_cast<float>(Wallclock::FloatingPointTimeInSeconds()) - fDelta;
+		float iThisSecond = static_cast<float>(Wallclock::FloatingPointTimeInSeconds());
 		if( iLastSecond != iThisSecond )
 		{
 			for( int s=0; s<NUM_INVENTORY_SLOTS; s++ )

--- a/src/LightsManager.cpp
+++ b/src/LightsManager.cpp
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "LightsManager.h"
 #include "GameState.h"
-#include "RageTimer.h"
+#include "Wallclock.h"
 #include "arch/Lights/LightsDriver.h"
 #include "RageUtil.h"
 #include "GameInput.h"	// for GameController
@@ -217,7 +217,7 @@ void LightsManager::Update( float fDeltaTime )
 
 		case LIGHTSMODE_ATTRACT:
 		{
-			int iSec = (int)RageTimer::GetTimeSinceStartFast();
+			int iSec = Wallclock::GetSystemTimeInSeconds();
 			int iTopIndex = iSec % 4;
 
 			// Aldo: Disabled this line, apparently it was a forgotten initialization

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -984,6 +984,12 @@ void MusicWheel::readyWheelItemsData(SortOrder so) {
 		if (so != SORT_PREFERRED) {
 			m_WheelItemDatasStatus[so]=VALID;
 		}
+		/*   THIS CHANGE IS ONLY INCLUDED TO PROVIDE A FULLY WORKING PATCH
+ *     DEMONSTRATING A COMPLETE RAGETIMER REMOVAL.
+ *	 
+ *	 ALL CHANGES TO THIS FILE WILL BE REMOVED BEFORE THE PR IS MERGED.
+ *   
+ */
 		LOG->Trace( "MusicWheel sorting took: %f", timer.Ago() );
 	}
 

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -984,7 +984,7 @@ void MusicWheel::readyWheelItemsData(SortOrder so) {
 		if (so != SORT_PREFERRED) {
 			m_WheelItemDatasStatus[so]=VALID;
 		}
-		LOG->Trace( "MusicWheel sorting took: %f", timer.GetTimeSinceStart() );
+		LOG->Trace( "MusicWheel sorting took: %f", timer.Ago() );
 	}
 
 }

--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -5,7 +5,7 @@
 #include "ArrowEffects.h"
 #include "GameManager.h"
 #include "GameState.h"
-#include "RageTimer.h"
+#include "Wallclock.h"
 #include "RageLog.h"
 #include "RageMath.h"
 #include "ThemeManager.h"
@@ -868,7 +868,7 @@ void NoteField::DrawPrimitives()
 		ASSERT(GAMESTATE->m_pCurSong != nullptr);
 
 		const TimingData &timing = *pTiming;
-		const RageColor text_glow= RageColor(1,1,1,RageFastCos(RageTimer::GetTimeSinceStartFast()*2)/2+0.5f);
+		const RageColor text_glow= RageColor(1,1,1,std::cos(Wallclock::GetElapsedGameTime()*2)/2+0.5f);
 
 		float horiz_align= align_right;
 		float side_sign= 1;
@@ -1055,7 +1055,7 @@ void NoteField::DrawPrimitives()
 		*m_FieldRenderArgs.selection_end_marker != -1)
 	{
 		m_FieldRenderArgs.selection_glow= SCALE(
-			RageFastCos(RageTimer::GetTimeSinceStartFast()*2), -1, 1, 0.1f, 0.3f);
+			std::cos(Wallclock::GetElapsedGameTime()*2), -1, 1, 0.1f, 0.3f);
 	}
 	m_FieldRenderArgs.fade_before_targets= FADE_BEFORE_TARGETS_PERCENT;
 

--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -6,6 +6,14 @@
 #include "GameManager.h"
 #include "GameState.h"
 #include "Wallclock.h"
+
+/*   THIS CHANGE IS ONLY INCLUDED TO PROVIDE A FULLY WORKING PATCH
+ *     DEMONSTRATING A COMPLETE RAGETIMER REMOVAL.
+ *	 
+ *	 ALL CHANGES TO THIS FILE WILL BE REMOVED BEFORE THE PR IS MERGED.
+ *   
+ */
+
 #include "RageLog.h"
 #include "RageMath.h"
 #include "ThemeManager.h"

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -40,6 +40,7 @@
 #include "GameCommand.h"
 #include "LocalizedString.h"
 #include "AdjustSync.h"
+#include "RandomSeed.h"
 
 #include <cmath>
 #include <cstddef>
@@ -3476,10 +3477,8 @@ RString Player::ApplyRandomAttack()
 		return "";
 
 	//int iAttackToUse = rand() % GAMESTATE->m_RandomAttacks.size();
-	DateTime now = DateTime::GetNowDate();
-	int iSeed = now.tm_hour * now.tm_min * now.tm_sec * now.tm_mday;
-	RandomGen rnd( GAMESTATE->m_iStageSeed * iSeed );
-	int iAttackToUse = rnd() % GAMESTATE->m_RandomAttacks.size();
+	int iSeed = GetRandomInt();
+	int iAttackToUse = iSeed % GAMESTATE->m_RandomAttacks.size();
 	return GAMESTATE->m_RandomAttacks[iAttackToUse];
 }
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -41,7 +41,12 @@
 #include "LocalizedString.h"
 #include "AdjustSync.h"
 #include "RandomSeed.h"
-
+/*   THIS CHANGE IS ONLY INCLUDED TO PROVIDE A FULLY WORKING PATCH
+ *     DEMONSTRATING A COMPLETE RAGETIMER REMOVAL.
+ *	 
+ *	 ALL CHANGES TO THIS FILE WILL BE REMOVED BEFORE THE PR IS MERGED.
+ *   
+ */
 #include <cmath>
 #include <cstddef>
 #include <vector>

--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "RageLog.h"
 #include "RageUtil.h"
-#include "RageTimer.h"
+#include "Wallclock.h"
 #include "RageFile.h"
 #include "RageThreads.h"
 
@@ -268,7 +268,7 @@ void RageLog::Write( int where, const RString &sLine )
 		puts( sWarningSeparator );
 	}
 
-	RString sTimestamp = SecondsToMMSSMsMsMs( RageTimer::GetTimeSinceStart() ) + ": ";
+	RString sTimestamp = DeltaToMMSSMsMsMs( Wallclock::GetElapsedGameTime() ) + ": ";
 	RString sWarning;
 	if( where & WRITE_LOUD )
 		sWarning = "WARNING: ";

--- a/src/RageSoundManager.cpp
+++ b/src/RageSoundManager.cpp
@@ -56,7 +56,12 @@ RageSoundManager::~RageSoundManager()
 		delete s.second;
 	m_mapPreloadedSounds.clear();
 }
-
+/*   THIS CHANGE IS ONLY INCLUDED TO PROVIDE A FULLY WORKING PATCH
+ *     DEMONSTRATING A COMPLETE RAGETIMER REMOVAL.
+ *	 
+ *	 ALL CHANGES TO THIS FILE WILL BE REMOVED BEFORE THE PR IS MERGED.
+ *   
+ */
 void RageSoundManager::fix_bogus_sound_driver_pref(RString const& valid_setting)
 {
 	g_sSoundDrivers.Set(valid_setting);

--- a/src/RageSoundManager.cpp
+++ b/src/RageSoundManager.cpp
@@ -57,12 +57,6 @@ RageSoundManager::~RageSoundManager()
 	m_mapPreloadedSounds.clear();
 }
 
-
-void RageSoundManager::low_sample_count_workaround()
-{
-	m_pDriver->low_sample_count_workaround();
-}
-
 void RageSoundManager::fix_bogus_sound_driver_pref(RString const& valid_setting)
 {
 	g_sSoundDrivers.Set(valid_setting);
@@ -104,7 +98,7 @@ std::int64_t RageSoundManager::GetPosition( RageTimer *pTimer ) const
 {
 	if( m_pDriver == nullptr )
 		return 0;
-	return m_pDriver->GetHardwareFrame( pTimer );
+	return m_pDriver->GetHardwareFrame();
 }
 
 void RageSoundManager::Update()

--- a/src/RageSoundManager.h
+++ b/src/RageSoundManager.h
@@ -47,7 +47,6 @@ public:
 	void AddLoadedSound( const RString &sPath, RageSoundReader_Preload *pSound );
 
 	void fix_bogus_sound_driver_pref(RString const& valid_setting);
-	void low_sample_count_workaround();
 
 private:
 	std::map<RString, RageSoundReader_Preload *> m_mapPreloadedSounds;

--- a/src/RageSoundManager.h
+++ b/src/RageSoundManager.h
@@ -47,7 +47,12 @@ public:
 	void AddLoadedSound( const RString &sPath, RageSoundReader_Preload *pSound );
 
 	void fix_bogus_sound_driver_pref(RString const& valid_setting);
-
+/*   THIS CHANGE IS ONLY INCLUDED TO PROVIDE A FULLY WORKING PATCH
+ *     DEMONSTRATING A COMPLETE RAGETIMER REMOVAL.
+ *	 
+ *	 ALL CHANGES TO THIS FILE WILL BE REMOVED BEFORE THE PR IS MERGED.
+ *   
+ */
 private:
 	std::map<RString, RageSoundReader_Preload *> m_mapPreloadedSounds;
 

--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -15,8 +15,10 @@
 #include "RageTimer.h"
 #include "RageLog.h"
 #include "RageUtil.h"
+#include "Wallclock.h"
 
 #include <cerrno>
+#include <cinttypes>
 #include <cstdint>
 #include <set>
 
@@ -662,7 +664,7 @@ LockMutex::LockMutex( RageMutex &pMutex, const char *file_, int line_ ):
 	mutex( pMutex ),
 	file( file_ ),
 	line( line_ ),
-	locked_at( RageTimer::GetTimeSinceStart() ),
+	locked_at( Wallclock::GetSystemTime() ),
 	locked(false) // ensure it gets locked inside.
 {
 	mutex.Lock();
@@ -684,9 +686,9 @@ void LockMutex::Unlock()
 
 	if( file && locked_at != -1 )
 	{
-		const float dur = RageTimer::GetTimeSinceStart() - locked_at;
-		if( dur > 0.015f )
-			LOG->Trace( "Lock at %s:%i took %f", file, line, dur );
+		const std::int64_t dur = Wallclock::GetSystemTime() - locked_at;
+		if( dur > 15000 ) // 0.015 seconds
+			LOG->Trace( "Lock at %s:%" PRId64 " took %" PRId64, file, line, dur );
 	}
 }
 

--- a/src/RageThreads.h
+++ b/src/RageThreads.h
@@ -127,8 +127,8 @@ class LockMutex
 	RageMutex &mutex;
 
 	const char *file;
-	int line;
-	float locked_at;
+	std::int64_t line;
+	std::int64_t locked_at;
 	bool locked;
 
 public:

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -23,9 +23,10 @@ public:
 	/* (alias) */
 	float PeekDeltaTime() const { return Ago(); }
 
-	static double GetTimeSinceStart( bool bAccurate = true );	// seconds since the program was started
+	/* DEPRECATED: these are left in for legacy compatibility with Lua
+	 * Use Wallclock.h instead for retrieving the game time. */
+	static float GetTimeSinceStart( bool bAccurate = true );
 	static float GetTimeSinceStartFast() { return GetTimeSinceStart(false); }
-	static std::uint64_t GetUsecsSinceStart();
 
 	/* Get a timer representing half of the time ago as this one. */
 	RageTimer Half() const;
@@ -53,23 +54,6 @@ private:
 };
 
 extern const RageTimer RageZeroTimer;
-
-// For profiling how long some chunk of code takes. -Kyz
-#define START_TIME(name) std::uint64_t name##_start_time= RageTimer::GetUsecsSinceStart();
-#define START_TIME_CALL_COUNT(name) START_TIME(name); ++name##_call_count;
-#define END_TIME(name) std::uint64_t name##_end_time= RageTimer::GetUsecsSinceStart();  LOG->Time(#name " time: %zu to %zu = %zu", name##_start_time, name##_end_time, name##_end_time - name##_start_time);
-#define END_TIME_ADD_TO(name) std::uint64_t name##_end_time= RageTimer::GetUsecsSinceStart();  name##_total += name##_end_time - name##_start_time;
-#define END_TIME_CALL_COUNT(name) END_TIME_ADD_TO(name); ++name##_end_count;
-
-#define DECL_TOTAL_TIME(name) extern std::uint64_t name##_total;
-#define DEF_TOTAL_TIME(name) std::uint64_t name##_total= 0;
-#define PRINT_TOTAL_TIME(name) LOG->Time(#name " total time: %zu", name##_total);
-#define DECL_TOT_CALL_PAIR(name) extern std::uint64_t name##_total; extern std::uint64_t name##_call_count;
-#define DEF_TOT_CALL_PAIR(name) std::uint64_t name##_total= 0; std::uint64_t name##_call_count= 0;
-#define PRINT_TOT_CALL_PAIR(name) LOG->Time(#name " calls: %zu, time: %zu, per: %f", name##_call_count, name##_total, static_cast<float>(name##_total) / name##_call_count);
-#define DECL_TOT_CALL_END(name) DECL_TOT_CALL_PAIR(name); extern std::uint64_t name##_end_count;
-#define DEF_TOT_CALL_END(name) DEF_TOT_CALL_PAIR(name); std::uint64_t name##_end_count= 0;
-#define PRINT_TOT_CALL_END(name) LOG->Time(#name " calls: %zu, time: %zu, early end: %zu, per: %f", name##_call_count, name##_total, name##_end_count, static_cast<float>(name##_total) / (name##_call_count - name##_end_count));
 
 #endif
 

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -210,6 +210,26 @@ bool HexToBinary( const RString &s, RString &sOut )
 	return HexToBinary(s, (unsigned char *) sOut.data());
 }
 
+RString DeltaToMMSSMsMs(std::int64_t fMicrosecs)
+{
+    const std::int64_t fSecs = fMicrosecs / 1000000;
+    const std::int64_t iMinsDisplay = fSecs / 60;
+    const std::int64_t iSecsDisplay = fSecs % 60; 
+    const std::int64_t iLeftoverDisplay = (fMicrosecs / 10000) % 100;
+    RString sReturn = ssprintf("%02lld:%02lld.%02lld", iMinsDisplay, iSecsDisplay, iLeftoverDisplay);
+    return sReturn;
+}
+
+RString DeltaToMMSSMsMsMs(std::int64_t fMicrosecs)
+{
+    const std::int64_t fSecs = fMicrosecs / 1000000;
+    const std::int64_t iMinsDisplay = fSecs / 60;
+    const std::int64_t iSecsDisplay = fSecs % 60; 
+    const std::int64_t iLeftoverDisplay = (fMicrosecs / 1000) % 1000;
+    RString sReturn = ssprintf("%02lld:%02lld.%03lld", iMinsDisplay, iSecsDisplay, iLeftoverDisplay);
+    return sReturn;
+}
+
 float HHMMSSToSeconds( const RString &sHHMMSS )
 {
 	std::vector<RString> arrayBits;

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -324,6 +324,8 @@ RString BinaryToHex( const void *pData_, std::size_t iNumBytes );
 RString BinaryToHex( const RString &sString );
 bool HexToBinary( const RString &s, unsigned char *stringOut );
 bool HexToBinary( const RString &s, RString *sOut );
+RString DeltaToMMSSMsMs(std::int64_t fMicrosecs);
+RString DeltaToMMSSMsMsMs(std::int64_t fMicrosecs);
 float HHMMSSToSeconds( const RString &sHMS );
 RString SecondsToHHMMSS( float fSecs );
 RString SecondsToMSSMsMs( float fSecs );

--- a/src/RandomSeed.cpp
+++ b/src/RandomSeed.cpp
@@ -1,3 +1,6 @@
+// RandomSeed might make sense to merge in the same PR as Wallclock,
+// but for now I intend to keep them separate.
+
 #include "global.h"
 #include "RandomSeed.h"
 #include <random>

--- a/src/RandomSeed.cpp
+++ b/src/RandomSeed.cpp
@@ -1,52 +1,23 @@
 #include "global.h"
-#include "RageSoundDriver_Null.h"
-#include "RageLog.h"
-#include "RageUtil.h"
-#include "PrefsManager.h"
-#include "Wallclock.h"
+#include "RandomSeed.h"
+#include <random>
 
-#include <cstdint>
-
-REGISTER_SOUND_DRIVER_CLASS( Null );
-
-const int channels = 2;
-
-void RageSoundDriver_Null::Update()
+int GetRandomInt()
 {
-	/* "Play" frames. */
-	while( m_iLastCursorPos < GetPosition()+1024*4 )
-	{
-		std::int16_t buf[256*channels];
-		this->Mix( buf, 256, m_iLastCursorPos, GetPosition() );
-		m_iLastCursorPos += 256;
-	}
-
-	RageSoundDriver::Update();
+	static std::random_device rd;
+	static std::mt19937 gen(rd());
+	return std::uniform_int_distribution<int>(0, INT_MAX)(gen);
 }
 
-std::int64_t RageSoundDriver_Null::GetPosition() const
+float GetRandomFloat()
 {
-	std::int64_t usec = Wallclock::GetSystemTime();
-	std::int64_t sampleRate = static_cast<int64_t>(m_iSampleRate);
-	return usec * sampleRate;
-}
-
-RageSoundDriver_Null::RageSoundDriver_Null()
-{
-	m_iSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
-	if( m_iSampleRate == 0 )
-		m_iSampleRate = 44100;
-	m_iLastCursorPos = GetPosition();
-	StartDecodeThread();
-}
-
-int RageSoundDriver_Null::GetSampleRate() const
-{
-	return m_iSampleRate;
+	std::mt19937 gen(GetRandomInt());
+	std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+	return dist(gen);
 }
 
 /*
- * (c) 2002-2004 Glenn Maynard, Aaron VonderHaar
+ * (c) 2024 sukibaby
  * All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/src/RandomSeed.h
+++ b/src/RandomSeed.h
@@ -1,52 +1,13 @@
-#include "global.h"
-#include "RageSoundDriver_Null.h"
-#include "RageLog.h"
-#include "RageUtil.h"
-#include "PrefsManager.h"
-#include "Wallclock.h"
+#ifndef RANDOMSEED_H
+#define RANDOMSEED_H
 
-#include <cstdint>
+int GetRandomInt();
+float GetRandomFloat();
 
-REGISTER_SOUND_DRIVER_CLASS( Null );
-
-const int channels = 2;
-
-void RageSoundDriver_Null::Update()
-{
-	/* "Play" frames. */
-	while( m_iLastCursorPos < GetPosition()+1024*4 )
-	{
-		std::int16_t buf[256*channels];
-		this->Mix( buf, 256, m_iLastCursorPos, GetPosition() );
-		m_iLastCursorPos += 256;
-	}
-
-	RageSoundDriver::Update();
-}
-
-std::int64_t RageSoundDriver_Null::GetPosition() const
-{
-	std::int64_t usec = Wallclock::GetSystemTime();
-	std::int64_t sampleRate = static_cast<int64_t>(m_iSampleRate);
-	return usec * sampleRate;
-}
-
-RageSoundDriver_Null::RageSoundDriver_Null()
-{
-	m_iSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
-	if( m_iSampleRate == 0 )
-		m_iSampleRate = 44100;
-	m_iLastCursorPos = GetPosition();
-	StartDecodeThread();
-}
-
-int RageSoundDriver_Null::GetSampleRate() const
-{
-	return m_iSampleRate;
-}
+#endif // RANDOMSEED_H
 
 /*
- * (c) 2002-2004 Glenn Maynard, Aaron VonderHaar
+ * (c) 2024 sukibaby
  * All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/src/RandomSeed.h
+++ b/src/RandomSeed.h
@@ -1,3 +1,6 @@
+// RandomSeed might make sense to merge in the same PR as Wallclock,
+// but for now I intend to keep them separate.
+
 #ifndef RANDOMSEED_H
 #define RANDOMSEED_H
 

--- a/src/ScreenDebugOverlay.cpp
+++ b/src/ScreenDebugOverlay.cpp
@@ -30,6 +30,7 @@
 #include "ScreenSyncOverlay.h"
 #include "ThemeMetric.h"
 #include "XmlToLua.h"
+#include "Wallclock.h"
 
 #include <vector>
 
@@ -1319,7 +1320,7 @@ class DebugLineForceCrash : public IDebugLine
 class DebugLineUptime : public IDebugLine
 {
 	virtual RString GetDisplayTitle() { return UPTIME.GetValue(); }
-	virtual RString GetDisplayValue() { return SecondsToMMSSMsMsMs(RageTimer::GetTimeSinceStart()); }
+	virtual RString GetDisplayValue() { return DeltaToMMSSMsMsMs(Wallclock::GetElapsedGameTime()); }
 	virtual bool IsEnabled() { return false; }
 	virtual void DoAndLog( RString &sMessageOut ) {}
 };

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -37,6 +37,7 @@
 #include "TimingData.h"
 #include "Game.h"
 #include "RageSoundReader.h"
+#include "Wallclock.h"
 
 #include <cfloat>
 #include <cmath>
@@ -48,9 +49,9 @@ static Preference<float> g_iDefaultRecordLength( "DefaultRecordLength", 4 );
 static Preference<bool> g_bEditorShowBGChangesPlay( "EditorShowBGChangesPlay", true );
 
 /** @brief How long must the button be held to generate a hold in record mode? */
-const float record_hold_default= 0.3f;
-float record_hold_seconds = record_hold_default;
-const float time_between_autosave= 300.0f; // 5 minutes. -Kyz
+const std::int64_t record_hold_default= 0.3;
+std::int64_t record_hold_seconds = record_hold_default;
+const std::int64_t time_between_autosave= 300; // 5 minutes. -Kyz
 
 #define PLAYER_X		(SCREEN_CENTER_X)
 #define PLAYER_Y		(SCREEN_CENTER_Y)
@@ -1667,7 +1668,7 @@ void ScreenEdit::Update( float fDeltaTime )
 	if(m_EditState == STATE_EDITING)
 	{
 		if(IsDirty() && m_next_autosave_time > -1.0f &&
-			RageTimer::GetTimeSinceStartFast() > m_next_autosave_time)
+			Wallclock::GetSystemTime() > m_next_autosave_time)
 		{
 			PerformSave(true);
 		}
@@ -4362,7 +4363,7 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 	else if( SM == SM_AutoSaveSuccessful )
 	{
 		LOG->Trace("AutoSave successful.");
-		m_next_autosave_time= RageTimer::GetTimeSinceStartFast() + time_between_autosave;
+		m_next_autosave_time= Wallclock::GetSystemTime() + time_between_autosave;
 		SCREENMAN->SystemMessage(AUTOSAVE_SUCCESSFUL);
 	}
 	else if( SM == SM_SaveFailed ) // save failed; stay in the editor
@@ -4438,19 +4439,19 @@ void ScreenEdit::SetDirty(bool dirty)
 	if(EDIT_MODE.GetValue() != EditMode_Full)
 	{
 		m_dirty= false;
-		m_next_autosave_time= -1.0f;
+		m_next_autosave_time= -1;
 		return;
 	}
 	if(dirty)
 	{
 		if(!m_dirty)
 		{
-			m_next_autosave_time= RageTimer::GetTimeSinceStartFast() + time_between_autosave;
+			m_next_autosave_time= Wallclock::GetSystemTime() + time_between_autosave;
 		}
 	}
 	else
 	{
-		m_next_autosave_time= -1.0f;
+		m_next_autosave_time= -1;
 	}
 	m_dirty= dirty;
 }

--- a/src/ScreenEdit.h
+++ b/src/ScreenEdit.h
@@ -340,7 +340,7 @@ protected:
 
 	/** @brief Has the NoteData been changed such that a user should be prompted to save? */
 	bool			m_dirty;
-	float m_next_autosave_time;
+	std::int64_t	m_next_autosave_time;
 
 	/** @brief The sound that is played when a note is added. */
 	RageSound		m_soundAddNote;

--- a/src/ScreenStatsOverlay.cpp
+++ b/src/ScreenStatsOverlay.cpp
@@ -5,6 +5,7 @@
 #include "RageDisplay.h"
 #include "RageLog.h"
 #include "ScreenDimensions.h"
+#include "Wallclock.h"
 
 REGISTER_SCREEN_CLASS( ScreenStatsOverlay );
 
@@ -125,7 +126,7 @@ void ScreenStatsOverlay::UpdateSkips()
 
 	if( skip )
 	{
-		RString sTime( SecondsToMMSSMsMs(RageTimer::GetTimeSinceStartFast()) );
+		RString sTime( DeltaToMMSSMsMs(Wallclock::GetElapsedGameTime()) );
 
 		static const RageColor colors[] =
 		{

--- a/src/Wallclock.h
+++ b/src/Wallclock.h
@@ -1,0 +1,172 @@
+/*++
+
+Module name:
+
+    Wallclock
+    
+Abstract:
+
+    All functions directly related to the system clock are stored here. Methods
+    are also provided to create and manage high-resolution timestamps.
+    
+Notes:
+
+    The engine makes use of two clocks - one driven by the audio frame position,
+    and one driven by the system's high resolution timer (a sub-1us resolution
+    timer which is not affected by time & date settings).
+    
+    This header provides lightweight methods to interact with the system timer
+    in any way needed. It is included everywhere the system timer is used.
+
+    Wallclock's timestamping functions can be used to provide greater accuracy
+    and lower overhead as compared to using RageTimer objects, so they are
+    preferred for time-critical operations. However, to ensure calls to the
+    system clock are reserved for important functions, RageTimer objects
+    should be used to take measurements in non-critical situations.
+
+    The accuracy of Wallclock is directly tied to the stability of the game
+    sync. Maintaining precision here is crucial. Too much error in the retrieval
+    of the system timestamp will manifest as a drastic shift in the game's sync,
+    and will feel like the global offset suddenly changed. Incorrect math here
+    will manifest as a _consistent_ sync offset in game.
+    
+    Resolution mismatches, unintended type conversions, or values truncated/
+    rounded when they shouldn't be can cause errors when the time is calculated
+    and manifest as a _sudden_ drift of sync.
+    
+    To minimize the potential for resolution errors:
+     - Time should only be stored as seconds or microseconds.
+     - Use of floating point values to store system time should be avoided
+       whenever possible.
+     - you should take care to use the constant that corresponds to your data
+       type when calling WC_USECTOSEC. Various constexpr's are used instead of
+       a single macro to ensure all values are type-checked. 
+    
+    The clock interface to Lua is handled via RageTimer in order to not break
+    legacy code or Lua which expects GetTimeSinceStart() to be there.
+    
+Usage examples:
+
+    - Get the current system time in microseconds:
+    std::int64_t systemTime = Wallclock::GetSystemTime();
+
+    - Get the current system time in seconds
+    unsigned systemTimeInSeconds = Wallclock::GetSystemTimeInSeconds();
+
+    - Get the time since game start in microseconds
+    std::int64_t elapsedGameTime = Wallclock::GetElapsedGameTime();
+
+    - Create multiple instances of Wallclock for timestamping purposes
+    Wallclock tracker1;
+    Wallclock tracker2;
+
+    - Update the timestamp for each instance
+    tracker1.UpdateTimestamp();
+    tracker2.UpdateTimestamp();
+
+    - Retrieve the elapsed time for tracker1
+    std::uint64_t elapsedTime1 = tracker1.GetTimestampDuration();
+    
+    - Return the timestamp taken earlier for tracker2
+    std::uint64_t timestampFromSpecificEvent = tracker2.ReturnTimestamp();
+    
+--*/
+
+#ifndef Wallclock_H
+#define Wallclock_H
+
+#include <cstdint>
+#include <mutex>
+#include "arch/ArchHooks/ArchHooks.h"
+
+static const std::int64_t WC_GAMESTART = 
+    ArchHooks::GetMicrosecondsSinceStart(true);
+
+static constexpr int WC_USECTOSEC_INT = 1000000;
+static constexpr unsigned WC_USECTOSEC_UNSIGNED = 1000000U;
+static constexpr float WC_USECTOSEC_FLOAT = 1000000.0f;
+static constexpr double WC_USECTOSEC_DOUBLE = 1000000.0;
+static constexpr std::int64_t WC_USECTOSEC_INT64 = 1000000LL;
+static constexpr std::uint64_t WC_USECTOSEC_UINT64 = 1000000ULL;
+
+class Wallclock {
+public:
+
+    //  System Time Retrieval
+    static inline std::int64_t GetSystemTime() noexcept { // Unit: usecs
+        return ArchHooks::GetMicrosecondsSinceStart(true);
+    }   
+
+    static inline std::int64_t GetElapsedGameTime() noexcept { // Unit: usecs
+        return ArchHooks::GetMicrosecondsSinceStart(true) - WC_GAMESTART;
+    }
+
+    static inline unsigned GetSystemTimeInSeconds() noexcept // Unit: secs
+    { 
+        return static_cast<unsigned>(
+            ArchHooks::GetMicrosecondsSinceStart(true) / WC_USECTOSEC_UNSIGNED);
+    }
+
+    static inline float FloatingPointTimeInSeconds() noexcept // Unit: secs
+    {
+        double determinator = static_cast<double>(
+            ArchHooks::GetMicrosecondsSinceStart(true) / WC_USECTOSEC_DOUBLE
+        );
+        return static_cast<float>(determinator);
+    }
+
+    // Timestamp Management
+    inline void UpdateTimestamp() noexcept { // Unit: usecs
+        std::lock_guard<std::mutex> lock(mutex_);
+        stamp = GetSystemTime();
+    }
+
+    inline uint64_t ReturnTimestamp() noexcept { // Unit: usecs
+        std::lock_guard<std::mutex> lock(mutex_);
+        return stamp;
+    }
+
+    inline std::int64_t GetTimestampDuration() const noexcept { // Unit: usecs
+        std::lock_guard<std::mutex> lock(mutex_);
+        std::int64_t now = GetSystemTime();
+        return now - stamp;
+    }
+
+    inline double GetTimestampDurationSeconds() const noexcept { // Unit: secs
+        std::lock_guard<std::mutex> lock(mutex_);
+        std::uint64_t now = GetSystemTime();
+        std::uint64_t elapsed = now - stamp;
+        return static_cast<double>(elapsed) / WC_USECTOSEC_DOUBLE;
+    }
+
+private:
+    std::uint64_t stamp;
+    mutable std::mutex mutex_;
+};
+
+#endif // Wallclock_H
+
+/*
+ * (c) 2024 sukibaby
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */ 

--- a/src/WheelNotifyIcon.cpp
+++ b/src/WheelNotifyIcon.cpp
@@ -4,7 +4,7 @@
 #include "GameConstantsAndTypes.h"
 #include "MusicWheel.h"
 #include "WheelNotifyIcon.h"
-#include "RageTimer.h"
+#include "Wallclock.h"
 #include "ThemeManager.h"
 
 #include <cmath>
@@ -86,8 +86,8 @@ void WheelNotifyIcon::Update( float fDeltaTime )
 		/* We should probably end up parsing the vector and then dynamically
 		 * insert flag icons based on "priority". Easy to do, hopefully
 			- Midiman */
-		const float fSecondFraction = std::fmod( RageTimer::GetTimeSinceStartFast(), 1 );
-		const int index = (int)(fSecondFraction*m_vIconsToShow.size());
+		const float fSecondFraction = std::fmod( Wallclock::FloatingPointTimeInSeconds(), 1 );
+		const int index = static_cast<int>(fSecondFraction * m_vIconsToShow.size());
 		Sprite::SetState( m_vIconsToShow[index] );
 	}
 

--- a/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
@@ -7,7 +7,7 @@
 #include "RageDisplay.h" // VideoModeParams
 #include "DisplaySpec.h"
 #include "LocalizedString.h"
-#include "RageTimer.h"
+#include "Wallclock.h"
 
 #include "RageDisplay_OGL_Helpers.h"
 using namespace RageDisplay_Legacy_Helpers;
@@ -627,7 +627,7 @@ void LowLevelWindow_X11::SwapBuffers()
 		 * it's already active.
 		 */
 
-		auto now = RageTimer::GetTimeSinceStartFast();
+		auto now = Wallclock::GetSystemTimeInSeconds();
 		if( (now - m_lastScreensaverInterrupt) > m_screensaverInterruptInterval ) {
 		  m_lastScreensaverInterrupt = now;
 		  XLockDisplay( Dpy );

--- a/src/arch/Sound/RageSoundDriver.h
+++ b/src/arch/Sound/RageSoundDriver.h
@@ -52,7 +52,12 @@ public:
 	 * RageSound::CommitPlayingPosition. */
 	std::int64_t GetHardwareFrame() const;
 	virtual std::int64_t GetPosition() const = 0;
-
+/*   THIS CHANGE IS ONLY INCLUDED TO PROVIDE A FULLY WORKING PATCH
+ *     DEMONSTRATING A COMPLETE RAGETIMER REMOVAL.
+ *	 
+ *	 ALL CHANGES TO THIS FILE WILL BE REMOVED BEFORE THE PR IS MERGED.
+ *   
+ */
 	/* When a sound is finished playing (GetDataToPlay returns 0) and the sound has
 	 * been completely flushed (so GetPosition is no longer meaningful), call
 	 * RageSoundBase::SoundIsFinishedPlaying(). */

--- a/src/arch/Sound/RageSoundDriver.h
+++ b/src/arch/Sound/RageSoundDriver.h
@@ -50,9 +50,8 @@ public:
 
 	/* Get the current hardware frame position, in the same time base as passed to
 	 * RageSound::CommitPlayingPosition. */
-	std::int64_t GetHardwareFrame( RageTimer *pTimer ) const;
+	std::int64_t GetHardwareFrame() const;
 	virtual std::int64_t GetPosition() const = 0;
-	void low_sample_count_workaround();
 
 	/* When a sound is finished playing (GetDataToPlay returns 0) and the sound has
 	 * been completely flushed (so GetPosition is no longer meaningful), call

--- a/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
@@ -292,7 +292,12 @@ void RageSoundDriver::Update()
 		m_Sounds[i].m_State = Sound::HALTING;
 //		LOG->Trace("set (#%i) %p from STOPPING to HALTING", i, m_Sounds[i].m_pSound);
 	}
-
+/*   THIS CHANGE IS ONLY INCLUDED TO PROVIDE A FULLY WORKING PATCH
+ *     DEMONSTRATING A COMPLETE RAGETIMER REMOVAL.
+ *	 
+ *	 ALL CHANGES TO THIS FILE WILL BE REMOVED BEFORE THE PR IS MERGED.
+ *   
+ */
 	static std::int64_t fNext = 0;
 	if( Wallclock::GetSystemTime() >= fNext )
 	{

--- a/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
@@ -6,6 +6,7 @@
 #include "RageUtil.h"
 #include "RageSoundMixBuffer.h"
 #include "RageSoundReader.h"
+#include "Wallclock.h"
 
 #include <cmath>
 #include <cstdint>
@@ -292,8 +293,8 @@ void RageSoundDriver::Update()
 //		LOG->Trace("set (#%i) %p from STOPPING to HALTING", i, m_Sounds[i].m_pSound);
 	}
 
-	static float fNext = 0;
-	if( RageTimer::GetTimeSinceStart() >= fNext )
+	static std::int64_t fNext = 0;
+	if( Wallclock::GetSystemTime() >= fNext )
 	{
 		/* Lockless: only Mix() can write to underruns. */
 		int current_underruns = underruns;
@@ -305,7 +306,7 @@ void RageSoundDriver::Update()
 
 			/* Don't log again for at least a second, or we'll burst output
 			 * and possibly cause more underruns. */
-			fNext = RageTimer::GetTimeSinceStart() + 1;
+			fNext = Wallclock::GetSystemTime() + 1;
 		}
 	}
 
@@ -440,11 +441,6 @@ void RageSoundDriver::SetDecodeBufferSize( int iFrames )
 	frames_to_buffer = iFrames;
 }
 
-void RageSoundDriver::low_sample_count_workaround()
-{
-	if (soundDriverMaxSamples != 0) GetHardwareFrame(nullptr);
-}
-
 RageSoundDriver::RageSoundDriver():
 	m_Mutex("RageSoundDriver"),
 	m_SoundListMutex("SoundListMutex")
@@ -474,89 +470,67 @@ RageSoundDriver::~RageSoundDriver()
 	}
 }
 
-std::int64_t RageSoundDriver::ClampHardwareFrame( std::int64_t iHardwareFrame ) const
+std::int64_t RageSoundDriver::ClampHardwareFrame( std::int64_t positionFromDriver ) const
 {
-	/* It's sometimes possible for the hardware position to move backwards, usually
-	 * on underrun.  We can try to prevent this in each driver, but it's an obscure
-	 * error, so let's clamp the result here instead. */
+	// An incorrect hardware position can make the game think it
+	// is running early or late, when in fact there are no issues.
+	// This would typically result in incorrect judgements.
+	//
+	// For example, if the player was stepping perfectly on time,
+	// it might drift out to the early or late Great window.
+	//
+	// It ultimately returns the highest known hardware frame position.
+	const static std::int64_t expected_intmax = 2147483647;
 
-	/* New extra logic for devices and drivers that cant return large numbers in their sample position
-	* calculate a diff and if the current sample # is >= 0 and less than a minute based on sample rate
-	* check if the user set soundDriverMaxSamples to a value, if they did
-	* (this is usually 134217728 aka 2^27 for some reason) hndle the wrap around to a rolling counter
-	* otherwise do the old logic for underrun
-	*/
-
-
-	//iHardwareFrame %= 0x800000; // debug test a sample value max of about 3 minutes so I dont have to spend an hour per test
-	std::int64_t diff = iHardwareFrame - m_iMaxHardwareFrame;
-	if( diff < 0 )
+	if (positionFromDriver > expected_intmax)
 	{
-		diff = 0;
-		int iMinuteSampleRate = GetSampleRate()*60; //get one minute worth of grace -- if you need more, there is very likely some other problem going on
-		//if we have a sample clamp and the new hardware frame is within a fresh minute of the sample rate max and have 'underrun'
-		if ((soundDriverMaxSamples>0) && (iHardwareFrame<iMinuteSampleRate) && iHardwareFrame >= 0)
-		{
-			LOG->Trace("RageSoundDriver: driver position mask adjustment hardware frame number: %d, last max frame number: %d, soundDriverMaxSamples: %d, iMinuteSampleRate: %d, m_iVMaxHardwareFrame: %d",
-																			(int)iHardwareFrame,    (int)m_iMaxHardwareFrame,  soundDriverMaxSamples,  iMinuteSampleRate, (int) m_iVMaxHardwareFrame);
-			diff = (soundDriverMaxSamples - m_iMaxHardwareFrame) + iHardwareFrame;
-			m_iMaxHardwareFrame = 0;
-		}
-		else
-		{
-			/* Clamp the output to one per second, so one underruns don't cascade due to
-			 * output spam. */
-			static RageTimer last(RageZeroTimer);
-			if (last.IsZero() || last.Ago() > 1.0f)
-			{
-
-				//try to hand hold the user if their audio driver is possibly bad
-				int p = 21; // save some time, assume the buffer has at least a minute of cd quality audio -- 2^21
-				while (std::pow(2,p) < m_iMaxHardwareFrame)
-				{
-					if (p == 31)  break; //do not want to go beyond signed DWORD size
-					p++;
-				}
-
-				LOG->Trace("RageSoundDriver: driver returned a lesser position (%d < %d). If this is a recurrent driver problem with your sound card and not an underrun, try setting the preference RageSoundSampleCountClamp to %d",
-					(int)iHardwareFrame, (int)m_iMaxHardwareFrame, (int)std::floor(std::pow(2.0, p)));
-				last.Touch();
-			}
-
-			//return m_iMaxHardwareFrame;
-
-		}
+		positionFromDriver = expected_intmax;
+		LOG->Trace("RageSoundDriver: audio position returned from the audio driver was larger than expected.");
 	}
 
-	m_iMaxHardwareFrame = iHardwareFrame = std::max( iHardwareFrame, m_iMaxHardwareFrame );
-	//return iHardwareFrame;
-	m_iVMaxHardwareFrame += diff;
-	return m_iVMaxHardwareFrame;
+	if (positionFromDriver > m_iMaxHardwareFrame)
+	{
+		m_iMaxHardwareFrame = positionFromDriver;
+	}
+
+	return m_iMaxHardwareFrame;
 }
 
-std::int64_t RageSoundDriver::GetHardwareFrame( RageTimer *pTimestamp=nullptr ) const
+std::int64_t RageSoundDriver::GetHardwareFrame() const
 {
-	if( pTimestamp == nullptr )
-		return ClampHardwareFrame( GetPosition() );
+	// We may have unpredictable scheduling delays between
+	// updating the timestamp and reading the sound position.
+	//
+	// To mitigate this, we use a high-resolution timer
+	// and an adaptive retry mechanism.
+	//
+	// The usleep in the loop is necessary to yield the processor.
+	//
+	// The boolean is used to determine whether to log the warning
+	// to ensure the warning is only logged once per function call.
+	//
+	// The time values below are measured in microseconds.
+	const int retry_count = 3;
+	const int sleep_interval = 100;
+	const std::int64_t duration_threshold = 2000;
+	std::int64_t startTime = Wallclock::GetSystemTime();
+	std::int64_t loop_duration = 0;
+	std::int64_t iPositionFrames = 0;
 
-	/*
-	 * We may have unpredictable scheduling delays between updating the timestamp
-	 * and reading the sound position.  If we're preempted while doing this and
-	 * it may have caused the timestamp to not match the returned time, retry.
-	 *
-	 * As a failsafe, only allow a few attempts.  If this has to try more than
-	 * a few times, then probably we have thread contention that's causing more
-	 * severe performance problems, anyway.
-	 */
-	int iTries = 3;
-	std::int64_t iPositionFrames;
-	do
+	for( int i = 0; i < retry_count; ++i )
 	{
-		pTimestamp->Touch();
 		iPositionFrames = GetPosition();
-	} while( --iTries && pTimestamp->Ago() > 0.002f );
+		loop_duration = Wallclock::GetSystemTime() - startTime;
 
-	if( iTries == 0 )
+		if (loop_duration < duration_threshold)
+		{
+			break;
+		}
+
+		usleep(sleep_interval);
+	}
+
+	if( loop_duration >= duration_threshold )
 	{
 		static bool bLogged = false;
 		if( !bLogged )


### PR DESCRIPTION
I designed this to be a RageTimer replacement originally, but it turned into a custom tool to help me with code profiling, so I've decided to move it into `src/tests` since it's really intended for debug use instead of in-game use (thread safety on the clock methods is very nice for methods related to code profiling, but not so nice for gameplay).

This code has been indispensable for me identifying bottlenecks in the codebase, so I'd like to include it for other developers to make use of.