### PR TITLE
Update ci.yml with "vswhere"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Checkout submodules
         run: git submodule update --init --recursive
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1
+      - name: Set up Visual Studio environment
+        run: |
+          $vsPath = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          &"$vsPath\VC\Auxiliary\Build\vcvarsall.bat" x64
+        shell: pwsh
       - name: Cache CMake build directory
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Prevents an issue where the runner may not be able to find the compiler.

I've been having this issue for the last few days:
![image](https://github.com/user-attachments/assets/181f08ef-1e2a-4db7-979b-6e0f0a17b746)

```
CMake Error at CMakeLists.txt:3 (project):
  The CMAKE_C_COMPILER:

    C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.40.33807/bin/Hostx[6](https://github.com/itgmania/itgmania/actions/runs/10613490710/job/29417388607#step:5:7)4/x64/cl.exe

  is not a full path to an existing compiler tool.



CMake Error at CMakeLists.txt:3 (project):
  The CMAKE_CXX_COMPILER:

    C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.40.3380[7](https://github.com/itgmania/itgmania/actions/runs/10613490710/job/29417388607#step:5:8)/bin/Hostx64/x64/cl.exe

  is not a full path to an existing compiler tool.
```

This was not caused directly by #446  because Windows CI worked for several days after that change.



Here's this new `ci.yml` working fine in my own branch:
![image](https://github.com/user-attachments/assets/66adbd04-c66a-4b3b-9ef4-a9a4e640b5d4)
