### PR TITLE
⚠️(0.7.1) Removing bApproximate (part 1)

### DIFF
--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -39,8 +39,6 @@
 #include <cmath>
 #include <cstdint>
 
-#define samplerate() m_pSource->GetSampleRate()
-
 RageSoundParams::RageSoundParams():
 	m_StartSecond(0), m_LengthSeconds(-1), m_fFadeInSeconds(0),
 	m_fFadeOutSeconds(0), m_Volume(1.0f), m_fAttractVolume(1.0f),
@@ -331,7 +329,7 @@ void RageSound::StartPlaying()
 	ASSERT( !m_bPlaying );
 
 	// Move to the start position.
-	SetPositionFrames( static_cast<int>((m_Param.m_StartSecond * samplerate())) + 0.5 );
+	SetPositionFrames(static_cast<int>(m_Param.m_StartSecond * m_pSource->GetSampleRate() + 0.5));
 
 	/* If m_StartTime is in the past, then we probably set a start time but took too
 	 * long loading.  We don't want that; log it, since it can be unobvious. */
@@ -385,10 +383,10 @@ void RageSound::SoundIsFinishedPlaying()
 		return;
 	}
 
-	/* Lock the mutex after calling SOUNDMAN->GetPosition().  We must not make driver
-	 * calls with our mutex locked (driver mutex < sound mutex). */
-	if( !m_HardwareToStreamMap.IsEmpty() && !m_StreamToSourceMap.IsEmpty() )
-		m_iStoppedSourceFrame = (int) GetSourceFrameFromHardwareFrame( iCurrentHardwareFrame );
+	// Update the stopped source frame using the current hardware frame,
+	// but only if the hardware-to-stream and stream-to-source maps are not empty
+	if (!m_HardwareToStreamMap.IsEmpty() && !m_StreamToSourceMap.IsEmpty())
+		m_iStoppedSourceFrame = static_cast<int>(GetSourceFrameFromHardwareFrame(iCurrentHardwareFrame));
 
 //	LOG->Trace("set playing false for %p (SoundIsFinishedPlaying) (%s)", this, this->GetLoadedFilePath().c_str());
 	m_bPlaying = false;
@@ -480,14 +478,11 @@ int RageSound::GetSourceFrameFromHardwareFrame( std::int64_t iHardwareFrame, boo
 	if( m_HardwareToStreamMap.IsEmpty() || m_StreamToSourceMap.IsEmpty() )
 		return 0;
 
-	bool bApprox;
-	std::int64_t iStreamFrame = m_HardwareToStreamMap.Search( iHardwareFrame, &bApprox );
-	if( bApproximate && bApprox )
-		*bApproximate = true;
-	std::int64_t iSourceFrame = m_StreamToSourceMap.Search( iStreamFrame, &bApprox );
-	if( bApproximate && bApprox )
-		*bApproximate = true;
-	return (int) iSourceFrame;
+	// TODO(sukibaby): The nullptrs passed to the functions below are part of a gradual
+	// procedure to remove bApproximate from the code base. Until it's fully removed,
+	// this will remain nullptr for now. In the future, these nullptr's should be removed.
+	std::int64_t iStreamFrame = m_HardwareToStreamMap.Search( iHardwareFrame, nullptr );
+	return static_cast<int>(m_StreamToSourceMap.Search( iStreamFrame, nullptr ));
 }
 
 /* If non-nullptr, approximate is set to true if the returned time is approximated because of
@@ -499,33 +494,28 @@ int RageSound::GetSourceFrameFromHardwareFrame( std::int64_t iHardwareFrame, boo
  */
 float RageSound::GetPositionSeconds( bool *bApproximate, RageTimer *pTimestamp ) const
 {
-	/* Get our current hardware position. */
-	std::int64_t iCurrentHardwareFrame = SOUNDMAN->GetPosition( pTimestamp );
+	// Get our current hardware position.
+	std::int64_t iCurrentHardwareFrame = SOUNDMAN->GetPosition(pTimestamp);
 
-	/* Lock the mutex after calling SOUNDMAN->GetPosition().  We must not make driver
-	 * calls with our mutex locked (driver mutex < sound mutex). */
-	LockMut( m_Mutex );
+	// Lock the mutex after calling SOUNDMAN->GetPosition().
+	LockMut(m_Mutex);
 
-	if( bApproximate )
-		*bApproximate = false;
+	// cast the sample rate to be used for the remainder of the function.
+	float fSampleRate = static_cast<float>(m_pSource->GetSampleRate());
 
 	/* If we're not playing, just report the static position. */
-	float sampleRate = static_cast<float>(samplerate());
 	if( !IsPlaying() )
-		return m_iStoppedSourceFrame / sampleRate;
+		return static_cast<float>(m_iStoppedSourceFrame) / fSampleRate;
 
 	/* If we don't yet have any position data, CommitPlayingPosition hasn't yet been called at all,
 	 * so guess what we think the real time is. */
 	if( m_HardwareToStreamMap.IsEmpty() || m_StreamToSourceMap.IsEmpty() )
 	{
-		// LOG->Trace( "no data yet; %i", m_iStoppedSourceFrame );
-		if( bApproximate )
-			*bApproximate = true;
-		return m_iStoppedSourceFrame / sampleRate;
+		return static_cast<float>(m_iStoppedSourceFrame) / fSampleRate;
 	}
 
 	int iSourceFrame = GetSourceFrameFromHardwareFrame( iCurrentHardwareFrame, bApproximate );
-	return iSourceFrame / sampleRate;
+	return static_cast<float>(iSourceFrame) / fSampleRate;
 }
 
 

--- a/src/RageSoundPosMap.cpp
+++ b/src/RageSoundPosMap.cpp
@@ -110,13 +110,8 @@ void pos_map_impl::Cleanup()
 
 std::int64_t pos_map_queue::Search( std::int64_t iSourceFrame, bool *bApproximate ) const
 {
-	if( bApproximate )
-		*bApproximate = false;
-
 	if( IsEmpty() )
 	{
-		if( bApproximate )
-			*bApproximate = true;
 		return 0;
 	}
 
@@ -168,8 +163,6 @@ std::int64_t pos_map_queue::Search( std::int64_t iSourceFrame, bool *bApproximat
 		LOG->Trace("Audio frame was out of range of the data sent - possible buffer underflow? This is not always an error, however if you see it frequently there could be sound buffer problems.");
 	}
 
-	if( bApproximate )
-		*bApproximate = true;
 	return iClosestPosition;
 }
 


### PR DESCRIPTION
**bApproximate** is left over from long ago when the method to retrieve the system time might be 32-bit-only or require correction (if a 32-bit integer wraps, etc). We don't need it now that microsecond precision is available on all platforms.

https://github.com/itgmania/itgmania/blob/5d4f9dcb07493ed4c51d6be23e9b41978162305a/src/arch/ArchHooks/ArchHooks.h#L79-L80
https://github.com/itgmania/itgmania/blob/5d4f9dcb07493ed4c51d6be23e9b41978162305a/src/arch/ArchHooks/ArchHooks.h#L86-L88

It is already commented out of several sections of the sm5.1 base code. It hasn't been used in RageTimer for a long time, for example:

https://github.com/itgmania/itgmania/blob/5d4f9dcb07493ed4c51d6be23e9b41978162305a/src/RageTimer.cpp#L38-L41

It can't be removed all at once just by deleting every instance of bApproximate, because it often refers to non-obvious pointers that go elsewhere. so, this is the first part of a multi-stage removal process.

Additional notes: some C-style casts are updated to static cast here, and a calculation which should not happen while mutexed is moved outside of the scope of the mutex.