### PR TITLE
Remove clamp(val,low,high) macro

### DIFF
--- a/src/ActorScroller.cpp
+++ b/src/ActorScroller.cpp
@@ -268,8 +268,8 @@ void ActorScroller::PositionItemsAndDrawPrimitives( bool bDrawPrimitives )
 	int iLastItemToDraw = std::ceil( fLastItemToDraw );
 	if( !m_bLoop && !m_bWrap )
 	{
-		iFirstItemToDraw = clamp( iFirstItemToDraw, 0, m_iNumItems );
-		iLastItemToDraw = clamp( iLastItemToDraw, 0, m_iNumItems );
+		iFirstItemToDraw = std::clamp( iFirstItemToDraw, 0, m_iNumItems );
+		iLastItemToDraw = std::clamp( iLastItemToDraw, 0, m_iNumItems );
 	}
 
 	std::vector<Actor*> subs;

--- a/src/ArrowEffects.cpp
+++ b/src/ArrowEffects.cpp
@@ -1124,7 +1124,7 @@ float ArrowGetPercentVisible(float fYPosWithoutReverse, int iCol, float fYOffset
 			* fAppearances[PlayerOptions::APPEARANCE_RANDOMVANISH];
 	}
 
-	return clamp(1 + fVisibleAdjust, 0.0f, 1.0f);
+	return std::clamp(1 + fVisibleAdjust, 0.0f, 1.0f);
 }
 
 float ArrowEffects::GetAlpha( const PlayerState* pPlayerState, int iCol, float fYOffset, float fPercentFadeToFail, float fYReverseOffsetPixels, float fDrawDistanceBeforeTargetsPixels, float fFadeInPercentOfDrawFar)

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -353,8 +353,8 @@ void BitmapText::DrawChars( bool bUseStrokeTexture )
 	const int iNumGlyphs = m_vpFontPageTextures.size();
 	int iStartGlyph = std::lrint( SCALE( m_pTempState->crop.left, 0.f, 1.f, 0, (float) iNumGlyphs ) );
 	int iEndGlyph = std::lrint( SCALE( m_pTempState->crop.right, 0.f, 1.f, (float) iNumGlyphs, 0 ) );
-	iStartGlyph = clamp( iStartGlyph, 0, iNumGlyphs );
-	iEndGlyph = clamp( iEndGlyph, 0, iNumGlyphs );
+	iStartGlyph = std::clamp( iStartGlyph, 0, iNumGlyphs );
+	iEndGlyph = std::clamp( iEndGlyph, 0, iNumGlyphs );
 
 	if( m_pTempState->fade.top > 0 ||
 		m_pTempState->fade.bottom > 0 ||
@@ -401,14 +401,14 @@ void BitmapText::DrawChars( bool bUseStrokeTexture )
 			{
 				// Add .5, so we fade wrt. the center of the vert, not the left side.
 				float fPercent = SCALE( start+0.5f, fLeftFadeStartGlyph, fLeftFadeStopGlyph, 0.0f, 1.0f );
-				fPercent = clamp( fPercent, 0.0f, 1.0f );
+				fPercent = std::clamp( fPercent, 0.0f, 1.0f );
 				fAlpha *= fPercent * fLeftAlpha;
 			}
 
 			if( FadeSize.right > 0.001f )
 			{
 				float fPercent = SCALE( start+0.5f, fRightFadeStartGlyph, fRightFadeStopGlyph, 1.0f, 0.0f );
-				fPercent = clamp( fPercent, 0.0f, 1.0f );
+				fPercent = std::clamp( fPercent, 0.0f, 1.0f );
 				fAlpha *= fPercent * fRightAlpha;
 			}
 

--- a/src/CombinedLifeMeterTug.cpp
+++ b/src/CombinedLifeMeterTug.cpp
@@ -126,7 +126,7 @@ void CombinedLifeMeterTug::ChangeLife( PlayerNumber pn, float fPercentToMove )
 		}
 
 		/* Clamp the life meter only for calculating the multiplier. */
-		fLifePercentage = clamp( fLifePercentage, 0.0f, 1.0f );
+		fLifePercentage = std::clamp( fLifePercentage, 0.0f, 1.0f );
 		fPercentToMove *= SCALE( fLifePercentage, 0.f, 1.f, 0.2f, 1.f);
 	}
 

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -585,7 +585,7 @@ bool Course::GetTrailUnsorted( StepsType st, CourseDifficulty cd, Trail &trail )
 			if( cd != Difficulty_Medium  &&  !e->bNoDifficult )
 			{
 				Difficulty new_dc = ( Difficulty )( dc + cd - Difficulty_Medium );
-				new_dc = clamp( new_dc, ( Difficulty )0, ( Difficulty )( Difficulty_Edit - 1 ) );
+				new_dc = std::clamp( new_dc, ( Difficulty )0, ( Difficulty )( Difficulty_Edit - 1 ) );
 				/*
 				// re-edit this code to work using the metric.
 				Difficulty new_dc;
@@ -817,7 +817,7 @@ void Course::GetTrailUnsortedEndless( const std::vector<CourseEntry> &entries, T
 			{
 				new_dc = cd;
 			}
-			new_dc = clamp( new_dc, ( Difficulty )0, ( Difficulty )( Difficulty_Edit - 1 ) );
+			new_dc = std::clamp( new_dc, ( Difficulty )0, ( Difficulty )( Difficulty_Edit - 1 ) );
 			/*
 			// re-edit this code to work using the metric.
 			Difficulty new_dc;

--- a/src/GameConstantsAndTypes.cpp
+++ b/src/GameConstantsAndTypes.cpp
@@ -406,7 +406,7 @@ float DisplayBpms::GetMaxWithin(float highest) const
 	for (float const &f : vfBpms)
 	{
 		if( f != -1 )
-			fMax = clamp(std::max( fMax, f ), 0.0f, highest);
+			fMax = std::clamp(std::max( fMax, f ), 0.0f, highest);
 	}
 	return fMax;
 }

--- a/src/GrooveRadar.cpp
+++ b/src/GrooveRadar.cpp
@@ -110,7 +110,7 @@ void GrooveRadar::GrooveRadarValueMap::SetFromSteps( const RadarValues &rv )
 	{
 		const float fValueCurrent = m_fValuesOld[c] * (1-m_PercentTowardNew) + m_fValuesNew[c] * m_PercentTowardNew;
 		m_fValuesOld[c] = fValueCurrent;
-		m_fValuesNew[c] = clamp(rv[c], 0.0f, 1.0f);
+		m_fValuesNew[c] = std::clamp(rv[c], 0.0f, 1.0f);
 	}
 
 	if( !m_bValuesVisible ) // the values WERE invisible

--- a/src/HighScore.cpp
+++ b/src/HighScore.cpp
@@ -163,7 +163,7 @@ void HighScoreImpl::LoadFromNode( const XNode *pNode )
 	pNode->GetChildValue( "Disqualified",		bDisqualified);
 
 	// Validate input.
-	grade = clamp( grade, Grade_Tier01, Grade_Failed );
+	grade = std::clamp( grade, Grade_Tier01, Grade_Failed );
 }
 
 REGISTER_CLASS_TRAITS( HighScoreImpl, new HighScoreImpl(*pCopy) )

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -1055,7 +1055,7 @@ static float scale( float x, float l1, float h1, float l2, float h2 )
 }
 LuaFunction( scale, scale(FArg(1), FArg(2), FArg(3), FArg(4), FArg(5)) );
 
-LuaFunction( clamp, clamp(FArg(1), FArg(2), FArg(3)) );
+LuaFunction( clamp, std::clamp(FArg(1), FArg(2), FArg(3)) );
 
 #include "LuaBinding.h"
 namespace

--- a/src/ModIconRow.cpp
+++ b/src/ModIconRow.cpp
@@ -157,7 +157,7 @@ void ModIconRow::SetFromGameState()
 	{
 		RString sOption = vsOptions[i];
 		int iPreferredCol = OptionToPreferredColumn( sOption );
-		iPreferredCol = clamp( iPreferredCol, 0, (int)m_vpModIcon.size()-1 );
+		iPreferredCol = std::clamp( iPreferredCol, 0, (int)m_vpModIcon.size()-1 );
 
 		// search for a vacant spot
 		for( int j=iPreferredCol; j<NUM_OPTION_ICONS; j++ )

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -570,7 +570,7 @@ void Model::PlayAnimation( const RString &sAniName, float fPlayRate )
 void Model::SetPosition( float fSeconds )
 {
 	m_fCurFrame = FRAMES_PER_SECOND * fSeconds;
-	m_fCurFrame = clamp( m_fCurFrame, (float) 0, (float) m_pCurAnimation->nTotalFrames );
+	m_fCurFrame = std::clamp( m_fCurFrame, (float) 0, (float) m_pCurAnimation->nTotalFrames );
 }
 
 void Model::AdvanceFrame( float fDeltaTime )
@@ -596,7 +596,7 @@ void Model::AdvanceFrame( float fDeltaTime )
 		else if( m_bLoop )
 			wrap( m_fCurFrame, (float) m_pCurAnimation->nTotalFrames );
 		else
-			m_fCurFrame = clamp( m_fCurFrame, (float) 0, (float) m_pCurAnimation->nTotalFrames );
+			m_fCurFrame = std::clamp( m_fCurFrame, (float) 0, (float) m_pCurAnimation->nTotalFrames );
 	}
 
 	SetBones( m_pCurAnimation, m_fCurFrame, m_vpBones );

--- a/src/NoteData.cpp
+++ b/src/NoteData.cpp
@@ -155,8 +155,8 @@ void NoteData::CopyRange( const NoteData& from, int rowFromBegin, int rowFromEnd
 				int iStartRow = lBegin->first + iMoveBy;
 				int iEndRow = iStartRow + head.iDuration;
 
-				iStartRow = clamp( iStartRow, rowToBegin, rowToEnd );
-				iEndRow = clamp( iEndRow, rowToBegin, rowToEnd );
+				iStartRow = std::clamp( iStartRow, rowToBegin, rowToEnd );
+				iEndRow = std::clamp( iEndRow, rowToBegin, rowToEnd );
 
 				this->AddHoldNote( t, iStartRow, iEndRow, head );
 			}

--- a/src/NoteDataWithScoring.cpp
+++ b/src/NoteDataWithScoring.cpp
@@ -163,7 +163,7 @@ float GetActualVoltageRadarValue( const NoteData &in, float fSongSeconds, const 
 	 * it's the percent of the song the longest combo took to get. */
 	const PlayerStageStats::Combo_t MaxCombo = pss.GetMaxCombo();
 	float fComboPercent = SCALE(MaxCombo.m_fSizeSeconds, 0, fSongSeconds, 0.0f, 1.0f);
-	return clamp( fComboPercent, 0.0f, 1.0f );
+	return std::clamp( fComboPercent, 0.0f, 1.0f );
 }
 
 // Return the ratio of actual to possible dance points.
@@ -174,7 +174,7 @@ float GetActualChaosRadarValue( const NoteData &in, float fSongSeconds, const Pl
 		return 1;
 
 	const int ActualDP = pss.m_iActualDancePoints;
-	return clamp( float(ActualDP)/iPossibleDP, 0.0f, 1.0f );
+	return std::clamp( float(ActualDP)/iPossibleDP, 0.0f, 1.0f );
 }
 }
 
@@ -401,16 +401,16 @@ void NoteDataWithScoring::GetActualRadarValues(const NoteData &in,
 		switch(rc)
 		{
 			case RadarCategory_Stream:
-				out[rc]= note_count == 0 ? 0.0f : clamp(float(state.notes_hit_for_stream) / note_count, 0.0f, 1.0f);
+				out[rc]= note_count == 0 ? 0.0f : std::clamp(float(state.notes_hit_for_stream) / note_count, 0.0f, 1.0f);
 				break;
 			case RadarCategory_Voltage:
 				out[rc]= GetActualVoltageRadarValue(in, hittable_steps_length, pss);
 				break;
 			case RadarCategory_Air:
-				out[rc]= jump_count == 0 ? 0.0f : clamp(float(state.jumps_hit_for_air) / jump_count, 0.0f, 1.0f);
+				out[rc]= jump_count == 0 ? 0.0f : std::clamp(float(state.jumps_hit_for_air) / jump_count, 0.0f, 1.0f);
 				break;
 			case RadarCategory_Freeze:
-				out[rc]= hold_count == 0 ? 0.0f : clamp(float(state.holds_held) / hold_count, 0.0f, 1.0f);
+				out[rc]= hold_count == 0 ? 0.0f : std::clamp(float(state.holds_held) / hold_count, 0.0f, 1.0f);
 				break;
 			case RadarCategory_Chaos:
 				out[rc]= GetActualChaosRadarValue(in, song_seconds, pss);

--- a/src/NoteDisplay.cpp
+++ b/src/NoteDisplay.cpp
@@ -1354,7 +1354,7 @@ void NoteDisplay::DrawActor(const TapNote& tn, Actor* pActor, NotePart part,
 		{
 		case NoteColorType_Denominator:
 			color = float( BeatToNoteType( fBeat ) );
-			color = clamp( color, 0.0f, (float) (cache->m_iNoteColorCount[part]-1) );
+			color = std::clamp( color, 0.0f, (float) (cache->m_iNoteColorCount[part]-1) );
 			break;
 		case NoteColorType_Progress:
 			color = std::fmod( std::ceil( fBeat * cache->m_iNoteColorCount[part] ), (float)cache->m_iNoteColorCount[part] );

--- a/src/NotesLoaderKSF.cpp
+++ b/src/NotesLoaderKSF.cpp
@@ -349,7 +349,7 @@ static bool LoadFromKSFFile( const RString &sPath, Steps &out, Song &song, bool 
 				// duh
 				iTickCount = static_cast<int>(numTemp);
 				// I have been owned by the man -DaisuMaster
-				stepsTiming.SetTickcountAtBeat( fCurBeat, clamp(iTickCount, 0, ROWS_PER_BEAT) );
+				stepsTiming.SetTickcountAtBeat( fCurBeat, std::clamp(iTickCount, 0, ROWS_PER_BEAT) );
 			}
 			else if (BeginsWith(sRowString, "|B"))
 			{

--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -856,7 +856,7 @@ void SMLoader::ProcessTickcounts( TimingData &out, const RString line, const int
 		}
 
 		const float fTickcountBeat = RowToBeat( arrayTickcountValues[0], rowsPerBeat );
-		int iTicks = clamp(atoi( arrayTickcountValues[1] ), 0, ROWS_PER_BEAT);
+		int iTicks = std::clamp(atoi( arrayTickcountValues[1] ), 0, ROWS_PER_BEAT);
 
 		out.AddSegment( TickcountSegment(BeatToNoteRow(fTickcountBeat), iTicks) );
 	}

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -1613,8 +1613,8 @@ void RageDisplay_Legacy::DrawLineStripInternal( const RageSpriteVertex v[], int 
 
 	/* Clamp the width to the hardware max for both lines and points (whichever
 	 * is more restrictive). */
-	fLineWidth = clamp( fLineWidth, g_line_range[0], g_line_range[1] );
-	fLineWidth = clamp( fLineWidth, g_point_range[0], g_point_range[1] );
+	fLineWidth = std::clamp( fLineWidth, g_line_range[0], g_line_range[1] );
+	fLineWidth = std::clamp( fLineWidth, g_point_range[0], g_point_range[1] );
 
 	/* Hmm.  The granularity of lines and points might be different; for example,
 	 * if lines are .5 and points are .25, we might want to snap the width to the

--- a/src/RageFileDriverMemory.cpp
+++ b/src/RageFileDriverMemory.cpp
@@ -79,7 +79,7 @@ int RageFileObjMem::WriteInternal( const void *buffer, std::size_t bytes )
 
 int RageFileObjMem::SeekInternal( int offset )
 {
-	m_iFilePos = clamp( offset, 0, GetFileSize() );
+	m_iFilePos = std::clamp( offset, 0, GetFileSize() );
 	return m_iFilePos;
 }
 

--- a/src/RageSoundMixBuffer.cpp
+++ b/src/RageSoundMixBuffer.cpp
@@ -77,7 +77,7 @@ void RageSoundMixBuffer::read( std::int16_t *pBuf )
 	for( unsigned iPos = 0; iPos < m_iBufUsed; ++iPos )
 	{
 		float iOut = m_pMixbuf[iPos];
-		iOut = clamp( iOut, -1.0f, +1.0f );
+		iOut = std::clamp( iOut, -1.0f, +1.0f );
 		pBuf[iPos] = static_cast<int>((iOut * 32767) + 0.5);
 	}
 	m_iBufUsed = 0;

--- a/src/RageSoundReader_PostBuffering.cpp
+++ b/src/RageSoundReader_PostBuffering.cpp
@@ -35,7 +35,7 @@ int RageSoundReader_PostBuffering::Read( float *pBuf, int iFrames )
 	// Square the master so lower volumes are more sensitive.
 	// This lines up better with perceived volume.
 	float fVolume = m_fVolume * g_fMasterVolume * g_fMasterVolume;
-	fVolume = clamp( fVolume, 0.0f, 1.0f );
+	fVolume = std::clamp( fVolume, 0.0f, 1.0f );
 	g_Mutex.Unlock();
 
 	if( fVolume != 1.0f )

--- a/src/RageSoundUtil.cpp
+++ b/src/RageSoundUtil.cpp
@@ -57,7 +57,7 @@ void RageSoundUtil::Fade( float *pBuffer, int iFrames, int iChannels, float fSta
 	{
 		float fVolPercent = SCALE( iFrame, 0, iFrames, fStartVolume, fEndVolume );
 
-		fVolPercent = clamp( fVolPercent, 0.f, 1.f );
+		fVolPercent = std::clamp( fVolPercent, 0.f, 1.f );
 		for( int i = 0; i < iChannels; ++i )
 		{
 			*pBuffer *= fVolPercent;
@@ -95,7 +95,7 @@ void RageSoundUtil::ConvertFloatToNativeInt16( const float *pFrom, std::int16_t 
 	for( int i = 0; i < iSamples; ++i )
 	{
 		int iOut = static_cast<int>((pFrom[i] * 32768.0f) + 0.5);
-		pTo[i] = clamp( iOut, -32768, 32767 );
+		pTo[i] = std::clamp( iOut, -32768, 32767 );
 	}
 }
 

--- a/src/RageSurfaceUtils.cpp
+++ b/src/RageSurfaceUtils.cpp
@@ -431,10 +431,10 @@ void RageSurfaceUtils::BlitTransform( const RageSurface *src, RageSurface *dst,
 			src_y[1] = src_y[0] + 1;
 
 			// Emulate GL_REPEAT.
-			src_x[0] = clamp(src_x[0], 0, src->w);
-			src_x[1] = clamp(src_x[1], 0, src->w);
-			src_y[0] = clamp(src_y[0], 0, src->h);
-			src_y[1] = clamp(src_y[1], 0, src->h);
+			src_x[0] = std::clamp(src_x[0], 0, src->w);
+			src_x[1] = std::clamp(src_x[1], 0, src->w);
+			src_y[0] = std::clamp(src_y[0], 0, src->h);
+			src_y[1] = std::clamp(src_y[1], 0, src->h);
 
 			// Decode our four pixels.
 			std::uint8_t v[4][4];
@@ -456,7 +456,7 @@ void RageSurfaceUtils::BlitTransform( const RageSurface *src, RageSurface *dst,
 				sum += v[1][i] * (1-weight_x) * (weight_y);
 				sum += v[2][i] * (weight_x)   * (1-weight_y);
 				sum += v[3][i] * (weight_x)   * (weight_y);
-				out[i] = (std::uint8_t) clamp( std::lrint(sum), 0L, 255L );
+				out[i] = (std::uint8_t) std::clamp( std::lrint(sum), 0L, 255L );
 			}
 
 			// If the source has no alpha, set the destination to opaque.
@@ -865,10 +865,10 @@ RageSurface *RageSurfaceUtils::PalettizeToGrayscale( const RageSurface *src_surf
 		const unsigned int A = (index & Amask) >> Ashift;
 
 		// if only one intensity value, always fullbright
-		const std::uint8_t ScaledI = Ivalues == 1 ? 255 : clamp( std::lrint(I * (255.0f / (Ivalues-1))), 0L, 255L );
+		const std::uint8_t ScaledI = Ivalues == 1 ? 255 : std::clamp( std::lrint(I * (255.0f / (Ivalues-1))), 0L, 255L );
 
 		// if only one alpha value, always opaque
-		const std::uint8_t ScaledA = Avalues == 1 ? 255 : clamp( std::lrint(A * (255.0f / (Avalues-1))), 0L, 255L );
+		const std::uint8_t ScaledA = Avalues == 1 ? 255 : std::clamp( std::lrint(A * (255.0f / (Avalues-1))), 0L, 255L );
 
 		RageSurfaceColor c;
 		c.r = ScaledI;

--- a/src/RageSurfaceUtils_Dither.cpp
+++ b/src/RageSurfaceUtils_Dither.cpp
@@ -147,7 +147,7 @@ static std::uint8_t EDDitherPixel( int x, int y, int intensity, int conv, std::i
 	 * To store it, we have to clamp it (prevent overflow) and shift it
 	 * from fixed-point to [0,255].  The error introduced in that calculation
 	 * becomes the new accumError. */
-	int clamped_intensity = clamp( out_intensity, 0, 0xFFFFFF );
+	int clamped_intensity = std::clamp( out_intensity, 0, 0xFFFFFF );
 	clamped_intensity &= 0xFF0000;
 
 	// Truncate.

--- a/src/RageSurfaceUtils_Palettize.cpp
+++ b/src/RageSurfaceUtils_Palettize.cpp
@@ -218,7 +218,7 @@ void RageSurfaceUtils::Palettize( RageSurface *&pImg, int iColors, bool bDither 
 				for( int c = 0; c < 4; ++c )
 				{
 					sc[c] = pixel[c] + thiserr[col + 1].c[c] / FS_SCALE;
-					sc[c] = clamp( sc[c], 0, (std::int32_t) maxval );
+					sc[c] = std::clamp( sc[c], 0, (std::int32_t) maxval );
 				}
 
 				PAM_ASSIGN( pixel, (std::uint8_t)sc[0], (std::uint8_t)sc[1], (std::uint8_t)sc[2], (std::uint8_t)sc[3] );

--- a/src/RageSurfaceUtils_Zoom.cpp
+++ b/src/RageSurfaceUtils_Zoom.cpp
@@ -71,8 +71,8 @@ static void InitVectors( std::vector<int> &s0, std::vector<int> &s1, std::vector
 			const float sax = sx*x;
 
 			// source x coordinates of left and right pixels to sample
-			s0.push_back( clamp(int(sax), 0, src-1));
-			s1.push_back( clamp(int(sax+1), 0, src-1) );
+			s0.push_back( std::clamp(int(sax), 0, src-1));
+			s1.push_back( std::clamp(int(sax+1), 0, src-1) );
 
 			const float p = (1.0f - (sax - std::floor(sax))) * 16777216.0f;
 			percent.push_back( std::uint32_t(p) );
@@ -155,8 +155,8 @@ void RageSurfaceUtils::Zoom( RageSurface *&src, int dstwidth, int dstheight )
 		/* Our filter is a simple linear filter, so it can't scale to less than
 		 * 1:2 or more than 2:1 very well. If we need to go beyond that, do it
 		 * iteratively. */
-		xscale = clamp( xscale, .5f, 2.0f );
-		yscale = clamp( yscale, .5f, 2.0f );
+		xscale = std::clamp( xscale, .5f, 2.0f );
+		yscale = std::clamp( yscale, .5f, 2.0f );
 
 		int target_width = std::lrint( src->w*xscale );
 		int target_height = std::lrint( src->h*yscale );

--- a/src/RageTypes.cpp
+++ b/src/RageTypes.cpp
@@ -55,10 +55,10 @@ void RageColor::FromStackCompat( lua_State *L, int iPos )
 
 RString RageColor::ToString() const
 {
-	int iR = clamp( static_cast<int>(std::lrint(r * 255)), 0, 255 );
-	int iG = clamp( static_cast<int>(std::lrint(g * 255)), 0, 255 );
-	int iB = clamp( static_cast<int>(std::lrint(b * 255)), 0, 255 );
-	int iA = clamp( static_cast<int>(std::lrint(a * 255)), 0, 255 );
+	int iR = std::clamp( static_cast<int>(std::lrint(r * 255)), 0, 255 );
+	int iG = std::clamp( static_cast<int>(std::lrint(g * 255)), 0, 255 );
+	int iB = std::clamp( static_cast<int>(std::lrint(b * 255)), 0, 255 );
+	int iA = std::clamp( static_cast<int>(std::lrint(a * 255)), 0, 255 );
 
 	if( iA == 255 )
 		return ssprintf( "#%02X%02X%02X", iR, iG, iB );

--- a/src/RageTypes.h
+++ b/src/RageTypes.h
@@ -278,7 +278,7 @@ public:
 inline unsigned char FTOC(float a)
 {
 	int value = static_cast<int>(a * 256.0f);
-	return static_cast<unsigned char>(clamp(value, 0, 255));
+	return static_cast<unsigned char>(std::clamp(value, 0, 255));
 }
 
 /* Color type used only in vertex lists.  OpenGL expects colors in

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -30,9 +30,6 @@ class RageFileDriver;
 
 extern const RString CUSTOM_SONG_PATH;
 
-/** @brief If outside the range from low to high, bring it within range. */
-#define clamp(val,low,high)	std::clamp( val, low, high )
-
 /**
  * @brief Scales x so that l1 corresponds to l2 and h1 corresponds to h2.
  *

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -2263,7 +2263,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 				INVERT_SCROLL_BUTTONS ? --iSpeed : ++iSpeed;
 				break;
 			}
-			iSpeed = clamp( iSpeed, 0, (int) ARRAYLEN(fSpeeds)-1 );
+			iSpeed = std::clamp( iSpeed, 0, (int) ARRAYLEN(fSpeeds)-1 );
 
 			if( fSpeeds[iSpeed] != fScrollSpeed )
 			{

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1243,7 +1243,7 @@ void ScreenGameplay::LoadNextSong()
 				int iMeter = pSteps->GetMeter();
 				int iNewSkill = SCALE( iMeter, MIN_METER, MAX_METER, 0, NUM_SKILL_LEVELS-1 );
 				/* Watch out: songs aren't actually bound by MAX_METER. */
-				iNewSkill = clamp( iNewSkill, 0, NUM_SKILL_LEVELS-1 );
+				iNewSkill = std::clamp( iNewSkill, 0, NUM_SKILL_LEVELS-1 );
 				pi->GetPlayerState()->m_iCpuSkill = iNewSkill;
 			}
 			else

--- a/src/ScreenSelectMaster.cpp
+++ b/src/ScreenSelectMaster.cpp
@@ -310,7 +310,7 @@ void ScreenSelectMaster::Init()
 				if( dir == MenuDir_Auto || (bool)WRAP_CURSOR )
 					wrap( m_mapCurrentChoiceToNextChoice[dir][c], m_aGameCommands.size() );
 				else
-					m_mapCurrentChoiceToNextChoice[dir][c] = clamp( m_mapCurrentChoiceToNextChoice[dir][c], 0, (int)m_aGameCommands.size()-1 );
+					m_mapCurrentChoiceToNextChoice[dir][c] = std::clamp( m_mapCurrentChoiceToNextChoice[dir][c], 0, (int)m_aGameCommands.size()-1 );
 			}
 		}
 	}

--- a/src/StatsManager.cpp
+++ b/src/StatsManager.cpp
@@ -131,7 +131,7 @@ void AddPlayerStatsToProfile( Profile *pProfile, const StageStats &ss, PlayerNum
 		pProfile->m_iNumSongsPlayedByStyle[sID] ++;
 		pProfile->m_iNumSongsPlayedByDifficulty[pSteps->GetDifficulty()] ++;
 
-		int iMeter = clamp( pSteps->GetMeter(), 0, MAX_METER );
+		int iMeter = std::clamp( pSteps->GetMeter(), 0, MAX_METER );
 		pProfile->m_iNumSongsPlayedByMeter[iMeter] ++;
 	}
 

--- a/src/TimingData.cpp
+++ b/src/TimingData.cpp
@@ -360,7 +360,7 @@ void TimingData::GetActualBPM( float &fMinBPMOut, float &fMaxBPMOut, float highe
 	for (unsigned i = 0; i < bpms.size(); i++)
 	{
 		const float fBPM = ToBPM(bpms[i])->GetBPM();
-		fMaxBPMOut = clamp(std::max( fBPM, fMaxBPMOut ), 0.0f, highest);
+		fMaxBPMOut = std::clamp(std::max( fBPM, fMaxBPMOut ), 0.0f, highest);
 		fMinBPMOut = std::min( fBPM, fMinBPMOut );
 	}
 }

--- a/src/WheelBase.cpp
+++ b/src/WheelBase.cpp
@@ -192,7 +192,7 @@ void WheelBase::Update( float fDeltaTime )
 			float t = std::min( fTime, 0.1f );
 			fTime -= t;
 
-			m_fPositionOffsetFromSelection = clamp( m_fPositionOffsetFromSelection, -0.3f, +0.3f );
+			m_fPositionOffsetFromSelection = std::clamp( m_fPositionOffsetFromSelection, -0.3f, +0.3f );
 
 			float fSpringForce = - m_fPositionOffsetFromSelection * LOCKED_INITIAL_VELOCITY;
 			m_fLockedWheelVelocity += fSpringForce;
@@ -218,7 +218,7 @@ void WheelBase::Update( float fDeltaTime )
 
 		/* Make sure that we don't go further than 1 away, in case the speed is
 		 * very high or we miss a lot of frames. */
-		m_fPositionOffsetFromSelection  = clamp(m_fPositionOffsetFromSelection, -1.0f, 1.0f);
+		m_fPositionOffsetFromSelection  = std::clamp(m_fPositionOffsetFromSelection, -1.0f, 1.0f);
 
 		// If it passed the selection, move again.
 		if((m_Moving == -1 && m_fPositionOffsetFromSelection >= 0) ||

--- a/src/arch/Sound/ALSA9Helpers.cpp
+++ b/src/arch/Sound/ALSA9Helpers.cpp
@@ -312,7 +312,7 @@ int Alsa9Buf::GetNumFramesToFill()
 	const snd_pcm_sframes_t filled_frames = std::max( 0l, total_frames - avail_frames );
 
 	/* Number of frames that don't have data, that are within the writeahead: */
-	snd_pcm_sframes_t unfilled_frames = clamp( ActualWriteahead - filled_frames, 0l, (snd_pcm_sframes_t)ActualWriteahead );
+	snd_pcm_sframes_t unfilled_frames = std::clamp( ActualWriteahead - filled_frames, 0l, (snd_pcm_sframes_t)ActualWriteahead );
 
 //	LOG->Trace( "total_fr: %i; avail_fr: %i; filled_fr: %i; ActualWr %i; chunksize %i; unfilled_frames %i ",
 //			total_frames, avail_frames, filled_frames, ActualWriteahead, chunksize, unfilled_frames );

--- a/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
@@ -95,7 +95,7 @@ RageSoundMixBuffer &RageSoundDriver::MixIntoBuffer( int iFrames, std::int64_t iF
 			const std::int64_t iFramesUntilThisBuffer = iFrameNumber - iCurrentFrame;
 			const float fSecondsBeforeStart = -s.m_StartTime.Ago();
 			const std::int64_t iFramesBeforeStart = std::int64_t(fSecondsBeforeStart * GetSampleRate());
-			const int iSilentFramesInThisBuffer = clamp( int(iFramesBeforeStart-iFramesUntilThisBuffer), 0, iFramesLeft );
+			const int iSilentFramesInThisBuffer = std::clamp( int(iFramesBeforeStart-iFramesUntilThisBuffer), 0, iFramesLeft );
 
 			iGotFrames += iSilentFramesInThisBuffer;
 			iFramesLeft -= iSilentFramesInThisBuffer;


### PR DESCRIPTION
Doesn't really need to exist since  all it's doing is inlining std::clamp. Not sure why it was there to begin with...