### PR TITLE
Parallel github workflow builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
           libxtst-dev
           nasm
       - name: Configure
-        run: cmake -B build
+        run: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
       - name: Build
-        run: cmake --build build
+        run: cmake --build build --parallel "$(nproc)"
 
   macos-build-arm64:
     name: macOS (M1)
@@ -46,9 +46,9 @@ jobs:
         run: brew install
           nasm
       - name: Configure
-        run: cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64
+        run: cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
       - name: Build
-        run: cmake --build build
+        run: cmake --build build --parallel "$(sysctl -n hw.logicalcpu)"
 
   macos-build-x86_64:
     name: macOS (Intel)
@@ -61,9 +61,9 @@ jobs:
         run: brew install
           nasm
       - name: Configure
-        run: cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64
+        run: cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
       - name: Build
-        run: cmake --build build
+        run: cmake --build build --parallel "$(sysctl -n hw.logicalcpu)"
 
   windows-build:
     name: Windows
@@ -73,9 +73,9 @@ jobs:
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Configure
-        run: cmake -B build
+        run: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
       - name: Build
-        run: cmake --build build
+        run: cmake --build build --parallel "$env:NUMBER_OF_PROCESSORS"
 
   validate-xml-docs:
     name: Validate Lua.xml, LuaDocumentation.xml


### PR DESCRIPTION
We can save a lot of server resources by using built-in parallel build options. As a side-effect, we also have a quicker failure feedback turnaround by at least 5 minutes -- we're still dominated by macOS x86_64 build.

There's definitely some variation in the times because we use public shared virtualized infra, but we save roughly 20 minutes of machine time per commit.

### before
![image](https://github.com/user-attachments/assets/d7aa21c5-9f27-44b2-9a06-0749af680732)
![image](https://github.com/user-attachments/assets/db43459d-eb59-45ea-890c-0d9fa441de4e)


### after
![image](https://github.com/user-attachments/assets/1afbcff6-573c-4c1a-8ef9-0f699396e5ed)
![image](https://github.com/user-attachments/assets/dd7e62bf-d111-4288-8409-739d5bc326d4)
![image](https://github.com/user-attachments/assets/95281042-b15d-48b7-88c0-bab16008a70b)
