### PR TITLE
Revert "Migrate to universal build for macOS"

### DIFF
--- a/Utils/build-release-macos.sh
+++ b/Utils/build-release-macos.sh
@@ -3,10 +3,14 @@ set -eux
 
 cd "$(dirname $0)/.."
 
-cmake -B Build/release-universal -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DWITH_CLUB_FANTASTIC=On
-cmake --build Build/release-universal -j $(sysctl -n hw.logicalcpu)
-cmake --build Build/release-universal --target package
+cmake -B Build/release-arm64 -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_CLUB_FANTASTIC=On
+cmake --build Build/release-arm64 -j $(sysctl -n hw.logicalcpu)
+cmake --build Build/release-arm64 --target package
+cmake -B Build/release-arm64 -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_CLUB_FANTASTIC=Off
+cmake --build Build/release-arm64 --target package
 
-cmake -B Build/release-universal -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DWITH_CLUB_FANTASTIC=Off
-cmake --build Build/release-universal -j $(sysctl -n hw.logicalcpu)
-cmake --build Build/release-universal --target package
+cmake -B Build/release-x86_64 -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_CLUB_FANTASTIC=On
+cmake --build Build/release-x86_64 -j $(sysctl -n hw.logicalcpu)
+cmake --build Build/release-x86_64 --target package
+cmake -B Build/release-x86_64 -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_CLUB_FANTASTIC=Off
+cmake --build Build/release-x86_64 --target package


### PR DESCRIPTION
Reverts itgmania/itgmania#406

This build method doesn't seem to work for ffmpeg, see the pipeline results where I tried to use it: https://github.com/florczakraf/itgmania/actions/runs/10355501236/job/28663288286#step:5:117

```
CMake Error at CMake/SetupFfmpeg.cmake:45 (message):
-- Configuring incomplete, errors occurred!
  Unsupported macOS architecture: arm64;x86_64, set CMAKE_OSX_ARCHITECTURES
  to either arm64 or x86_64
Call Stack (most recent call first):
  StepmaniaCore.cmake:212 (include)
  CMakeLists.txt:5 (include)
```