### PR TITLE
Two small MovieTexture_FFMpeg.cpp fixes

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -166,7 +166,7 @@ float MovieDecoder_FFMpeg::GetTimestamp() const
 	}
 
 	// In a logical situation, this means that display is outpacing decoding.
-	if (m_iFrameNumber >= m_FrameBuffer.size()) {
+	if (m_iFrameNumber >= static_cast<int>(m_FrameBuffer.size())) {
 		return 0;
 	}
 	return m_FrameBuffer[m_iFrameNumber].frameTimestamp;
@@ -174,7 +174,7 @@ float MovieDecoder_FFMpeg::GetTimestamp() const
 
 bool MovieDecoder_FFMpeg::IsCurrentFrameReady() {
 	// We're displaying faster than decoding. Do not even try to display the frame.
-	if (m_iFrameNumber >= m_FrameBuffer.size()) {
+	if (m_iFrameNumber >= static_cast<int>(m_FrameBuffer.size())) {
 		return false;
 	}
 	// If the whole movie is decoded, then the frame is definitely ready.

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -182,7 +182,7 @@ bool MovieDecoder_FFMpeg::IsCurrentFrameReady() {
 		return true;
 	}
 
-	std::lock_guard<std::mutex>(m_FrameBuffer[m_iFrameNumber].lock);
+	std::lock_guard<std::mutex> lock(m_FrameBuffer[m_iFrameNumber].lock);
 	if (m_FrameBuffer[m_iFrameNumber].skip) {
 		LOG->Info("Frame %i not decoded, skipping...", m_iFrameNumber);
 		return true;
@@ -197,7 +197,7 @@ int MovieDecoder_FFMpeg::DecodeNextFrame()
 {
 	// Add in a new FrameBuffer entry, and lock it immediately.
 	m_FrameBuffer.push_back(FrameHolder());
-	std::lock_guard<std::mutex>(m_FrameBuffer.back().lock);
+	std::lock_guard<std::mutex> lock(m_FrameBuffer.back().lock);
 	int status = SendPacketToBuffer();
 	if (status < 0) {
 		return status;


### PR DESCRIPTION
Just a minor thing which resulted in these compiler warning:

1. warning C4858: discarding return value: A lock should be stored in a variable to protect the scope. If you're intentionally constructing a temporary to protect the rest of the current expression using the comma operator, you can cast the temporary to void or define _SILENCE_NODISCARD_LOCK_WARNINGS to suppress this warning.
2. warning: comparison of integer expressions of different signedness: ‘const int’ and ‘std::vector<FrameHolder>::size_type’ {aka ‘long unsigned int’}