### PR TITLE
I closed this to fix it and then squashed while it was closed so i can't reopen it :(

### DIFF
--- a/src/RageSound.h
+++ b/src/RageSound.h
@@ -175,9 +175,13 @@ private:
 
 	RString m_sError;
 
-	int GetSourceFrameFromHardwareFrame( std::int64_t iHardwareFrame, bool *bApproximate = nullptr ) const;
+	std::int_fast32_t CalculateFrames(float startSecond, int sampleRate)
+	{
+		return static_cast<std::int_fast32_t>(startSecond * sampleRate + 0.5f);
+	}
 
-	bool SetPositionFrames( int frames = -1 );
+	int GetSourceFrameFromHardwareFrame( std::int64_t iHardwareFrame, bool *bApproximate = nullptr ) const;
+	bool SetPositionFrames( float startSecond, int sampleRate );
 	RageSoundParams::StopMode_t GetStopMode() const; // resolves M_AUTO
 
 	void SoundIsFinishedPlaying(); // called by sound drivers


### PR DESCRIPTION
_(Closed and reopened to fix a small bit of code which compiled fine in VS 2022 and Xcode but not Linux GCC)_

Currently, the calculation of the audio frame position is being split between StartPlaying and SetPositionFrames. This PR aims to delegate that job to a dedicated function for that purpose, thereby following the single responsibility principle.

Slight changes were made to the existing functions in order to pass the values to `CalculateFrames`.

Other small performance enhancements are applied, as speed is crucial but the exact data type used is not. This consists of replacing several internally-used `int`'s with `std::int_fast32_t`, so the compiler can choose the fastest data type that can store at least the size needed. A macro (`samplerate()`) is also undefined to allow the compiler to further optimize.