### PR TITLE
WIP: Add ASan and UBSan builds, resolve discovered undefined behavior

### DIFF
--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -166,9 +166,9 @@ Actor::Actor()
 	m_size = RageVector2( 1, 1 );
 	InitState();
 	m_pParent = nullptr;
-	m_FakeParent= nullptr;
+	m_FakeParent = nullptr;
 	m_bFirstUpdate = true;
-	m_tween_uses_effect_delta= false;
+	m_tween_uses_effect_delta = false;
 }
 
 Actor::~Actor()
@@ -215,6 +215,7 @@ Actor::Actor( const Actor &cpy ):
 		m_Tweens.push_back( new TweenStateAndInfo(*cpy.m_Tweens[i]) );
 
 	CPY( m_bFirstUpdate );
+	CPY (m_tween_uses_effect_delta );
 
 	CPY( m_fHorizAlign );
 	CPY( m_fVertAlign );
@@ -741,7 +742,7 @@ void Actor::BeginDraw()
 	const float skewX = m_pTempState->fSkewX;
 	if (skewX != 0)
 	{
-		DISPLAY->SkewX(skewX); 
+		DISPLAY->SkewX(skewX);
 	}
 
 	// Get the skew of the actor along the Y-axis

--- a/src/ArrowEffects.cpp
+++ b/src/ArrowEffects.cpp
@@ -1142,7 +1142,7 @@ float ArrowEffects::GetAlpha( const PlayerState* pPlayerState, int iCol, float f
 	if( fYPosWithoutReverse > fFullAlphaY )
 	{
 		float f = SCALE( fYPosWithoutReverse, fFullAlphaY, fDrawDistanceBeforeTargetsPixels, 1.0f, 0.0f );
-		return f;
+		return CLAMP( f, 0.0, 1.0 ); // SCALE can return -inf when fFullAlphaY - fDrawDistanceBeforeTargetsPixels == 0
 	}
 	return (fPercentVisible>0.5f) ? 1.0f : 0.0f;
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,11 +52,13 @@ if(MSVC OR APPLE)
   set(SM_NAME_DEBUG "ITGmania-debug")
   set(SM_NAME_MINSIZEREL "ITGmania-min-size")
   set(SM_NAME_RELWITHDEBINFO "ITGmania-release-symbols")
+  set(SM_NAME_DEBWITHASAN "ITGMania-debug-asan")
 else()
   set(SM_NAME_RELEASE "itgmania")
   set(SM_NAME_DEBUG "itgmania-debug")
   set(SM_NAME_MINSIZEREL "itgmania-min-size")
   set(SM_NAME_RELWITHDEBINFO "itgmania-release-symbols")
+  set(SM_NAME_DEBWITHASAN "itgmania-debug-asan")
 endif()
 
 if(APPLE)
@@ -94,7 +96,8 @@ set_target_properties("${SM_EXE_NAME}"
                                  RELEASE_OUTPUT_NAME "${SM_NAME_RELEASE}"
                                  DEBUG_OUTPUT_NAME "${SM_NAME_DEBUG}"
                                  MINSIZEREL_OUTPUT_NAME "${SM_NAME_MINSIZEREL}"
-                                 RELWITHDEBINFO_OUTPUT_NAME "${SM_NAME_RELWITHDEBINFO}")
+                                 RELWITHDEBINFO_OUTPUT_NAME "${SM_NAME_RELWITHDEBINFO}"
+                                 DEBWITHASAN_OUTPUT_NAME "${SM_NAME_DEBWITHASAN}")
 
 if(WITH_LTO)
   include(CheckIPOSupported)
@@ -115,6 +118,7 @@ target_compile_definitions("${SM_EXE_NAME}" PRIVATE $<$<CONFIG:Release>:RELEASE>
 target_compile_definitions("${SM_EXE_NAME}" PRIVATE $<$<CONFIG:MinSizeRel>:MINSIZEREL>)
 target_compile_definitions("${SM_EXE_NAME}" PRIVATE
                            $<$<CONFIG:RelWithDebInfo>:RELWITHDEBINFO>)
+target_compile_definitions("${SM_EXE_NAME}" PRIVATE $<$<CONFIG:DebWithAsan>:DEBWITHASAN>)
 
 # For Apple Clang, CMAKE_<LANG>_COMPILER_ID will be set to AppleClang instead of Clang.
 if (POLICY CMP0025)
@@ -131,6 +135,9 @@ target_compile_options("${SM_EXE_NAME}" PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:
     /W4 /wd4100 /wd4189 /wd4244 /wd4267 /wd4702>
 )
+
+set (CMAKE_CXX_FLAGS_DEBWITHASAN "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+set (CMAKE_LINKER_FLAGS_DEBWITHASAN "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
 
 set(SM_COMPILE_FLAGS "")
 
@@ -159,7 +166,8 @@ set_target_properties("${SM_EXE_NAME}"
 set_target_properties("${SM_EXE_NAME}"
                       PROPERTIES OUTPUT_NAME_DEBUG "${SM_NAME_DEBUG}"
                                  OUTPUT_NAME_MINSIZEREL "${SM_NAME_MINSIZEREL}"
-                                 OUTPUT_NAME_RELWITHDEBINFO "${SM_NAME_RELWITHDEBINFO}")
+                                 OUTPUT_NAME_RELWITHDEBINFO "${SM_NAME_RELWITHDEBINFO}"
+                                 OUTPUT_NAME_DEBWITHASAN "${SM_NAME_DEBWITHASAN}")
 
 if(WIN32)
   target_compile_definitions("${SM_EXE_NAME}" PRIVATE WINDOWS)
@@ -208,6 +216,8 @@ elseif(APPLE)
       "${SM_ROOT_DIR}"
       RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO
       "${SM_ROOT_DIR}"
+      RUNTIME_OUTPUT_DIRECTORY_DEBWITHASAN
+      "${SM_ROOT_DIR}"
       MACOSX_BUNDLE_INFO_PLIST
       "${SM_XCODE_DIR}/Info.plist.in")
 
@@ -236,6 +246,8 @@ elseif(APPLE)
     set(SM_APP_RELEASE_NAME "${SM_NAME_MINSIZEREL}")
   elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     set(SM_APP_RELEASE_NAME "${SM_NAME_RELWITHDEBINFO}")
+  elseif(CMAKE_BUILD_TYPE STREQUAL "DebugWithAsan")
+    set(SM_APP_RELEASE_NAME "${SM_NAME_DEBWITHASAN}")
   else()
     set(SM_APP_RELEASE_NAME "${SM_NAME_RELEASE}")
   endif()
@@ -258,7 +270,10 @@ else() # Linux
                                    RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL
                                    "${SM_ROOT_DIR}"
                                    RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO
-                                   "${SM_ROOT_DIR}")
+                                   "${SM_ROOT_DIR}"
+                                   RUNTIME_OUTPUT_DIRECTORY_DEBWITHASAN
+                                   "${SM_ROOT_DIR}"
+                                   )
 
   if(${WITH_CRASH_HANDLER})
     target_compile_definitions("${SM_EXE_NAME}" PRIVATE CRASH_HANDLER)
@@ -374,6 +389,8 @@ if(WIN32)
                         PROPERTIES LINK_FLAGS_MINSIZEREL "/SUBSYSTEM:WINDOWS")
 
 elseif(APPLE)
+  set_target_properties("${SM_EXE_NAME}"
+                        PROPERTIES LINK_FLAGS_DEBWITHASAN "-fsanitize=address")
   list(INSERT SMDATA_LINK_LIB
               0
               ${MAC_FRAME_ACCELERATE}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,12 +53,14 @@ if(MSVC OR APPLE)
   set(SM_NAME_MINSIZEREL "ITGmania-min-size")
   set(SM_NAME_RELWITHDEBINFO "ITGmania-release-symbols")
   set(SM_NAME_DEBWITHASAN "ITGMania-debug-asan")
+  set(SM_NAME_DEBWITHUBSAN "ITGMania-debug-ubsan")
 else()
   set(SM_NAME_RELEASE "itgmania")
   set(SM_NAME_DEBUG "itgmania-debug")
   set(SM_NAME_MINSIZEREL "itgmania-min-size")
   set(SM_NAME_RELWITHDEBINFO "itgmania-release-symbols")
   set(SM_NAME_DEBWITHASAN "itgmania-debug-asan")
+  set(SM_NAME_DEBWITHUBSAN "itgmania-debug-ubsan")
 endif()
 
 if(APPLE)
@@ -97,7 +99,8 @@ set_target_properties("${SM_EXE_NAME}"
                                  DEBUG_OUTPUT_NAME "${SM_NAME_DEBUG}"
                                  MINSIZEREL_OUTPUT_NAME "${SM_NAME_MINSIZEREL}"
                                  RELWITHDEBINFO_OUTPUT_NAME "${SM_NAME_RELWITHDEBINFO}"
-                                 DEBWITHASAN_OUTPUT_NAME "${SM_NAME_DEBWITHASAN}")
+                                 DEBWITHASAN_OUTPUT_NAME "${SM_NAME_DEBWITHASAN}"
+                                 DEBWITHUBSAN_OUTPUT_NAME "${SM_NAME_DEBWITHUBSAN}")
 
 if(WITH_LTO)
   include(CheckIPOSupported)
@@ -119,6 +122,7 @@ target_compile_definitions("${SM_EXE_NAME}" PRIVATE $<$<CONFIG:MinSizeRel>:MINSI
 target_compile_definitions("${SM_EXE_NAME}" PRIVATE
                            $<$<CONFIG:RelWithDebInfo>:RELWITHDEBINFO>)
 target_compile_definitions("${SM_EXE_NAME}" PRIVATE $<$<CONFIG:DebWithAsan>:DEBWITHASAN>)
+target_compile_definitions("${SM_EXE_NAME}" PRIVATE $<$<CONFIG:DebWithUbsan>:DEBWITHUBSAN>)
 
 # For Apple Clang, CMAKE_<LANG>_COMPILER_ID will be set to AppleClang instead of Clang.
 if (POLICY CMP0025)
@@ -138,6 +142,9 @@ target_compile_options("${SM_EXE_NAME}" PRIVATE
 
 set (CMAKE_CXX_FLAGS_DEBWITHASAN "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
 set (CMAKE_LINKER_FLAGS_DEBWITHASAN "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+
+set (CMAKE_CXX_FLAGS_DEBWITHUBSAN "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=undefined -O0 -fno-sanitize-recover=all")
+set (CMAKE_LINKER_FLAGS_DEBWITHUBSAN "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=undefined -O0 -fno-sanitize-recover=all")
 
 set(SM_COMPILE_FLAGS "")
 
@@ -167,7 +174,8 @@ set_target_properties("${SM_EXE_NAME}"
                       PROPERTIES OUTPUT_NAME_DEBUG "${SM_NAME_DEBUG}"
                                  OUTPUT_NAME_MINSIZEREL "${SM_NAME_MINSIZEREL}"
                                  OUTPUT_NAME_RELWITHDEBINFO "${SM_NAME_RELWITHDEBINFO}"
-                                 OUTPUT_NAME_DEBWITHASAN "${SM_NAME_DEBWITHASAN}")
+                                 OUTPUT_NAME_DEBWITHASAN "${SM_NAME_DEBWITHASAN}"
+                                 OUTPUT_NAME_DEBWITHUBSAN "${SM_NAME_DEBWITHUBSAN}")
 
 if(WIN32)
   target_compile_definitions("${SM_EXE_NAME}" PRIVATE WINDOWS)
@@ -218,6 +226,8 @@ elseif(APPLE)
       "${SM_ROOT_DIR}"
       RUNTIME_OUTPUT_DIRECTORY_DEBWITHASAN
       "${SM_ROOT_DIR}"
+      RUNTIME_OUTPUT_DIRECTORY_DEBWITHUBSAN
+      "${SM_ROOT_DIR}"
       MACOSX_BUNDLE_INFO_PLIST
       "${SM_XCODE_DIR}/Info.plist.in")
 
@@ -248,6 +258,8 @@ elseif(APPLE)
     set(SM_APP_RELEASE_NAME "${SM_NAME_RELWITHDEBINFO}")
   elseif(CMAKE_BUILD_TYPE STREQUAL "DebugWithAsan")
     set(SM_APP_RELEASE_NAME "${SM_NAME_DEBWITHASAN}")
+    elseif(CMAKE_BUILD_TYPE STREQUAL "DebugWithUbsan")
+    set(SM_APP_RELEASE_NAME "${SM_NAME_DEBWITHUBSAN}")
   else()
     set(SM_APP_RELEASE_NAME "${SM_NAME_RELEASE}")
   endif()
@@ -272,6 +284,8 @@ else() # Linux
                                    RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO
                                    "${SM_ROOT_DIR}"
                                    RUNTIME_OUTPUT_DIRECTORY_DEBWITHASAN
+                                   "${SM_ROOT_DIR}"
+                                   RUNTIME_OUTPUT_DIRECTORY_DEBWITHUBSAN
                                    "${SM_ROOT_DIR}"
                                    )
 
@@ -390,7 +404,9 @@ if(WIN32)
 
 elseif(APPLE)
   set_target_properties("${SM_EXE_NAME}"
-                        PROPERTIES LINK_FLAGS_DEBWITHASAN "-fsanitize=address")
+                        PROPERTIES LINK_FLAGS_DEBWITHASAN "-fsanitize=address -O0")
+  set_target_properties("${SM_EXE_NAME}"
+                        PROPERTIES LINK_FLAGS_DEBWITHUBSAN "-fsanitize=undefined -O0")
   list(INSERT SMDATA_LINK_LIB
               0
               ${MAC_FRAME_ACCELERATE}
@@ -413,6 +429,10 @@ elseif(APPLE)
               "${MAC_FRAME_COREVIDEO}"
               "${MAC_FRAME_VIDEOTOOLBOX}")
 else() # Unix / Linux TODO: Remember to find and locate the zip archive files.
+  set_target_properties("${SM_EXE_NAME}"
+                        PROPERTIES LINK_FLAGS_DEBWITHASAN "-fsanitize=address")
+  set_target_properties("${SM_EXE_NAME}"
+                        PROPERTIES LINK_FLAGS_DEBWITHUBSAN "-fsanitize=undefined")
   list(APPEND SMDATA_LINK_LIB
               "${SM_FFMPEG_LIB}/libavformat.a"
               "${SM_FFMPEG_LIB}/libavcodec.a"

--- a/src/CMakeProject-mapconv.cmake
+++ b/src/CMakeProject-mapconv.cmake
@@ -26,6 +26,8 @@ set_target_properties("mapconv"
                                  RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO
                                  "${SM_PROGRAM_DIR}"
                                  RUNTIME_OUTPUT_DIRECTORY_DEBWITHASAN
+                                 "${SM_PROGRAM_DIR}"
+                                 RUNTIME_OUTPUT_DIRECTORY_DEBWITHUBSAN
                                  "${SM_PROGRAM_DIR}")
 
 set_target_properties("mapconv"
@@ -40,4 +42,6 @@ set_target_properties("mapconv"
                                  RELWITHDEBINFO_OUTPUT_NAME
                                  "mapconv"
                                  DEBWITHASAN_OUTPUT_NAME
+                                 "mapconv"
+                                 DEBWITHUBSAN_OUTPUT_NAME
                                  "mapconv")

--- a/src/CMakeProject-mapconv.cmake
+++ b/src/CMakeProject-mapconv.cmake
@@ -24,6 +24,8 @@ set_target_properties("mapconv"
                                  RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL
                                  "${SM_PROGRAM_DIR}"
                                  RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO
+                                 "${SM_PROGRAM_DIR}"
+                                 RUNTIME_OUTPUT_DIRECTORY_DEBWITHASAN
                                  "${SM_PROGRAM_DIR}")
 
 set_target_properties("mapconv"
@@ -36,4 +38,6 @@ set_target_properties("mapconv"
                                  MINSIZEREL_OUTPUT_NAME
                                  "mapconv"
                                  RELWITHDEBINFO_OUTPUT_NAME
+                                 "mapconv"
+                                 DEBWITHASAN_OUTPUT_NAME
                                  "mapconv")

--- a/src/CMakeProject-texture.cmake
+++ b/src/CMakeProject-texture.cmake
@@ -59,6 +59,8 @@ set_target_properties("TextureFontGenerator"
                                  RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL
                                  "${SM_PROGRAM_DIR}"
                                  RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO
+                                 "${SM_PROGRAM_DIR}"
+                                 RUNTIME_OUTPUT_DIRECTORY_DEBWITHASAN
                                  "${SM_PROGRAM_DIR}")
 
 set_target_properties("TextureFontGenerator"
@@ -71,4 +73,6 @@ set_target_properties("TextureFontGenerator"
                                  MINSIZEREL_OUTPUT_NAME
                                  "Texture Font Generator"
                                  RELWITHDEBINFO_OUTPUT_NAME
+                                 "Texture Font Generator"
+                                 DEBWITHASAN_OUTPUT_NAME
                                  "Texture Font Generator")

--- a/src/CMakeProject-texture.cmake
+++ b/src/CMakeProject-texture.cmake
@@ -61,6 +61,8 @@ set_target_properties("TextureFontGenerator"
                                  RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO
                                  "${SM_PROGRAM_DIR}"
                                  RUNTIME_OUTPUT_DIRECTORY_DEBWITHASAN
+                                 "${SM_PROGRAM_DIR}"
+                                 RUNTIME_OUTPUT_DIRECTORY_DEBWITHUBSAN
                                  "${SM_PROGRAM_DIR}")
 
 set_target_properties("TextureFontGenerator"
@@ -75,4 +77,6 @@ set_target_properties("TextureFontGenerator"
                                  RELWITHDEBINFO_OUTPUT_NAME
                                  "Texture Font Generator"
                                  DEBWITHASAN_OUTPUT_NAME
+                                 "Texture Font Generator"
+                                 DEBWITHUBSAN_OUTPUT_NAME
                                  "Texture Font Generator")

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -39,7 +39,7 @@ StringToX( SongSort );
 struct OldStyleStringToSongSortMapHolder
 {
 	std::map<RString, SongSort> conversion_map;
-	
+
 	OldStyleStringToSongSortMapHolder()
 	{
 		conversion_map["best"] = SongSort_MostPlays;
@@ -421,8 +421,8 @@ static void CourseSortSongs( SongSort sort, std::vector<Song*> &vpPossibleSongs,
 			SongUtil::SortSongPointerArrayByNumPlays( vpPossibleSongs, PROFILEMAN->GetMachineProfile(), false );	// ascending
 		break;
 	case SongSort_TopGrades:
-		// SongUtil::SortSongPointerArrayByGrades() will crash if called in a state where there's no current master player 
-		// (for instance when returning to the Title Menu). 
+		// SongUtil::SortSongPointerArrayByGrades() will crash if called in a state where there's no current master player
+		// (for instance when returning to the Title Menu).
 		// A workaround is to just not call it if we know that GAMESTATE->GetMasterPlayerNumber() == PlayerNumber_Invalid
 		if( PROFILEMAN && GAMESTATE->GetMasterPlayerNumber() != PlayerNumber_Invalid )
 			SongUtil::SortSongPointerArrayByGrades( vpPossibleSongs, true );	// descending
@@ -561,7 +561,7 @@ bool Course::GetTrailUnsorted( StepsType st, CourseDifficulty cd, Trail &trail )
 				if( v.size() == 1 )
 					vpSongs.push_back( sas->pSong );
 			}
-			
+
 			CourseSortSongs(e->songSort, vpSongs, rnd);
 
 			ASSERT( e->iChooseIndex >= 0 );

--- a/src/Difficulty.cpp
+++ b/src/Difficulty.cpp
@@ -50,6 +50,17 @@ CourseDifficulty GetNextShownCourseDifficulty( CourseDifficulty cd )
 	return Difficulty_Invalid;
 }
 
+CourseDifficulty GetFirstShownCourseDifficulty()
+{
+	CourseDifficulty d = Difficulty_Beginner;
+	for( ; d<NUM_Difficulty; enum_add(d, 1) )
+	{
+		if( GAMESTATE->IsCourseDifficultyShown(d) )
+			return d;
+	}
+	return Difficulty_Invalid;
+}
+
 struct OldStyleStringToDifficultyMapHolder
 {
 	std::map<RString, Difficulty> conversion_map;

--- a/src/Difficulty.h
+++ b/src/Difficulty.h
@@ -28,12 +28,13 @@ typedef Difficulty CourseDifficulty;
 const int NUM_CourseDifficulty = NUM_Difficulty;
 /** @brief Loop through the shown course difficulties. */
 #define FOREACH_ShownCourseDifficulty( cd ) \
-for( Difficulty cd=GetNextShownCourseDifficulty((CourseDifficulty)-1); \
+for( Difficulty cd=GetFirstShownCourseDifficulty(); \
 	cd!=Difficulty_Invalid; cd=GetNextShownCourseDifficulty(cd) )
 
 const RString& CourseDifficultyToLocalizedString( Difficulty dc );
 
 Difficulty GetNextShownCourseDifficulty( Difficulty pn );
+Difficulty GetFirstShownCourseDifficulty();
 
 
 // CustomDifficulty is a themeable difficulty name based on Difficulty, string matching on StepsType, and CourseType.
@@ -49,7 +50,7 @@ RString TrailToCustomDifficulty( const Trail *pTrail );
 /*
  * (c) 2001-2004 Chris Danford
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -59,7 +60,7 @@ RString TrailToCustomDifficulty( const Trail *pTrail );
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF

--- a/src/GameConstantsAndTypes.cpp
+++ b/src/GameConstantsAndTypes.cpp
@@ -51,6 +51,8 @@ LuaXType( RadarCategory );
 
 RString StepsTypeToString( StepsType st )
 {
+	ASSERT_M( GAMEMAN != nullptr, "GAMEMAN is not available yet." );
+
 	RString s = GAMEMAN->GetStepsTypeInfo( st ).szName; // "dance-single"
 	/* foo-bar -> Foo_Bar */
 	s.Replace('-','_');

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -1744,9 +1744,13 @@ int GameState::GetNumHumanPlayers() const
 
 PlayerNumber GameState::GetFirstHumanPlayer() const
 {
-	FOREACH_HumanPlayer( pn )
-		return pn;
+	PlayerNumber pn = PLAYER_1;
+
+	for( ; pn < NUM_PLAYERS; enum_add(pn, 1) )
+		if( GAMESTATE->IsHumanPlayer(pn) )
+			return pn;
 	return PLAYER_INVALID;
+
 }
 
 PlayerNumber GameState::GetFirstDisabledPlayer() const
@@ -2701,9 +2705,29 @@ PlayerNumber GetNextEnabledPlayer( PlayerNumber pn )
 	return PLAYER_INVALID;
 }
 
+PlayerNumber GetFirstEnabledPlayer()
+{
+	PlayerNumber pn = PLAYER_1;
+
+	for( ; pn < NUM_PLAYERS; enum_add(pn, 1) )
+		if( GAMESTATE->IsPlayerEnabled(pn) )
+			return pn;
+	return PLAYER_INVALID;
+}
+
 PlayerNumber GetNextCpuPlayer( PlayerNumber pn )
 {
 	for( enum_add(pn, 1); pn < NUM_PLAYERS; enum_add(pn, 1) )
+		if( GAMESTATE->IsCpuPlayer(pn) )
+			return pn;
+	return PLAYER_INVALID;
+}
+
+PlayerNumber GetFirstCpuPlayer()
+{
+	PlayerNumber pn = PLAYER_1;
+
+	for( ; pn < NUM_PLAYERS; enum_add(pn, 1) )
 		if( GAMESTATE->IsCpuPlayer(pn) )
 			return pn;
 	return PLAYER_INVALID;
@@ -2717,9 +2741,29 @@ PlayerNumber GetNextPotentialCpuPlayer( PlayerNumber pn )
 	return PLAYER_INVALID;
 }
 
+PlayerNumber GetFirstPotentialCpuPlayer()
+{
+	PlayerNumber pn = PLAYER_1;
+
+	for( ; pn < NUM_PLAYERS; enum_add(pn, 1) )
+		if( !GAMESTATE->IsHumanPlayer(pn) )
+			return pn;
+	return PLAYER_INVALID;
+}
+
 MultiPlayer GetNextEnabledMultiPlayer( MultiPlayer mp )
 {
 	for( enum_add(mp, 1); mp < NUM_MultiPlayer; enum_add(mp, 1) )
+		if( GAMESTATE->IsMultiPlayerEnabled(mp) )
+			return mp;
+	return MultiPlayer_Invalid;
+}
+
+MultiPlayer GetFirstEnabledMultiPlayer()
+{
+	MultiPlayer mp = MultiPlayer_P1;
+
+	for( ; mp < NUM_MultiPlayer; enum_add(mp, 1) )
 		if( GAMESTATE->IsMultiPlayerEnabled(mp) )
 			return mp;
 	return MultiPlayer_Invalid;

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -448,17 +448,22 @@ PlayerNumber GetNextEnabledPlayer( PlayerNumber pn );
 PlayerNumber GetNextCpuPlayer( PlayerNumber pn );
 PlayerNumber GetNextPotentialCpuPlayer( PlayerNumber pn );
 MultiPlayer GetNextEnabledMultiPlayer( MultiPlayer mp );
+PlayerNumber GetFirstEnabledPlayer();
+PlayerNumber GetFirstCpuPlayer();
+PlayerNumber GetFirstPotentialCpuPlayer();
+MultiPlayer GetFirstEnabledMultiPlayer();
+
 
 /** @brief A foreach loop to act on each human Player. */
-#define FOREACH_HumanPlayer( pn ) for( PlayerNumber pn=GetNextHumanPlayer((PlayerNumber)-1); pn!=PLAYER_INVALID; pn=GetNextHumanPlayer(pn) )
+#define FOREACH_HumanPlayer( pn ) for( PlayerNumber pn=GAMESTATE->GetFirstHumanPlayer(); pn!=PLAYER_INVALID; pn=GetNextHumanPlayer(pn) )
 /** @brief A foreach loop to act on each enabled Player. */
-#define FOREACH_EnabledPlayer( pn ) for( PlayerNumber pn=GetNextEnabledPlayer((PlayerNumber)-1); pn!=PLAYER_INVALID; pn=GetNextEnabledPlayer(pn) )
+#define FOREACH_EnabledPlayer( pn ) for( PlayerNumber pn=GetFirstEnabledPlayer(); pn!=PLAYER_INVALID; pn=GetNextEnabledPlayer(pn) )
 /** @brief A foreach loop to act on each CPU Player. */
-#define FOREACH_CpuPlayer( pn ) for( PlayerNumber pn=GetNextCpuPlayer((PlayerNumber)-1); pn!=PLAYER_INVALID; pn=GetNextCpuPlayer(pn) )
+#define FOREACH_CpuPlayer( pn ) for( PlayerNumber pn=GetFirstCpuPlayer(); pn!=PLAYER_INVALID; pn=GetNextCpuPlayer(pn) )
 /** @brief A foreach loop to act on each potential CPU Player. */
-#define FOREACH_PotentialCpuPlayer( pn ) for( PlayerNumber pn=GetNextPotentialCpuPlayer((PlayerNumber)-1); pn!=PLAYER_INVALID; pn=GetNextPotentialCpuPlayer(pn) )
+#define FOREACH_PotentialCpuPlayer( pn ) for( PlayerNumber pn=GetFirstPotentialCpuPlayer(); pn!=PLAYER_INVALID; pn=GetNextPotentialCpuPlayer(pn) )
 /** @brief A foreach loop to act on each Player in MultiPlayer. */
-#define FOREACH_EnabledMultiPlayer( mp ) for( MultiPlayer mp=GetNextEnabledMultiPlayer((MultiPlayer)-1); mp!=MultiPlayer_Invalid; mp=GetNextEnabledMultiPlayer(mp) )
+#define FOREACH_EnabledMultiPlayer( mp ) for( MultiPlayer mp=GetFirstEnabledMultiPlayer(); mp!=MultiPlayer_Invalid; mp=GetNextEnabledMultiPlayer(mp) )
 
 
 

--- a/src/Grade.h
+++ b/src/Grade.h
@@ -10,7 +10,7 @@
  * TODO: Look into a more flexible system without a fixed number of grades. -Wolfman2000
  */
 enum Grade
-{ 
+{
 	Grade_Tier01,	/**< Usually an AAAA */
 	Grade_Tier02,	/**< Usually an AAA */
 	Grade_Tier03,	/**< Usually an AA */
@@ -32,7 +32,7 @@ enum Grade
 	Grade_Tier19,
 	Grade_Tier20,
 	Grade_Failed,	/**< Usually an E */
-	NUM_Grade, 
+	NUM_Grade,
 	Grade_Invalid,
 };
 /** @brief Have an alternative for if there is no data for grading. */
@@ -84,8 +84,7 @@ extern ThemeMetric<int> NUM_GRADE_TIERS_USED;
  * @return the next Grade. */
 Grade GetNextPossibleGrade( Grade g );
 /** @brief Loop through each possible Grade. */
-#define FOREACH_PossibleGrade( g ) \
-for( Grade g = (Grade)(0); g != Grade_Invalid; g = GetNextPossibleGrade(g) )
+#define FOREACH_PossibleGrade( g ) FOREACH_ENUM( Grade, g )
 
 #endif
 
@@ -94,7 +93,7 @@ for( Grade g = (Grade)(0); g != Grade_Invalid; g = GetNextPossibleGrade(g) )
  * @author Chris Danford (c) 2001-2004
  * @section LICENSE
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -104,7 +103,7 @@ for( Grade g = (Grade)(0); g != Grade_Invalid; g = GetNextPossibleGrade(g) )
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF

--- a/src/HighScore.cpp
+++ b/src/HighScore.cpp
@@ -91,6 +91,7 @@ HighScoreImpl::HighScoreImpl()
 	ZERO( iHoldNoteScores );
 	radarValues.MakeUnknown();
 	fLifeRemainingSeconds = 0;
+	bDisqualified = false;
 }
 
 XNode *HighScoreImpl::CreateNode() const
@@ -441,7 +442,7 @@ void HighScoreList::MergeFromOtherHSL(HighScoreList& other, bool is_machine)
 	vHighScores.erase(unique_end, vHighScores.end());
 	// Reverse it because sort moved the lesser scores to the top.
 	std::reverse(vHighScores.begin(), vHighScores.end());
-	
+
 	if (!PREFSMAN->m_bAllowMultipleHighScoreWithSameName)
 	{
 		// erase all but the highest score for each name

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -271,8 +271,6 @@ LuaManager::LuaManager()
 	// Store the thread pool in a table on the stack, in the main thread.
 #define THREAD_POOL 1
 	lua_newtable( L );
-
-	RegisterTypes();
 }
 
 LuaManager::~LuaManager()

--- a/src/MemoryCardManager.cpp
+++ b/src/MemoryCardManager.cpp
@@ -140,7 +140,8 @@ bool ThreadedMemoryCardWorker::StorageDevicesChanged( std::vector<UsbStorageDevi
 
 ThreadedMemoryCardWorker::ThreadedMemoryCardWorker():
 	RageWorkerThread("MemoryCardWorker"),
-	UsbStorageDevicesMutex("UsbStorageDevicesMutex")
+	UsbStorageDevicesMutex("UsbStorageDevicesMutex"),
+	m_bUsbStorageDevicesChanged(false)
 {
 	if( g_bMemoryCards )
 		m_pDriver = MemoryCardDriver::Create();

--- a/src/ModsGroup.h
+++ b/src/ModsGroup.h
@@ -8,12 +8,12 @@
 
 enum ModsLevel
 {
-	ModsLevel_Preferred,	// user-chosen player options.  Does not include any forced mods.
+	ModsLevel_Preferred = 0,	// user-chosen player options.  Does not include any forced mods.
 	ModsLevel_Stage,	// Preferred + forced stage mods
 	ModsLevel_Song,		// Stage + forced attack mods
 	ModsLevel_Current, // Approaches Song
 	NUM_ModsLevel,
-	ModsLevel_Invalid
+	ModsLevel_Invalid = -1
 };
 LuaDeclareType( ModsLevel );
 

--- a/src/NoteDisplay.cpp
+++ b/src/NoteDisplay.cpp
@@ -1550,8 +1550,8 @@ void NoteColumnRenderer::DrawPrimitives()
 	// lists to the displays to draw.
 	// The vector in the NUM_PlayerNumber slot should stay empty, not worth
 	// optimizing it out. -Kyz
-	std::vector<std::vector<NoteData::TrackMap::const_iterator> > holds(PLAYER_INVALID+1);
-	std::vector<std::vector<NoteData::TrackMap::const_iterator> > taps(PLAYER_INVALID+1);
+	std::vector<std::vector<NoteData::TrackMap::const_iterator> > holds(4);
+	std::vector<std::vector<NoteData::TrackMap::const_iterator> > taps(4);
 	NoteData::TrackMap::const_iterator begin, end;
 	m_field_render_args->note_data->GetTapNoteRangeInclusive(m_column,
 		m_field_render_args->first_row, m_field_render_args->last_row+1, begin, end);

--- a/src/NoteDisplay.h
+++ b/src/NoteDisplay.h
@@ -291,7 +291,7 @@ private:
 
 struct NoteColumnRenderer : public Actor
 {
-	NoteDisplay* m_displays[PLAYER_INVALID+1];
+	NoteDisplay* m_displays[4];
 	NoteFieldRenderArgs* m_field_render_args;
 	NoteColumnRenderArgs m_column_render_args;
 	int m_column;

--- a/src/PlayerNumber.h
+++ b/src/PlayerNumber.h
@@ -73,7 +73,7 @@ LuaDeclareType( MultiPlayer );
 /*
  * (c) 2001-2004 Chris Danford, Chris Gomez
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -83,7 +83,7 @@ LuaDeclareType( MultiPlayer );
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -1321,7 +1321,7 @@ PlayerOptions::Accel PlayerOptions::GetFirstAccel()
 	for( int i=0; i<NUM_ACCELS; i++ )
 		if( m_fAccels[i] == 1.f )
 			return (Accel)i;
-	return (Accel)-1;
+	return ACCEL_INVALID;
 }
 
 PlayerOptions::Effect PlayerOptions::GetFirstEffect()
@@ -1329,7 +1329,7 @@ PlayerOptions::Effect PlayerOptions::GetFirstEffect()
 	for( int i=0; i<NUM_EFFECTS; i++ )
 		if( m_fEffects[i] == 1.f )
 			return (Effect)i;
-	return (Effect)-1;
+	return EFFECT_INVALID;
 }
 
 PlayerOptions::Appearance PlayerOptions::GetFirstAppearance()
@@ -1337,7 +1337,7 @@ PlayerOptions::Appearance PlayerOptions::GetFirstAppearance()
 	for( int i=0; i<NUM_APPEARANCES; i++ )
 		if( m_fAppearances[i] == 1.f )
 			return (Appearance)i;
-	return (Appearance)-1;
+	return APPEARANCE_INVALID;
 }
 
 PlayerOptions::Scroll PlayerOptions::GetFirstScroll()
@@ -1345,7 +1345,7 @@ PlayerOptions::Scroll PlayerOptions::GetFirstScroll()
 	for( int i=0; i<NUM_SCROLLS; i++ )
 		if( m_fScrolls[i] == 1.f )
 			return (Scroll)i;
-	return (Scroll)-1;
+	return SCROLL_INVALID;
 }
 
 void PlayerOptions::SetOneAccel( Accel a )

--- a/src/PlayerOptions.h
+++ b/src/PlayerOptions.h
@@ -148,7 +148,8 @@ public:
 		ACCEL_TAN_EXPAND,
 		ACCEL_TAN_EXPAND_PERIOD,
 		ACCEL_BOOMERANG, /**< The arrows start from above the targets, go down, then come back up. */
-		NUM_ACCELS
+		NUM_ACCELS,
+		ACCEL_INVALID
 	};
 	enum Effect	{
 		EFFECT_DRUNK,
@@ -273,7 +274,8 @@ public:
 		EFFECT_XMODE,
 		EFFECT_TWIRL,
 		EFFECT_ROLL,
-		NUM_EFFECTS
+		NUM_EFFECTS,
+		EFFECT_INVALID
 	};
 	/** @brief The various appearance mods. */
 	enum Appearance {
@@ -284,7 +286,8 @@ public:
 		APPEARANCE_STEALTH, /**< The arrows are not shown at all. */
 		APPEARANCE_BLINK, /**< The arrows blink constantly. */
 		APPEARANCE_RANDOMVANISH, /**< The arrows disappear, and then reappear in a different column. */
-		NUM_APPEARANCES
+		NUM_APPEARANCES,
+		APPEARANCE_INVALID
 	};
 	/** @brief The various turn mods. */
 	enum Turn {
@@ -299,7 +302,8 @@ public:
 		TURN_SOFT_SHUFFLE, /**< Only shuffle arrow columns on an axis of symmetry. */
 		TURN_SUPER_SHUFFLE, /**< Every arrow is placed on a random column. */
 		TURN_HYPER_SHUFFLE, /**< Every arrow is placed on a random column, but more fairly than SuperShuffle. */
-		NUM_TURNS
+		NUM_TURNS,
+		TURN_INVALID
 	};
 	enum Transform {
 		TRANSFORM_NOHOLDS,
@@ -325,7 +329,8 @@ public:
 		TRANSFORM_NOFAKES,
 		TRANSFORM_NOQUADS,
 		TRANSFORM_NOSTRETCH,
-		NUM_TRANSFORMS
+		NUM_TRANSFORMS,
+		TRANSFORM_INVALID
 	};
 	enum Scroll {
 		SCROLL_REVERSE=0,
@@ -333,7 +338,8 @@ public:
 		SCROLL_ALTERNATE,
 		SCROLL_CROSS,
 		SCROLL_CENTERED,
-		NUM_SCROLLS
+		NUM_SCROLLS,
+		SCROLL_INVALID
 	};
 
 	float GetReversePercentForColumn( int iCol ) const; // accounts for all Directions

--- a/src/RageFileBasic.cpp
+++ b/src/RageFileBasic.cpp
@@ -341,7 +341,11 @@ int RageFileObj::GetLine( RString &sOut )
 		bool bDone = false;
 
 		/* Find the end of the block we'll move to out. */
-		char *p = (char *) memchr( m_pReadBuf, '\n', m_iReadBufAvail );
+		char *p = nullptr;
+		if (m_pReadBuf && m_iReadBufAvail)
+		{
+			p = (char *) memchr( m_pReadBuf, '\n', m_iReadBufAvail );
+		}
 		bool bReAddCR = false;
 		if( p == nullptr )
 		{
@@ -481,4 +485,3 @@ void RageFileObj::ResetReadBuf()
  * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  * PERFORMANCE OF THIS SOFTWARE.
  */
-

--- a/src/ScreenOptions.h
+++ b/src/ScreenOptions.h
@@ -29,7 +29,7 @@ InputMode StringToInputMode( const RString& str );
 
 /** @brief A custom foreach loop for the player options for each player. */
 #define FOREACH_OptionsPlayer( pn ) \
-	for( PlayerNumber pn=GetNextHumanPlayer((PlayerNumber)-1); \
+	for( PlayerNumber pn=GAMESTATE->GetFirstHumanPlayer(); \
 	pn!=PLAYER_INVALID && (m_InputMode==INPUTMODE_INDIVIDUAL || pn==0); \
 	pn=GetNextHumanPlayer(pn) )
 

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -867,6 +867,8 @@ int sm_main(int argc, char* argv[])
 	HOOKS->Init();
 
 	LUA		= new LuaManager;
+	GAMEMAN		= new GameManager;
+	LUA -> RegisterTypes();
 	HOOKS->RegisterWithLua();
 
 	// Initialize the file extension type lists so everything can ask ActorUtil
@@ -949,7 +951,6 @@ int sm_main(int argc, char* argv[])
 
 	AdjustForChangedSystemCapabilities();
 
-	GAMEMAN		= new GameManager;
 	THEME		= new ThemeManager;
 	ANNOUNCER	= new AnnouncerManager;
 	NOTESKIN	= new NoteSkinManager;

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -78,7 +78,7 @@ static int FindCompatibleAVFormat( bool bHighColor )
 	return -1;
 }
 
-RageSurface *RageMovieTextureDriver_FFMpeg::AVCodecCreateCompatibleSurface( int iTextureWidth, int iTextureHeight, bool bPreferHighColor, int &iAVTexfmt, MovieDecoderPixelFormatYCbCr &fmtout )
+RageSurface *RageMovieTextureDriver_FFMpeg::AVCodecCreateCompatibleSurface( int iTextureWidth, int iTextureHeight, bool bPreferHighColor, avcodec::AVPixelFormat* AVTexfmt, MovieDecoderPixelFormatYCbCr &fmtout )
 {
 	FixLilEndian();
 
@@ -97,11 +97,11 @@ RageSurface *RageMovieTextureDriver_FFMpeg::AVCodecCreateCompatibleSurface( int 
 	}
 
 	const AVPixelFormat_t *pfd = &AVPixelFormats[iAVTexfmtIndex];
-	iAVTexfmt = pfd->pf;
+	*AVTexfmt = pfd->pf;
 	fmtout = pfd->YUV;
 
-	LOG->Trace( "Texture pixel format: %i %i (%ibpp, %08x %08x %08x %08x)", iAVTexfmt, fmtout,
-		pfd->bpp, pfd->masks[0], pfd->masks[1], pfd->masks[2], pfd->masks[3] );
+	LOG->Trace( "Texture pixel format: %i %i (%ibpp, %08x %08x %08x %08x)", static_cast<int>(*AVTexfmt), fmtout,
+		pfd->bpp, pfd->masks[0], pfd->masks[1], pfd->masks[2], pfd->masks[3] );  // TODO this is wrong for enum. use underlying_type?
 
 	if( pfd->YUV == PixelFormatYCbCr_YUYV422 )
 		iTextureWidth /= 2;
@@ -698,7 +698,7 @@ void MovieDecoder_FFMpeg::Rewind()
 
 RageSurface *MovieDecoder_FFMpeg::CreateCompatibleSurface( int iTextureWidth, int iTextureHeight, bool bPreferHighColor, MovieDecoderPixelFormatYCbCr &fmtout )
 {
-	return RageMovieTextureDriver_FFMpeg::AVCodecCreateCompatibleSurface( iTextureWidth, iTextureHeight, bPreferHighColor, *ConvertValue<int>(&m_AVTexfmt), fmtout );
+	return RageMovieTextureDriver_FFMpeg::AVCodecCreateCompatibleSurface( iTextureWidth, iTextureHeight, bPreferHighColor, &m_AVTexfmt, fmtout );
 }
 
 MovieTexture_FFMpeg::MovieTexture_FFMpeg( RageTextureID ID ):

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -50,14 +50,14 @@ class MovieTexture_FFMpeg: public MovieTexture_Generic
 public:
 	MovieTexture_FFMpeg( RageTextureID ID );
 
-	static RageSurface *AVCodecCreateCompatibleSurface( int iTextureWidth, int iTextureHeight, bool bPreferHighColor, int &iAVTexfmt, MovieDecoderPixelFormatYCbCr &fmtout );
+	static RageSurface *AVCodecCreateCompatibleSurface( int iTextureWidth, int iTextureHeight, bool bPreferHighColor, avcodec::AVPixelFormat* AVTexfmt, MovieDecoderPixelFormatYCbCr &fmtout );
 };
 
 class RageMovieTextureDriver_FFMpeg: public RageMovieTextureDriver
 {
 public:
 	virtual RageMovieTexture *Create( RageTextureID ID, RString &sError );
-	static RageSurface *AVCodecCreateCompatibleSurface( int iTextureWidth, int iTextureHeight, bool bPreferHighColor, int &iAVTexfmt, MovieDecoderPixelFormatYCbCr &fmtout );
+	static RageSurface *AVCodecCreateCompatibleSurface( int iTextureWidth, int iTextureHeight, bool bPreferHighColor, avcodec::AVPixelFormat* AVTexfmt, MovieDecoderPixelFormatYCbCr &fmtout );
 };
 
 class MovieDecoder_FFMpeg: public MovieDecoder

--- a/src/archutils/Unix/Backtrace.cpp
+++ b/src/archutils/Unix/Backtrace.cpp
@@ -372,7 +372,7 @@ static void do_backtrace( const void **buf, std::size_t size, const BacktraceCon
 				buf[i++] = *p;
 
 			/* The frame pointer is invalid.  Just move forward one word. */
-			frame = (StackFrame *) (((char *)frame)+4);
+			frame = (StackFrame *) (((char *)frame)+sizeof(void*));
 			continue;
 		}
 


### PR DESCRIPTION
This is an ongoing thing, the changes were made on the go to just resolve the crashes while trying to play the game with UBSan. It should be in a playable state at the moment. But requires a lot of cleanup.

Funny thing: one of the code paths triggers UBSan on GCC because of the bug in the compiler itself, because it generates code that reads from an uninitialized register. Clang works as expected, so it should be used at the moment for testing.

- A lot of problems come from using enums for arithmetic, while the underlying types for them are entirely up to the compiler to decide. For example we've had some (Enum)-1s (causing UB when compiler uses unsigned type) and (NUM_Enum+1)s (which is just undefined, because we're only guaranteed to express all the enumerated values).
- There's some kind of race in lua and gamemanager init but I haven't gotten to the bottom if it yet (it's related to registering enums for lua), just moved the stuff around to not crash anymore under ubsan.
- Found some uninitialized variables
- Some counters overflow unsigned types which is also an undefined behavior
- crash handler for linux assumed offset of 4, which resulted in dereferencing at unaligned addresses, also causing crashes while handling crashes ;)

This should be split into smaller patches but I'd like to keep a common place to discuss ideas about how to fix stuff while also keeping it playable under UBSan.