### PR TITLE
Collection of small fixes in Actor files

### DIFF
--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -1078,13 +1078,14 @@ void Actor::ScaleTo( const RectF &rect, StretchType st )
 	float fNewZoomY = std::abs(rect_height / m_size.y);
 
 	float fNewZoom = 0.f;
-	switch( st )
+
+	switch (st)
 	{
-	case cover:
-		fNewZoom = fNewZoomX>fNewZoomY ? fNewZoomX : fNewZoomY;	// use larger zoom
+	case kCover:
+		fNewZoom = fNewZoomX > fNewZoomY ? fNewZoomX : fNewZoomY; // use larger zoom
 		break;
-	case fit_inside:
-		fNewZoom = fNewZoomX>fNewZoomY ? fNewZoomY : fNewZoomX; // use smaller zoom
+	case kFitInside:
+		fNewZoom = fNewZoomX > fNewZoomY ? fNewZoomY : fNewZoomX; // use smaller zoom
 		break;
 	}
 

--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -1081,10 +1081,10 @@ void Actor::ScaleTo( const RectF &rect, StretchType st )
 
 	switch (st)
 	{
-	case kCover:
+	case StretchType::kCover:
 		fNewZoom = fNewZoomX > fNewZoomY ? fNewZoomX : fNewZoomY; // use larger zoom
 		break;
-	case kFitInside:
+	case StretchType::kFitInside:
 		fNewZoom = fNewZoomX > fNewZoomY ? fNewZoomY : fNewZoomX; // use smaller zoom
 		break;
 	}

--- a/src/Actor.h
+++ b/src/Actor.h
@@ -501,12 +501,12 @@ public:
 	/** @brief How do we handle stretching the Actor? */
 	enum StretchType
 	{
-		fit_inside, /**< Have the Actor fit inside its parent, using the smaller zoom. */
-		cover /**< Have the Actor cover its parent, using the larger zoom. */
+		kFitInside, /**< Have the Actor fit inside its parent, using the smaller zoom. */
+		kCover /**< Have the Actor cover its parent, using the larger zoom. */
 	};
 
-	void ScaleToCover( const RectF &rect )		{ ScaleTo( rect, cover ); }
-	void ScaleToFitInside( const RectF &rect )	{ ScaleTo( rect, fit_inside); };
+	void ScaleToCover( const RectF &rect )		{ ScaleTo( rect, kCover ); }
+	void ScaleToFitInside( const RectF &rect )	{ ScaleTo( rect, kFitInside); };
 	void ScaleTo( const RectF &rect, StretchType st );
 
 	void StretchTo( const RectF &rect );

--- a/src/Actor.h
+++ b/src/Actor.h
@@ -499,14 +499,14 @@ public:
 	const TweenState& DestTweenState() const { return const_cast<Actor*>(this)->DestTweenState(); }
 
 	/** @brief How do we handle stretching the Actor? */
-	enum StretchType
+	enum class StretchType
 	{
 		kFitInside, /**< Have the Actor fit inside its parent, using the smaller zoom. */
 		kCover /**< Have the Actor cover its parent, using the larger zoom. */
 	};
 
-	void ScaleToCover( const RectF &rect )		{ ScaleTo( rect, kCover ); }
-	void ScaleToFitInside( const RectF &rect )	{ ScaleTo( rect, kFitInside); };
+	void ScaleToCover( const RectF &rect )		{ ScaleTo( rect, StretchType::kCover ); }
+	void ScaleToFitInside( const RectF &rect )	{ ScaleTo( rect, StretchType::kFitInside); };
 	void ScaleTo( const RectF &rect, StretchType st );
 
 	void StretchTo( const RectF &rect );

--- a/src/ActorFrame.cpp
+++ b/src/ActorFrame.cpp
@@ -413,17 +413,17 @@ void ActorFrame::PushChildTable(lua_State* L, const RString &sName)
 	{
 		if(a->GetName() == sName)
 		{
-			switch(found)
+			if (found == 0)
 			{
-				case 0:
-					a->PushSelf(L);
-					break;
-				case 1:
-					CreateChildTable(L, a);
-					break;
-				default:
-					AddToChildTable(L, a);
-					break;
+				a->PushSelf(L);
+			}
+			else if (found == 1)
+			{
+				CreateChildTable(L, a);
+			}
+			else
+			{
+				AddToChildTable(L, a);
 			}
 			++found;
 		}

--- a/src/ActorMultiVertex.cpp
+++ b/src/ActorMultiVertex.cpp
@@ -502,6 +502,7 @@ void ActorMultiVertex::UpdateAnimationState(bool force_update)
 					break;
 				}
 			}
+        [[fallthrough]];
 		case DrawMode_QuadStrip:
 			for (std::size_t i = first; i < last; ++i)
 			{

--- a/src/ScreenDimensions.h
+++ b/src/ScreenDimensions.h
@@ -33,7 +33,7 @@ namespace ScreenDimensions
  * This is referenced in ArrowEffects, GameManager, NoteField, and SnapDisplay.
  * XXX: doesn't always have to be 64. -aj
  */
-#define	ARROW_SIZE	(64)
+constexpr int	ARROW_SIZE = 64;
 
 #endif
 


### PR DESCRIPTION
A collection of smaller commits not worth individual PR's mainly concerning improvement of switches (for readability, or for performance) in Actor* code, or stuff heavily used by it..

The commits in this PR are:

1. **Change `ARROW_SIZE` (defined in ScreenDimensions.h) from a macro to a constexpr**
    - Used repeatedly in various switch cases targeted by this PR.
  
2. **ActorFrame: replace a switch with an if/else**
    - More of a stylistic change than an optimization, but makes it easier to understand what's happening.
    
3. **Rename the `StretchType` enum in Actor**
    - The lowercase enum is confusing because it looks like a variable. This prefixes it with a class name so it's easier to understand its purpose.
    
4. **Indicate fallthrough to prevent a GCC warning in ActorMultiVertex**
    - Without this here, GCC 11 and 12 will print a warning during compilation about a possible fallthrough, but we're doing that on purpose, so this simply adds an indicator to the compiler that we know what we're doing. The ifdef's are necessary because, annoyingly, MSVC / XCode may complain if we put the [[fallthrough]] here.