### PR TITLE
[low priority]  Prevent overlapping assist tick sounds

### DIFF
--- a/src/GameplayAssist.cpp
+++ b/src/GameplayAssist.cpp
@@ -43,8 +43,13 @@ void GameplayAssist::PlayTicks( const NoteData &nd, const PlayerState *ps )
 		int iClapRow = -1;
 		// for each index we crossed since the last update:
 		FOREACH_NONEMPTY_ROW_ALL_TRACKS_RANGE( nd, r, iRowLastCrossed+1, iSongRow+1 )
+		{
 			if( nd.IsThereATapOrHoldHeadAtRow( r ) )
+			{
 				iClapRow = r;
+				break;
+			}
+		}
 
 		if( iClapRow != -1 && timing.IsJudgableAtRow(iClapRow))
 		{


### PR DESCRIPTION
The game might play overlapping assist tick sounds, leading to the assist tick sound going out-of-phase or being slightly off time. This simple patch prevents that from happening.