### PR TITLE
[low priority]  Declare a NoteData template as noexcept

### DIFF
--- a/src/NoteData.h
+++ b/src/NoteData.h
@@ -386,10 +386,7 @@ public:
 /** @brief Allow a quick way to swap notedata. */
 namespace std
 {
-	template<> inline void swap<NoteData>( NoteData &nd1, NoteData &nd2 )
-#if !defined(_MSC_VER)
-	noexcept(is_nothrow_move_constructible<NoteData>::value && is_nothrow_move_assignable<NoteData>::value)
-#endif
+	template<> inline void swap<NoteData>( NoteData &nd1, NoteData &nd2 ) noexcept
 	{
 		nd1.swap( nd2 );
 	}


### PR DESCRIPTION
Another small bug fix found by the compiler, thanks to removal of macros in other functions.

The error received was:

`Warning	C26439	This kind of function should not throw. Declare it 'noexcept' (f.6). (src\NoteData.h	389)`

We can see in the old code is a way to attempt to declare the function noexcept for MSVC 2013 (according to blame layer), but it's not working as intended anymore in the newest MSVC.

Refer to: https://learn.microsoft.com/en-us/cpp/code-quality/c26439?view=msvc-170