### PR TITLE
Remove skip frames feature in ffmpeg code.

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -30,7 +30,6 @@ struct FrameHolder {
 	float frameTimestamp = 0;
 	float frameDelay = 0;
 	bool decoded = false;
-	bool skip = false;
 	std::mutex lock; // Protects the frame as it's being initialized.
 
 	FrameHolder() = default;
@@ -41,7 +40,6 @@ struct FrameHolder {
 		frameTimestamp = fh.frameTimestamp;
 		frameDelay = fh.frameDelay;
 		decoded = fh.decoded;
-		skip = fh.skip;
 	}
 
 	~FrameHolder() {
@@ -109,9 +107,6 @@ public:
 	float GetTimestamp() const;
 
 	void Cancel() { cancel = true; };
-
-	// If the next frame to display had an issue decoding, skip it.
-	bool SkipNextFrame();
 
 private:
 	void Init();

--- a/src/arch/MovieTexture/MovieTexture_Generic.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Generic.cpp
@@ -342,10 +342,6 @@ void MovieTexture_Generic::UpdateFrame()
 	/* Just in case we were invalidated: */
 	CreateTexture();
 
-	if (m_pDecoder->SkipNextFrame()) {
-		return;
-	}
-
 	if(m_pTextureLock != nullptr)
 	{
 		std::uintptr_t iHandle = m_pTextureIntermediate != nullptr ? m_pTextureIntermediate->GetTexHandle(): this->GetTexHandle();

--- a/src/arch/MovieTexture/MovieTexture_Generic.h
+++ b/src/arch/MovieTexture/MovieTexture_Generic.h
@@ -42,9 +42,6 @@ public:
 	 */
 	virtual bool GetFrame( RageSurface *pOut ) = 0;
 
-	// Returns true if the frame should be skipped.
-	virtual bool SkipNextFrame() = 0;
-
 	/* Return the dimensions of the image, in pixels (before aspect ratio
 	 * adjustments). */
 	virtual int GetWidth() const  = 0;


### PR DESCRIPTION
This is a bit too conservative, the old code handled displaying these types of frames with non-fatal errors--so there's not much reason we should shy away from taking advantage of it. I tested this with the same files that spurred the addition of the skipping code, and saw no change in performance.