### PR TITLE
Migrate to universal build for macOS

### DIFF
--- a/Utils/build-release-macos.sh
+++ b/Utils/build-release-macos.sh
@@ -3,14 +3,10 @@ set -eux
 
 cd "$(dirname $0)/.."
 
-cmake -B Build/release-arm64 -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_CLUB_FANTASTIC=On
-cmake --build Build/release-arm64 -j $(sysctl -n hw.logicalcpu)
-cmake --build Build/release-arm64 --target package
-cmake -B Build/release-arm64 -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_CLUB_FANTASTIC=Off
-cmake --build Build/release-arm64 --target package
+cmake -B Build/release-universal -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DWITH_CLUB_FANTASTIC=On
+cmake --build Build/release-universal -j $(sysctl -n hw.logicalcpu)
+cmake --build Build/release-universal --target package
 
-cmake -B Build/release-x86_64 -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_CLUB_FANTASTIC=On
-cmake --build Build/release-x86_64 -j $(sysctl -n hw.logicalcpu)
-cmake --build Build/release-x86_64 --target package
-cmake -B Build/release-x86_64 -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_CLUB_FANTASTIC=Off
-cmake --build Build/release-x86_64 --target package
+cmake -B Build/release-universal -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DWITH_CLUB_FANTASTIC=Off
+cmake --build Build/release-universal -j $(sysctl -n hw.logicalcpu)
+cmake --build Build/release-universal --target package


### PR DESCRIPTION
This changes the build script to instruct cmake to generate a universal release, instead of separate executables for ARM64 and x86_64.

edit: I don't think the original script is actually using the value of cpu cores for all builds. I've added that line to the 2nd build as well to make sure it's used there. The original commit https://github.com/itgmania/itgmania/commit/2cb4881c1e78e2a27c242489836e357479306d1a is more like how the original script is structured.