### PR TITLE
Make ArchHooks::GetMicrosecondsSinceStart noexcept

### DIFF
--- a/src/arch/ArchHooks/ArchHooks.h
+++ b/src/arch/ArchHooks/ArchHooks.h
@@ -87,7 +87,7 @@ public:
 	 * underlying timers may be 32-bit, but implementations should try to avoid
 	 * wrapping if possible.
 	 */
-	static std::int64_t GetMicrosecondsSinceStart( bool bAccurate );
+	static std::int64_t GetMicrosecondsSinceStart( bool bAccurate ) noexcept;
 
 	/*
 	 * Add file search paths, higher priority first.

--- a/src/arch/ArchHooks/ArchHooks_MacOSX.mm
+++ b/src/arch/ArchHooks/ArchHooks_MacOSX.mm
@@ -258,7 +258,7 @@ bool ArchHooks_MacOSX::GoToURL( RString sUrl )
 	return result == 0;
 }
 
-std::int64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate )
+std::int64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate ) noexcept
 {
 	// http://developer.apple.com/qa/qa2004/qa1398.html
 	static double factor = 0.0;

--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -149,7 +149,7 @@ clockid_t ArchHooks_Unix::GetClock()
 	return g_Clock;
 }
 
-std::int64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate )
+std::int64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate ) noexcept
 {
 	OpenGetTime();
 
@@ -162,7 +162,7 @@ std::int64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate )
 	return iRet;
 }
 #else
-std::int64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate )
+std::int64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate ) noexcept
 {
 	struct timeval tv;
 	gettimeofday( &tv, nullptr );


### PR DESCRIPTION
Potential improvement where the compiler may be able to further optimize , plus this function doesn't throw exceptions so it should be `noexcept` anyway.