### PR TITLE
Getter function to protect underruns variable in RageSoundDriver_Generic_Software.cpp

### DIFF
--- a/src/arch/Sound/RageSoundDriver.h
+++ b/src/arch/Sound/RageSoundDriver.h
@@ -58,7 +58,9 @@ public:
 	 * been completely flushed (so GetPosition is no longer meaningful), call
 	 * RageSoundBase::SoundIsFinishedPlaying(). */
 
-
+	/* Exists to protect the value of underruns from being modified by another
+	 * thread unexpectedly.  */
+	static int GetUnderruns();
 
 	/* Optional, if needed:  */
 	virtual void Update();

--- a/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
@@ -26,6 +26,11 @@ RageSoundDriver::Sound::Sound()
 	m_bPaused = false;
 }
 
+int RageSoundDriver::GetUnderruns()
+{
+    return underruns;
+}
+
 void RageSoundDriver::Sound::Allocate( int iFrames )
 {
 	/* Reserve enough blocks in the buffer to hold the buffer.  Add one, to account for
@@ -296,7 +301,7 @@ void RageSoundDriver::Update()
 	if( RageTimer::GetTimeSinceStart() >= fNext )
 	{
 		/* Lockless: only Mix() can write to underruns. */
-		int current_underruns = underruns;
+		int current_underruns = RageSoundDriver::GetUnderruns();
 		if( current_underruns > logged_underruns )
 		{
 			LOG->MapLog( "GenericMixingUnderruns", "Mixing underruns: %i", current_underruns - logged_underruns );


### PR DESCRIPTION
The variable `underruns` is shared by two functions within this source file.

I tried making it an atomic int, but performance was negatively impacted too significantly by making that change, so I've added a getter function to help add some safety to the usage of this variable.

The only function modifying the variable is `&RageSoundDriver::MixIntoBuffer`, so this improves safety if `RageSoundDriver::Update()` is trying to access `underruns` while `MixIntoBuffer` is modifying it.