### PR TITLE
Define RSTRING_SUCCESS global constant

### DIFF
--- a/src/AnnouncerManager.cpp
+++ b/src/AnnouncerManager.cpp
@@ -142,7 +142,7 @@ RString AnnouncerManager::GetPathTo( RString sAnnouncerName, RString sFolderName
 	temp.Open( AnnouncerPath+sFolderName + "/announcer files go here.txt", RageFile::WRITE );
 #endif
 
-	return RString();
+	return RString(); // no announcer found or usable
 }
 
 RString AnnouncerManager::GetPathTo( RString sFolderName )

--- a/src/Character.cpp
+++ b/src/Character.cpp
@@ -80,7 +80,7 @@ RString GetRandomFileInDir( RString sDir )
 	std::vector<RString> asFiles;
 	GetDirListing( sDir, asFiles, false, true );
 	if( asFiles.empty() )
-		return RString();
+		return RString(); // empty rstring indicates no file was selected
 	else
 		return asFiles[RandomInt(asFiles.size())];
 }
@@ -91,7 +91,7 @@ RString Character::GetModelPath() const
 	if( DoesFileExist(s) )
 		return s;
 	else
-		return RString();
+		return RString(); // empty rstring indicates model.txt does not exist
 }
 
 RString Character::GetRestAnimationPath() const	{ return DerefRedir(GetRandomFileInDir(m_sCharDir + "Rest/")); }
@@ -106,7 +106,7 @@ RString Character::GetTakingABreakPath() const
 	GetDirListing( m_sCharDir+"break.gif", as, false, true );
 	GetDirListing( m_sCharDir+"break.bmp", as, false, true );
 	if( as.empty() )
-		return RString();
+		return RString(); // empty rstring indicates no file was selected
 	else
 		return as[0];
 }
@@ -131,7 +131,7 @@ RString Character::GetSongSelectIconPath() const
 		GetDirListing( m_sCharDir+"icon.gif", as, false, true );
 		GetDirListing( m_sCharDir+"icon.bmp", as, false, true );
 		if( as.empty() )
-			return RString();
+			return RString(); // empty rstring indicates no file was selected
 		else
 			return as[0];
 	}
@@ -159,7 +159,7 @@ RString Character::GetStageIconPath() const
 		GetDirListing( m_sCharDir+"card.gif", as, false, true );
 		GetDirListing( m_sCharDir+"card.bmp", as, false, true );
 		if( as.empty() )
-			return RString();
+			return RString(); // empty rstring indicates no file was selected
 		else
 			return as[0];
 	}

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -12,7 +12,7 @@
 RString Command::GetName() const
 {
 	if( m_vsArgs.empty() )
-		return RString();
+		return RSTRING_SUCCESS;
 	RString s = m_vsArgs[0];
 	Trim( s );
 	return s;

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -1120,7 +1120,7 @@ bool Course::CourseHasBestOrWorst() const
 RString Course::GetBannerPath() const
 {
 	if( m_sBannerPath.empty() )
-		return RString();
+		return RSTRING_SUCCESS;
 	if( m_sBannerPath[0] == '/' )
 		return m_sBannerPath;
 	return Dirname(m_sPath) + m_sBannerPath;
@@ -1129,7 +1129,7 @@ RString Course::GetBannerPath() const
 RString Course::GetBackgroundPath() const
 {
 	if( m_sBackgroundPath.empty() )
-		return RString();
+		return RSTRING_SUCCESS;
 	if( m_sBackgroundPath[0] == '/' )
 		return m_sBackgroundPath;
 	return Dirname(m_sPath) + m_sBackgroundPath;

--- a/src/CourseUtil.cpp
+++ b/src/CourseUtil.cpp
@@ -597,7 +597,7 @@ RString CourseID::ToString() const
 		return sPath;
 	if( !sFullTitle.empty() )
 		return sFullTitle;
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 bool CourseID::IsValid() const

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -699,7 +699,7 @@ RString FontPageSettings::MapRange( RString sMapping, int iMapOffset, int iGlyph
 			iCount--;
 		}
 
-		return RString();
+		return RSTRING_SUCCESS;
 	}
 
 	const wchar_t *pMapping = FontCharmaps::get_char_map( sMapping );
@@ -730,7 +730,7 @@ RString FontPageSettings::MapRange( RString sMapping, int iMapOffset, int iGlyph
 	if( iCount )
 		return "Map overflow"; // there aren't enough characters in the map
 
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 static std::vector<RString> LoadStack;

--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -168,7 +168,7 @@ namespace
 		SCREENMAN->SetNewScreen(newScreenName);
 
 		// Indicate no further theme change is needed
-		g_NewTheme = RString();
+		g_NewTheme = RSTRING_SUCCESS;
 	}
 
 	void DoChangeGame()
@@ -238,8 +238,8 @@ namespace
 		 * what it'd be. -aj */
 		THEME->UpdateLuaGlobals();
 		THEME->ReloadMetrics();
-		g_NewGame= RString();
-		g_NewTheme= RString();
+		g_NewGame= RSTRING_SUCCESS;
+		g_NewTheme= RSTRING_SUCCESS;
 	}
 }
 

--- a/src/RageDisplay.h
+++ b/src/RageDisplay.h
@@ -123,7 +123,7 @@ public:
 					bpp(0), rate(0), vsync(false), interlaced(false),
 					bSmoothLines(false), bTrilinearFiltering(false),
 					bAnisotropicFiltering(false), bWindowIsFullscreenBorderless(false),
-					sWindowTitle(RString()), sIconFile(RString()),
+					sWindowTitle(RSTRING_SUCCESS), sIconFile(RSTRING_SUCCESS),
 					PAL(false), fDisplayAspectRatio(0.0f) {}
 
 	// Subclassing VideoModeParams in ActualVideoModeParams. Make destructor virtual just in case
@@ -362,7 +362,7 @@ public:
 	};
 	bool SaveScreenshot( RString sPath, GraphicsFileFormat format );
 
-	virtual RString GetTextureDiagnostics( std::uintptr_t /* id */ ) const { return RString(); }
+	virtual RString GetTextureDiagnostics( std::uintptr_t /* id */ ) const { return RSTRING_SUCCESS; }
 	virtual RageSurface* CreateScreenshot() = 0;	// allocates a surface.  Caller must delete it.
 	virtual RageSurface *GetTexture( std::uintptr_t /* iTexture */ ) { return nullptr; } // allocates a surface.  Caller must delete it.
 
@@ -377,7 +377,7 @@ protected:
 	virtual void DrawSymmetricQuadStripInternal( const RageSpriteVertex v[], int iNumVerts ) = 0;
 	virtual void DrawCircleInternal( const RageSpriteVertex &v, float radius );
 
-	// return RString() if mode change was successful, an error message otherwise.
+	// return RSTRING_SUCCESS if mode change was successful, an error message otherwise.
 	// bNewDeviceOut is set true if a new device was created and textures
 	// need to be reloaded.
 	virtual RString TryVideoMode( const VideoModeParams &p, bool &bNewDeviceOut ) = 0;

--- a/src/RageDisplay_D3D.cpp
+++ b/src/RageDisplay_D3D.cpp
@@ -394,7 +394,7 @@ RString SetD3DParams( bool &bNewDeviceOut )
 	// Palettes were lost by Reset(), so mark them unloaded.
 	g_TexResourceToPaletteIndex.clear();
 
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 // If the given parameters have failed, try to lower them.
@@ -556,7 +556,7 @@ RString RageDisplay_D3D::TryVideoMode( const VideoModeParams &_p, bool &bNewDevi
 
 	ResolutionChanged();
 
-	return RString(); // mode change successful
+	return RSTRING_SUCCESS; // mode change successful
 }
 
 void RageDisplay_D3D::ResolutionChanged()

--- a/src/RageDisplay_Null.cpp
+++ b/src/RageDisplay_Null.cpp
@@ -81,7 +81,7 @@ RString RageDisplay_Null::Init( const VideoModeParams &p, bool /* bAllowUnaccele
 {
 	bool bIgnore = false;
 	SetVideoMode( p, bIgnore );
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 void RageDisplay_Null::GetDisplaySpecs(DisplaySpecs &out) const

--- a/src/RageDisplay_Null.h
+++ b/src/RageDisplay_Null.h
@@ -79,7 +79,7 @@ protected:
 	void DrawSymmetricQuadStripInternal( const RageSpriteVertex v[], int /* iNumVerts */ ) { }
 
 	VideoModeParams m_Params;
-	RString TryVideoMode( const VideoModeParams &p, bool & /* bNewDeviceOut */ ) { m_Params = p; return RString(); }
+	RString TryVideoMode( const VideoModeParams &p, bool & /* bNewDeviceOut */ ) { m_Params = p; return RSTRING_SUCCESS; }
 	RageSurface* CreateScreenshot();
 	RageMatrix GetOrthoMatrix( float l, float r, float b, float t, float zn, float zf );
 	bool SupportsSurfaceFormat( RagePixelFormat ) { return true; }

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -562,7 +562,7 @@ RString RageDisplay_Legacy::Init( const VideoModeParams &p, bool bAllowUnacceler
 	glGetFloatv( GL_LINE_WIDTH_RANGE, g_line_range );
 	glGetFloatv( GL_POINT_SIZE_RANGE, g_point_range );
 
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 RageDisplay_Legacy::~RageDisplay_Legacy()
@@ -822,7 +822,7 @@ RString RageDisplay_Legacy::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 
 	ResolutionChanged();
 
-	return RString();	// successfully set mode
+	return RSTRING_SUCCESS;	// successfully set mode
 }
 
 int RageDisplay_Legacy::GetMaxTextureSize() const
@@ -2718,7 +2718,7 @@ RString RageDisplay_Legacy::GetTextureDiagnostics(std::uintptr_t iTexture) const
 			break;
 		}
 */
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 /*

--- a/src/RageFile.cpp
+++ b/src/RageFile.cpp
@@ -37,7 +37,7 @@ RageFile *RageFile::Copy() const
 RString RageFile::GetPath() const
 {
 	if ( !IsOpen() )
-		return RString();
+		return RSTRING_SUCCESS;
 
 	RString sRet = m_File->GetDisplayPath();
 	if( sRet != "" )
@@ -233,7 +233,7 @@ void FileReading::ReadBytes( RageFileBasic &f, void *buf, int size, RString &sEr
 RString FileReading::ReadString( RageFileBasic &f, int size, RString &sError )
 {
 	if( sError.size() != 0 )
-		return RString();
+		return RSTRING_SUCCESS;
 
 	RString sBuf;
 	int ret = f.Read( sBuf, size );

--- a/src/ScreenMessage.cpp
+++ b/src/ScreenMessage.cpp
@@ -36,7 +36,7 @@ RString	ScreenMessageHelpers::ScreenMessageToString( ScreenMessage SM )
 		if( SM == it.second )
 			return it.first;
 
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 /*

--- a/src/ScreenOptionsManageProfiles.cpp
+++ b/src/ScreenOptionsManageProfiles.cpp
@@ -503,7 +503,7 @@ RString ScreenOptionsManageProfiles::GetLocalProfileIDWithFocus() const
 {
 	int iIndex = GetLocalProfileIndexWithFocus();
 	if( iIndex == -1 )
-		return RString();
+		return RSTRING_SUCCESS;
 	return m_vsLocalProfileID[iIndex];
 }
 

--- a/src/ScreenSystemLayer.cpp
+++ b/src/ScreenSystemLayer.cpp
@@ -127,7 +127,7 @@ namespace
 				// Probably something like "Please Wait" or "Cannot Join"? -freem
 			}
 		}
-		return RString();
+		return RSTRING_SUCCESS;
 	}
 
 };

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -949,7 +949,7 @@ RString ThemeManager::GetMetricsGroupFallback( const RString &sMetricsGroup )
 	// always look in iniMetrics for "Fallback"
 	RString sFallback;
 	if( !GetMetricRawRecursive(g_pLoadedThemeData->iniMetrics,sMetricsGroup,"Fallback",sFallback) )
-		return RString();
+		return RSTRING_SUCCESS;
 
 	Lua *L = LUA->Get();
 	LuaHelpers::RunExpression( L, sFallback );
@@ -1034,7 +1034,7 @@ RString ThemeManager::GetMetricRaw( const IniFile &ini, const RString &sMetricsG
 					"could not be found in \"%s\" or \"%s\".",
 					sCurMetricPath.c_str(),
 					sDefaultMetricPath.c_str() );
-				return RString();
+				return RSTRING_SUCCESS;
 			default:
 				FAIL_M("Unexpected answer to Abort/Retry/Ignore dialog");
 		}
@@ -1271,7 +1271,7 @@ RString ThemeManager::GetString( const RString &sMetricsGroup, const RString &sV
 			if( pos == s.npos )
 			{
 				sTranslated += PseudoLocalize( s );
-				s = RString();
+				s = RSTRING_SUCCESS;
 				break;
 			}
 			else

--- a/src/arch/LowLevelWindow/LowLevelWindow_Win32.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_Win32.cpp
@@ -262,7 +262,7 @@ RString LowLevelWindow_Win32::TryVideoMode( const VideoModeParams &p, bool &bNew
 			return hr_ssprintf( err, "wglCreateContext" );
 		}
 	}
-	return RString();	// we set the video mode successfully
+	return RSTRING_SUCCESS;
 }
 
 bool LowLevelWindow_Win32::SupportsThreadedRendering()

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -503,7 +503,7 @@ RString MovieDecoder_FFMpeg::Open( RString sFile )
 	}
 	LOG->Trace("Number of frames detected: %i", m_totalFrames);
 
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 RString MovieDecoder_FFMpeg::OpenCodec()
@@ -529,7 +529,7 @@ RString MovieDecoder_FFMpeg::OpenCodec()
 		return RString( averr_ssprintf(ret, "Couldn't open codec \"%s\"", pCodec->name) );
 	ASSERT( m_pStreamCodec->codec != nullptr );
 
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 void MovieDecoder_FFMpeg::Close()

--- a/src/arch/MovieTexture/MovieTexture_Generic.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Generic.cpp
@@ -76,7 +76,7 @@ RString MovieTexture_Generic::Init()
 
 	CHECKPOINT_M("Generic initialization completed. No errors found.");
 
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 MovieTexture_Generic::~MovieTexture_Generic()

--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -136,7 +136,7 @@ RString DSound::Init()
 
 	SetPrimaryBufferMode();
 
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 DSound::~DSound()
@@ -269,7 +269,7 @@ RString DSoundBuf::Init( DSound &ds, DSoundBuf::hw hardware,
 
 	m_pTempBuffer = new char[m_iBufferSize];
 
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 void DSoundBuf::SetSampleRate( int hz )

--- a/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
@@ -110,7 +110,7 @@ RString RageSoundDriver_DSound_Software::Init()
 	m_MixingThread.SetName("Mixer thread");
 	m_MixingThread.Create( MixerThread_start, this );
 
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 RageSoundDriver_DSound_Software::~RageSoundDriver_DSound_Software()

--- a/src/arch/Sound/RageSoundDriver_WDMKS.cpp
+++ b/src/arch/Sound/RageSoundDriver_WDMKS.cpp
@@ -1326,7 +1326,7 @@ RString RageSoundDriver_WDMKS::Init()
 	MixingThread.SetName( "Mixer thread" );
 	MixingThread.Create( MixerThread_start, this );
 
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 RageSoundDriver_WDMKS::~RageSoundDriver_WDMKS()

--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -182,7 +182,7 @@ RString RageSoundDriver_WaveOut::Init()
 	MixingThread.Create( MixerThread_start, this );
 
 	b_InitSuccess = true;
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 RageSoundDriver_WaveOut::~RageSoundDriver_WaveOut()

--- a/src/archutils/Win32/GetFileInformation.cpp
+++ b/src/archutils/Win32/GetFileInformation.cpp
@@ -84,7 +84,7 @@ RString FindSystemFile( RString sFile )
 			return sPath;
 	}
 
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 /* Get the full path of the process running in iProcessID. On error, false is

--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -229,7 +229,7 @@ RString GraphicsWindow::SetScreenMode( const VideoModeParams &p )
 		// We're going windowed. If we were previously fullscreen, reset.
 		ChangeDisplaySettings( nullptr, 0 );
 
-		return RString();
+		return RSTRING_SUCCESS;
 	}
 
 	DEVMODE DevMode;
@@ -259,7 +259,7 @@ RString GraphicsWindow::SetScreenMode( const VideoModeParams &p )
 		return "Couldn't set screen mode";
 
 	g_FullScreenDevMode = DevMode;
-	return RString();
+	return RSTRING_SUCCESS;
 }
 
 static int GetWindowStyle( bool bWindowed , bool bWindowIsFullscreenBorderless)

--- a/src/archutils/Win32/USB.cpp
+++ b/src/archutils/Win32/USB.cpp
@@ -30,7 +30,7 @@ static RString GetUSBDevicePath( int iNum )
 		nullptr, &guid, iNum, &DeviceInterface) )
 	{
 		SetupDiDestroyDeviceInfoList( DeviceInfo );
-		return RString();
+		return RSTRING_SUCCESS;
 	}
 
 	unsigned long iSize;

--- a/src/global.h
+++ b/src/global.h
@@ -107,7 +107,7 @@ void ShowWarningOrTrace( const char *file, int line, const char *message, bool b
 typedef StdString::CStdString RString;
 
 #include "RageException.h"
-
+const RString RSTRING_SUCCESS = RString();
 /* Don't include our own headers here, since they tend to change often. */
 
 #endif


### PR DESCRIPTION
It isn't immediately obvious that an empty RString is used throughout the codebase to indicate success, so this constant makes its purpose more clear. The purpose of the empty RString is documented in very few places, so unless you happen to find one of them, it's not at all clear what the empty RString is doing.