### PR TITLE
hid gamepad event rollover fix

### DIFF
--- a/src/arch/InputHandler/InputHandler_Linux_Event.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Event.cpp
@@ -391,7 +391,7 @@ void InputHandler_Linux_Event::InputThread()
 				if (event.code >= BTN_JOYSTICK && event.code <= BTN_JOYSTICK + 0xf) {
 					// These guys have arbitrary names, but the kernel code in hid-input.c maps exactly 0xf of them.
 					iNum = event.code - BTN_JOYSTICK;
-				} else if (event.code >= BTN_GAMEPAD && event.code <= BTN_THUMBR) {
+				} else if (event.code >= BTN_GAMEPAD && event.code <= BTN_GAMEPAD + 0x0f) {
 					iNum = event.code - BTN_GAMEPAD;
 				} else if (event.code >= BTN_TRIGGER_HAPPY1 && event.code <= BTN_TRIGGER_HAPPY40) {
 					// Actually, we only have 32 buttons defined.

--- a/src/arch/InputHandler/InputHandler_Linux_Event.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Event.cpp
@@ -391,6 +391,8 @@ void InputHandler_Linux_Event::InputThread()
 				if (event.code >= BTN_JOYSTICK && event.code <= BTN_JOYSTICK + 0xf) {
 					// These guys have arbitrary names, but the kernel code in hid-input.c maps exactly 0xf of them.
 					iNum = event.code - BTN_JOYSTICK;
+				} else if (event.code >= BTN_GAMEPAD && event.code <= BTN_THUMBR) {
+					iNum = event.code - BTN_GAMEPAD;
 				} else if (event.code >= BTN_TRIGGER_HAPPY1 && event.code <= BTN_TRIGGER_HAPPY40) {
 					// Actually, we only have 32 buttons defined.
 					iNum = event.code - BTN_TRIGGER_HAPPY1 + 0x10;


### PR DESCRIPTION
I am in the midst of making a custom JAMMA adapter which reports itself has a HID Gamepad with 32 buttons.

This should be no issue as Stepmania's engine has for a long time had events for up to `JOY_BUTTON_32` available.

But during integration testing on Linux I ran into issues with...buttons overlapping?

So I found this bug that was introduced by [this commit](https://github.com/stepmania/stepmania/pull/144), which did attempt to try fixing some of the over-bounding issues...but did not account for the `GAMEPAD` events.

Before this commit I was limited to 16 buttons as the code was overlapping the gamepad events, but with this additional check I am able to use the full `JOY_BUTTON_32` array as intended.

Testing was done with a custom usb hid firmware, comparing to jstesk-gtk during runtime on currently updated arch install.
 
Before: https://streamable.com/85kt7u
After: https://streamable.com/rbar6w

BTW Snek Board is finally coming along well, I think I have a viable prototype after four years of being on the back-burner.

https://x.com/dinsfire64/status/1832570747568492827