### PR TITLE
Implement sliding window between AVPackets and AVFrames, to save memory.

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_Generic.h
+++ b/src/arch/MovieTexture/MovieTexture_Generic.h
@@ -28,10 +28,11 @@ public:
 	virtual RString Open( RString sFile ) = 0;
 	virtual void Close() = 0;
 	virtual void Rewind() = 0;
+	virtual void Rollover() = 0;
 
 	// Decode the next frame.
 	// Return 1 on success, 0 on EOF, -1 on fatal error, -2 on cancel.
-	virtual int DecodeNextFrame() = 0;
+	virtual int DecodeFrame() = 0;
 	virtual int DecodeMovie() = 0;
 
 	// Returns true if the frame we want to display has been decoded already.
@@ -40,10 +41,7 @@ public:
 	/*
 	 * Get the currently-decoded frame.
 	 */
-	virtual bool GetFrame( RageSurface *pOut ) = 0;
-
-	// Returns true if the frame should be skipped.
-	virtual bool SkipNextFrame() = 0;
+	virtual int GetFrame( RageSurface *pOut ) = 0;
 
 	/* Return the dimensions of the image, in pixels (before aspect ratio
 	 * adjustments). */
@@ -76,6 +74,12 @@ public:
 
 	// Cancels the decoding of the movie.
 	virtual void Cancel() = 0;
+
+	// Sets the looping property on the decoder.
+	virtual void SetLooping(bool loop) = 0;
+
+	// Returns true if the the final frame was displayed.
+	virtual bool EndOfMovie() = 0;
 };
 
 
@@ -110,6 +114,7 @@ private:
 
 	float m_fRate;
 	bool m_bLoop;
+	bool finished_ = false;
 
 	// If true, halts all decoding and display.
 	bool m_failure = false;
@@ -131,7 +136,6 @@ private:
 	void CreateTexture();
 	void DestroyTexture();
 
-	bool DecodeFrame();
 	float CheckFrameTime();
 };
 


### PR DESCRIPTION
Create two buffers for video display, one holding `AVPackets` and the other holding `AVFrames`. Limit the `av_frame_buffer_` to 50 frames, as to prevent the code from completely overwhelming RAM. Fixes the issues found in #414.

The nitty-gritty:
* `AVPacket`s are much much smaller compared to `AVFrame`s, hence limiting the number of the latter we have in memory.
* When `frame_buffer_` is full, it waits until the `AVFrame` at `frame_buffer_position_` has been displayed before overwriting it.
* Chrono is removed in favor of `usleep` (since chrono doesn't play nice with Ryzen gen 1). The timing of the sleep isn't important, just that we don't busy loop as fast as possible and hurt CPU performance.
* `skip` was explicitly removed. Mangled frames can be displayable without much of an impact, but we can actually check where the AVFrame is being stretched onto the `RageSurface`, and if there's an issue there we can skip.
* With 10 random movies enabled and the `frame_buffer_` of size 50, RAM usage is at about 1gb, and CPU usage is around 10% of my system.
* Looping has an optimization when "rolling over" to the next replay (writing the 0th frame onward ahead of time), hence why there's a `Rollover` and `Rewind` function.
* Removes the "first frame loading" in `MovieTexture::Init`. In practice, the decoder is fast enough that it shouldn't be an issue, not to mention most movie loads are on screen transitions so there's extra time to generate the frames.

Known issues/caveats:
* ~~If the last frame displayed in a non-looping movie has an error, the decode loop won't exit correctly.~~ Done
* This doesn't actually speed up or improve the ffmpeg decoding, but by messing with kSwsFlags we might see some improvement (dependent on the ffmpeg version and features).
* Despite the above bullet, the frames themselves being decoded ahead of time should still make video playback much smoother (as evidenced by current beta).

Tested the following use cases:
* Random movies
* A pack of files with movie banners on everything, scrolling the song wheel
* Playing a song with a bg movie
* Playing a song with a bg movie and a video banner with step statistics enabled (two 30+ song sets)
* Results screen with multiple video banners
* The Bee Movie chart