### PR TITLE
[low priority] Make PulseAudio the preferred Linux audio driver

### DIFF
--- a/src/arch/arch_default.h
+++ b/src/arch/arch_default.h
@@ -39,14 +39,15 @@
 #define DEFAULT_INPUT_DRIVER_LIST "X11"
 #endif
 #define DEFAULT_MOVIE_DRIVER_LIST "FFMpeg,Null"
-// ALSA comes first, as the system may have OSS compat but we don't want to use
-// it if it's actually an ALSA wrapper.
+// PulseAudio is the preferred Unix driver since it allows the gives non
+// exclusive access to the audio device, unlike ALSA.
+// Use ALSA next because it is the lowest latency.
 // Then try OSS before daemon drivers so we're going direct instead of
 // unwittingly starting a daemon.
-// JACK gives us an explicit option to NOT start a daemon, so try it third,
+// JACK gives us an explicit option to NOT start a daemon, so try it last,
 // as PulseAudio will successfully Init() but not actually work if the
 // PulseAudio daemon has been suspended by/for jackd.
-#define DEFAULT_SOUND_DRIVER_LIST "ALSA-sw,OSS,JACK,Pulse,Null"
+#define DEFAULT_SOUND_DRIVER_LIST "Pulse,ALSA-sw,OSS,JACK,Null"
 #else
 #error Which arch?
 #endif


### PR DESCRIPTION
I didn't realize PulseAudio wasn't the preferred audio driver for Linux. It should be because of the work recently done to it, and because times have changed since the default driver list and its accompanying comment were written, and at this point in time, it's much more likely that Linux users will be using a distribution that has PulseAudio pre-installed and preferred as the default audio handler.