### PR TITLE
ci.yml: Don't cache windows build.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,14 +103,6 @@ jobs:
           $vsPath = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
           &"$vsPath\VC\Auxiliary\Build\vcvarsall.bat" x64
         shell: pwsh
-      - name: Cache CMake build directory
-        uses: actions/cache@v4
-        with:
-          path: |
-            build
-          key: ${{ runner.os }}-cmake-build-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-cmake-build-
       - name: Configure
         run: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
       - name: Build


### PR DESCRIPTION
Attempt to fix the failing CI for the short term.

I guess the wrong version of the MSVC compiler can get cached because 5df59b8 and 98ba0b8 successfully  built.

The existing CI still works fine on my branch though 🤷‍♀️ 