### PR TITLE
Remove libGLU.so.1 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ You can choose between using the installer or using the portable build. Using th
 
 * **Debian-based**:
 
-  * `sudo apt install libgdk-pixbuf-2.0-0 libgl1 libglu1-mesa libglvnd0 libgtk-3-0 libusb-0.1-4 libxinerama1 libxtst6`
+  * `sudo apt install libgdk-pixbuf-2.0-0 libgl1 libglvnd0 libgtk-3-0 libusb-0.1-4 libxinerama1 libxtst6`
 
 * **Fedora-based**:
 
-  * `sudo yum install gdk-pixbuf2 mesa-libGLU gtk3 libusb-compat-0.1 libXinerama libXtst`
+  * `sudo yum install gdk-pixbuf2 gtk3 libusb-compat-0.1 libXinerama libXtst`
 
 *  **Arch Linux**:
 
@@ -56,7 +56,7 @@ You can choose between using the installer or using the portable build. Using th
 
 * **OpenSUSE**:
 
-   * `sudo zypper install libGLU1`
+   * OpenSUSE comes with everything you need pre-installed.
 
 
 ### Build From Source


### PR DESCRIPTION
`gluGetString`, `gluBuild2DMipmaps`, and `gluErrorString` are all functions from the GLU library, which is not part of OpenGL.

An added benefit would be, with this change, OpenSUSE would be able to run the game out-of-the-box GNOME or KDE install,  as for release 0.9.0 on OpenSUSE the only dependency the user needs to install is libGLU1.

This works because I can remove the libGLU devel package and build the game.

Sorry about the extra pushes, I realized I should update the README accordingly. I would not intend to touch the `ci.yml` until after this is merged, if it is.