### PR TITLE
Revert  c4d6305 & eeb2528 (REPLACED BY #457)

### DIFF
--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -772,7 +772,6 @@ void SMLoader::ProcessDelays( TimingData &out, const RString line, const int row
 void SMLoader::ProcessTimeSignatures( TimingData &out, const RString line, const int rowsPerBeat )
 {
 	std::vector<RString> vs1;
-	std::vector<TimeSignatureSegment> segments;
 	split( line, ",", vs1 );
 
 	for (RString const &s1 : vs1)
@@ -819,21 +818,8 @@ void SMLoader::ProcessTimeSignatures( TimingData &out, const RString line, const
 				     fBeat, iDenominator );
 			continue;
 		}
-		segments.push_back( TimeSignatureSegment(BeatToNoteRow(fBeat), iNumerator, iDenominator) );
-	}
-	
-	// If there are any time signatures defined, but there isn't one
-	// for the very first beat of the song, then add one.
-	// Without it, calls to functions like TimingData::NoteRowToMeasureAndBeat
-	// can fail for charts that are otherwise valid.
-	if ( segments.size() > 0 && segments[0].GetRow() > 0 )
-	{
-		out.AddSegment( TimeSignatureSegment(0, 4, 4) );
-	}
 
-	for( TimeSignatureSegment segment: segments )
-	{
-		out.AddSegment( segment );
+		out.AddSegment( TimeSignatureSegment(BeatToNoteRow(fBeat), iNumerator, iDenominator) );
 	}
 }
 

--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -821,6 +821,11 @@ void SMLoader::ProcessTimeSignatures( TimingData &out, const RString line, const
 
 		out.AddSegment( TimeSignatureSegment(BeatToNoteRow(fBeat), iNumerator, iDenominator) );
 	}
+
+	if (!hasInitialValue)
+	{
+		out.AddSegment(TimeSignatureSegment(0, 4));
+	}
 }
 
 void SMLoader::ProcessTickcounts( TimingData &out, const RString line, const int rowsPerBeat )
@@ -1115,6 +1120,9 @@ bool SMLoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCache
 	out.m_sSongFileName = sPath;
 
 	SMSongTagInfo reused_song_info(&*this, &out, sPath);
+
+	// Reset hasInitialValue for the new song
+	hasInitialValue = false;
 
 	for( unsigned i=0; i<msd.GetNumValues(); i++ )
 	{

--- a/src/NotesLoaderSM.h
+++ b/src/NotesLoaderSM.h
@@ -225,6 +225,15 @@ private:
 	RString songTitle;
 
 	std::vector<RString> m_SongDirFiles;
+
+	// NOTE(mjvotaw): If there are any time signatures defined, but there isn't
+	// one for the very first beat of the song, then add one.
+	// Without it, calls to functions like TimingData::NoteRowToMeasureAndBeat
+	// can fail for charts that are otherwise valid.
+	// NOTE(sukibaby): I'm using a boolean to track if there is an initial value
+	// and only apply the default if there isn't one. This is to optimize for the
+	// common case where there is an initial value.
+	bool hasInitialValue = false;
 };
 
 #endif

--- a/src/NotesLoaderSMA.cpp
+++ b/src/NotesLoaderSMA.cpp
@@ -48,7 +48,6 @@ void SMALoader::ProcessMultipliers( TimingData &out, const int iRowsPerBeat, con
 void SMALoader::ProcessBeatsPerMeasure( TimingData &out, const RString sParam )
 {
 	std::vector<RString> vs1;
-	std::vector<TimeSignatureSegment> segments;
 	split( sParam, ",", vs1 );
 
 	for (RString const &s1 : vs1)
@@ -83,21 +82,8 @@ void SMALoader::ProcessBeatsPerMeasure( TimingData &out, const RString sParam )
 				     fBeat, iNumerator );
 			continue;
 		}
-		segments.push_back( TimeSignatureSegment(BeatToNoteRow(fBeat), iNumerator) );
-	}
 
-	// If there are any time signatures defined, but there isn't one
-	// for the very first beat of the song, then add one.
-	// Without it, calls to functions like TimingData::NoteRowToMeasureAndBeat
-	// can fail for charts that are otherwise valid.
-	if ( segments.size() > 0 && segments[0].GetRow() > 0 )
-	{
-		out.AddSegment( TimeSignatureSegment(0, 4, 4) );
-	}
-
-	for( TimeSignatureSegment segment: segments )
-	{
-		out.AddSegment( segment );
+		out.AddSegment( TimeSignatureSegment(BeatToNoteRow(fBeat), iNumerator) );
 	}
 }
 

--- a/src/NotesLoaderSMA.cpp
+++ b/src/NotesLoaderSMA.cpp
@@ -82,8 +82,17 @@ void SMALoader::ProcessBeatsPerMeasure( TimingData &out, const RString sParam )
 				     fBeat, iNumerator );
 			continue;
 		}
+		if (fBeat == 0)
+		{
+			hasInitialValue = true;
+		}
 
-		out.AddSegment( TimeSignatureSegment(BeatToNoteRow(fBeat), iNumerator) );
+		out.AddSegment(TimeSignatureSegment(BeatToNoteRow(fBeat), iNumerator));
+	}
+
+	if (!hasInitialValue)
+	{
+		out.AddSegment(TimeSignatureSegment(0, 4));
 	}
 }
 
@@ -167,6 +176,9 @@ bool SMALoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCach
 	Steps* pNewNotes = nullptr;
 	int iRowsPerBeat = -1; // Start with an invalid value: needed for checking.
 	std::vector<std::pair<float, float>> vBPMChanges, vStops;
+
+	// Reset hasInitialValue for the new song
+	hasInitialValue = false;
 
 	for( unsigned i=0; i<msd.GetNumValues(); i++ )
 	{

--- a/src/NotesLoaderSMA.h
+++ b/src/NotesLoaderSMA.h
@@ -26,6 +26,15 @@ struct SMALoader : public SMLoader
 	 * @param line the string in question.
 	 * @param rowsPerBeat the number of rows per beat for this purpose. */
 	virtual void ProcessSpeeds( TimingData &out, const RString line, const int rowsPerBeat );
+private:
+	// NOTE(mjvotaw): If there are any time signatures defined, but there isn't
+	// one for the very first beat of the song, then add one.
+	// Without it, calls to functions like TimingData::NoteRowToMeasureAndBeat
+	// can fail for charts that are otherwise valid.
+	// NOTE(sukibaby): I'm using a boolean to track if there is an initial value
+	// and only apply the default if there isn't one. This is to optimize for the
+	// common case where there is an initial value.
+	bool hasInitialValue = false;
 };
 
 #endif

--- a/src/TimingData.h
+++ b/src/TimingData.h
@@ -313,313 +313,50 @@ public:
 		return GetSegmentAtRow( BeatToNoteRow(fBeat), tst );
 	}
 
-		// BPM / BPM
+	#define DefineSegmentWithName(Seg, SegName, SegType) \
+		const Seg* Get##Seg##AtRow( int iNoteRow ) const \
+		{ \
+			const TimingSegment *t = GetSegmentAtRow( iNoteRow, SegType ); \
+			return To##SegName( t ); \
+		} \
+		Seg* Get##Seg##AtRow( int iNoteRow ) \
+		{ \
+			return const_cast<Seg*> (((const TimingData*)this)->Get##Seg##AtRow(iNoteRow) ); \
+		} \
+		const Seg* Get##Seg##AtBeat( float fBeat ) const \
+		{ \
+			return Get##Seg##AtRow( BeatToNoteRow(fBeat) ); \
+		} \
+		Seg* Get##Seg##AtBeat( float fBeat ) \
+		{ \
+			return const_cast<Seg*> (((const TimingData*)this)->Get##Seg##AtBeat(fBeat) ); \
+		} \
+		void AddSegment( const Seg &seg ) \
+		{ \
+			AddSegment( &seg ); \
+		}
 
-	const BPMSegment* GetBPMSegmentAtRow(int iNoteRow) const
-	{
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_BPM);
-		return ToBPM(t);
-	}
-	
-	BPMSegment* GetBPMSegmentAtRow(int iNoteRow)
-	{
-		return const_cast<BPMSegment*> (((const TimingData*)this)->GetBPMSegmentAtRow(iNoteRow));
-	}
-	
-	const BPMSegment* GetBPMSegmentAtBeat(float fBeat) const
-	{
-		return GetBPMSegmentAtRow(BeatToNoteRow(fBeat));
-	}
-	
-	BPMSegment* GetBPMSegmentAtBeat(float fBeat)
-	{
-		return const_cast<BPMSegment*> (((const TimingData*)this)->GetBPMSegmentAtBeat(fBeat));
-	}
-	
-	void AddSegment(const BPMSegment& seg)
-	{
-		AddSegment(&seg);
-	}
+	// "XXX: this comment (and quote mark) exists so nano won't
+	// display the rest of this file as one giant string
 
-		// Stop / STOP
+	// (TimeSignature,TIME_SIG) -> (TimeSignatureSegment,SEGMENT_TIME_SIG)
+	#define DefineSegment(Seg, SegType ) \
+		DefineSegmentWithName( Seg##Segment, Seg, SEGMENT_##SegType )
 
-	const StopSegment* GetStopSegmentAtRow(int iNoteRow) const
-	{
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_STOP);
-		return ToStop(t);
-	}
-	
-	StopSegment* GetStopSegmentAtRow(int iNoteRow)
-	{
-		return const_cast<StopSegment*>(((const TimingData*)this)->GetStopSegmentAtRow(iNoteRow));
-	}
-	
-	const StopSegment* GetStopSegmentAtBeat(float fBeat) const
-	{
-		return GetStopSegmentAtRow(BeatToNoteRow(fBeat));
-	}
-	
-	StopSegment* GetStopSegmentAtBeat(float fBeat)
-	{
-		return const_cast<StopSegment*>(((const TimingData*)this)->GetStopSegmentAtBeat(fBeat));
-	}
-	
-	void AddSegment(const StopSegment& seg)
-	{
-		AddSegment(&seg);
-	}
+	DefineSegment( BPM, BPM );
+	DefineSegment( Stop, STOP );
+	DefineSegment( Delay, DELAY );
+	DefineSegment( Warp, WARP );
+	DefineSegment( Label, LABEL );
+	DefineSegment( Tickcount, TICKCOUNT );
+	DefineSegment( Combo, COMBO );
+	DefineSegment( Speed, SPEED );
+	DefineSegment( Scroll, SCROLL );
+	DefineSegment( Fake, FAKE );
+	DefineSegment( TimeSignature, TIME_SIG );
 
-		// Delay / DELAY
-
-	const DelaySegment* GetDelaySegmentAtRow(int iNoteRow) const
-	{
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_DELAY);
-		return ToDelay(t);
-	}
-	
-	DelaySegment* GetDelaySegmentAtRow(int iNoteRow)
-	{
-		return const_cast<DelaySegment*>(((const TimingData*)this)->GetDelaySegmentAtRow(iNoteRow));
-	}
-	
-	const DelaySegment* GetDelaySegmentAtBeat(float fBeat) const
-	{
-		return GetDelaySegmentAtRow(BeatToNoteRow(fBeat));
-	}
-	
-	DelaySegment* GetDelaySegmentAtBeat(float fBeat)
-	{
-		return const_cast<DelaySegment*>(((const TimingData*)this)->GetDelaySegmentAtBeat(fBeat));
-	}
-	
-	void AddSegment(const DelaySegment& seg)
-	{
-		AddSegment(&seg);
-	}
-
-		// Warp / WARP
-
-	const WarpSegment* GetWarpSegmentAtRow(int iNoteRow) const
-	{
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_WARP);
-		return ToWarp(t);
-	}
-	
-	WarpSegment* GetWarpSegmentAtRow(int iNoteRow)
-	{
-		return const_cast<WarpSegment*>(((const TimingData*)this)->GetWarpSegmentAtRow(iNoteRow));
-	}
-	
-	const WarpSegment* GetWarpSegmentAtBeat(float fBeat) const
-	{
-		return GetWarpSegmentAtRow(BeatToNoteRow(fBeat));
-	}
-	
-	WarpSegment* GetWarpSegmentAtBeat(float fBeat)
-	{
-		return const_cast<WarpSegment*>(((const TimingData*)this)->GetWarpSegmentAtBeat(fBeat));
-	}
-	
-	void AddSegment(const WarpSegment& seg)
-	{
-		AddSegment(&seg);
-	}
-
-		// Label / LABEL
-
-	const LabelSegment* GetLabelSegmentAtRow(int iNoteRow) const
-	{
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_LABEL);
-		return ToLabel(t);
-	}
-	
-	LabelSegment* GetLabelSegmentAtRow(int iNoteRow)
-	{
-		return const_cast<LabelSegment*>(((const TimingData*)this)->GetLabelSegmentAtRow(iNoteRow));
-	}
-	
-	const LabelSegment* GetLabelSegmentAtBeat(float fBeat) const
-	{
-		return GetLabelSegmentAtRow(BeatToNoteRow(fBeat));
-	}
-	
-	LabelSegment* GetLabelSegmentAtBeat(float fBeat)
-	{
-		return const_cast<LabelSegment*>(((const TimingData*)this)->GetLabelSegmentAtBeat(fBeat));
-	}
-	
-	void AddSegment(const LabelSegment& seg)
-	{
-		AddSegment(&seg);
-	}
-
-		// Tickcount / TICKCOUNT
-
-	const TickcountSegment* GetTickcountSegmentAtRow(int iNoteRow) const
-	{
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_TICKCOUNT);
-		return ToTickcount(t);
-	}
-	
-	TickcountSegment* GetTickcountSegmentAtRow(int iNoteRow)
-	{
-		return const_cast<TickcountSegment*>(((const TimingData*)this)->GetTickcountSegmentAtRow(iNoteRow));
-	}
-	
-	const TickcountSegment* GetTickcountSegmentAtBeat(float fBeat) const
-	{
-		return GetTickcountSegmentAtRow(BeatToNoteRow(fBeat));
-	}
-	
-	TickcountSegment* GetTickcountSegmentAtBeat(float fBeat)
-	{
-		return const_cast<TickcountSegment*>(((const TimingData*)this)->GetTickcountSegmentAtBeat(fBeat));
-	}
-	
-	void AddSegment(const TickcountSegment& seg)
-	{
-		AddSegment(&seg);
-	}
-
-		// Combo / COMBO
-
-	const ComboSegment* GetComboSegmentAtRow(int iNoteRow) const
-	{
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_COMBO);
-		return ToCombo(t);
-	}
-	
-	ComboSegment* GetComboSegmentAtRow(int iNoteRow)
-	{
-		return const_cast<ComboSegment*>(((const TimingData*)this)->GetComboSegmentAtRow(iNoteRow));
-	}
-	
-	const ComboSegment* GetComboSegmentAtBeat(float fBeat) const
-	{
-		return GetComboSegmentAtRow(BeatToNoteRow(fBeat));
-	}
-	
-	ComboSegment* GetComboSegmentAtBeat(float fBeat)
-	{
-		return const_cast<ComboSegment*>(((const TimingData*)this)->GetComboSegmentAtBeat(fBeat));
-	}
-	
-	void AddSegment(const ComboSegment& seg)
-	{
-		AddSegment(&seg);
-	}
-
-		// Speed / SPEED
-
-	const SpeedSegment* GetSpeedSegmentAtRow(int iNoteRow) const
-	{
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_SPEED);
-		return ToSpeed(t);
-	}
-	
-	SpeedSegment* GetSpeedSegmentAtRow(int iNoteRow)
-	{
-		return const_cast<SpeedSegment*>(((const TimingData*)this)->GetSpeedSegmentAtRow(iNoteRow));
-	}
-	
-	const SpeedSegment* GetSpeedSegmentAtBeat(float fBeat) const
-	{
-		return GetSpeedSegmentAtRow(BeatToNoteRow(fBeat));
-	}
-	
-	SpeedSegment* GetSpeedSegmentAtBeat(float fBeat)
-	{
-		return const_cast<SpeedSegment*>(((const TimingData*)this)->GetSpeedSegmentAtBeat(fBeat));
-	}
-	
-	void AddSegment(const SpeedSegment& seg)
-	{
-		AddSegment(&seg);
-	}
-
-		// Scroll / SCROLL
-
-	const ScrollSegment* GetScrollSegmentAtRow(int iNoteRow) const
-	{
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_SCROLL);
-		return ToScroll(t);
-	}
-	
-	ScrollSegment* GetScrollSegmentAtRow(int iNoteRow)
-	{
-		return const_cast<ScrollSegment*>(((const TimingData*)this)->GetScrollSegmentAtRow(iNoteRow));
-	}
-	
-	const ScrollSegment* GetScrollSegmentAtBeat(float fBeat) const
-	{
-		return GetScrollSegmentAtRow(BeatToNoteRow(fBeat));
-	}
-	
-	ScrollSegment* GetScrollSegmentAtBeat(float fBeat)
-	{
-		return const_cast<ScrollSegment*>(((const TimingData*)this)->GetScrollSegmentAtBeat(fBeat));
-	}
-	
-	void AddSegment(const ScrollSegment& seg)
-	{
-		AddSegment(&seg);
-	}
-
-		// Fake / FAKE
-
-	const FakeSegment* GetFakeSegmentAtRow(int iNoteRow) const
-	{
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_FAKE);
-		return ToFake(t);
-	}
-	
-	FakeSegment* GetFakeSegmentAtRow(int iNoteRow)
-	{
-		return const_cast<FakeSegment*>(((const TimingData*)this)->GetFakeSegmentAtRow(iNoteRow));
-	}
-	
-	const FakeSegment* GetFakeSegmentAtBeat(float fBeat) const
-	{
-		return GetFakeSegmentAtRow(BeatToNoteRow(fBeat));
-	}
-	
-	FakeSegment* GetFakeSegmentAtBeat(float fBeat)
-	{
-		return const_cast<FakeSegment*>(((const TimingData*)this)->GetFakeSegmentAtBeat(fBeat));
-	}
-	
-	void AddSegment(const FakeSegment& seg)
-	{
-		AddSegment(&seg);
-	}
-
-		// TimeSignature / TIME_SIG
-
-	const TimeSignatureSegment* GetTimeSignatureSegmentAtRow(int iNoteRow) const
-	{
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_TIME_SIG);
-		return ToTimeSignature(t);
-	}
-	
-	TimeSignatureSegment* GetTimeSignatureSegmentAtRow(int iNoteRow)
-	{
-		return const_cast<TimeSignatureSegment*>(((const TimingData*)this)->GetTimeSignatureSegmentAtRow(iNoteRow));
-	}
-	
-	const TimeSignatureSegment* GetTimeSignatureSegmentAtBeat(float fBeat) const
-	{
-		return GetTimeSignatureSegmentAtRow(BeatToNoteRow(fBeat));
-	}
-	
-	TimeSignatureSegment* GetTimeSignatureSegmentAtBeat(float fBeat)
-	{
-		return const_cast<TimeSignatureSegment*>(((const TimingData*)this)->GetTimeSignatureSegmentAtBeat(fBeat));
-	}
-	
-	void AddSegment(const TimeSignatureSegment& seg)
-	{
-		AddSegment(&seg);
-	}
+	#undef DefineSegmentWithName
+	#undef DefineSegment
 
 	/* convenience aliases (Set functions are deprecated) */
 	float GetBPMAtRow( int iNoteRow ) const { return GetBPMSegmentAtRow(iNoteRow)->GetBPM(); }

--- a/src/TimingData.h
+++ b/src/TimingData.h
@@ -24,159 +24,36 @@ inline T ToDerived( const TimingSegment *t, TimingSegmentType tst )
 	return static_cast<T>( t );
 }
 
-	// ToBPM
+#define TimingSegmentToXWithName(Seg, SegName, SegType) \
+	inline const Seg* To##SegName( const TimingSegment *t ) \
+	{ \
+		ASSERT( t->GetType() == SegType ); \
+		return static_cast<const Seg*>( t ); \
+	} \
+	inline Seg* To##SegName( TimingSegment *t ) \
+	{ \
+		ASSERT( t->GetType() == SegType ); \
+		return static_cast<Seg*>( t ); \
+	}
 
-inline const BPMSegment* ToBPM(const TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_BPM);
-	return static_cast<const BPMSegment*>(t);
-}
+#define TimingSegmentToX(Seg, SegType) \
+	TimingSegmentToXWithName(Seg##Segment, Seg, SEGMENT_##SegType)
 
-inline BPMSegment* ToBPM(TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_BPM);
-	return static_cast<BPMSegment*>(t);
-}
+/* ToBPM(TimingSegment*), ToTimeSignature(TimingSegment*), etc. */
+TimingSegmentToX( BPM, BPM );
+TimingSegmentToX( Stop, STOP );
+TimingSegmentToX( Delay, DELAY );
+TimingSegmentToX( TimeSignature, TIME_SIG );
+TimingSegmentToX( Warp, WARP );
+TimingSegmentToX( Label, LABEL );
+TimingSegmentToX( Tickcount, TICKCOUNT );
+TimingSegmentToX( Combo, COMBO );
+TimingSegmentToX( Speed, SPEED );
+TimingSegmentToX( Scroll, SCROLL );
+TimingSegmentToX( Fake, FAKE );
 
-	// ToStop
-
-inline const StopSegment* ToStop(const TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_STOP);
-	return static_cast<const StopSegment*>(t);
-}
-
-inline StopSegment* ToStop(TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_STOP);
-	return static_cast<StopSegment*>(t);
-}
-
-	// ToDelay
-
-inline const DelaySegment* ToDelay(const TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_DELAY);
-	return static_cast<const DelaySegment*>(t);
-}
-
-inline DelaySegment* ToDelay(TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_DELAY);
-	return static_cast<DelaySegment*>(t);
-}
-
-	// ToTimeSignature
-
-inline const TimeSignatureSegment* ToTimeSignature(const TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_TIME_SIG);
-	return static_cast<const TimeSignatureSegment*>(t);
-}
-
-inline TimeSignatureSegment* ToTimeSignature(TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_TIME_SIG);
-	return static_cast<TimeSignatureSegment*>(t);
-}
-
-	// ToWarp
-
-inline const WarpSegment* ToWarp(const TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_WARP);
-	return static_cast<const WarpSegment*>(t);
-}
-
-inline WarpSegment* ToWarp(TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_WARP);
-	return static_cast<WarpSegment*>(t);
-}
-
-	// ToLabel
-
-inline const LabelSegment* ToLabel(const TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_LABEL);
-	return static_cast<const LabelSegment*>(t);
-}
-
-inline LabelSegment* ToLabel(TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_LABEL);
-	return static_cast<LabelSegment*>(t);
-}
-
-	// ToTickcount
-
-inline const TickcountSegment* ToTickcount(const TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_TICKCOUNT);
-	return static_cast<const TickcountSegment*>(t);
-}
-
-inline TickcountSegment* ToTickcount(TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_TICKCOUNT);
-	return static_cast<TickcountSegment*>(t);
-}
-
-	// ToCombo
-	
-inline const ComboSegment* ToCombo(const TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_COMBO);
-	return static_cast<const ComboSegment*>(t);
-}
-
-inline ComboSegment* ToCombo(TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_COMBO);
-	return static_cast<ComboSegment*>(t);
-}
-
-	// ToSpeed
-	
-inline const SpeedSegment* ToSpeed(const TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_SPEED);
-	return static_cast<const SpeedSegment*>(t);
-}
-
-inline SpeedSegment* ToSpeed(TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_SPEED);
-	return static_cast<SpeedSegment*>(t);
-}
-
-	// ToScroll
-	
-inline const ScrollSegment* ToScroll(const TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_SCROLL);
-	return static_cast<const ScrollSegment*>(t);
-}
-
-inline ScrollSegment* ToScroll(TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_SCROLL);
-	return static_cast<ScrollSegment*>(t);
-}
-
-	// ToFake
-
-inline const FakeSegment* ToFake(const TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_FAKE);
-	return static_cast<const FakeSegment*>(t);
-}
-
-inline FakeSegment* ToFake(TimingSegment* t)
-{
-	ASSERT(t->GetType() == SEGMENT_FAKE);
-	return static_cast<FakeSegment*>(t);
-}
+#undef TimingSegmentToXWithName
+#undef TimingSegmentToX
 
 /**
  * @brief Holds data for translating beats<->seconds.

--- a/src/TimingData.h
+++ b/src/TimingData.h
@@ -193,50 +193,313 @@ public:
 		return GetSegmentAtRow( BeatToNoteRow(fBeat), tst );
 	}
 
-	#define DefineSegmentWithName(Seg, SegName, SegType) \
-		const Seg* Get##Seg##AtRow( int iNoteRow ) const \
-		{ \
-			const TimingSegment *t = GetSegmentAtRow( iNoteRow, SegType ); \
-			return To##SegName( t ); \
-		} \
-		Seg* Get##Seg##AtRow( int iNoteRow ) \
-		{ \
-			return const_cast<Seg*> (((const TimingData*)this)->Get##Seg##AtRow(iNoteRow) ); \
-		} \
-		const Seg* Get##Seg##AtBeat( float fBeat ) const \
-		{ \
-			return Get##Seg##AtRow( BeatToNoteRow(fBeat) ); \
-		} \
-		Seg* Get##Seg##AtBeat( float fBeat ) \
-		{ \
-			return const_cast<Seg*> (((const TimingData*)this)->Get##Seg##AtBeat(fBeat) ); \
-		} \
-		void AddSegment( const Seg &seg ) \
-		{ \
-			AddSegment( &seg ); \
-		}
+		// BPM / BPM
 
-	// "XXX: this comment (and quote mark) exists so nano won't
-	// display the rest of this file as one giant string
+	const BPMSegment* GetBPMSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_BPM);
+		return ToBPM(t);
+	}
+	
+	BPMSegment* GetBPMSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<BPMSegment*> (((const TimingData*)this)->GetBPMSegmentAtRow(iNoteRow));
+	}
+	
+	const BPMSegment* GetBPMSegmentAtBeat(float fBeat) const
+	{
+		return GetBPMSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	BPMSegment* GetBPMSegmentAtBeat(float fBeat)
+	{
+		return const_cast<BPMSegment*> (((const TimingData*)this)->GetBPMSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const BPMSegment& seg)
+	{
+		AddSegment(&seg);
+	}
 
-	// (TimeSignature,TIME_SIG) -> (TimeSignatureSegment,SEGMENT_TIME_SIG)
-	#define DefineSegment(Seg, SegType ) \
-		DefineSegmentWithName( Seg##Segment, Seg, SEGMENT_##SegType )
+		// Stop / STOP
 
-	DefineSegment( BPM, BPM );
-	DefineSegment( Stop, STOP );
-	DefineSegment( Delay, DELAY );
-	DefineSegment( Warp, WARP );
-	DefineSegment( Label, LABEL );
-	DefineSegment( Tickcount, TICKCOUNT );
-	DefineSegment( Combo, COMBO );
-	DefineSegment( Speed, SPEED );
-	DefineSegment( Scroll, SCROLL );
-	DefineSegment( Fake, FAKE );
-	DefineSegment( TimeSignature, TIME_SIG );
+	const StopSegment* GetStopSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_STOP);
+		return ToStop(t);
+	}
+	
+	StopSegment* GetStopSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<StopSegment*>(((const TimingData*)this)->GetStopSegmentAtRow(iNoteRow));
+	}
+	
+	const StopSegment* GetStopSegmentAtBeat(float fBeat) const
+	{
+		return GetStopSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	StopSegment* GetStopSegmentAtBeat(float fBeat)
+	{
+		return const_cast<StopSegment*>(((const TimingData*)this)->GetStopSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const StopSegment& seg)
+	{
+		AddSegment(&seg);
+	}
 
-	#undef DefineSegmentWithName
-	#undef DefineSegment
+		// Delay / DELAY
+
+	const DelaySegment* GetDelaySegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_DELAY);
+		return ToDelay(t);
+	}
+	
+	DelaySegment* GetDelaySegmentAtRow(int iNoteRow)
+	{
+		return const_cast<DelaySegment*>(((const TimingData*)this)->GetDelaySegmentAtRow(iNoteRow));
+	}
+	
+	const DelaySegment* GetDelaySegmentAtBeat(float fBeat) const
+	{
+		return GetDelaySegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	DelaySegment* GetDelaySegmentAtBeat(float fBeat)
+	{
+		return const_cast<DelaySegment*>(((const TimingData*)this)->GetDelaySegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const DelaySegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// Warp / WARP
+
+	const WarpSegment* GetWarpSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_WARP);
+		return ToWarp(t);
+	}
+	
+	WarpSegment* GetWarpSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<WarpSegment*>(((const TimingData*)this)->GetWarpSegmentAtRow(iNoteRow));
+	}
+	
+	const WarpSegment* GetWarpSegmentAtBeat(float fBeat) const
+	{
+		return GetWarpSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	WarpSegment* GetWarpSegmentAtBeat(float fBeat)
+	{
+		return const_cast<WarpSegment*>(((const TimingData*)this)->GetWarpSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const WarpSegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// Label / LABEL
+
+	const LabelSegment* GetLabelSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_LABEL);
+		return ToLabel(t);
+	}
+	
+	LabelSegment* GetLabelSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<LabelSegment*>(((const TimingData*)this)->GetLabelSegmentAtRow(iNoteRow));
+	}
+	
+	const LabelSegment* GetLabelSegmentAtBeat(float fBeat) const
+	{
+		return GetLabelSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	LabelSegment* GetLabelSegmentAtBeat(float fBeat)
+	{
+		return const_cast<LabelSegment*>(((const TimingData*)this)->GetLabelSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const LabelSegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// Tickcount / TICKCOUNT
+
+	const TickcountSegment* GetTickcountSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_TICKCOUNT);
+		return ToTickcount(t);
+	}
+	
+	TickcountSegment* GetTickcountSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<TickcountSegment*>(((const TimingData*)this)->GetTickcountSegmentAtRow(iNoteRow));
+	}
+	
+	const TickcountSegment* GetTickcountSegmentAtBeat(float fBeat) const
+	{
+		return GetTickcountSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	TickcountSegment* GetTickcountSegmentAtBeat(float fBeat)
+	{
+		return const_cast<TickcountSegment*>(((const TimingData*)this)->GetTickcountSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const TickcountSegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// Combo / COMBO
+
+	const ComboSegment* GetComboSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_COMBO);
+		return ToCombo(t);
+	}
+	
+	ComboSegment* GetComboSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<ComboSegment*>(((const TimingData*)this)->GetComboSegmentAtRow(iNoteRow));
+	}
+	
+	const ComboSegment* GetComboSegmentAtBeat(float fBeat) const
+	{
+		return GetComboSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	ComboSegment* GetComboSegmentAtBeat(float fBeat)
+	{
+		return const_cast<ComboSegment*>(((const TimingData*)this)->GetComboSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const ComboSegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// Speed / SPEED
+
+	const SpeedSegment* GetSpeedSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_SPEED);
+		return ToSpeed(t);
+	}
+	
+	SpeedSegment* GetSpeedSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<SpeedSegment*>(((const TimingData*)this)->GetSpeedSegmentAtRow(iNoteRow));
+	}
+	
+	const SpeedSegment* GetSpeedSegmentAtBeat(float fBeat) const
+	{
+		return GetSpeedSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	SpeedSegment* GetSpeedSegmentAtBeat(float fBeat)
+	{
+		return const_cast<SpeedSegment*>(((const TimingData*)this)->GetSpeedSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const SpeedSegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// Scroll / SCROLL
+
+	const ScrollSegment* GetScrollSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_SCROLL);
+		return ToScroll(t);
+	}
+	
+	ScrollSegment* GetScrollSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<ScrollSegment*>(((const TimingData*)this)->GetScrollSegmentAtRow(iNoteRow));
+	}
+	
+	const ScrollSegment* GetScrollSegmentAtBeat(float fBeat) const
+	{
+		return GetScrollSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	ScrollSegment* GetScrollSegmentAtBeat(float fBeat)
+	{
+		return const_cast<ScrollSegment*>(((const TimingData*)this)->GetScrollSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const ScrollSegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// Fake / FAKE
+
+	const FakeSegment* GetFakeSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_FAKE);
+		return ToFake(t);
+	}
+	
+	FakeSegment* GetFakeSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<FakeSegment*>(((const TimingData*)this)->GetFakeSegmentAtRow(iNoteRow));
+	}
+	
+	const FakeSegment* GetFakeSegmentAtBeat(float fBeat) const
+	{
+		return GetFakeSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	FakeSegment* GetFakeSegmentAtBeat(float fBeat)
+	{
+		return const_cast<FakeSegment*>(((const TimingData*)this)->GetFakeSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const FakeSegment& seg)
+	{
+		AddSegment(&seg);
+	}
+
+		// TimeSignature / TIME_SIG
+
+	const TimeSignatureSegment* GetTimeSignatureSegmentAtRow(int iNoteRow) const
+	{
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_TIME_SIG);
+		return ToTimeSignature(t);
+	}
+	
+	TimeSignatureSegment* GetTimeSignatureSegmentAtRow(int iNoteRow)
+	{
+		return const_cast<TimeSignatureSegment*>(((const TimingData*)this)->GetTimeSignatureSegmentAtRow(iNoteRow));
+	}
+	
+	const TimeSignatureSegment* GetTimeSignatureSegmentAtBeat(float fBeat) const
+	{
+		return GetTimeSignatureSegmentAtRow(BeatToNoteRow(fBeat));
+	}
+	
+	TimeSignatureSegment* GetTimeSignatureSegmentAtBeat(float fBeat)
+	{
+		return const_cast<TimeSignatureSegment*>(((const TimingData*)this)->GetTimeSignatureSegmentAtBeat(fBeat));
+	}
+	
+	void AddSegment(const TimeSignatureSegment& seg)
+	{
+		AddSegment(&seg);
+	}
 
 	/* convenience aliases (Set functions are deprecated) */
 	float GetBPMAtRow( int iNoteRow ) const { return GetBPMSegmentAtRow(iNoteRow)->GetBPM(); }

--- a/src/TimingData.h
+++ b/src/TimingData.h
@@ -27,36 +27,159 @@ inline T ToDerived( const TimingSegment *t, TimingSegmentType tst )
 	return static_cast<T>( t );
 }
 
-#define TimingSegmentToXWithName(Seg, SegName, SegType) \
-	inline const Seg* To##SegName( const TimingSegment *t ) \
-	{ \
-		ASSERT( t->GetType() == SegType ); \
-		return static_cast<const Seg*>( t ); \
-	} \
-	inline Seg* To##SegName( TimingSegment *t ) \
-	{ \
-		ASSERT( t->GetType() == SegType ); \
-		return static_cast<Seg*>( t ); \
-	}
+	// ToBPM
 
-#define TimingSegmentToX(Seg, SegType) \
-	TimingSegmentToXWithName(Seg##Segment, Seg, SEGMENT_##SegType)
+inline const BPMSegment* ToBPM(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_BPM);
+	return static_cast<const BPMSegment*>(t);
+}
 
-/* ToBPM(TimingSegment*), ToTimeSignature(TimingSegment*), etc. */
-TimingSegmentToX( BPM, BPM );
-TimingSegmentToX( Stop, STOP );
-TimingSegmentToX( Delay, DELAY );
-TimingSegmentToX( TimeSignature, TIME_SIG );
-TimingSegmentToX( Warp, WARP );
-TimingSegmentToX( Label, LABEL );
-TimingSegmentToX( Tickcount, TICKCOUNT );
-TimingSegmentToX( Combo, COMBO );
-TimingSegmentToX( Speed, SPEED );
-TimingSegmentToX( Scroll, SCROLL );
-TimingSegmentToX( Fake, FAKE );
+inline BPMSegment* ToBPM(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_BPM);
+	return static_cast<BPMSegment*>(t);
+}
 
-#undef TimingSegmentToXWithName
-#undef TimingSegmentToX
+	// ToStop
+
+inline const StopSegment* ToStop(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_STOP);
+	return static_cast<const StopSegment*>(t);
+}
+
+inline StopSegment* ToStop(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_STOP);
+	return static_cast<StopSegment*>(t);
+}
+
+	// ToDelay
+
+inline const DelaySegment* ToDelay(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_DELAY);
+	return static_cast<const DelaySegment*>(t);
+}
+
+inline DelaySegment* ToDelay(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_DELAY);
+	return static_cast<DelaySegment*>(t);
+}
+
+	// ToTimeSignature
+
+inline const TimeSignatureSegment* ToTimeSignature(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_TIME_SIG);
+	return static_cast<const TimeSignatureSegment*>(t);
+}
+
+inline TimeSignatureSegment* ToTimeSignature(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_TIME_SIG);
+	return static_cast<TimeSignatureSegment*>(t);
+}
+
+	// ToWarp
+
+inline const WarpSegment* ToWarp(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_WARP);
+	return static_cast<const WarpSegment*>(t);
+}
+
+inline WarpSegment* ToWarp(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_WARP);
+	return static_cast<WarpSegment*>(t);
+}
+
+	// ToLabel
+
+inline const LabelSegment* ToLabel(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_LABEL);
+	return static_cast<const LabelSegment*>(t);
+}
+
+inline LabelSegment* ToLabel(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_LABEL);
+	return static_cast<LabelSegment*>(t);
+}
+
+	// ToTickcount
+
+inline const TickcountSegment* ToTickcount(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_TICKCOUNT);
+	return static_cast<const TickcountSegment*>(t);
+}
+
+inline TickcountSegment* ToTickcount(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_TICKCOUNT);
+	return static_cast<TickcountSegment*>(t);
+}
+
+	// ToCombo
+	
+inline const ComboSegment* ToCombo(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_COMBO);
+	return static_cast<const ComboSegment*>(t);
+}
+
+inline ComboSegment* ToCombo(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_COMBO);
+	return static_cast<ComboSegment*>(t);
+}
+
+	// ToSpeed
+	
+inline const SpeedSegment* ToSpeed(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_SPEED);
+	return static_cast<const SpeedSegment*>(t);
+}
+
+inline SpeedSegment* ToSpeed(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_SPEED);
+	return static_cast<SpeedSegment*>(t);
+}
+
+	// ToScroll
+	
+inline const ScrollSegment* ToScroll(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_SCROLL);
+	return static_cast<const ScrollSegment*>(t);
+}
+
+inline ScrollSegment* ToScroll(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_SCROLL);
+	return static_cast<ScrollSegment*>(t);
+}
+
+	// ToFake
+
+inline const FakeSegment* ToFake(const TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_FAKE);
+	return static_cast<const FakeSegment*>(t);
+}
+
+inline FakeSegment* ToFake(TimingSegment* t)
+{
+	ASSERT(t->GetType() == SEGMENT_FAKE);
+	return static_cast<FakeSegment*>(t);
+}
 
 /**
  * @brief Holds data for translating beats<->seconds.


### PR DESCRIPTION
Please refer to my comment in #451 and following discussion: https://github.com/itgmania/itgmania/issues/451#issuecomment-2311467883

Okay, so I am a little doubtful this is the responsible patch after further investigation, but I'll leave the PR open until that's confirmed or refuted. Besides, these are the only changes that affect TimingData / visual delay so I still mainly suspect it.

If these two PR's un-doing some TimingData macros could get merged, that would help a lot with diagnosing whether or not this is responsible:
https://github.com/itgmania/itgmania/pull/325
https://github.com/itgmania/itgmania/pull/327