### PR TITLE
Change lots of macros to constexpr in Actor.h

### DIFF
--- a/src/Actor.h
+++ b/src/Actor.h
@@ -19,19 +19,19 @@ class LuaClass;
 typedef AutoPtrCopyOnWrite<LuaReference> apActorCommands;
 
 /** @brief The background layer. */
-#define DRAW_ORDER_BEFORE_EVERYTHING		-200
+constexpr int DRAW_ORDER_BEFORE_EVERYTHING = -200;
 /** @brief The underlay layer. */
-#define DRAW_ORDER_UNDERLAY			-100
+constexpr int DRAW_ORDER_UNDERLAY = -100;
 /** @brief The decorations layer. */
-#define DRAW_ORDER_DECORATIONS			   0
+constexpr int DRAW_ORDER_DECORATIONS = 0;
 /** @brief The overlay layer.
  *
  * Normal screen elements go here. */
-#define DRAW_ORDER_OVERLAY			+100
+constexpr int DRAW_ORDER_OVERLAY = 100;
 /** @brief The transitions layer. */
-#define DRAW_ORDER_TRANSITIONS			+200
+constexpr int DRAW_ORDER_TRANSITIONS = 200;
 /** @brief The over everything layer. */
-#define DRAW_ORDER_AFTER_EVERYTHING		+300
+constexpr int DRAW_ORDER_AFTER_EVERYTHING = 300;
 
 /** @brief The different horizontal alignments. */
 enum HorizAlign
@@ -56,24 +56,24 @@ enum VertAlign
 LuaDeclareType( VertAlign );
 
 /** @brief The left horizontal alignment constant. */
-#define align_left 0.0f
+constexpr float align_left = 0.0f;
 /** @brief The center horizontal alignment constant. */
-#define align_center 0.5f
+constexpr float align_center = 0.5f;
 /** @brief The right horizontal alignment constant. */
-#define align_right 1.0f
+constexpr float align_right = 1.0f;
 /** @brief The top vertical alignment constant. */
-#define align_top 0.0f
+constexpr float align_top = 0.0f;
 /** @brief The middle vertical alignment constant. */
-#define align_middle 0.5f
+constexpr float align_middle = 0.5f;
 /** @brief The bottom vertical alignment constant. */
-#define align_bottom 1.0f
+constexpr float align_bottom = 1.0f;
 
 // This is the number of colors in Actor::diffuse.  Actor has multiple
 // diffuse colors so that each edge can be a different color, and the actor
 // is drawn with a gradient between them.
 // I doubt I actually found all the places that touch diffuse and rely on the
 // number of diffuse colors, so change this at your own risk. -Kyz
-#define NUM_DIFFUSE_COLORS 4
+constexpr int NUM_DIFFUSE_COLORS = 4;
 
 // ssc futures:
 /*


### PR DESCRIPTION
For the purposes of type safety,  allowing the compiler to further optimize, and preventing possible name collisions, I've converted these 13 macros to constexpr's.