### PR TITLE
Reapply "Windows: Compile with /utf-8 flag"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -150,7 +150,7 @@ endif()
 
 if(MSVC)
   # TODO: Find a way to do this cleanly for non MSVC users.
-  set(SM_COMPILE_FLAGS "${SM_COMPILE_FLAGS} /MP2")
+  set(SM_COMPILE_FLAGS "${SM_COMPILE_FLAGS} /MP2 /utf-8")
 endif()
 
 set_target_properties("${SM_EXE_NAME}"


### PR DESCRIPTION
This reverts commit 48c1fe38567a4ed79eab3c8ac6c34b0b3c38d1ac.

I've profiled this compared to a build without the /utf-8 flag, and it's no longer causing a performance hit. I believe this is possible because of the StdString.cpp patch.