### PR TITLE
Allow frames that didn't decode to skip.

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -30,6 +30,7 @@ struct FrameHolder {
 	float frameTimestamp;
 	float frameDelay;
 	bool decoded = false;
+	bool skip = false;
 	std::mutex lock; // Protects the frame as it's being initialized.
 
 	FrameHolder() = default;
@@ -42,6 +43,7 @@ struct FrameHolder {
 		frameTimestamp = fh.frameTimestamp;
 		frameDelay = fh.frameDelay;
 		decoded = fh.decoded;
+		skip = fh.skip;
 	}
 };
 
@@ -101,6 +103,9 @@ public:
 	float GetFrameDuration() const;
 
 	void Cancel() { cancel = true; };
+
+	// If the next frame to display had an issue decoding, skip it.
+	bool SkipNextFrame();
 
 private:
 	void Init();

--- a/src/arch/MovieTexture/MovieTexture_Generic.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Generic.cpp
@@ -407,6 +407,10 @@ void MovieTexture_Generic::UpdateFrame()
 	/* Just in case we were invalidated: */
 	CreateTexture();
 
+	if (m_pDecoder->SkipNextFrame()) {
+		return;
+	}
+
 	if(m_pTextureLock != nullptr)
 	{
 		std::uintptr_t iHandle = m_pTextureIntermediate != nullptr ? m_pTextureIntermediate->GetTexHandle(): this->GetTexHandle();

--- a/src/arch/MovieTexture/MovieTexture_Generic.h
+++ b/src/arch/MovieTexture/MovieTexture_Generic.h
@@ -54,6 +54,9 @@ public:
 	 */
 	virtual bool GetFrame( RageSurface *pOut ) = 0;
 
+	// Returns true if the frame should be skipped.
+	virtual bool SkipNextFrame() = 0;
+
 	/* Return the dimensions of the image, in pixels (before aspect ratio
 	 * adjustments). */
 	virtual int GetWidth() const  = 0;


### PR DESCRIPTION
Not all decoding errors need to be fatal. There are a few packets that can fall through the `DecodePacketInBuffer` while loop, and thus are never marked as decoded. Instead, since the code is unsure if the frame is properly displayable, flip a boolean so that display skips the frame.

Without this change, a few bad frames can halt the display. This bug was found while playing Damonisch from ForcedNature's OTOGE FUSION (https://zenius-i-vanisher.com/v5.2/viewsimfilecategory.php?categoryid=1497)