### PR TITLE
⚠️(0.7.1) Remove timer from NoteField::DrawPrimitives(), replace with counter-based method to calculate an oscillating glow

### DIFF
--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -867,7 +867,15 @@ void NoteField::DrawPrimitives()
 		ASSERT(GAMESTATE->m_pCurSong != nullptr);
 
 		const TimingData &timing = *pTiming;
-		const RageColor text_glow= RageColor(1,1,1,std::cos(RageTimer::GetTimeSinceStartFast()*2)/2+0.5f);
+
+		// Create an oscillating / pulsing glow effect.
+		// Converts a counter to radians and uses the cosine for a cyclic appearance.
+		static std::uint_fast16_t iGlowCounter;
+		static constexpr float fCyclical = 2.0f * 3.14159265f / 360.0f;
+		iGlowCounter = (iGlowCounter + 1) % 360;
+		float phase = iGlowCounter * fCyclical;
+		float glow = std::cos(phase) * 0.5f + 0.5f;
+		const RageColor text_glow = RageColor(1.0f, 1.0f, 1.0f, glow);
 
 		float horiz_align= align_right;
 		float side_sign= 1;


### PR DESCRIPTION
Currently, NoteField calls GetTimeSinceStart in a loop to provide a cyclic source of data for the text_glow variable in DrawPrimitives().

I've replaced it with a function that uses a simple counter to provide the same effect, and to take that burden off of the system timer.

As you can see, it's indiscernible from the current method which calls GetTimeSinceStart in a loop. The first clip is the existing code, and the second clip is with the code of this PR.

https://github.com/user-attachments/assets/b87763b1-cc39-45ea-98ca-2aa8c42c69b7


https://github.com/user-attachments/assets/d12bd232-db39-4966-830c-6c0341df72ce

