### PR TITLE
Rename function to get system timer usecs value

### DIFF
--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -35,11 +35,11 @@ const std::int64_t ONE_SECOND_IN_MICROSECONDS_LL = 1000000LL;
 const double ONE_SECOND_IN_MICROSECONDS_DBL = 1000000.0;
 
 const RageTimer RageZeroTimer(0,0);
-static std::uint64_t g_iStartTime = ArchHooks::GetMicrosecondsSinceStart( true );
+static std::uint64_t g_iStartTime = ArchHooks::GetElapsedSystemMicroseconds( true );
 
 static std::uint64_t GetTime( bool /* bAccurate */ )
 {
-	return ArchHooks::GetMicrosecondsSinceStart( true );
+	return ArchHooks::GetElapsedSystemMicroseconds( true );
 }
 
 /* The accuracy of RageTimer::GetTimeSinceStart() is directly tied to the

--- a/src/arch/ArchHooks/ArchHooks.h
+++ b/src/arch/ArchHooks/ArchHooks.h
@@ -87,7 +87,7 @@ public:
 	 * underlying timers may be 32-bit, but implementations should try to avoid
 	 * wrapping if possible.
 	 */
-	static std::int64_t GetMicrosecondsSinceStart( bool bAccurate );
+	static std::int64_t GetElapsedSystemMicroseconds( bool bAccurate ) noexcept;
 
 	/*
 	 * Add file search paths, higher priority first.
@@ -129,7 +129,7 @@ public:
 	void RegisterWithLua();
 
 private:
-	/* This are helpers for GetMicrosecondsSinceStart on systems with a timer
+	/* This are helpers for GetElapsedSystemMicroseconds on systems with a timer
 	 * that may loop or move backwards. */
 	static std::int64_t FixupTimeIfLooped( std::int64_t usecs );
 	static std::int64_t FixupTimeIfBackwards( std::int64_t usecs );

--- a/src/arch/ArchHooks/ArchHooksUtil.cpp
+++ b/src/arch/ArchHooks/ArchHooksUtil.cpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 
 /*
- * This is a helper for GetMicrosecondsSinceStart on systems with a system
+ * This is a helper for GetElapsedSystemMicroseconds on systems with a system
  * timer that may loop or move backwards.
  *
  * The time may decrease last for at least two reasons:
@@ -23,7 +23,7 @@
  *
  * This helper only needs to be used if one or both of the above conditions can occur.
  * If the underlying timer is reliable, this doesn't need to be used (for a small
- * efficiency bonus).  Also, you may omit this for GetMicrosecondsSinceStart() when
+ * efficiency bonus).  Also, you may omit this for GetElapsedSystemMicroseconds() when
  * bAccurate == false.
  */
 

--- a/src/arch/ArchHooks/ArchHooks_MacOSX.mm
+++ b/src/arch/ArchHooks/ArchHooks_MacOSX.mm
@@ -258,7 +258,7 @@ bool ArchHooks_MacOSX::GoToURL( RString sUrl )
 	return result == 0;
 }
 
-std::int64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate )
+std::int64_t ArchHooks::GetElapsedSystemMicroseconds( bool bAccurate ) noexcept
 {
 	// http://developer.apple.com/qa/qa2004/qa1398.html
 	static double factor = 0.0;

--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -120,7 +120,7 @@ static void TestTLS()
 #endif
 
 #if 1
-/* If librt is available, use CLOCK_MONOTONIC to implement GetMicrosecondsSinceStart,
+/* If librt is available, use CLOCK_MONOTONIC to implement GetElapsedSystemMicroseconds,
  * if supported, so changes to the system clock don't cause problems. */
 namespace
 {
@@ -149,7 +149,7 @@ clockid_t ArchHooks_Unix::GetClock()
 	return g_Clock;
 }
 
-std::int64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate )
+std::int64_t ArchHooks::GetElapsedSystemMicroseconds( bool bAccurate ) noexcept
 {
 	OpenGetTime();
 
@@ -162,7 +162,7 @@ std::int64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate )
 	return iRet;
 }
 #else
-std::int64_t ArchHooks::GetMicrosecondsSinceStart( bool bAccurate )
+std::int64_t ArchHooks::GetElapsedSystemMicroseconds( bool bAccurate ) noexcept
 {
 	struct timeval tv;
 	gettimeofday( &tv, nullptr );

--- a/src/arch/ArchHooks/ArchHooks_Unix.h
+++ b/src/arch/ArchHooks/ArchHooks_Unix.h
@@ -13,7 +13,7 @@ public:
 	void DumpDebugInfo();
 
 	void SetTime( tm newtime );
-	std::int64_t GetMicrosecondsSinceStart();
+	std::int64_t GetElapsedSystemMicroseconds();
 
 	void MountInitialFilesystems( const RString &sDirOfExecutable );
 	float GetDisplayAspectRatio() { return 4.0f/3; }

--- a/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
@@ -39,7 +39,7 @@ static void InitTimer()
 	QueryPerformanceFrequency(&g_liFrequency);
 }
 
-std::int64_t ArchHooks::GetMicrosecondsSinceStart(bool bAccurate)
+std::int64_t ArchHooks::GetElapsedSystemMicroseconds(bool bAccurate) noexcept
 {
 	// Make sure the timer is initialized.
 	if (!g_bTimerInitialized) {


### PR DESCRIPTION
The old name was too confusing. Noexcept it while we're here.

Re-created because I messed up https://github.com/itgmania/itgmania/pull/409.