### PR TITLE
Remove DeleteSelfWhenFinishedPlaying(), implement direct deletion of finished sounds

### DIFF
--- a/src/GameSoundManager.cpp
+++ b/src/GameSoundManager.cpp
@@ -286,7 +286,8 @@ static void DoPlayOnce( RString sPath )
 	pSound->Load( sPath, false );
 
 	pSound->Play(false);
-	pSound->DeleteSelfWhenFinishedPlaying();
+	if( !pSound->IsPlaying() )
+		delete pSound;
 }
 
 static void DoPlayOnceFromDir( RString sPath )


### PR DESCRIPTION
This is a finished patch, but I've made it a draft because I'd welcome further scrutinization of this change.

I've found it to be a performance deficit during profiling, so I'm removing the function and opting to directly and immediately delete the sound.

I had no errors playing for a couple hours with this patch, so I don't think there's any risk of sounds trying to be accessed after they've been deleted, but I'd like to confirm that it's safe and doesn't affect sync.

After that, the logical next step is probably to implement `std::shared_ptr` or `std::unique_ptr` in `RageSound` objects and the `MusicPlaying` struct so that the lifetime of each object is automatically managed.
