### PR TITLE
Very minimal method of trunctating overlapping attributes in BitmapText

### DIFF
--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -871,84 +871,35 @@ BitmapText::Attribute BitmapText::GetDefaultAttribute() const
 	return attr;
 }
 
-void BitmapText::AddAttribute( std::size_t iPos, const Attribute &attr )
+// NOTE(sukibaby): This function indirectly affects the amount of latency before a sound is played.
+// Please take care to keep this function as minimal as possible.
+// This implementation may not handle all edge cases perfectly, but handles most of cases as intended.
+void BitmapText::AddAttribute(std::size_t iPos, const Attribute &attr)
 {
 	// Fixup position for new lines.
 	Attribute newAttr = attr;
-	auto lineIter = m_wTextLines.cbegin();
-
-	int iLines = 0;
 	std::size_t iAdjustedPos = iPos;
-
-	for( ; lineIter != m_wTextLines.cend(); ++lineIter )
+	for (const auto& line : m_wTextLines)
 	{
-		std::size_t length = lineIter->length() + 1; // +1 to account for implicit newline at the end
+		std::size_t length = line.length() + 1; // +1 to account for implicit newline at the end
 		if( length > iAdjustedPos )
 			break;
 		iAdjustedPos -= length;
-		++iLines;
-	}
-
-	if( newAttr.length > 0 )
-	{
-		// Fixup length for new lines.
-		std::size_t iAdjustedEndPos = iAdjustedPos + newAttr.length;
-		for( ; lineIter != m_wTextLines.cend(); ++lineIter )
-		{
-			std::size_t length = lineIter->length() + 1; // +1 to account for implicit newline at the end
-			if( length > iAdjustedEndPos || newAttr.length == 0 )
-				break;
-			iAdjustedEndPos -= length;
-			newAttr.length -= 1;
-		}
 	}
 
 	if( newAttr.length == 0 ) // Attribute doesn't cover any printable characters
 		return;
 
 	// Check if there are existing attributes overlapping this one. We might need to remove or fix them up.
-	const std::size_t iStartPos = iPos - iLines;
+	const std::size_t iStartPos = iPos;
 	const std::size_t iEndPos = iStartPos + newAttr.length;
 
-	// First attribute starting at the same position or further than the new attribute
-	const auto iterFirstAfterStart = m_mAttributes.lower_bound( iStartPos );
-	if( iterFirstAfterStart != m_mAttributes.begin() )
-	{
-		// Last attribute starting at earlier position than the new attribute (if it exists)
-		auto iterLastBeforeStart = iterFirstAfterStart;
-		--iterLastBeforeStart;
+	// Remove overlapping attributes
+	auto itStart = m_mAttributes.lower_bound(iStartPos);
+	auto itEnd = m_mAttributes.upper_bound(iEndPos);
+	m_mAttributes.erase(itStart, itEnd);
 
-		// Fixup the length so that it ends before the new attribute
-		iterLastBeforeStart->second.length = std::min( iterLastBeforeStart->second.length, static_cast<int>(iStartPos - iterLastBeforeStart->first) );
-	}
-
-	// First attribute starting after the end of the new attribute
-	auto iterLastBeforeEnd = m_mAttributes.lower_bound( iEndPos );
-	if( iterLastBeforeEnd != iterFirstAfterStart )
-	{
-		// Go back one, so that we are at the last overlapping attribute
-		--iterLastBeforeEnd;
-		const bool lastAttrOverlappingCompletely = iterLastBeforeEnd->first + iterLastBeforeEnd->second.length <= iEndPos;
-
-		auto iterEraseEnd = iterLastBeforeEnd;
-		// If it's overlapping completely, erase it as well
-		if( lastAttrOverlappingCompletely )
-			++iterEraseEnd;
-		m_mAttributes.erase( iterFirstAfterStart, iterEraseEnd );
-
-		// Otherwise it's only overlapping partially so fix it up
-		if( !lastAttrOverlappingCompletely )
-		{
-			// Fixup the length accordingly
-			Attribute lastAttr = iterLastBeforeEnd->second;
-			lastAttr.length -= iEndPos - iterLastBeforeEnd->first;
-
-			// Erase it and insert just after the new attribute
-			m_mAttributes.erase( iterLastBeforeEnd );
-			m_mAttributes[iEndPos] = lastAttr;
-		}
-	}
-
+	// Insert the new attribute
 	m_mAttributes[iStartPos] = newAttr;
 	m_bHasGlowAttribute = m_bHasGlowAttribute || attr.glow.a > 0.0001f;
 }


### PR DESCRIPTION
Rewrite of commit 208494b

This function indirectly affects the amount of latency before a sound is played. For this reason it has been rewritten with a focus on minimalism while accomplishing the original goal of correcting overlapping attributes.

This is not quite as lightweight as the [original method](https://github.com/itgmania/itgmania/blob/28b7659a0999fea52b6fc475673a52157d903454/src/BitmapText.cpp#L879-L895) which doesn't account for overlapping attributes at all, but results in far less audio latency than the current method.

This implementation may not handle all edge cases perfectly, but will handle most cases correctly.

Please point out any removed functionality in this commit which should be restored.