### PR TITLE
Bring <atomic> into RageTimer.cpp

### DIFF
--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -29,13 +29,14 @@
 
 #include <cmath>
 #include <cstdint>
+#include <atomic>
 
 const std::uint64_t ONE_SECOND_IN_MICROSECONDS_ULL = 1000000ULL;
 const std::int64_t ONE_SECOND_IN_MICROSECONDS_LL = 1000000LL;
 const double ONE_SECOND_IN_MICROSECONDS_DBL = 1000000.0;
 
 const RageTimer RageZeroTimer(0,0);
-static std::uint64_t g_iStartTime = ArchHooks::GetMicrosecondsSinceStart( true );
+static std::atomic<std::uint64_t> g_iStartTime = ArchHooks::GetMicrosecondsSinceStart(true);
 
 static std::uint64_t GetTime( bool /* bAccurate */ )
 {
@@ -53,13 +54,13 @@ static std::uint64_t GetTime( bool /* bAccurate */ )
 double RageTimer::GetTimeSinceStart(bool bAccurate)
 {
 	std::uint64_t usecs = GetTime(bAccurate);
-	usecs -= g_iStartTime;
+	usecs -= g_iStartTime.load();
 	return usecs / ONE_SECOND_IN_MICROSECONDS_DBL;
 }
 
 std::uint64_t RageTimer::GetUsecsSinceStart()
 {
-	return GetTime(true) - g_iStartTime;
+	return GetTime(true) - g_iStartTime.load();
 }
 
 void RageTimer::Touch()


### PR DESCRIPTION
### Apologies or making a new PR out of this, but I messed it up trying to merge beta changes into the original PR.

### Here is where the old PR left off:

> If this is always g_iGlobalStartTime, and we never actually modify g_iGlobalStartTime or g_iThreadStartTime, do we even need the thread-local variable?

_Originally posted by @teejusb in https://github.com/itgmania/itgmania/pull/389#discussion_r1706257091_
            

> There would not be any point to the PR without the existence of the thread local variable.
> 
> This is very based on theory since it's almost impossible to properly measure.
> 
> In theory, each thread has to wait for the other to finish calling `GetTimeSinceStart()` before it can do so. This would result in very small but unpredictable/unmeasurable delays in the `GetTimeSinceStart()` call.
>
>At any given time during a song you have 3 threads going which want `RageTimer::GetTimeSinceStart()` access. The idea here is that, with the thread-local variable, we can prevent race conditions caused by different threads trying to access the start time variable.

_Originally posted by @sukibaby in https://github.com/itgmania/itgmania/pull/389#discussion_r1706433697_
            