### PR TITLE
🔥Refactored StdString.h / Create StdString.cpp (1st step towards improving RStrings)🔥

### DIFF
--- a/src/CMakeData-globals.cmake
+++ b/src/CMakeData-globals.cmake
@@ -2,6 +2,7 @@ list(APPEND SMDATA_GLOBAL_FILES_SRC
             "GameLoop.cpp"
             "global.cpp"
             "SpecialFiles.cpp"
+            "StdString.cpp"
             "StepMania.cpp" # TODO: Refactor into separate main project.
             "${SM_GENERATED_SRC_DIR}/verstub.cpp")
 

--- a/src/CreateZip.cpp
+++ b/src/CreateZip.cpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <cstdarg>
 
 #if defined(_WIN32)
 #include <tchar.h>

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -21,6 +21,7 @@
 #include <map>
 #include <sstream> // conversion for lua functions.
 #include <vector>
+#include <cstdarg>
 
 LuaManager *LUA = nullptr;
 struct Impl

--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -8,6 +8,7 @@
 #include <ctime>
 #include <map>
 #include <vector>
+#include <cstdarg>
 
 #if defined(_WIN32)
 #include <windows.h>

--- a/src/RageSoundReader_Vorbisfile.cpp
+++ b/src/RageSoundReader_Vorbisfile.cpp
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <cstdarg>
 
 static std::size_t OggRageFile_read_func( void *ptr, std::size_t size, std::size_t nmemb, void *datasource )
 {

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -12,6 +12,7 @@
 #include <json/json.h>
 #include <pcre.h>
 
+#include <cstdarg>
 #include <cfloat>
 #include <cmath>
 #include <cstddef>

--- a/src/StdString.cpp
+++ b/src/StdString.cpp
@@ -1,0 +1,106 @@
+// I've reorganized StdString.h to be optimized for the ITGmania engine.
+// Performance issues with RStrings are largely mitigated by migrating
+// frequently used functions here. Aside from some added functions to handle
+// wstring/wchar's, and the added declaration of 'noexcept', everything here is
+// the same as it was when it was in the original header file.  -sukibaby
+
+#include "global.h"
+#include "StdString.h"
+
+namespace StdString
+{
+	void ssasn(std::string& sDst, const std::string& sSrc) noexcept
+	{
+		if (sDst.c_str() != sSrc.c_str())
+		{
+			sDst = sSrc;
+		}
+	}
+
+	void ssasn(std::wstring& sDst, const std::wstring& sSrc) noexcept
+	{
+		if (sDst.c_str() != sSrc.c_str())
+		{
+			sDst = sSrc;
+		}
+	}
+
+	void ssasn(std::string& sDst, PCSTR pA) noexcept
+	{
+		sDst = pA ? pA : "";
+	}
+
+	void ssasn(std::wstring& sDst, PCWSTR pA) noexcept
+	{
+		sDst = pA ? pA : L"";
+	}
+
+	void ssadd(std::string& sDst, const std::string& sSrc) noexcept
+	{
+		sDst += sSrc;
+	}
+
+	void ssadd(std::wstring& sDst, const std::wstring& sSrc) noexcept
+	{
+		sDst += sSrc;
+	}
+
+	void ssadd(std::string& sDst, PCSTR pA) noexcept
+	{
+		if (pA)
+		{
+			if (pA >= sDst.c_str() && pA <= sDst.c_str() + sDst.length())
+			{
+				if (sDst.capacity() <= sDst.size() + strlen(pA))
+					sDst.append(std::string(pA));
+				else
+					sDst.append(pA);
+			}
+			else
+			{
+				sDst.append(pA);
+			}
+		}
+	}
+
+	void ssadd(std::wstring& sDst, PCWSTR pA) noexcept
+	{
+		if (pA)
+		{
+			if (pA >= sDst.c_str() && pA <= sDst.c_str() + sDst.length())
+			{
+				if (sDst.capacity() <= sDst.size() + wcslen(pA))
+					sDst.append(std::wstring(pA));
+				else
+					sDst.append(pA);
+			}
+			else
+			{
+				sDst.append(pA);
+			}
+		}
+	}
+
+	char sstoupper(char ch) noexcept
+	{
+		return (ch >= 'a' && ch <= 'z') ? char(ch + 'A' - 'a') : ch;
+	}
+
+	char sstolower(char ch) noexcept
+	{
+		return (ch >= 'A' && ch <= 'Z') ? char(ch + 'a' - 'A') : ch;
+	}
+
+	wchar_t sstoupper(wchar_t ch) noexcept
+	{
+		return (ch >= L'a' && ch <= L'z') ? wchar_t(ch + L'A' - L'a') : ch;
+	}
+
+	wchar_t sstolower(wchar_t ch) noexcept
+	{
+		return (ch >= L'A' && ch <= L'Z') ? wchar_t(ch + L'a' - L'A') : ch;
+	}
+
+} // namespace StdString
+
+// see StdString.h for license

--- a/src/StdString.h
+++ b/src/StdString.h
@@ -1,3 +1,406 @@
+/*
+
+	StdString.h (for RString)
+	
+	I've optimized StdString.h (RString) for the ITGmania engine by reducing its
+	unneeded dependencies, and moving many functions into StdString.cpp.
+	
+	The original comments are located at the end of the file.
+	
+	2024 sukibaby
+	
+*/
+
+#if defined(_MSC_VER)
+	#pragma component(browser, off, references, "CStdString")
+	#pragma warning (push)
+	#pragma warning (disable : 4290) // C++ Exception Specification ignored
+	#pragma warning (disable : 4127) // Conditional expression is constant
+	#pragma warning (disable : 4097) // typedef name used as synonym for class name
+	#pragma warning (disable : 4512) // assignment operator could not be generated
+#endif
+
+#ifndef STDSTRING_H
+#define STDSTRING_H
+
+#include <string>
+#include <cstring>
+#include <algorithm>
+#include <cctype>
+
+typedef const char* PCSTR;
+typedef char* PSTR;
+typedef const wchar_t* PCWSTR;
+typedef wchar_t* PWSTR;
+
+/* In RageUtil: */
+void MakeUpper( char *p, std::size_t iLen );
+void MakeLower( char *p, std::size_t iLen );
+void MakeUpper( wchar_t *p, std::size_t iLen );
+void MakeLower( wchar_t *p, std::size_t iLen );
+
+namespace StdString
+{
+typedef std::string::size_type SS_SIZETYPE;
+typedef std::string::pointer SS_PTRTYPE;
+
+// Function declarations
+void ssasn(std::string& sDst, const std::string& sSrc) noexcept;
+void ssasn(std::wstring& sDst, const std::wstring& sSrc) noexcept;
+void ssasn(std::string& sDst, PCSTR pA) noexcept;
+void ssasn(std::wstring& sDst, PCWSTR pA) noexcept;
+void ssadd(std::string& sDst, const std::string& sSrc) noexcept;
+void ssadd(std::wstring& sDst, const std::wstring& sSrc) noexcept;
+void ssadd(std::string& sDst, PCSTR pA) noexcept;
+void ssadd(std::wstring& sDst, PCWSTR pA) noexcept;
+char sstoupper(char ch) noexcept;
+char sstolower(char ch) noexcept;
+wchar_t sstoupper(wchar_t ch) noexcept;
+wchar_t sstolower(wchar_t ch) noexcept;
+
+template<typename CT>
+inline int ssicmp(const CT* pA1, const CT* pA2) noexcept
+{
+	CT f;
+	CT l;
+
+	do
+	{
+		f = sstolower(*(pA1++));
+		l = sstolower(*(pA2++));
+	} while ((f) && (f == l));
+
+	return static_cast<int>(f - l);
+}
+
+inline void sslwr(char *pT, std::size_t nLen) noexcept
+{
+	MakeLower(pT, nLen);
+}
+
+inline void ssupr(char *pT, std::size_t nLen) noexcept
+{
+	MakeUpper(pT, nLen);
+}
+
+inline void sslwr(wchar_t *pT, std::size_t nLen) noexcept
+{
+	MakeLower(pT, nLen);
+}
+
+inline void ssupr(wchar_t *pT, std::size_t nLen) noexcept
+{
+	MakeUpper(pT, nLen);
+}
+
+#if defined(WIN32)
+#define vsnprintf _vsnprintf
+#endif
+
+template<typename CT>
+class CStdStr;
+
+template<typename CT>
+inline
+CStdStr<CT> operator+(const CStdStr<CT>& str1, const CStdStr<CT>& str2) noexcept
+{
+	CStdStr<CT> strRet(str1);
+	strRet.append(str2);
+	return strRet;
+}
+
+template<typename CT>
+inline
+CStdStr<CT> operator+(const CStdStr<CT>& str, CT t) noexcept
+{
+	CStdStr<CT> strRet(str);
+	strRet.append(1, t);
+	return strRet;
+}
+
+template<typename CT>
+inline
+CStdStr<CT> operator+(const CStdStr<CT>& str, const CT* pA) noexcept
+{
+	return CStdStr<CT>(str) + CStdStr<CT>(pA);
+}
+
+template<typename CT>
+inline
+CStdStr<CT> operator+(const CT* pA, const CStdStr<CT>& str) noexcept
+{
+	CStdStr<CT> strRet(pA);
+	strRet.append(str);
+	return strRet;
+}
+
+template<typename CT>
+class CStdStr : public std::basic_string<CT>
+{
+	typedef typename std::basic_string<CT> MYBASE;
+	typedef CStdStr<CT> MYTYPE;
+	typedef typename MYBASE::const_pointer PCMYSTR;
+	typedef typename MYBASE::pointer PMYSTR;
+	typedef typename MYBASE::iterator MYITER;
+	typedef typename MYBASE::const_iterator MYCITER;
+	typedef typename MYBASE::reverse_iterator MYRITER;
+	typedef typename MYBASE::size_type MYSIZE;
+	typedef typename MYBASE::value_type MYVAL;
+	typedef typename MYBASE::allocator_type MYALLOC;
+	typedef typename MYBASE::traits_type MYTRAITS;
+
+public:
+	CStdStr() {}
+
+	CStdStr(const MYTYPE& str) : MYBASE(str) {}
+
+	CStdStr(const std::basic_string<CT>& str) : MYBASE(str) {}
+
+	CStdStr(PCMYSTR pT, MYSIZE n) : MYBASE(pT, n) {}
+
+	CStdStr(const CT* pA)
+	{
+		*this = pA;
+	}
+
+	CStdStr(MYCITER first, MYCITER last) : MYBASE(first, last) {}
+
+	CStdStr(MYSIZE nSize, MYVAL ch, const MYALLOC& al = MYALLOC()) : MYBASE(nSize, ch, al) {}
+
+	MYTYPE& operator=(const MYTYPE& str) noexcept
+	{
+		ssasn(*this, str);
+		return *this;
+	}
+
+	MYTYPE& operator=(const std::basic_string<CT>& str) noexcept
+	{
+		ssasn(*this, str);
+		return *this;
+	}
+
+	MYTYPE& operator=(const CT* pA) noexcept
+	{
+		ssasn(*this, pA);
+		return *this;
+	}
+
+	MYTYPE& operator=(CT t) noexcept
+	{
+		this->assign(1, t);
+		return *this;
+	}
+
+	MYTYPE& operator+=(const MYTYPE& str) noexcept
+	{
+		ssadd(*this, str);
+		return *this;
+	}
+
+	MYTYPE& operator+=(const std::basic_string<CT>& str) noexcept
+	{
+		ssadd(*this, str);
+		return *this;
+	}
+
+	MYTYPE& operator+=(const CT* pA) noexcept
+	{
+		ssadd(*this, pA);
+		return *this;
+	}
+
+	MYTYPE& operator+=(CT t) noexcept
+	{
+		this->append(1, t);
+		return *this;
+	}
+
+	friend MYTYPE operator+ <>(const MYTYPE& str1, const MYTYPE& str2) noexcept;
+	friend MYTYPE operator+ <>(const MYTYPE& str, CT t) noexcept;
+	friend MYTYPE operator+ <>(const MYTYPE& str, const CT* sz) noexcept;
+	friend MYTYPE operator+ <>(const CT* pA, const MYTYPE& str) noexcept;
+
+	MYTYPE& MakeUpper() noexcept
+	{
+		if (!this->empty())
+			ssupr(GetBuffer(), this->size());
+
+		return *this;
+	}
+
+	MYTYPE& MakeLower() noexcept
+	{
+		if (!this->empty())
+			sslwr(GetBuffer(), this->size());
+
+		return *this;
+	}
+
+	CT* GetBuffer(int nMinLen = -1) noexcept
+	{
+		if (static_cast<int>(this->size()) < nMinLen)
+			this->resize(static_cast<MYSIZE>(nMinLen));
+
+		return this->empty() ? const_cast<CT*>(this->data()) : &(this->at(0));
+	}
+
+	void ReleaseBuffer(int nNewLen = -1) noexcept
+	{
+		this->resize(static_cast<MYSIZE>(nNewLen > -1 ? nNewLen : MYTRAITS::length(this->c_str())));
+	}
+
+	int CompareNoCase(PCMYSTR szThat) const noexcept
+	{
+		return ssicmp(this->c_str(), szThat);
+	}
+
+	bool EqualsNoCase(PCMYSTR szThat) const noexcept
+	{
+		return CompareNoCase(szThat) == 0;
+	}
+
+	MYTYPE Left(int nCount) const noexcept
+	{
+		nCount = std::max(0, std::min(nCount, static_cast<int>(this->size())));
+		return this->substr(0, static_cast<MYSIZE>(nCount));
+	}
+
+	int Replace(CT chOld, CT chNew) noexcept
+	{
+		int nReplaced = 0;
+		for (MYITER iter = this->begin(); iter != this->end(); iter++)
+		{
+			if (*iter == chOld)
+			{
+				*iter = chNew;
+				nReplaced++;
+			}
+		}
+		return nReplaced;
+	}
+
+	int Replace(PCMYSTR szOld, PCMYSTR szNew) noexcept
+	{
+		int nReplaced = 0;
+		MYSIZE nIdx = 0;
+		MYSIZE nOldLen = MYTRAITS::length(szOld);
+		if (0 == nOldLen)
+			return 0;
+
+		static const CT ch = CT(0);
+		MYSIZE nNewLen = MYTRAITS::length(szNew);
+		PCMYSTR szRealNew = szNew == 0 ? &ch : szNew;
+
+		while ((nIdx = this->find(szOld, nIdx)) != MYBASE::npos)
+		{
+			MYBASE::replace(this->begin() + nIdx, this->begin() + nIdx + nOldLen, szRealNew);
+			nReplaced++;
+			nIdx += nNewLen;
+		}
+		return nReplaced;
+	}
+
+	MYTYPE Right(int nCount) const noexcept
+	{
+		nCount = std::max(0, std::min(nCount, static_cast<int>(this->size())));
+		return this->substr(this->size() - static_cast<MYSIZE>(nCount));
+	}
+
+	CT& operator[](int nIdx) noexcept
+	{
+		return MYBASE::operator[](static_cast<MYSIZE>(nIdx));
+	}
+
+	const CT& operator[](int nIdx) const noexcept
+	{
+		return MYBASE::operator[](static_cast<MYSIZE>(nIdx));
+	}
+
+	CT& operator[](unsigned int nIdx) noexcept
+	{
+		return MYBASE::operator[](static_cast<MYSIZE>(nIdx));
+	}
+
+	const CT& operator[](unsigned int nIdx) const noexcept
+	{
+		return MYBASE::operator[](static_cast<MYSIZE>(nIdx));
+	}
+
+	CT& operator[](long unsigned int nIdx) noexcept
+	{
+		return MYBASE::operator[](static_cast<MYSIZE>(nIdx));
+	}
+
+	const CT& operator[](long unsigned int nIdx) const noexcept
+	{
+		return MYBASE::operator[](static_cast<MYSIZE>(nIdx));
+	}
+
+	CT& operator[](long long unsigned int nIdx) noexcept
+	{
+		return MYBASE::operator[](static_cast<MYSIZE>(nIdx));
+	}
+
+	const CT& operator[](long long unsigned int nIdx) const noexcept
+	{
+		return MYBASE::operator[](static_cast<MYSIZE>(nIdx));
+	}
+
+#ifndef SS_NO_IMPLICIT_CASTS
+	operator const CT*() const noexcept
+	{
+		return this->c_str();
+	}
+#endif
+};
+
+typedef CStdStr<char> CStdStringA;
+typedef CStdStr<wchar_t> CStdStringW;
+#define CStdString CStdStringA
+
+#define StdStringLessNoCase SSLNCA
+#define StdStringEqualsNoCase SSENCA
+
+struct StdStringLessNoCase
+{
+	inline
+	bool operator()(const CStdStringA& sLeft, const CStdStringA& sRight) const noexcept
+	{
+		return ssicmp(sLeft.c_str(), sRight.c_str()) < 0;
+	}
+
+	inline
+	bool operator()(const CStdStringW& sLeft, const CStdStringW& sRight) const noexcept
+	{
+		return ssicmp(sLeft.c_str(), sRight.c_str()) < 0;
+	}
+};
+
+struct StdStringEqualsNoCase
+{
+	inline
+	bool operator()(const CStdStringA& sLeft, const CStdStringA& sRight) const noexcept
+	{
+		return ssicmp(sLeft.c_str(), sRight.c_str()) == 0;
+	}
+
+	inline
+	bool operator()(const CStdStringW& sLeft, const CStdStringW& sRight) const noexcept
+	{
+		return ssicmp(sLeft.c_str(), sRight.c_str()) == 0;
+	}
+};
+
+}
+
+#if defined(_MSC_VER)
+	#pragma warning (pop)
+#endif
+
+#endif 
+
+/* Original comments:
+
 // =============================================================================
 //  FILE:  StdString.h
 //  AUTHOR:	Joe O'Leary (with outside help noted in comments)
@@ -67,626 +470,7 @@
 //			- Wang Haifeng
 //			- Tim Dowty
 //          - Arnt Witteveen
-
-// Turn off browser references
-// Turn off unavoidable compiler warnings
-
-
-#if defined(_MSC_VER)
-	#pragma component(browser, off, references, "CStdString")
-	#pragma warning (push)
-	#pragma warning (disable : 4290) // C++ Exception Specification ignored
-	#pragma warning (disable : 4127) // Conditional expression is constant
-	#pragma warning (disable : 4097) // typedef name used as synonym for class name
-	#pragma warning (disable : 4512) // assignment operator could not be generated
-#endif
-
-#ifndef STDSTRING_H
-#define STDSTRING_H
-
-// If they want us to use only standard C++ stuff (no Win32 stuff)
-
-typedef const char*		PCSTR;
-typedef char*			PSTR;
-
-// Standard headers needed
-#include <string>			// basic_string
-#include <algorithm>			// for_each, etc.
-
-#if defined(WIN32)
-#include <malloc.h>			// _alloca
-#endif
-
-#include <cctype>
-#include <cstdarg>
-#include <cstddef>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-
-/* In RageUtil: */
-void MakeUpper( char *p, std::size_t iLen );
-void MakeLower( char *p, std::size_t iLen );
-void MakeUpper( wchar_t *p, std::size_t iLen );
-void MakeLower( wchar_t *p, std::size_t iLen );
-
-/**
- * @brief Inline functions on which CStdString relies on.
- *
- * Usually for generic text mapping, we rely on preprocessor macro definitions
- * to map to string functions.  However the CStdStr<> template cannot use
- * macro-based generic text mappings because its character types do not get
- * resolved until template processing which comes AFTER macro processing.  In
- * other words, UNICODE is of little help to us in the CStdStr template.
- *
- * Therefore, to keep the CStdStr declaration simple, we have these inline
- * functions.  The template calls them often.  Since they are inline (and NOT
- * exported when this is built as a DLL), they will probably be resolved away
- * to nothing.
- *
- * Without these functions, the CStdStr<> template would probably have to broken
- * out into two, almost identical classes.  Either that or it would be a huge,
- * convoluted mess, with tons of "if" statements all over the place checking the
- * size of template parameter CT.
- *
- * In several cases, you will see two versions of each function.  One version is
- * the more portable, standard way of doing things, while the other is the
- * non-standard, but often significantly faster Visual C++ way.
- */
-namespace StdString
-{
-// -----------------------------------------------------------------------------
-// sstolower/sstoupper -- convert characters to upper/lower case
-// -----------------------------------------------------------------------------
-//inline char sstoupper(char ch)		{ return (char)::toupper(ch); }
-//inline char sstolower(char ch)		{ return (char)::tolower(ch); }
-/* Our strings are UTF-8; instead of having to play around with locales,
- * let's just manually toupper ASCII only.  If we really want to play with
- * Unicode cases, we can do it ourself in RageUtil. */
-/**
- * @brief Turn the character into its uppercase equivalent.
- * @param ch the character to convert.
- * @return the converted character.
- */
-inline char sstoupper(char ch)		{ return (ch >= 'a' && ch <= 'z')? char(ch + 'A' - 'a'): ch; }
-/**
- * @brief Turn the character into its lowercase equivalent.
- * @param ch the character to convert.
- * @return the converted character.
- */
-inline char sstolower(char ch)		{ return (ch >= 'A' && ch <= 'Z')? char(ch + 'a' - 'A'): ch; }
-
-// -----------------------------------------------------------------------------
-// ssasn: assignment functions -- assign "sSrc" to "sDst"
-// -----------------------------------------------------------------------------
-typedef std::string::size_type		SS_SIZETYPE; // just for shorthand, really
-typedef std::string::pointer		SS_PTRTYPE;
-
-/**
- * @brief Assign one string to another.
- * @param sDst the destination string.
- * @param sSrc the source string.
- */
-inline void	ssasn(std::string& sDst, const std::string& sSrc)
-{
-	if ( sDst.c_str() != sSrc.c_str() )
-	{
-		sDst.erase();
-		sDst.assign(sSrc);
-	}
-}
-/**
- * @brief Assign one string to another.
- * @param sDst the destination string.
- * @param pA the source string.
- */
-inline void	ssasn(std::string& sDst, PCSTR pA)
-{
-		sDst.assign(pA);
-}
-#undef StrSizeType
-
-
-// -----------------------------------------------------------------------------
-// ssadd: string object concatenation -- add second argument to first
-// -----------------------------------------------------------------------------
-/**
- * @brief Concatenate one string with another.
- * @param sDst the original string.
- * @param sSrc the string being added.
- */
-inline void	ssadd(std::string& sDst, const std::string& sSrc)
-{
-	sDst += sSrc;
-}
-/**
- * @brief Concatenate one string with another.
- * @param sDst the original string.
- * @param pA the string being added.
- */
-inline void	ssadd(std::string& sDst, PCSTR pA)
-{
-	// If the string being added is our internal string or a part of our
-	// internal string, then we must NOT do any reallocation without
-	// first copying that string to another object (since we're using a
-	// direct pointer)
-
-	if ( pA >= sDst.c_str() && pA <= sDst.c_str()+sDst.length())
-	{
-		if ( sDst.capacity() <= sDst.size()+strlen(pA) )
-			sDst.append(std::string(pA));
-		else
-			sDst.append(pA);
-	}
-	else
-	{
-		sDst.append(pA);
-	}
-}
-
-// -----------------------------------------------------------------------------
-// ssicmp: comparison (case insensitive )
-// -----------------------------------------------------------------------------
-/**
- * @brief Perform a case insensitive comparison of the two strings.
- * @param pA1 the first string.
- * @param pA2 the second string.
- * @return >0 if pA1 > pA2, <0 if pA1 < pA2, or 0 otherwise.
- */
-template<typename CT>
-inline int ssicmp(const CT* pA1, const CT* pA2)
-{
-	CT f;
-	CT l;
-
-	do
-	{
-		f = sstolower(*(pA1++));
-		l = sstolower(*(pA2++));
-	} while ( (f) && (f == l) );
-
-	return (int)(f - l);
-}
-
-// -----------------------------------------------------------------------------
-// ssupr/sslwr: Uppercase/Lowercase conversion functions
-// -----------------------------------------------------------------------------
-#if 0
-	template<typename CT>
-	inline void sslwr(CT* pT, std::size_t nLen)
-	{
-		for ( CT* p = pT; static_cast<std::size_t>(p - pT) < nLen; ++p)
-			*p = (CT)sstolower(*p);
-	}
-	template<typename CT>
-	inline void ssupr(CT* pT, std::size_t nLen)
-	{
-		for ( CT* p = pT; static_cast<std::size_t>(p - pT) < nLen; ++p)
-			*p = (CT)sstoupper(*p);
-	}
-#endif
-
-inline void sslwr(char *pT, std::size_t nLen)
-{
-	MakeLower( pT, nLen );
-}
-inline void ssupr(char *pT, std::size_t nLen)
-{
-	MakeUpper( pT, nLen );
-}
-inline void sslwr(wchar_t *pT, std::size_t nLen)
-{
-	MakeLower( pT, nLen );
-}
-inline void ssupr(wchar_t *pT, std::size_t nLen)
-{
-	MakeUpper( pT, nLen );
-}
-
-#if defined(WIN32)
-#define vsnprintf _vsnprintf
-#endif
-
-//			Now we can define the template (finally!)
-// =============================================================================
-// TEMPLATE: CStdStr
-//		template<typename CT> class CStdStr : public std::basic_string<CT>
-//
-// REMARKS:
-//		This template derives from basic_string<CT> and adds some MFC RString-
-//		like functionality
-//
-//		Basically, this is my attempt to make Standard C++ library strings as
-//		easy to use as the MFC RString class.
-//
-//		Note that although this is a template, it makes the assumption that the
-//		template argument (CT, the character type) is either char or wchar_t.
-// =============================================================================
-
-//#define CStdStr _SS	// avoid compiler warning 4786
-template<typename CT>
-class CStdStr;
-
-/**
- * @brief Another way to concatenate two strings together.
- * @param str1 the original string.
- * @param str2 the string to be added.
- * @return the longer string.
- */
-template<typename CT>
-inline
-CStdStr<CT> operator+(const  CStdStr<CT>& str1, const  CStdStr<CT>& str2)
-{
-	CStdStr<CT> strRet(str1);
-	strRet.append(str2);
-	return strRet;
-}
-/**
- * @brief Another way to concatenate two strings together.
- * @param str the original string.
- * @param t the string to be added.
- * @return the longer string.
- */
-template<typename CT>
-inline
-CStdStr<CT> operator+(const  CStdStr<CT>& str, CT t)
-{
-	// this particular overload is needed for disabling reference counting
-	// though it's only an issue from line 1 to line 2
-
-	CStdStr<CT> strRet(str);	// 1
-	strRet.append(1, t);				// 2
-	return strRet;
-}
-/**
- * @brief Another way to concatenate two strings together.
- * @param str the original string.
- * @param pA the string to be added.
- * @return the longer string.
- */
-template<typename CT>
-inline
-CStdStr<CT> operator+(const  CStdStr<CT>& str, PCSTR pA)
-{
-	return CStdStr<CT>(str) + CStdStr<CT>(pA);
-}
-/**
- * @brief Another way to concatenate two strings together.
- * @param pA the original string.
- * @param str the string to be added.
- * @return the longer string.
- */
-template<typename CT>
-inline
-CStdStr<CT> operator+(PCSTR pA, const  CStdStr<CT>& str)
-{
-	CStdStr<CT> strRet(pA);
-	strRet.append(str);
-	return strRet;
-}
-
-
-/** @brief Our wrapper for std::string. */
-template<typename CT>
-class CStdStr : public std::basic_string<CT>
-{
-	// Typedefs for shorter names.  Using these names also appears to help
-	// us avoid some ambiguities that otherwise arise on some platforms
-
-	typedef typename std::basic_string<CT>		MYBASE;	 // my base class
-	typedef CStdStr<CT>				MYTYPE;	 // myself
-	typedef typename MYBASE::const_pointer		PCMYSTR; // PCSTR
-	typedef typename MYBASE::pointer		PMYSTR;	 // PSTR
-	typedef typename MYBASE::iterator		MYITER;  // my iterator type
-	typedef typename MYBASE::const_iterator		MYCITER; // you get the idea...
-	typedef typename MYBASE::reverse_iterator	MYRITER;
-	typedef typename MYBASE::size_type		MYSIZE;
-	typedef typename MYBASE::value_type		MYVAL;
-	typedef typename MYBASE::allocator_type		MYALLOC;
-	typedef typename MYBASE::traits_type		MYTRAITS;
-
-public:
-
-	// CStdStr inline constructors
-	CStdStr()
-	{
-	}
-
-	CStdStr(const MYTYPE& str) : MYBASE(str)
-	{
-	}
-
-	CStdStr(const std::string& str): MYBASE(str)
-	{
-	}
-
-	CStdStr(PCMYSTR pT, MYSIZE n) : MYBASE(pT, n)
-	{
-	}
-
-	CStdStr(PCSTR pA)
-	{
-		*this = pA;
-	}
-
-	CStdStr(MYCITER first, MYCITER last)
-		: MYBASE(first, last)
-	{
-	}
-
-	CStdStr(MYSIZE nSize, MYVAL ch, const MYALLOC& al=MYALLOC())
-		: MYBASE(nSize, ch, al)
-	{
-	}
-
-	// CStdStr inline assignment operators
-	MYTYPE& operator=(const MYTYPE& str)
-	{
-		ssasn(*this, str);
-		return *this;
-	}
-
-	MYTYPE& operator=(const std::string& str)
-	{
-		ssasn(*this, str);
-		return *this;
-	}
-
-	MYTYPE& operator=(PCSTR pA)
-	{
-		ssasn(*this, pA);
-		return *this;
-	}
-
-	MYTYPE& operator=(CT t)
-	{
-		this->assign(1, t);
-		return *this;
-	}
-
-	// -------------------------------------------------------------------------
-	// CStdStr inline concatenation.
-	// -------------------------------------------------------------------------
-	MYTYPE& operator+=(const MYTYPE& str)
-	{
-		ssadd(*this, str);
-		return *this;
-	}
-
-	MYTYPE& operator+=(const std::string& str)
-	{
-		ssadd(*this, str);
-		return *this;
-	}
-
-	MYTYPE& operator+=(PCSTR pA)
-	{
-		ssadd(*this, pA);
-		return *this;
-	}
-
-	MYTYPE& operator+=(CT t)
-	{
-		this->append(1, t);
-		return *this;
-	}
-
-
-	// addition operators -- global friend functions.
-	friend	MYTYPE	operator+ <>(const MYTYPE& str1,	const MYTYPE& str2);
-	friend	MYTYPE	operator+ <>(const MYTYPE& str,	CT t);
-	friend	MYTYPE	operator+ <>(const MYTYPE& str,	PCSTR sz);
-	friend	MYTYPE	operator+ <>(PCSTR pA,				const MYTYPE& str);
-
-	// -------------------------------------------------------------------------
-	// Case changing functions
-	// -------------------------------------------------------------------------
-	MYTYPE& MakeUpper()
-	{
-		if ( !this->empty() )
-			ssupr(GetBuffer(), this->size());
-
-		return *this;
-	}
-
-	MYTYPE& MakeLower()
-	{
-		if ( !this->empty() )
-			sslwr(GetBuffer(), this->size());
-
-		return *this;
-	}
-
-
-
-	// -------------------------------------------------------------------------
-	// CStdStr -- Direct access to character buffer.  In the MS' implementation,
-	// the at() function that we use here also calls _Freeze() providing us some
-	// protection from multithreading problems associated with ref-counting.
-	// -------------------------------------------------------------------------
-	CT* GetBuffer(int nMinLen=-1)
-	{
-		if ( static_cast<int>(this->size()) < nMinLen )
-			this->resize(static_cast<MYSIZE>(nMinLen));
-
-		return this->empty() ? const_cast<CT*>(this->data()) : &(this->at(0));
-	}
-
-	void ReleaseBuffer(int nNewLen=-1)
-	{
-		this->resize(static_cast<MYSIZE>(nNewLen > -1 ? nNewLen : MYTRAITS::length(this->c_str())));
-	}
-
-
-
-	// -------------------------------------------------------------------------
-	// RString Facade Functions:
-	//
-	// The following methods are intended to allow you to use this class as a
-	// drop-in replacement for CString.
-	// -------------------------------------------------------------------------
-	int CompareNoCase(PCMYSTR szThat)	const
-	{
-		return ssicmp(this->c_str(), szThat);
-	}
-
-	bool EqualsNoCase(PCMYSTR szThat)	const
-	{
-		return CompareNoCase(szThat) == 0;
-	}
-
-	MYTYPE Left(int nCount) const
-	{
-		// Range check the count.
-
-		nCount = std::max(0, std::min(nCount, static_cast<int>(this->size())));
-		return this->substr(0, static_cast<MYSIZE>(nCount));
-	}
-
-	int Replace(CT chOld, CT chNew)
-	{
-		int nReplaced	= 0;
-		for ( MYITER iter=this->begin(); iter != this->end(); iter++ )
-		{
-			if ( *iter == chOld )
-			{
-				*iter = chNew;
-				nReplaced++;
-			}
-		}
-		return nReplaced;
-	}
-
-	int Replace(PCMYSTR szOld, PCMYSTR szNew)
-	{
-		int nReplaced		= 0;
-		MYSIZE nIdx			= 0;
-		MYSIZE nOldLen		= MYTRAITS::length(szOld);
-		if ( 0 == nOldLen )
-			return 0;
-
-		static const CT ch	= CT(0);
-		MYSIZE nNewLen		= MYTRAITS::length(szNew);
-		PCMYSTR szRealNew	= szNew == 0 ? &ch : szNew;
-
-		while ( (nIdx=this->find(szOld, nIdx)) != MYBASE::npos )
-		{
-			MYBASE::replace(this->begin()+nIdx, this->begin()+nIdx+nOldLen, szRealNew);
-			nReplaced++;
-			nIdx += nNewLen;
-		}
-		return nReplaced;
-	}
-
-	MYTYPE Right(int nCount) const
-	{
-		// Range check the count.
-
-		nCount = std::max(0, std::min(nCount, static_cast<int>(this->size())));
-		return this->substr(this->size()-static_cast<MYSIZE>(nCount));
-	}
-
-	// Array-indexing operators.  Required because we defined an implicit cast
-	// to operator const CT* (Thanks to Julian Selman for pointing this out)
-	CT& operator[](int nIdx)
-	{
-		return MYBASE::operator[](static_cast<MYSIZE>(nIdx));
-	}
-
-	const CT& operator[](int nIdx) const
-	{
-		return MYBASE::operator[](static_cast<MYSIZE>(nIdx));
-	}
-
-	CT& operator[](unsigned int nIdx)
-	{
-		return MYBASE::operator[](static_cast<MYSIZE>(nIdx));
-	}
-
-	const CT& operator[](unsigned int nIdx) const
-	{
-		return MYBASE::operator[](static_cast<MYSIZE>(nIdx));
-	}
-
-	CT& operator[](long unsigned int nIdx){
-	  return MYBASE::operator[](static_cast<MYSIZE>(nIdx));
-	}
-
-	const CT& operator[](long unsigned int nIdx) const {
-	  return MYBASE::operator[](static_cast<MYSIZE>(nIdx));
-	}
-
-	CT& operator[](long long unsigned int nIdx){
-	  return MYBASE::operator[](static_cast<MYSIZE>(nIdx));
-	}
-
-	const CT& operator[](long long unsigned int nIdx) const {
-	  return MYBASE::operator[](static_cast<MYSIZE>(nIdx));
-	}
-#ifndef SS_NO_IMPLICIT_CASTS
-	operator const CT*() const
-	{
-		return this->c_str();
-	}
-#endif
-};
-
-
-// =============================================================================
-//						END OF CStdStr INLINE FUNCTION DEFINITIONS
-// =============================================================================
-
-//	Now typedef our class names based upon this humongous template
-/** @brief Typedef the class names based on the template */
-typedef CStdStr<char>		CStdStringA;	// a better std::string
-#define CStdString				CStdStringA
-
-
-// -----------------------------------------------------------------------------
-// FUNCTIONAL COMPARATORS:
-// REMARKS:
-//		These structs give us functional classes (which may be used in
-//		Standard C++ Library collections and algorithms) that perform
-//		case-insensitive comparisons of CStdString objects.  This is
-//		useful for maps in which the key may be the proper string but
-//		in the wrong case.
-// -----------------------------------------------------------------------------
-
-#define StdStringLessNoCase		SSLNCA
-#define StdStringEqualsNoCase		SSENCA
-
-struct StdStringLessNoCase
-{
-	inline
-	bool operator()(const CStdStringA& sLeft, const CStdStringA& sRight) const
-	{ return ssicmp(sLeft.c_str(), sRight.c_str()) < 0; }
-};
-struct StdStringEqualsNoCase
-{
-	inline
-	bool operator()(const CStdStringA& sLeft, const CStdStringA& sRight) const
-	{ return ssicmp(sLeft.c_str(), sRight.c_str()) == 0; }
-};
-
-// These std::swap specializations come courtesy of Mike Crusader.
-
-//namespace std
-//{
-//	inline void swap(CStdStringA& s1, CStdStringA& s2) throw()
-//	{
-//		s1.swap(s2);
-//	}
-//}
-
-}	// namespace StdString
-
-#if defined(_MSC_VER)
-	#pragma warning (pop)
-#endif
-
-#endif	// #ifndef STDSTRING_H
-
-/**
+*
  * @file
  * @author Joseph M. O'Leary (c) 1999
  * @section LICENSE
@@ -700,4 +484,4 @@ struct StdStringEqualsNoCase
  *
  *			jmoleary@earthlink.net
  *			http://home.earthlink.net/~jmoleary
- */
+*/

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <thread>
+#include <cstdarg>
 
 static void FixLilEndian()
 {

--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -15,7 +15,7 @@
 
 #include <cstdint>
 #include <vector>
-
+#include <cstdarg>
 
 REGISTER_SOUND_DRIVER_CLASS( WaveOut );
 

--- a/src/archutils/Win32/DebugInfoHunt.cpp
+++ b/src/archutils/Win32/DebugInfoHunt.cpp
@@ -6,6 +6,7 @@
 #include "RegistryAccess.h"
 
 #include <vector>
+#include <cstdarg>
 
 #include <windows.h>
 #include <mmsystem.h>

--- a/src/archutils/Win32/DirectXHelpers.cpp
+++ b/src/archutils/Win32/DirectXHelpers.cpp
@@ -2,6 +2,8 @@
 #include "DirectXHelpers.h"
 #include "RageUtil.h"
 
+#include <cstdarg>
+
 RString hr_ssprintf( int hr, const char *fmt, ... )
 {
 	va_list	va;

--- a/src/archutils/Win32/ErrorStrings.cpp
+++ b/src/archutils/Win32/ErrorStrings.cpp
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "ErrorStrings.h"
 #include "RageUtil.h"
-
+#include <cstdarg>
 #include <windows.h>
 
 RString werr_ssprintf( int err, const char *fmt, ... )


### PR DESCRIPTION
I gained up to 200FPS on my Ryzen machine with integrated graphics with this change. Refactoring StdString to be optimized for its place at the core of the ITGmania engine is the single largest performance improvement I've committed to date.

I determined not much more work would be needed to make RStrings Unicode-compatible after this.

### Why work on StdString.h

- StdString/ RString types are integral to the game engine as well as its performance.
- This header was basically written to port some Microsoft MFC features to C++99. It was designed to extend an old set of string handling abilities in C++. It was designed to fit a wide variety of use cases and was NOT designed for performance.
- The header file is loaded with templates and heavier inline functions which are not ideal for performance.

### What was improved

- Moved many functions to a **.cpp** file

- More `wchar_t` versions of functions

- reduction in the number of included headers.
   -   `cstdarg` was indirectly included in 10 files via `StdString.h`, those files now have `cstdarg` in their include list... the rest were not needed

- marked all functions as noexcept

### Next steps: Making RString Unicode-compatible

As for working Unicode support into this header, we would need to decide how to handle Unicode in 
 MakeUpper and MakeLower functions.

Besides that, a few functions cast to char* and would need to be adjusted to make Unicode in RString possible.
