### PR TITLE
😩 Fix an issue in RageSoundReader where GCC 12 and above will fail

### DIFF
--- a/src/RageSoundReader.cpp
+++ b/src/RageSoundReader.cpp
@@ -14,7 +14,7 @@ int RageSoundReader::RetriedRead(float* pBuffer, int iFrames, int* iSourceFrame,
 	// pReader may return 0, which means "try again immediately". As a failsafe,
 	// only try this a finite number of times. Use a high number, because in
 	// principle each filter in the stack may cause this.
-	std::uint8_t retryCount = 50;
+	unsigned retryCount = 50;
 	while (--retryCount) {
 		if (fRate) {
 			*fRate = this->GetStreamToSourceRatio();


### PR DESCRIPTION
Users attempting to build the beta branch with GCC 12, 13 or 14 have a failure here due to the  `std::uint8_t` data type, despite `<cstdint>` already being brought in via included headers. 

The reason I changed it to an `unsigned` instead of including `<cstdint>` is because behavior on versions of GCC 12 and up were not consistent. It's not an issue on MSVC or XCode, only GCC. I haven't quite identified why yet.

I changed the iterator from `std::uint8_t` to an `unsigned` because all versions of GCC were happy with that. `unsigned` also has the benefit of being unable to handle a negative number, making it the safer choice compared to an int for this kind of counter.