### PR TITLE
New function to determine audio frame position 

### DIFF
--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -39,8 +39,6 @@
 #include <cmath>
 #include <cstdint>
 
-#define samplerate() m_pSource->GetSampleRate()
-
 RageSoundParams::RageSoundParams():
 	m_StartSecond(0), m_LengthSeconds(-1), m_fFadeInSeconds(0),
 	m_fFadeOutSeconds(0), m_Volume(1.0f), m_fAttractVolume(1.0f),
@@ -272,9 +270,8 @@ int RageSound::GetDataToPlay( float *pBuffer, int iFrames, std::int64_t &iStream
 {
 	/* We only update m_iStreamFrame; only take a shared lock, so we don't block the main thread. */
 //	LockMut(m_Mutex);
-
-	ASSERT_M( m_bPlaying, ssprintf("%p", static_cast<void*>(this)) );
-	ASSERT( m_pSource != nullptr );
+	ASSERT_M(m_bPlaying, ssprintf("%p", static_cast<void*>(this)));
+	ASSERT(m_pSource != nullptr);
 
 	iFramesStored = 0;
 	iStreamFrame = m_iStreamFrame;
@@ -302,9 +299,13 @@ int RageSound::GetDataToPlay( float *pBuffer, int iFrames, std::int64_t &iStream
 				break;
 		}
 
-		m_Mutex.Lock();
-		m_StreamToSourceMap.Insert( m_iStreamFrame, iGotFrames, iSourceFrame, fRate );
-		m_Mutex.Unlock();
+		/* A scope is used here for exception safety.
+		 * It ensures the mutex is properly managed. */
+		{
+			m_Mutex.Lock();
+			m_StreamToSourceMap.Insert(m_iStreamFrame, iGotFrames, iSourceFrame, fRate);
+			m_Mutex.Unlock();
+		}
 
 		m_iStreamFrame += iGotFrames;
 
@@ -331,7 +332,7 @@ void RageSound::StartPlaying()
 	ASSERT( !m_bPlaying );
 
 	// Move to the start position.
-	SetPositionFrames( static_cast<int>((m_Param.m_StartSecond * samplerate())) + 0.5 );
+	SetPositionFrames( m_Param.m_StartSecond, m_pSource->GetSampleRate() );
 
 	/* If m_StartTime is in the past, then we probably set a start time but took too
 	 * long loading.  We don't want that; log it, since it can be unobvious. */
@@ -487,7 +488,7 @@ int RageSound::GetSourceFrameFromHardwareFrame( std::int64_t iHardwareFrame, boo
 	std::int64_t iSourceFrame = m_StreamToSourceMap.Search( iStreamFrame, &bApprox );
 	if( bApproximate && bApprox )
 		*bApproximate = true;
-	return (int) iSourceFrame;
+	return static_cast<int>(iSourceFrame);
 }
 
 /* If non-nullptr, approximate is set to true if the returned time is approximated because of
@@ -510,7 +511,7 @@ float RageSound::GetPositionSeconds( bool *bApproximate, RageTimer *pTimestamp )
 		*bApproximate = false;
 
 	/* If we're not playing, just report the static position. */
-	float sampleRate = static_cast<float>(samplerate());
+	float sampleRate = static_cast<float>(m_pSource->GetSampleRate());
 	if( !IsPlaying() )
 		return m_iStoppedSourceFrame / sampleRate;
 
@@ -528,18 +529,18 @@ float RageSound::GetPositionSeconds( bool *bApproximate, RageTimer *pTimestamp )
 	return iSourceFrame / sampleRate;
 }
 
-
-bool RageSound::SetPositionFrames( int iFrames )
+bool RageSound::SetPositionFrames(float startSecond, int sampleRate)
 {
-	LockMut( m_Mutex );
+    std::int_fast32_t iFrames = CalculateFrames(startSecond, sampleRate);
+	LockMut(m_Mutex);
 
 	if( m_pSource == nullptr )
 	{
-		LOG->Warn( "RageSound::SetPositionFrames(%d): sound not loaded", iFrames );
+		LOG->Warn( "RageSound::SetPositionFrames(%ld): sound not loaded", iFrames );
 		return false;
 	}
 
-	int iRet = m_pSource->SetPosition( iFrames );
+	std::int_fast32_t iRet = m_pSource->SetPosition( iFrames );
 	RString filePath = GetLoadedFilePath();
 	if( iRet == -1 )
 	{
@@ -549,12 +550,11 @@ bool RageSound::SetPositionFrames( int iFrames )
 	else if( iRet == 0 )
 	{
 		/* Seeked past EOF. */
-		LOG->Warn( "SetPositionFrames: %i samples is beyond EOF in %s",
-			iFrames, filePath.c_str() );
+		LOG->Warn("SetPositionFrames: %ld samples is beyond EOF in %s", iFrames, filePath.c_str());
 	}
 	else
 	{
-		m_iStoppedSourceFrame = iFrames;
+		m_iStoppedSourceFrame = static_cast<int>(iFrames);
 	}
 
 	return iRet == 1;

--- a/src/RageSound.h
+++ b/src/RageSound.h
@@ -176,11 +176,15 @@ private:
 	RString m_sError;
 
 	int GetSourceFrameFromHardwareFrame( std::int64_t iHardwareFrame, bool *bApproximate = nullptr ) const;
-
-	bool SetPositionFrames( int frames = -1 );
+	bool SetPositionFrames( float startSecond, int sampleRate );
 	RageSoundParams::StopMode_t GetStopMode() const; // resolves M_AUTO
 
 	void SoundIsFinishedPlaying(); // called by sound drivers
+	
+	static inline std::int_fast32_t CalculateFrames(float startSecond, int sampleRate)
+	{
+		return static_cast<std::int_fast32_t>(startSecond * sampleRate + 0.5f);
+	}
 
 public:
 	// These functions are called only by sound drivers.


### PR DESCRIPTION
8/16/2024 - squashed, no other changes.

### Overview

1) Undefine samplerate macro

2) Create a dedicated function for the purpose of calculating the audio frame position, instead of having that calculation be split between StartPlaying and SetPositionFrames, neither of which should be partially calculating the current position alongside its main job

3) Change some interally-used int to int_fast32_t so the compiler can choose the most efficient datatype to use on whatever given platform.

### More details

Currently, the calculation of the audio frame position is being split between `StartPlaying` and `SetPositionFrames`. This PR aims to delegate that job to a dedicated function for that purpose, thereby following the single responsibility principle.

Slight changes were made to the existing functions in order to pass the values to `CalculateFrames`.

Other small performance enhancements are applied, as speed is crucial but the exact data type used is not. This consists of replacing several internally-used `int`'s with `std::int_fast32_t`, so the compiler can choose the fastest data type that can store at least the size needed. A macro (`samplerate()`) is also undefined to allow the compiler to further optimize.