### PR TITLE
Rewrite RageSoundMixBuffer for <vector> (REOPENED IN #475)

### DIFF
--- a/src/RageSoundMixBuffer.cpp
+++ b/src/RageSoundMixBuffer.cpp
@@ -5,54 +5,28 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <vector>
 
-RageSoundMixBuffer::RageSoundMixBuffer()
+void RageSoundMixBuffer::Extend(unsigned iSamples) noexcept
 {
-	m_pMixbuf = static_cast<float*>(std::malloc(BUF_SIZE * sizeof(float)));
-	if (m_pMixbuf == nullptr)
+	static const std::int_fast64_t chunksize = 1024; // in samples
+	const std::int_fast64_t realsize = static_cast<std::int_fast64_t>(iSamples) + m_iOffset;
+	std::int_fast64_t newsize = ((realsize + chunksize - 1) / chunksize) * chunksize; // find the next multiple of 1024
+
+	if( m_iBufSize < newsize )
 	{
-		ASSERT_M(false, "Failed to allocate memory for the sound mixing buffer");
-	}
-	m_iBufSize = BUF_SIZE;
-	std::memset(m_pMixbuf, 0, m_iBufSize * sizeof(float));
-	m_iBufUsed = 0;
-	m_iOffset = 0;
-}
-
-
-RageSoundMixBuffer::~RageSoundMixBuffer()
-{
-	std::free(m_pMixbuf);
-}
-
-/* write() will start mixing iOffset samples into the buffer.  Be careful; this is
- * measured in samples, not frames, so if the data is stereo, multiply by two. */
-void RageSoundMixBuffer::SetWriteOffset( int iOffset )
-{
-	m_iOffset = iOffset;
-}
-
-void RageSoundMixBuffer::Extend(unsigned iSamples)
-{
-	const std::uint64_t realsize = static_cast<std::uint64_t>(iSamples) + static_cast<std::uint64_t>(m_iOffset);
-	if( m_iBufSize < realsize )
-	{
-		m_pMixbuf = static_cast<float*>(std::realloc(m_pMixbuf, sizeof(float) * realsize));
-		if (m_pMixbuf == nullptr)
-		{
-			ASSERT_M(false, "Failed to re-allocate memory for the sound mixing buffer.");
-		}
-		m_iBufSize = realsize;
+		m_pMixbuf.resize(newsize);
+		m_iBufSize = newsize;
 	}
 
 	if( m_iBufUsed < realsize )
 	{
-		std::memset(m_pMixbuf + m_iBufUsed, 0, (realsize - m_iBufUsed) * sizeof(float));
+		std::fill(m_pMixbuf.begin() + m_iBufUsed, m_pMixbuf.begin() + realsize, 0.0f);
 		m_iBufUsed = realsize;
 	}
 }
 
-void RageSoundMixBuffer::write( const float *pBuf, unsigned iSize, int iSourceStride, int iDestStride )
+void RageSoundMixBuffer::write( const float *pBuf, unsigned iSize, int iSourceStride, int iDestStride ) noexcept
 {
 	if( iSize == 0 )
 		return;
@@ -61,7 +35,7 @@ void RageSoundMixBuffer::write( const float *pBuf, unsigned iSize, int iSourceSt
 	Extend( iSize * iDestStride - (iDestStride-1) );
 
 	// Scale volume and add.
-	float *pDestBuf = m_pMixbuf+m_iOffset;
+	float *pDestBuf = m_pMixbuf.data() + m_iOffset;
 
 	while( iSize )
 	{
@@ -72,24 +46,7 @@ void RageSoundMixBuffer::write( const float *pBuf, unsigned iSize, int iSourceSt
 	}
 }
 
-void RageSoundMixBuffer::read( std::int16_t *pBuf )
-{
-	for( unsigned iPos = 0; iPos < m_iBufUsed; ++iPos )
-	{
-		float iOut = m_pMixbuf[iPos];
-		iOut = clamp( iOut, -1.0f, +1.0f );
-		pBuf[iPos] = static_cast<int>((iOut * 32767) + 0.5);
-	}
-	m_iBufUsed = 0;
-}
-
-void RageSoundMixBuffer::read( float *pBuf )
-{
-	std::memcpy( pBuf, m_pMixbuf, m_iBufUsed * sizeof(float) );
-	m_iBufUsed = 0;
-}
-
-void RageSoundMixBuffer::read_deinterlace( float **pBufs, int channels )
+void RageSoundMixBuffer::read_deinterlace( float **pBufs, int channels ) noexcept
 {
 	for( unsigned i = 0; i < m_iBufUsed / channels; ++i )
 		for( int ch = 0; ch < channels; ++ch )

--- a/src/RageSoundMixBuffer.cpp
+++ b/src/RageSoundMixBuffer.cpp
@@ -9,35 +9,36 @@
 
 void RageSoundMixBuffer::Extend(unsigned iSamples) noexcept
 {
-	static const std::int_fast64_t chunksize = 1024; // in samples
+	// Ensure the extended size is a multiple of 1024.
+	static const std::int_fast64_t chunksize = 1024;
 	const std::int_fast64_t realsize = static_cast<std::int_fast64_t>(iSamples) + m_iOffset;
-	std::int_fast64_t newsize = ((realsize + chunksize - 1) / chunksize) * chunksize; // find the next multiple of 1024
+	std::int_fast64_t newsize = ((realsize + chunksize - 1) / chunksize) * chunksize;
 
-	if( m_iBufSize < newsize )
+	if (m_iBufSize < newsize)
 	{
 		m_pMixbuf.resize(newsize);
 		m_iBufSize = newsize;
 	}
 
-	if( m_iBufUsed < realsize )
+	if (m_iBufUsed < realsize)
 	{
 		std::fill(m_pMixbuf.begin() + m_iBufUsed, m_pMixbuf.begin() + realsize, 0.0f);
 		m_iBufUsed = realsize;
 	}
 }
 
-void RageSoundMixBuffer::write( const float *pBuf, unsigned iSize, int iSourceStride, int iDestStride ) noexcept
+void RageSoundMixBuffer::write(const float* pBuf, unsigned iSize, int iSourceStride, int iDestStride) noexcept
 {
-	if( iSize == 0 )
+	if (iSize == 0)
 		return;
 
 	// iSize = 3, iDestStride = 2 uses 4 frames.  Don't allocate the stride of the last sample.
-	Extend( iSize * iDestStride - (iDestStride-1) );
+	Extend(iSize * iDestStride - (iDestStride - 1));
 
 	// Scale volume and add.
-	float *pDestBuf = m_pMixbuf.data() + m_iOffset;
+	float* pDestBuf = m_pMixbuf.data() + m_iOffset;
 
-	while( iSize )
+	while (iSize)
 	{
 		*pDestBuf += *pBuf;
 		pBuf += iSourceStride;
@@ -46,10 +47,10 @@ void RageSoundMixBuffer::write( const float *pBuf, unsigned iSize, int iSourceSt
 	}
 }
 
-void RageSoundMixBuffer::read_deinterlace( float **pBufs, int channels ) noexcept
+void RageSoundMixBuffer::read_deinterlace(float** pBufs, int channels) noexcept
 {
-	for( unsigned i = 0; i < m_iBufUsed / channels; ++i )
-		for( int ch = 0; ch < channels; ++ch )
+	for (unsigned i = 0; i < m_iBufUsed / channels; ++i)
+		for (int ch = 0; ch < channels; ++ch)
 			pBufs[ch][i] = m_pMixbuf[channels * i + ch];
 	m_iBufUsed = 0;
 }

--- a/src/RageSoundMixBuffer.h
+++ b/src/RageSoundMixBuffer.h
@@ -36,7 +36,6 @@ private:
 	std::int_fast64_t m_iOffset = 0; // the offset in samples to start mixing into the buffer
 };
 
-// Inline functions
 inline void RageSoundMixBuffer::read(std::int16_t *pBuf) noexcept
 {
 	constexpr int16_t MAX_INT16 = 32767;

--- a/src/RageSoundMixBuffer.h
+++ b/src/RageSoundMixBuffer.h
@@ -4,37 +4,65 @@
 #define RAGE_SOUND_MIX_BUFFER_H
 
 #include <cstdint>
+#include <vector>
 
 class RageSoundMixBuffer
 {
 public:
-	RageSoundMixBuffer();
-	~RageSoundMixBuffer();
-
-	// See how many samples we can stuff into 2MB.
-	static constexpr size_t BUF_SIZE = 2 * 1024 * 1024 / sizeof(float);
-
 	// Mix the given buffer of samples.
-	void write( const float *pBuf, unsigned iSize, int iSourceStride = 1, int iDestStride = 1 );
+	void write( const float *pBuf, unsigned iSize, int iSourceStride = 1, int iDestStride = 1 ) noexcept;
 
 	// Extend the buffer as if write() was called with a buffer of silence.
-	void Extend( unsigned iSamples );
+	void Extend( unsigned iSamples ) noexcept;
 
-	void read( std::int16_t *pBuf );
-	void read( float *pBuf );
-	void read_deinterlace( float **pBufs, int channels );
-	float *read() { return m_pMixbuf; }
+	// Deinterlaces the mixed audio buffer into separate channel buffers.
+	void read_deinterlace( float **pBufs, int channels ) noexcept;
+
+	// Returns a pointer to the internal mixed audio buffer.
+	float *read() { return m_pMixbuf.data(); }
+
+	// Returns the number of samples in the mixed audio buffer.
 	unsigned size() const { return m_iBufUsed; }
-	void SetWriteOffset( int iOffset );
+
+	// These inline functions can be found below the class.
+	void SetWriteOffset(int iOffset) noexcept;
+	void read(std::int16_t *pBuf) noexcept;
+	void read(float *pBuf) noexcept;
 
 private:
-	float *m_pMixbuf;
-	std::uint64_t m_iBufSize; // actual allocated samples
-	std::uint64_t m_iBufUsed; // used samples
-	int m_iOffset;
+	std::vector<float> m_pMixbuf;
+	std::int_fast64_t m_iBufSize = 0; // the actual allocated samples
+	std::int_fast64_t m_iBufUsed = 0; // the number of samples currently held in the buffer
+	std::int_fast64_t m_iOffset = 0; // the offset in samples to start mixing into the buffer
 };
 
-#endif
+// Inline functions
+inline void RageSoundMixBuffer::read(std::int16_t *pBuf) noexcept
+{
+	constexpr int16_t MAX_INT16 = 32767;
+	for (unsigned iPos = 0; iPos < m_iBufUsed; ++iPos)
+	{
+		float iOut = m_pMixbuf[iPos];
+		iOut = std::max(-1.0f, std::min(iOut, 1.0f));
+		pBuf[iPos] = static_cast<int16_t>((iOut * MAX_INT16) + 0.5f);
+	}
+	m_iBufUsed = 0;
+}
+
+inline void RageSoundMixBuffer::read(float *pBuf) noexcept
+{
+	std::memcpy(pBuf, m_pMixbuf.data(), m_iBufUsed * sizeof(float));
+	m_iBufUsed = 0;
+}
+
+// write() will start mixing iOffset samples into the buffer. Be careful; this is
+// measured in samples, not frames, so if the data is stereo, multiply by two.
+inline void RageSoundMixBuffer::SetWriteOffset(int iOffset) noexcept
+{
+	m_iOffset = iOffset;
+}
+
+#endif // RAGE_SOUND_MIX_BUFFER_H
 
 /*
  * Copyright (c) 2002-2004 Glenn Maynard


### PR DESCRIPTION
Finally no more manual memory management here 🤯  thanks to the fix in Extend to ensure all chunks are 1024 samples, so now we can finally use <vector> here for automatic memory management.

(I almost changed the 0.7.1 RageSoundMixBuffer PR to have this change, but I ultimately decided to leave it alone if the non-vector version of this needs to be used for some reason.)