### PR TITLE
Use an unordered_map to uniquely ID input devices

### DIFF
--- a/src/RageInputDevice.cpp
+++ b/src/RageInputDevice.cpp
@@ -5,6 +5,32 @@
 #include "RageInputDevice.h"
 #include "RageUtil.h"
 #include "LocalizedString.h"
+#include <unordered_map>
+#include <string>
+#include <mutex>
+
+std::unordered_map<std::string, int> dev_id_map;
+int next_unique_id = 1;
+std::mutex dev_id_mutex;
+
+int device_id_handler(const std::string& itg_device_persistent_id)
+{
+    std::lock_guard<std::mutex> lock(dev_id_mutex);
+    std::unordered_map<std::string, int>::iterator it = dev_id_map.find(itg_device_persistent_id);
+    if (it != dev_id_map.end())
+    {
+        return it->second;
+    }
+    else
+    {
+        int new_id = next_unique_id++;
+        dev_id_map[itg_device_persistent_id] = new_id;
+        return new_id;
+    }
+}
+
+//DeviceInput::DeviceInput(InputDevice dev, DeviceButton btn, const std::string& itg_device_persistent_id)
+//    : device(dev), button(btn), unique_id(device_id_handler(itg_device_persistent_id)), level(0), z(0), b_down(false), ts(RageZeroTimer) {}
 
 static const char *InputDeviceStateNames[] = {
 	"Connected",

--- a/src/RageInputDevice.cpp
+++ b/src/RageInputDevice.cpp
@@ -29,9 +29,6 @@ int device_id_handler(const std::string& itg_device_persistent_id)
     }
 }
 
-//DeviceInput::DeviceInput(InputDevice dev, DeviceButton btn, const std::string& itg_device_persistent_id)
-//    : device(dev), button(btn), unique_id(device_id_handler(itg_device_persistent_id)), level(0), z(0), b_down(false), ts(RageZeroTimer) {}
-
 static const char *InputDeviceStateNames[] = {
 	"Connected",
 	"Unplugged",

--- a/src/RageInputDevice.h
+++ b/src/RageInputDevice.h
@@ -315,11 +315,14 @@ enum DeviceButton
 RString DeviceButtonToString( DeviceButton i );
 DeviceButton StringToDeviceButton( const RString& s );
 
+int device_id_handler(const std::string& itg_device_persistent_id);
+
 struct DeviceInput
 {
 public:
 	InputDevice device;
 	DeviceButton button;
+	int uniqueID;
 
 	/* This is usually 0 or 1. Analog joystick inputs can set this to a percentage
 	 * (0..1). This should be 0 for analog axes within the dead zone. */
@@ -335,19 +338,20 @@ public:
 	bool bDown;
 
 	RageTimer ts;
+	
+	DeviceInput(InputDevice dev, DeviceButton btn, const std::string& itgDevicePersistentID)
+		: device(dev), button(btn), uniqueID(device_id_handler(itgDevicePersistentID)), level(0), z(0), bDown(false), ts(RageZeroTimer) {}
 
-	DeviceInput(): device(InputDevice_Invalid), button(DeviceButton_Invalid), level(0), z(0), bDown(false), ts(RageZeroTimer) { }
-	DeviceInput( InputDevice d, DeviceButton b, float l=0 ): device(d), button(b), level(l), z(0), bDown(l > 0.5f), ts(RageZeroTimer) { }
-	DeviceInput( InputDevice d, DeviceButton b, float l, const RageTimer &t ):
-		device(d), button(b), level(l), z(0), bDown(level > 0.5f), ts(t) { }
-	DeviceInput( InputDevice d, DeviceButton b, const RageTimer &t, int zVal=0 ):
-		device(d), button(b), level(0), z(zVal), bDown(false), ts(t) { }
+	DeviceInput(): device(InputDevice_Invalid), button(DeviceButton_Invalid), uniqueID(-1), level(0), z(0), bDown(false), ts(RageZeroTimer) {}
+	DeviceInput(InputDevice d, DeviceButton b, float l=0): device(d), button(b), uniqueID(-1), level(l), z(0), bDown(l > 0.5f), ts(RageZeroTimer) {}
+	DeviceInput(InputDevice d, DeviceButton b, float l, const RageTimer &t): device(d), button(b), uniqueID(-1), level(l), z(0), bDown(level > 0.5f), ts(t) {}
+	DeviceInput(InputDevice d, DeviceButton b, const RageTimer &t, int zVal=0): device(d), button(b), uniqueID(-1), level(0), z(zVal), bDown(false), ts(t) {}
 
 	RString ToString() const;
-	bool FromString( const RString &s );
+	bool FromString(const RString &s);
 
-	bool IsValid() const { return device != InputDevice_Invalid; };
-	void MakeInvalid() { device = InputDevice_Invalid; };
+	bool IsValid() const { return device != InputDevice_Invalid; }
+	void MakeInvalid() { device = InputDevice_Invalid; }
 
 	bool IsJoystick() const { return ::IsJoystick(device); }
 	bool IsMouse() const { return ::IsMouse(device); }

--- a/src/arch/InputHandler/InputHandler.cpp
+++ b/src/arch/InputHandler/InputHandler.cpp
@@ -128,8 +128,6 @@ RString InputHandler::GetDeviceSpecificInputString( const DeviceInput &di )
 	if( di.device == InputDevice_Invalid )
 		return RString();
 
-    RString deviceString = InputDeviceToString(di.device) + " (ID: " + std::to_string(di.uniqueID) + ")";
-
 	if( di.device == DEVICE_KEYBOARD )
 	{
 		if( di.button >= KEY_KP_C0 && di.button <= KEY_KP_ENTER )

--- a/src/arch/InputHandler/InputHandler.cpp
+++ b/src/arch/InputHandler/InputHandler.cpp
@@ -36,7 +36,7 @@ void InputHandler::ButtonPressed( DeviceInput di )
 		 * a timestamp are counted; if the driver provides its own timestamps, UpdateTimer is
 		 * optional.
 		 */
-		LOG->Warn( "InputHandler::ButtonPressed: Driver sent many updates without calling UpdateTimer" );
+		LOG->Warn( "InputHandler::ButtonPressed: Driver sent many updates without calling UpdateTimer. Device ID: %d", di.uniqueID );
 		FAIL_M("x");
 	}
 }
@@ -128,6 +128,8 @@ RString InputHandler::GetDeviceSpecificInputString( const DeviceInput &di )
 	if( di.device == InputDevice_Invalid )
 		return RString();
 
+    RString deviceString = InputDeviceToString(di.device) + " (ID: " + std::to_string(di.uniqueID) + ")";
+
 	if( di.device == DEVICE_KEYBOARD )
 	{
 		if( di.button >= KEY_KP_C0 && di.button <= KEY_KP_ENTER )
@@ -144,30 +146,35 @@ RString InputHandler::GetDeviceSpecificInputString( const DeviceInput &di )
 	return s;
 }
 
-RString InputHandler::GetLocalizedInputString( const DeviceInput &di )
+RString InputHandler::GetLocalizedInputString(const DeviceInput &di)
 {
-	switch( di.button )
+	RString localizedString;
+
+	switch (di.button)
 	{
-	case KEY_HOME:		return HOME.GetValue();
-	case KEY_END:		return END.GetValue();
-	case KEY_UP:		return UP.GetValue();
-	case KEY_DOWN:		return DOWN.GetValue();
-	case KEY_SPACE:	return SPACE.GetValue();
-	case KEY_LSHIFT:	case KEY_RSHIFT:	return SHIFT.GetValue();
-	case KEY_LCTRL:	case KEY_RCTRL:	return CTRL.GetValue();
-	case KEY_LALT:		case KEY_RALT:		return ALT.GetValue();
-	case KEY_INSERT:	return INSERT.GetValue();
-	case KEY_DEL:		return DEL.GetValue();
-	case KEY_PGUP:		return PGUP.GetValue();
-	case KEY_PGDN:		return PGDN.GetValue();
-	case KEY_BACKSLASH:	return BACKSLASH.GetValue();
+	case KEY_HOME: localizedString = HOME.GetValue(); break;
+	case KEY_END: localizedString = END.GetValue(); break;
+	case KEY_UP: localizedString = UP.GetValue(); break;
+	case KEY_DOWN: localizedString = DOWN.GetValue(); break;
+	case KEY_SPACE: localizedString = SPACE.GetValue(); break;
+	case KEY_LSHIFT: case KEY_RSHIFT: localizedString = SHIFT.GetValue(); break;
+	case KEY_LCTRL: case KEY_RCTRL: localizedString = CTRL.GetValue(); break;
+	case KEY_LALT: case KEY_RALT: localizedString = ALT.GetValue(); break;
+	case KEY_INSERT: localizedString = INSERT.GetValue(); break;
+	case KEY_DEL: localizedString = DEL.GetValue(); break;
+	case KEY_PGUP: localizedString = PGUP.GetValue(); break;
+	case KEY_PGDN: localizedString = PGDN.GetValue(); break;
+	case KEY_BACKSLASH: localizedString = BACKSLASH.GetValue(); break;
 	default:
 		wchar_t c = DeviceButtonToChar( di.button, false );
 		if( c && c != L' ' ) // Don't show "Key  " for space.
-			return Capitalize( WStringToRString(std::wstring()+c) );
-
-		return DeviceButtonToString( di.button );
+			localizedString = Capitalize(WStringToRString(std::wstring() + c));
+		else
+			localizedString = DeviceButtonToString(di.button);
+		break;
 	}
+
+	return localizedString + " (ID: " + std::to_string(di.uniqueID) + ")";
 }
 
 DriverList InputHandler::m_pDriverList;


### PR DESCRIPTION
This aims to help out with devices which might disconnect/reconnect in game. It prevents devices previously seen during the lifetime of the game from being re-initialized on reconnection.  For example people complain about the USB-C momentarily coming loose from the SMX stage.

This doesn't affect XInput controllers (which is only something like an xbox 360 controller) as that uses a different system but for most input devices on Windows this will get the job done.  It requires testing on other OS's.

I tried starting a game with my pad, stepping off and setting it to autoplay, unplugging the pad, waiting ~15 seconds (so the game loop timer to check for a new USB device had time to cycle) and plugged it back in to a different USB port. There was no stutter or indication the game processed a new device,  and I could keep playing as expected. The same thing also worked with a keyboard and a LTEK.