### PR TITLE
Remove the "EndOfSong" fail type  (REPLACED BY Simply Love #567)

### DIFF
--- a/src/GameConstantsAndTypes.cpp
+++ b/src/GameConstantsAndTypes.cpp
@@ -514,7 +514,6 @@ LuaFunction( CourseTypeToLocalizedString, CourseTypeToLocalizedString( Enum::Che
 static const char *FailTypeNames[] = {
 	"Immediate",
 	"ImmediateContinue",
-	"EndOfSong",
 	"Off",
 };
 XToString( FailType );

--- a/src/GameConstantsAndTypes.h
+++ b/src/GameConstantsAndTypes.h
@@ -706,7 +706,6 @@ enum FailType
 {
 	FailType_Immediate,		/**< fail immediately when life touches 0 */
 	FailType_ImmediateContinue,	/**< Same as above, but allow playing the rest of the song */
-	FailType_EndOfSong,			/**< fail if life is at 0 when the song ends */
 	FailType_Off,			/**< never fail */
 	NUM_FailType,
 	FailType_Invalid

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -529,7 +529,6 @@ void PlayerOptions::GetMods( std::vector<RString> &AddTo, bool bForceNoteSkin ) 
 	{
 	case FailType_Immediate:							break;
 	case FailType_ImmediateContinue:		AddTo.push_back("FailImmediateContinue");	break;
-	case FailType_EndOfSong:			AddTo.push_back("FailAtEnd");	break;
 	case FailType_Off:				AddTo.push_back("FailOff");	break;
 	default:
 		FAIL_M(ssprintf("Invalid FailType: %i", m_FailType));
@@ -1122,7 +1121,6 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 		 sBit == "failimmediate" )			m_FailType = FailType_Immediate;
 	else if( sBit == "failendofsong" ||
 		 sBit == "failimmediatecontinue" )		m_FailType = FailType_ImmediateContinue;
-	else if( sBit == "failatend" )				m_FailType = FailType_EndOfSong;
 	else if( sBit == "failoff" )				m_FailType = FailType_Off;
 	else if( sBit == "faildefault" )
 	{

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1742,7 +1742,7 @@ void ScreenGameplay::Update( float fDeltaTime )
 
 				FailType ft = GAMESTATE->GetPlayerFailType( pi->GetPlayerState() );
 				LifeType lt = pi->GetPlayerState()->m_PlayerOptions.GetStage().m_LifeType;
-				if( ft == FailType_Off || ft == FailType_EndOfSong )
+				if( ft == FailType_Off )
 					continue;
 
 				// check for individual fail
@@ -1790,7 +1790,6 @@ void ScreenGameplay::Update( float fDeltaTime )
 						bAllFailed = false;
 					break;
 				case FailType_ImmediateContinue:
-				case FailType_EndOfSong:
 					bAllFailed = false;	// wait until the end of the song to fail.
 					break;
 				case FailType_Off:

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -361,7 +361,6 @@ static void DefaultFailChoices(std::vector<RString>& out)
 {
 	out.push_back("Immediate");
 	out.push_back("ImmediateContinue");
-	out.push_back("EndOfSong");
 	out.push_back("Off");
 }
 


### PR DESCRIPTION
By removing all references to the EndOfSong fail type, it isn't presented as an option theme-side.

Of course, theme side stuff making references to EndOfSong should be removed but it doesn't seem like anything else is needed theme-side.


https://github.com/user-attachments/assets/4a1b2db2-fe94-4b16-a210-807f6cc54f07

