### PR TITLE
Use vectors of RStrings for default driver lists in arch_default.h

### DIFF
--- a/src/GameSoundManager.cpp
+++ b/src/GameSoundManager.cpp
@@ -915,8 +915,7 @@ LUA_REGISTER_CLASS(GameSoundManager);
 int LuaFunc_get_sound_driver_list(lua_State* L);
 int LuaFunc_get_sound_driver_list(lua_State* L)
 {
-	std::vector<RString> driver_names;
-	split(RageSoundDriver::GetDefaultSoundDriverList(), ",", driver_names, true);
+	std::vector<RString> driver_names = RageSoundDriver::GetSoundDriverList();
 	lua_createtable(L, driver_names.size(), 0);
 	for(std::size_t n= 0; n < driver_names.size(); ++n)
 	{

--- a/src/RageSoundManager.cpp
+++ b/src/RageSoundManager.cpp
@@ -63,11 +63,6 @@ void RageSoundManager::low_sample_count_workaround()
 	m_pDriver->low_sample_count_workaround();
 }
 
-void RageSoundManager::fix_bogus_sound_driver_pref(RString const& valid_setting)
-{
-	g_sSoundDrivers.Set(valid_setting);
-}
-
 /*
  * Previously, we went to some lengths to shut down sounds before exiting threads.
  * The only other thread that actually starts sounds is SOUND.  Doing this was ugly;

--- a/src/RageSoundManager.h
+++ b/src/RageSoundManager.h
@@ -46,7 +46,6 @@ public:
 	RageSoundReader *GetLoadedSound( const RString &sPath );
 	void AddLoadedSound( const RString &sPath, RageSoundReader_Preload *pSound );
 
-	void fix_bogus_sound_driver_pref(RString const& valid_setting);
 	void low_sample_count_workaround();
 
 private:

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -843,6 +843,14 @@ void split( const std::wstring &sSource, const std::wstring &sDelimitor, std::ve
 		do_split( sSource, sDelimitor, asAddIt, bIgnoreEmpty );
 }
 
+std::vector<RString> split( const RString& sSource, const char delimiter, const bool bIgnoreEmpty )
+{
+	std::vector<RString> result;
+	RString sDelimiter(1, delimiter); // Create an RString from the char delimiter
+	split(sSource, sDelimiter, result, bIgnoreEmpty);
+	return result;
+}
+
 /* Use:
 
 RString str="a,b,c";

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -405,6 +405,7 @@ RString GetLanguageNameFromISO639Code( RString sName );
 // Splits a RString into an std::vector<RString> according the Delimitor.
 void split( const RString &sSource, const RString &sDelimitor, std::vector<RString>& asAddIt, const bool bIgnoreEmpty = true );
 void split( const std::wstring &sSource, const std::wstring &sDelimitor, std::vector<std::wstring> &asAddIt, const bool bIgnoreEmpty = true );
+std::vector<RString> split( const RString &sSource, const char delimiter, const bool bIgnoreEmpty = true );
 
 /* In-place split. */
 void split( const RString &sSource, const RString &sDelimitor, int &iBegin, int &iSize, const bool bIgnoreEmpty = true );

--- a/src/arch/InputHandler/InputHandler.cpp
+++ b/src/arch/InputHandler/InputHandler.cpp
@@ -173,16 +173,16 @@ RString InputHandler::GetLocalizedInputString( const DeviceInput &di )
 DriverList InputHandler::m_pDriverList;
 
 static LocalizedString INPUT_HANDLERS_EMPTY( "Arch", "Input Handlers cannot be empty." );
-void InputHandler::Create( const RString &drivers_, std::vector<InputHandler *> &Add )
+void InputHandler::Create( const RString &drivers_, std::vector<InputHandler *> &add )
 {
-	const RString drivers = drivers_.empty()? RString(DEFAULT_INPUT_DRIVER_LIST):drivers_;
-	std::vector<RString> DriversToTry;
-	split( drivers, ",", DriversToTry, true );
+	const std::vector<RString>& driversToTry = drivers_.empty() ? GetDefaultInputDriverList() : split(drivers_, ',', true);
 
-	if( DriversToTry.empty() )
-		RageException::Throw( "%s", INPUT_HANDLERS_EMPTY.GetValue().c_str() );
+	if (driversToTry.empty())
+	{
+		RageException::Throw("%s", INPUT_HANDLERS_EMPTY.GetValue().c_str());
+	}
 
-	for (RString const &s : DriversToTry)
+	for (const RString &s : driversToTry)
 	{
 		RageDriver *pDriver = InputHandler::m_pDriverList.Create( s );
 		if( pDriver == nullptr )
@@ -193,14 +193,13 @@ void InputHandler::Create( const RString &drivers_, std::vector<InputHandler *> 
 
 		InputHandler *ret = dynamic_cast<InputHandler *>( pDriver );
 		DEBUG_ASSERT( ret );
-		Add.push_back( ret );
+		add.push_back( ret );
 	}
 
 	// Always add
-	Add.push_back( new InputHandler_MonkeyKeyboard );
-//    Add.push_back( new InputHandler_NSEvent );
+	add.push_back(new InputHandler_MonkeyKeyboard);
+//    add.push_back(new InputHandler_NSEvent);
 }
-
 
 /*
  * (c) 2003-2004 Glenn Maynard

--- a/src/arch/MovieTexture/MovieTexture.cpp
+++ b/src/arch/MovieTexture/MovieTexture.cpp
@@ -86,11 +86,16 @@ RageMovieTexture *RageMovieTexture::Create( RageTextureID ID )
 	DumpAVIDebugInfo( ID.filename );
 
 	RString sDrivers = g_sMovieDrivers;
-	if( sDrivers.empty() )
-		sDrivers = DEFAULT_MOVIE_DRIVER_LIST;
-
 	std::vector<RString> DriversToTry;
-	split( sDrivers, ",", DriversToTry, true );
+
+	if (sDrivers.empty())
+	{
+		DriversToTry = GetDefaultMovieDriverList();
+	}
+	else
+	{
+		DriversToTry = split(sDrivers, ',');
+	}
 
 	if( DriversToTry.empty() )
 		RageException::Throw( "%s", MOVIE_DRIVERS_EMPTY.GetValue().c_str() );

--- a/src/arch/Sound/RageSoundDriver.h
+++ b/src/arch/Sound/RageSoundDriver.h
@@ -20,7 +20,7 @@ public:
 	/* Pass an empty string to get the default sound driver list. */
 	static RageSoundDriver *Create( const RString &sDrivers );
 	static DriverList m_pDriverList;
-	static RString GetDefaultSoundDriverList();
+	static std::vector<RString> GetSoundDriverList();
 
 	friend class RageSoundManager;
 

--- a/src/arch/arch_default.h
+++ b/src/arch/arch_default.h
@@ -1,26 +1,50 @@
 #ifndef ARCH_DEFAULT_H
 #define ARCH_DEFAULT_H
 
+#include <vector>
+
 /* Define the default driver sets. */
 #if defined(WINDOWS)
 #include "ArchHooks/ArchHooks_Win32.h"
 #include "LoadingWindow/LoadingWindow_Win32.h"
 #include "LowLevelWindow/LowLevelWindow_Win32.h"
 #include "MemoryCard/MemoryCardDriverThreaded_Windows.h"
-#define DEFAULT_INPUT_DRIVER_LIST "DirectInput,Pump,Para"
-#define DEFAULT_MOVIE_DRIVER_LIST "FFMpeg,Null"
-#define DEFAULT_SOUND_DRIVER_LIST "WaveOut,DirectSound-sw,WDMKS,Null"
 
+inline const std::vector<RString>& GetDefaultInputDriverList() {
+	static const std::vector<RString> inputDriverList = { "DirectInput", "Pump", "Para" };
+	return inputDriverList;
+}
+
+inline const std::vector<RString>& GetDefaultMovieDriverList() {
+	static const std::vector<RString> movieDriverList = { "FFMpeg", "Null" };
+	return movieDriverList;
+}
+
+inline const std::vector<RString>& GetDefaultSoundDriverList() {
+	static const std::vector<RString> soundDriverList = { "WaveOut", "DirectSound-sw", "WDMKS", "Null" };
+	return soundDriverList;
+}
 
 #elif defined(MACOSX)
 #include "ArchHooks/ArchHooks_MacOSX.h"
 #include "LoadingWindow/LoadingWindow_MacOSX.h"
 #include "LowLevelWindow/LowLevelWindow_MacOSX.h"
 #include "MemoryCard/MemoryCardDriverThreaded_MacOSX.h"
-#define DEFAULT_INPUT_DRIVER_LIST "HID"
-#define DEFAULT_MOVIE_DRIVER_LIST "FFMpeg,Null"
-#define DEFAULT_SOUND_DRIVER_LIST "AudioUnit,Null"
 
+inline const std::vector<RString>& GetDefaultInputDriverList() {
+	static const std::vector<RString> inputDriverList = { "HID" };
+	return inputDriverList;
+}
+
+inline const std::vector<RString>& GetDefaultMovieDriverList() {
+	static const std::vector<RString> movieDriverList = { "FFMpeg", "Null" };
+	return movieDriverList;
+}
+
+inline const std::vector<RString>& GetDefaultSoundDriverList() {
+	static const std::vector<RString> soundDriverList = { "AudioUnit", "Null" };
+	return soundDriverList;
+}
 
 #elif defined(UNIX)
 #include "ArchHooks/ArchHooks_Unix.h"
@@ -33,12 +57,22 @@
 #if defined(HAVE_GTK)
 #include "LoadingWindow/LoadingWindow_Gtk.h"
 #endif
+
 #if defined(LINUX)
-#define DEFAULT_INPUT_DRIVER_LIST "X11,LinuxEvent,LinuxJoystick"
+inline const std::vector<RString>& GetDefaultInputDriverList() {
+	static const std::vector<RString> inputDriverList = { "X11", "LinuxEvent", "LinuxJoystick" };
+	return inputDriverList;
+}
 #else
-#define DEFAULT_INPUT_DRIVER_LIST "X11"
+inline const std::vector<RString>& GetDefaultInputDriverList() {
+	static const std::vector<RString> inputDriverList = { "X11" };
+	return inputDriverList;
+}
 #endif
-#define DEFAULT_MOVIE_DRIVER_LIST "FFMpeg,Null"
+inline const std::vector<RString>& GetDefaultMovieDriverList() {
+	static const std::vector<RString> movieDriverList = { "FFMpeg", "Null" };
+	return movieDriverList;
+}
 // PulseAudio is the preferred Unix driver since it allows the gives non
 // exclusive access to the audio device, unlike ALSA.
 // Use ALSA next because it is the lowest latency.
@@ -47,7 +81,10 @@
 // JACK gives us an explicit option to NOT start a daemon, so try it last,
 // as PulseAudio will successfully Init() but not actually work if the
 // PulseAudio daemon has been suspended by/for jackd.
-#define DEFAULT_SOUND_DRIVER_LIST "Pulse,ALSA-sw,OSS,JACK,Null"
+inline const std::vector<RString>& GetDefaultSoundDriverList() {
+	static const std::vector<RString> soundDriverList = { "Pulse", "ALSA-sw", "OSS", "JACK", "Null" };
+	return soundDriverList;
+}
 #else
 #error Which arch?
 #endif
@@ -57,7 +94,7 @@
 #include "MemoryCard/MemoryCardDriver_Null.h"
 #include "MemoryCard/MemoryCardDriverThreaded_Folder.h"
 
-#endif
+#endif // ARCH_DEFAULT_H
 
 /*
  * (c) 2002-2006 Glenn Maynard, Ben Anderson, Steve Checkoway


### PR DESCRIPTION
Currently we are storing the default driver lists as a macro, and splitting them into RString vectors every time they are needed. This commit changes the macros in `arch_default.h` into vectors of RStrings, so that they do not need to be splitted each time.

I have updated all references where the default driver lists are being called so that the vector is used directly.

A new function is added to RageUtil to make a compatible vector of RStrings from user input which may be separated with a comma.

RageSoundDriver was refactored to check user input in Preferences.ini against the default driver list, and in case of incorrect spelling or failure, provides a detailed error message (including a list of valid options) in logs so the user can resolve the problem.

`fix_bogus_sound_driver_pref` is no longer needed, since we are now telling the user what their valid options are if the user provides an incorrect entry for the `SoundDrivers` preference, instead of silently attempting to guess what the user wanted. Since I think it's rare that someone wants to specify a driver to begin with, we should let them know their exact options if they put something wrong here, instead of silently failing or using an unwanted driver.

I tested this on Windows by specifying `DirectSound-sw` in Preferences.ini, and it worked as expected. I also tried putting an unusable value in, and got the error in logs letting me know what my valid driver options were. Of course, input and movies all work as expected too.