### PR TITLE
Cache CMake build directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Checkout submodules
         run: git submodule update --init --recursive
+      - name: Cache CMake build directory
+        uses: actions/cache@v4
+        with:
+          path: |
+            build
+          key: ${{ runner.os }}-cmake-build-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-cmake-build-
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y
           libasound2-dev
@@ -42,6 +50,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Checkout submodules
         run: git submodule update --init --recursive
+      - name: Cache CMake build directory
+        uses: actions/cache@v4
+        with:
+          path: |
+            build
+          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-cmake-build-
       - name: Install dependencies
         run: brew install
           nasm
@@ -57,6 +73,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Checkout submodules
         run: git submodule update --init --recursive
+      - name: Cache CMake build directory
+        uses: actions/cache@v4
+        with:
+          path: |
+            build
+          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-cmake-build-
       - name: Install dependencies
         run: brew install
           nasm
@@ -72,6 +96,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Checkout submodules
         run: git submodule update --init --recursive
+      - name: Cache CMake build directory
+        uses: actions/cache@v4
+        with:
+          path: |
+            build
+          key: ${{ runner.os }}-cmake-build-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-cmake-build-
       - name: Configure
         run: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
       - name: Build


### PR DESCRIPTION
Adds a cache to the build steps in the workflow here, reference https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#using-the-cache-action and https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#managing-caches.

Compare run times on this repository without a cache - https://github.com/itgmania/itgmania/actions/runs/10518411494/usage - to my fork with a cache - https://github.com/ScottBrenner/itgmania/actions/runs/10518354251/usage - the cache can be seen at https://github.com/itgmania/itgmania/actions/caches. Example usage - https://github.com/ScottBrenner/itgmania/actions/runs/10518354251/job/29143997746#step:4:1

Just caches the `build` directory, is there a better path?