### PR TITLE
Sort Linux Input Devices by Physical Location

### DIFF
--- a/src/arch/InputHandler/LinuxInputManager.cpp
+++ b/src/arch/InputHandler/LinuxInputManager.cpp
@@ -21,8 +21,6 @@
 
 #include <errno.h>
 
-Preference<bool> g_bInputLinuxOrderByLocation( "InputLinuxOrderByLocation", false );
-
 RString getDevice(RString inputDir, RString type)
 {
 	RString result = "";
@@ -86,18 +84,9 @@ LinuxInputManager::LinuxInputManager()
 			LOG->Info("LinuxInputManager: %s seems to have no eventNN or jsNN.", dName.c_str() );
 	}
 
-	if(g_bInputLinuxOrderByLocation)
-	{
-		// use Presort to sort the devices by unique location (like USB port/hub number.)
-		PresortPhysical(m_vsPendingEventDevices, "event");
-		PresortPhysical(m_vsPendingJoystickDevices, "js");
-	}
-	else
-	{
-		// Sort devices for more consistent numbering.
-		std::sort(m_vsPendingEventDevices.begin(), m_vsPendingEventDevices.end(), cmpDevices);
-		std::sort(m_vsPendingJoystickDevices.begin(), m_vsPendingJoystickDevices.end(), cmpDevices);
-	}
+	// use Presort to sort the devices by unique location (like USB port/hub number.)
+	PresortPhysical(m_vsPendingEventDevices, "event");
+	PresortPhysical(m_vsPendingJoystickDevices, "js");
 
 	closedir(sysClassInput);
 }

--- a/src/arch/InputHandler/LinuxInputManager.cpp
+++ b/src/arch/InputHandler/LinuxInputManager.cpp
@@ -13,7 +13,15 @@
 #include <dirent.h>
 #endif
 
+#if defined(HAVE_FCNTL_H)
+#include <fcntl.h>
+#endif
+
+#include <linux/input.h>
+
 #include <errno.h>
+
+Preference<bool> g_bInputLinuxOrderByLocation( "InputLinuxOrderByLocation", false );
 
 RString getDevice(RString inputDir, RString type)
 {
@@ -21,7 +29,7 @@ RString getDevice(RString inputDir, RString type)
 	DIR* dir = opendir( inputDir.c_str() );
 	if(dir == nullptr)
 		{ LOG->Warn("LinuxInputManager: Couldn't open %s: %s.", inputDir.c_str(), strerror(errno) ); return ""; }
-	
+
 	struct dirent* d;
 	while( ( d = readdir(dir) ) != nullptr)
 		if( strncmp( type.c_str(), d->d_name, type.size() ) == 0)
@@ -29,7 +37,7 @@ RString getDevice(RString inputDir, RString type)
 			result = RString("/dev/input/") + d->d_name;
 			break;
 		}
-	
+
 	closedir(dir);
 	return result;
 }
@@ -46,10 +54,10 @@ LinuxInputManager::LinuxInputManager()
 	// HACK: If empty, assume both are enabled
 	if( g_sInputDrivers.Get() == "" )
 		{ m_bEventEnabled = true; m_bJoystickEnabled = true; }
-	
+
 	m_EventDriver = nullptr;
 	m_JoystickDriver = nullptr;
-	
+
 	// XXX: Can I use RageFile for this?
 	DIR* sysClassInput = opendir("/sys/class/input");
 	if( sysClassInput == nullptr)
@@ -58,31 +66,91 @@ LinuxInputManager::LinuxInputManager()
 		LOG->Warn("Couldn't open /sys/class/input: %s. Joysticks will not work!", strerror(errno) );
 		return;
 	}
-	
+
 	struct dirent* d;
 	while( ( d = readdir(sysClassInput) ) != nullptr)
 	{
 		if( strncmp( "input", d->d_name, 5) != 0) continue;
-		
+
 		RString dName = RString("/sys/class/input/") + d->d_name;
-		
+
 		bool bEventPresent = getDevice(dName, "event") != "";
-		if( m_bEventEnabled && bEventPresent ) 
+		if( m_bEventEnabled && bEventPresent )
 			{ m_vsPendingEventDevices.push_back(dName); continue; }
-		
+
 		bool bJoystickPresent = getDevice(dName, "js") != "";
 		if( m_bJoystickEnabled && bJoystickPresent )
 			{ m_vsPendingJoystickDevices.push_back(dName); continue; }
-			
+
 		if( !bEventPresent && !bJoystickPresent )
 			LOG->Info("LinuxInputManager: %s seems to have no eventNN or jsNN.", dName.c_str() );
 	}
 
-	// Sort devices for more consistent numbering.
-	std::sort(m_vsPendingEventDevices.begin(), m_vsPendingEventDevices.end(), cmpDevices);
-	std::sort(m_vsPendingJoystickDevices.begin(), m_vsPendingJoystickDevices.end(), cmpDevices);
+	if(g_bInputLinuxOrderByLocation)
+	{
+		// use Presort to sort the devices by unique location (like USB port/hub number.)
+		PresortPhysical(m_vsPendingEventDevices, "event");
+		PresortPhysical(m_vsPendingJoystickDevices, "js");
+	}
+	else
+	{
+		// Sort devices for more consistent numbering.
+		std::sort(m_vsPendingEventDevices.begin(), m_vsPendingEventDevices.end(), cmpDevices);
+		std::sort(m_vsPendingJoystickDevices.begin(), m_vsPendingJoystickDevices.end(), cmpDevices);
+	}
 
 	closedir(sysClassInput);
+}
+
+
+static bool presort_cmpDevices(LinuxInputSort a, LinuxInputSort b)
+{
+	return a.UniqueString < b.UniqueString;
+}
+
+void LinuxInputManager::PresortPhysical(std::vector<RString>& sortingArray, RString sortBy)
+{
+	m_vPreSort.clear();
+
+	for (RString &dev : sortingArray)
+	{
+		LinuxInputSort entry;
+
+		entry.DeviceName = dev;
+		entry.UniqueString = "";
+
+		int m_iFD = open(getDevice(dev, sortBy.c_str()).c_str(), O_RDWR);
+
+		if(m_iFD >= 0)
+		{
+			char szLocation[1024];
+
+			// EVIOCGPHYS can return values like "usb-0000:0d:00.3-4"
+			// telling us where the device is located physically on the computer.
+			if(ioctl(m_iFD, EVIOCGPHYS(sizeof(szLocation)), szLocation) != -1)
+			{
+				entry.UniqueString += szLocation;
+			}
+
+			close(m_iFD);
+		}
+
+		// in the event we didn't get a unique location from ioctl
+		// default to the name so that sorting by number still works as intended.
+		entry.UniqueString += entry.DeviceName;
+
+		m_vPreSort.push_back(entry);
+	}
+
+	std::sort(m_vPreSort.begin(), m_vPreSort.end(), presort_cmpDevices);
+
+	sortingArray.clear();
+
+	for (LinuxInputSort &dev : m_vPreSort)
+	{
+		// LOG->Info("%s -> %s", dev.DeviceName.c_str(), dev.UniqueString.c_str());
+		sortingArray.push_back(dev.DeviceName);
+	}
 }
 
 void LinuxInputManager::InitDriver(InputHandler_Linux_Event* driver)
@@ -93,7 +161,7 @@ void LinuxInputManager::InitDriver(InputHandler_Linux_Event* driver)
 	{
 		RString devFile = getDevice(dev, "event");
 		ASSERT( devFile != "" );
-		
+
 		if( ! driver->TryDevice(devFile) && m_bJoystickEnabled && getDevice(dev, "js") != "" )
 			m_vsPendingJoystickDevices.push_back(dev);
 	}
@@ -105,7 +173,7 @@ void LinuxInputManager::InitDriver(InputHandler_Linux_Event* driver)
 void LinuxInputManager::InitDriver(InputHandler_Linux_Joystick* driver)
 {
 	m_JoystickDriver = driver;
-	// Discard all the joystick devices if they were assigned manually via 
+	// Discard all the joystick devices if they were assigned manually via
 	// 	InputDeviceOrder
 	if( g_sInputDeviceOrder.Get() != "" ) {
 		m_vsPendingJoystickDevices.clear();
@@ -115,7 +183,7 @@ void LinuxInputManager::InitDriver(InputHandler_Linux_Joystick* driver)
 	{
 		RString devFile = getDevice(dev, "js");
 		ASSERT( devFile != "" );
-		
+
 		driver->TryDevice(devFile);
 	}
 
@@ -134,7 +202,7 @@ LinuxInputManager* LINUXINPUT = nullptr; // global and accessible anywhere in ou
 /*
  * (c) 2013 Ben "root" Anderson
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -144,7 +212,7 @@ LinuxInputManager* LINUXINPUT = nullptr; // global and accessible anywhere in ou
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF

--- a/src/arch/InputHandler/LinuxInputManager.h
+++ b/src/arch/InputHandler/LinuxInputManager.h
@@ -7,8 +7,15 @@
 class InputHandler_Linux_Joystick;
 class InputHandler_Linux_Event;
 
-// Enumerates the input devices on the system and dispatches them to 
+// Enumerates the input devices on the system and dispatches them to
 // IH_Linux_Event and IH_Linux_Joystick as appropriate.
+
+// Helper struct for keeping track of inputs.
+struct LinuxInputSort
+{
+    RString DeviceName;
+    RString UniqueString;
+};
 
 class LinuxInputManager
 {
@@ -18,10 +25,13 @@ public:
 	void InitDriver(InputHandler_Linux_Event* drv);
 	~LinuxInputManager();
 private:
+	std::vector<LinuxInputSort> m_vPreSort;
+	void PresortPhysical(std::vector<RString>& sortingArray, RString sortBy);
+
 	bool m_bEventEnabled;
 	InputHandler_Linux_Event* m_EventDriver;
 	std::vector<RString> m_vsPendingEventDevices;
-	
+
 	bool m_bJoystickEnabled;
 	InputHandler_Linux_Joystick* m_JoystickDriver;
 	std::vector<RString> m_vsPendingJoystickDevices;
@@ -34,7 +44,7 @@ extern LinuxInputManager* LINUXINPUT; // global and accessible from anywhere in 
 /*
  * (c) 2013 Ben "root" Anderson
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -44,7 +54,7 @@ extern LinuxInputManager* LINUXINPUT; // global and accessible from anywhere in 
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF


### PR DESCRIPTION
### Scenario

You own a very feature rich ITGmania setup. You have multiple input devices like two SMX stages, maybe a set of arcade pads with STACs, or a pair of LTEKs, and add some custom USB joyboxes for menu navigation you made with some "zero delay" encoders....you have a couple of Joy devices that ITGMania has to keep track of.

But every once in a while, the order is messed up...what's going on?

Surely @natano solved this with [this](https://github.com/stepmania/stepmania/pull/1926/files) right? Ordering by linux event number?

Or even @sergioperez  with [this](https://github.com/itgmania/itgmania/pull/151) PR which let you set joystick order right?

### Problem

So the Linux kernel sadly isn't as predicable as we wish it to be. Certain USB controllers when booted will get us different event/joystick numbers. This worked for natano since they were using a virtual driver, which booted up after the kernel started and was predicable, but didn't work for sergio.

Sergio solved this by using udev to uniquely identify the device in question and assign it a very specific location for ITGMania to pick it up.

But what if we don't want the udev rules and initial setup required by the end user? What can we do for ITGMania to allow for predicable enumeration of input devices?

What if we uniquely identified the device in question right? Each USB device has a VID, PID, BCD version, some strings, and a serial number...but there's a problem. A lot of cheap device manufactures don't provide serial numbers for their devices. They also like to reuse VID/PID combos, they make it difficult to know if you bought two of the same devices, which one is which. Pragmatically it makes it hard to know for example if you made two menu button boxes...which one is P1 and P2.

From a hardware device manufacturing perspective, I attempted to solve this by engineering devices like the STAC to have unique PID and strings which identified each side as the user installed it..but natano's fix of sorting the event numbers didn't solve the problem of on boot sometimes them getting swapped. Linux didn't really care what my device's PID number was or string, sometimes it would generate it's number in a different spot. Making dedicated setups a pain to troubleshoot why inputs aren't working.

So how else can we *guarantee* that on each boot of the system, every device enumerates with the proper Joy number without the user having to unplug/replug/restart the system in question?

### Solution

Well the best solution I was able to come up with was calling `ioctl` with `EVIOCGPHYS` and sorting according to the result.

This allows ITGMania to pre-sort the devices in question by *location on the system* before enumerating and giving it a Joy number. So where the device is plugged in means the most, down to the USB hub and port number.

By doing so that means if you didn't change the location in which the device was plugged in (IE if you didn't change the USB port the device is connected to) or add any new USB devices to the system, such as powering on a cabinet for the first time at the arcade, your devices are given the same Joy number.

This should allow a consistent experience for dedicated ITGMania users who use the same devices on the same system every boot.

I introduced this as a preference, which defaults to off to not mess with everyone's current mapping but please advise how you wish to proceed in this manner. Or even if I'm off base entirely, let me know!

Hopefully this will help someone who just booted into the game from remapping their settings every boot.

### Thank you for Playing

