### PR TITLE
⚠️(0.7.1) Optimized pos_map_backlog_frames value

### DIFF
--- a/src/RageSoundPosMap.cpp
+++ b/src/RageSoundPosMap.cpp
@@ -9,12 +9,12 @@
 #include <cstdint>
 #include <list>
 
-// The number of frames we should keep pos_map data for.
-// This comes out to about ~800kb in audio frames, assuming 44.1khz.
-// File bitrate, metadata, etc will factor in here. If the queue is
-// TOO big it will make things slow, but 200k frames is no problem.
-// Making the queue larger than 200k hasn't been tested extensively.
-const int pos_map_backlog_frames = 200000;
+// NOTE(sukibaby): The number of frames we should keep pos_map data for.
+// File bitrate, metadata, etc will factor in here. 80k is a safe value
+// to provide a good balance of stability and low latency. It is stable
+// up to 200k, but increased latency is the main reason not to increase
+// this to a very large number. 
+static int pos_map_backlog_frames = 80000;
 
 struct pos_map_t
 {
@@ -165,11 +165,9 @@ std::int64_t pos_map_queue::Search( std::int64_t iSourceFrame, bool *bApproximat
 	if( last.PeekDeltaTime() >= 1.0f )
 	{
 		last.Touch();
-		LOG->Trace("Audio frame was out of range of the data sent - possible buffer underflow? This is not always an error, however if you see it frequently there could be sound buffer problems.");
+		LOG->Trace("Audio frame (%lld) was out of range of the data sent - possible buffer underflow? This is not always an error, however if you see it frequently there could be sound buffer problems.", iSourceFrame);
 	}
 
-	if( bApproximate )
-		*bApproximate = true;
 	return iClosestPosition;
 }
 


### PR DESCRIPTION
I chose the value of 200000 currently used in 0.9.0 because, at the time, the underlying causes of "audio frame out of range" issues were not fully known yet. 

To ensure a fresh stream of timing data, and to keep the posmap as fast as it can be, we should lower this again.

I went down to 80000 instead of 100000 because I profiled this value as low as 50000 and found "audio frame out of range" errors drop off at ~60000. 80000 is a middle ground between that value and the traditionally used value of 100000, so that's why I picked that number. 

The short version of it is that with a properly working audio backend, 200000 introduces extra latency compared to what's needed.