### PR TITLE
Consume background thread in ffmpeg movie decoding

### DIFF
--- a/src/Banner.cpp
+++ b/src/Banner.cpp
@@ -43,7 +43,6 @@ void Banner::Load( RageTextureID ID, bool bIsBanner )
 	m_bScrolling = false;
 
 	TEXTUREMAN->DisableOddDimensionWarning();
-	TEXTUREMAN->VolatileTexture( ID );
 	Sprite::Load( ID );
 	TEXTUREMAN->EnableOddDimensionWarning();
 };

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -70,7 +70,9 @@ public:
 	void Close();
 	void Rewind();
 
-	void GetFrame( RageSurface *pOut );
+	// This draws a frame from the buffer onto the provided RageSurface.
+	// Returns true if returning the last frame in the movie.
+	bool GetFrame(RageSurface* pOut);
 	int DecodeFrame( float fTargetTime );
 
 	// Decode a single frame.  Return -2 on cancel, -1 on error, 0 on EOF, 1 if we have a frame.

--- a/src/arch/MovieTexture/MovieTexture_Generic.h
+++ b/src/arch/MovieTexture/MovieTexture_Generic.h
@@ -4,6 +4,7 @@
 #include "MovieTexture.h"
 
 #include <cstdint>
+#include <thread>
 
 class FFMpeg_Helper;
 struct RageSurface;
@@ -51,7 +52,7 @@ public:
 	/*
 	 * Get the currently-decoded frame.
 	 */
-	virtual void GetFrame( RageSurface *pOut ) = 0;
+	virtual bool GetFrame( RageSurface *pOut ) = 0;
 
 	/* Return the dimensions of the image, in pixels (before aspect ratio
 	 * adjustments). */
@@ -117,12 +118,17 @@ public:
 private:
 	MovieDecoder *m_pDecoder;
 
+	std::unique_ptr<std::thread> decoding_thread;
+
 	float m_fRate;
 	enum {
 		FRAME_NONE, /* no frame available; call GetFrame to get one */
 		FRAME_DECODED /* frame decoded; waiting until it's time to display it */
 	} m_ImageWaiting;
 	bool m_bLoop;
+
+	// If true, halts all decoding and display.
+	bool m_failure = false;
 	bool m_bWantRewind;
 
 	enum State { DECODER_QUIT, DECODER_RUNNING } m_State;


### PR DESCRIPTION
This switches the default behavior of ffmpeg movie decoder to use the new buffer decoding code in a new thread. The `MovieTexture` instantiates the background decoding thread in `Init()`, and then consumes the buffer during display.

In practice, the game will keep several banners in memory based on how `FadingBanner.cpp` operates, though (on my machine) after 5 banners it will begin unloading the oldest. The biggest improvement in performance is seen when a video banner is playing at the same time as a BGMovie (like when step statistics are enabled).

This also removes a call to `VolatileTexture` in `Banner.cpp`, which was extraneous before, causing unneeded banner reloads.

See,
* #361 for full context
* #378 for previous part

(Review the latest commit to see the overall diff between this and the prior part)