### PR TITLE
WaveOut 16x512 buffer instead of 8x1024

### DIFF
--- a/src/arch/Sound/RageSoundDriver_WaveOut.h
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.h
@@ -18,7 +18,7 @@ public:
 	std::int64_t GetPosition() const;
 	float GetPlayLatency() const;
 	int GetSampleRate() const { return m_iSampleRate; }
-
+	static const int NUM_BUFFERS = 32;
 private:
 	static int MixerThread_start( void *p );
 	void MixerThread();
@@ -28,7 +28,7 @@ private:
 
 	HWAVEOUT m_hWaveOut;
 	HANDLE m_hSoundEvent;
-	WAVEHDR m_aBuffers[8];
+	WAVEHDR m_aBuffers[NUM_BUFFERS];
 	int m_iSampleRate;
 	bool m_bShutdown;
 	int m_iLastCursorPos;


### PR DESCRIPTION
You can give WaveOut an arbitrary number of buffers so you can adjust it along with the size of each buffer; any combination of the two results in a particular amount of latency.

RageSoundDriver.h defines samples_per_block as 512, so this aims to have chunksize_frames equal 512. (16384 ÷ 32)

https://github.com/itgmania/itgmania/blob/5d4f9dcb07493ed4c51d6be23e9b41978162305a/src/arch/Sound/RageSoundDriver.h#L15

16 x 512 would match the latency of 8 x 1024 but i feel 32 x 512 is more stable, it's also not a huge deal because the difference would be accounted for when the player resyncs their setup.