### PR TITLE
Optimizing BitmapText

### DIFF
--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -598,28 +598,44 @@ void BitmapText::UpdateBaseZoom()
 	// Never apply a zoom greater than 1.
 	// Factor in the non-base zoom so that maxwidth will be in terms of theme
 	// pixels when zoom is used.
-#define APPLY_DIMENSION_ZOOM(dimension_max, dimension_get, dimension_zoom_get, base_zoom_set) \
-	if(dimension_max == 0) \
-	{ \
-		base_zoom_set(1); \
-	} \
-	else \
-	{ \
-		float dimension= dimension_get(); \
-		if(m_MaxDimensionUsesZoom) \
-		{ \
-			dimension/= dimension_zoom_get(); \
-		} \
-		if(dimension != 0) \
-		{ \
-			const float zoom= std::fmin(1, dimension_max / dimension); \
-			base_zoom_set(zoom); \
-		} \
+
+	constexpr float maxZoom = 1.0f;
+
+	if (m_fMaxWidth == 0)
+	{
+		SetBaseZoomX(1);
+	}
+	else
+	{
+		float width = GetUnzoomedWidth();
+		if (m_MaxDimensionUsesZoom)
+		{
+			width /= GetZoomX();
+		}
+		if (width != 0)
+		{
+			const float zoom = std::fmin(maxZoom, m_fMaxWidth / width);
+			SetBaseZoomX(zoom);
+		}
 	}
 
-	APPLY_DIMENSION_ZOOM(m_fMaxWidth, GetUnzoomedWidth, GetZoomX, SetBaseZoomX);
-	APPLY_DIMENSION_ZOOM(m_fMaxHeight, GetUnzoomedHeight, GetZoomY, SetBaseZoomY);
-#undef APPLY_DIMENSION_ZOOM
+	if (m_fMaxHeight == 0)
+	{
+		SetBaseZoomY(1);
+	}
+	else
+	{
+		float height = GetUnzoomedHeight();
+		if (m_MaxDimensionUsesZoom)
+		{
+			height /= GetZoomY();
+		}
+		if (height != 0)
+		{
+			const float zoom = std::fmin(maxZoom, m_fMaxHeight / height);
+			SetBaseZoomY(zoom);
+		}
+	}
 }
 
 bool BitmapText::StringWillUseAlternate( const RString& sText, const RString& sAlternateText ) const

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -643,13 +643,13 @@ bool BitmapText::StringWillUseAlternate( const RString& sText, const RString& sA
 	return true;
 }
 
-void BitmapText::CropLineToWidth(std::size_t l, int width)
+void BitmapText::CropLineToWidth(size_t l, int width)
 {
 	if(l < m_wTextLines.size())
 	{
 		int used_width= width;
 		std::wstring& line= m_wTextLines[l];
-		const std::size_t fit= m_pFont->GetGlyphsThatFit(line, &used_width);
+		const size_t fit= m_pFont->GetGlyphsThatFit(line, &used_width);
 		if(fit < line.size())
 		{
 			line.erase(line.begin()+fit, line.end());
@@ -660,7 +660,7 @@ void BitmapText::CropLineToWidth(std::size_t l, int width)
 
 void BitmapText::CropToWidth(int width)
 {
-	for(std::size_t l= 0; l < m_wTextLines.size(); ++l)
+	for(size_t l= 0; l < m_wTextLines.size(); ++l)
 	{
 		CropLineToWidth(l, width);
 	}
@@ -761,8 +761,8 @@ void BitmapText::DrawPrimitives() noexcept
 		}
 		else
 		{
-			std::size_t i = 0;
-			std::map<std::size_t,Attribute>::const_iterator iter = m_mAttributes.begin();
+			size_t i = 0;
+			std::map<size_t,Attribute>::const_iterator iter = m_mAttributes.begin();
 			while( i < m_aVertices.size() )
 			{
 				// Set the colors up to the next attribute.
@@ -783,7 +783,7 @@ void BitmapText::DrawPrimitives() noexcept
 					iEnd = i + attr.length*4;
 				iEnd = ClampToVertexSize(iEnd, m_aVertices.size());
 				std::vector<RageColor> temp_attr_diffuse(NUM_DIFFUSE_COLORS, m_internalDiffuse);
-				for(std::size_t c= 0; c < NUM_DIFFUSE_COLORS; ++c)
+				for(size_t c= 0; c < NUM_DIFFUSE_COLORS; ++c)
 				{
 					temp_attr_diffuse[c]*= attr.diffuse[c];
 					if(m_mult_attrs_with_diffuse)
@@ -831,12 +831,12 @@ void BitmapText::DrawPrimitives() noexcept
 	{
 		DISPLAY->SetTextureMode( TextureUnit_1, TextureMode_Glow );
 
-		std::size_t i = 0;
+		size_t i = 0;
 		auto iter = m_mAttributes.begin();
 		while( i < m_aVertices.size() )
 		{
 			// Set the glow up to the next attribute.
-			std::size_t iEnd = CalculateEndIndex(iter == m_mAttributes.end(), m_aVertices.size(), iter->first);
+			size_t iEnd = CalculateEndIndex(iter == m_mAttributes.end(), m_aVertices.size(), iter->first);
 			iEnd = ClampToVertexSize(iEnd, m_aVertices.size());
 			for( ; i < iEnd; ++i )
 			{
@@ -903,18 +903,18 @@ BitmapText::Attribute BitmapText::GetDefaultAttribute() const
 	return attr;
 }
 
-void BitmapText::AddAttribute( std::size_t iPos, const Attribute &attr )
+void BitmapText::AddAttribute( size_t iPos, const Attribute &attr )
 {
 	// Fixup position for new lines.
 	Attribute newAttr = attr;
 	std::vector<std::wstring>::const_iterator lineIter = m_wTextLines.cbegin();
 
 	int iLines = 0;
-	std::size_t iAdjustedPos = iPos;
+	size_t iAdjustedPos = iPos;
 
 	for( ; lineIter != m_wTextLines.cend(); ++lineIter )
 	{
-		std::size_t length = lineIter->length() + 1; // +1 to account for implicit newline at the end
+		size_t length = lineIter->length() + 1; // +1 to account for implicit newline at the end
 		if( length > iAdjustedPos )
 			break;
 		iAdjustedPos -= length;
@@ -924,10 +924,10 @@ void BitmapText::AddAttribute( std::size_t iPos, const Attribute &attr )
 	if( newAttr.length > 0 )
 	{
 		// Fixup length for new lines.
-		std::size_t iAdjustedEndPos = iAdjustedPos + newAttr.length;
+		size_t iAdjustedEndPos = iAdjustedPos + newAttr.length;
 		for( ; lineIter != m_wTextLines.cend(); ++lineIter )
 		{
-			std::size_t length = lineIter->length() + 1; // +1 to account for implicit newline at the end
+			size_t length = lineIter->length() + 1; // +1 to account for implicit newline at the end
 			if( length > iAdjustedEndPos || newAttr.length == 0 )
 				break;
 			iAdjustedEndPos -= length;
@@ -939,8 +939,8 @@ void BitmapText::AddAttribute( std::size_t iPos, const Attribute &attr )
 		return;
 
 	// Check if there are existing attributes overlapping this one. We might need to remove or fix them up.
-	const std::size_t iStartPos = iPos - iLines;
-	const std::size_t iEndPos = iStartPos + newAttr.length;
+	const size_t iStartPos = iPos - iLines;
+	const size_t iEndPos = iStartPos + newAttr.length;
 
 	// First attribute starting at the same position or further than the new attribute
 	const auto iterFirstAfterStart = m_mAttributes.lower_bound( iStartPos );
@@ -1082,7 +1082,7 @@ public:
 	static int GetText( T* p, lua_State *L )		{ lua_pushstring( L, p->GetText() ); return 1; }
 	static int AddAttribute( T* p, lua_State *L )
 	{
-		std::size_t iPos = IArg(1);
+		size_t iPos = IArg(1);
 		BitmapText::Attribute attr = p->GetDefaultAttribute();
 
 		attr.FromStack( L, 2 );

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -79,29 +79,27 @@ BitmapText & BitmapText::operator=(const BitmapText &cpy)
 {
 	Actor::operator=(cpy);
 
-#define CPY(a) a = cpy.a
-	CPY( m_bUppercase );
-	CPY( m_sText );
-	CPY( m_wTextLines );
-	CPY( m_iLineWidths );
-	CPY( m_iWrapWidthPixels );
-	CPY( m_fMaxWidth );
-	CPY( m_fMaxHeight );
-	CPY( m_bRainbowScroll );
-	CPY( m_bJitter );
-	CPY( m_fDistortion );
-	CPY( m_bUsingDistortion );
-	CPY( m_mult_attrs_with_diffuse );
-	CPY( m_iVertSpacing );
-	CPY( m_MaxDimensionUsesZoom );
-	CPY( m_aVertices );
-	CPY( m_vpFontPageTextures );
-	CPY( m_mAttributes );
-	CPY( m_bHasGlowAttribute );
-	CPY( BMT_Tweens );
-	CPY( BMT_current );
-	CPY( BMT_start );
-#undef CPY
+	m_bUppercase = cpy.m_bUppercase;
+	m_sText = cpy.m_sText;
+	m_wTextLines = cpy.m_wTextLines;
+	m_iLineWidths = cpy.m_iLineWidths;
+	m_iWrapWidthPixels = cpy.m_iWrapWidthPixels;
+	m_fMaxWidth = cpy.m_fMaxWidth;
+	m_fMaxHeight = cpy.m_fMaxHeight;
+	m_bRainbowScroll = cpy.m_bRainbowScroll;
+	m_bJitter = cpy.m_bJitter;
+	m_fDistortion = cpy.m_fDistortion;
+	m_bUsingDistortion = cpy.m_bUsingDistortion;
+	m_mult_attrs_with_diffuse = cpy.m_mult_attrs_with_diffuse;
+	m_iVertSpacing = cpy.m_iVertSpacing;
+	m_MaxDimensionUsesZoom = cpy.m_MaxDimensionUsesZoom;
+	m_aVertices = cpy.m_aVertices;
+	m_vpFontPageTextures = cpy.m_vpFontPageTextures;
+	m_mAttributes = cpy.m_mAttributes;
+	m_bHasGlowAttribute = cpy.m_bHasGlowAttribute;
+	BMT_Tweens = cpy.BMT_Tweens;
+	BMT_current = cpy.BMT_current;
+	BMT_start = cpy.BMT_start;
 
 	if( m_pFont )
 		FONT->UnloadFont( m_pFont );

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -28,8 +28,6 @@ REGISTER_ACTOR_CLASS( BitmapText );
  * a waste, when we're usually setting them all to the same value. Rainbow and
  * fading are annoying to optimize, but rarely used. Iterating over every
  * character in Draw() is dumb. */
-#define NUM_RAINBOW_COLORS	THEME->GetMetricI("BitmapText","NumRainbowColors")
-#define RAINBOW_COLOR(n)	THEME->GetMetricC("BitmapText",ssprintf("RainbowColor%i", n+1))
 
 static std::vector<RageColor> RAINBOW_COLORS;
 
@@ -40,9 +38,11 @@ BitmapText::BitmapText()
 	static int iReloadCounter = 0;
 	if( iReloadCounter % 20==0 )
 	{
-		RAINBOW_COLORS.resize( NUM_RAINBOW_COLORS );
-		for( unsigned i = 0; i < RAINBOW_COLORS.size(); ++i )
-			RAINBOW_COLORS[i] = RAINBOW_COLOR(i);
+		RAINBOW_COLORS.resize(THEME->GetMetricI("BitmapText", "NumRainbowColors"));
+		for (unsigned i = 0; i < RAINBOW_COLORS.size(); ++i)
+		{
+			RAINBOW_COLORS[i] = THEME->GetMetricC("BitmapText", ssprintf("RainbowColor%i", i + 1));
+		}
 	}
 	iReloadCounter++;
 

--- a/src/BitmapText.h
+++ b/src/BitmapText.h
@@ -70,7 +70,7 @@ public:
 	void CropToWidth(int width);
 
 	virtual bool EarlyAbortDraw() const override;
-	virtual void DrawPrimitives() override;
+	virtual void DrawPrimitives() noexcept override;
 
 	void SetUppercase( bool b );
 	void SetRainbowScroll( bool b )	{ m_bRainbowScroll = b; }

--- a/src/RollingNumbers.cpp
+++ b/src/RollingNumbers.cpp
@@ -43,7 +43,7 @@ void RollingNumbers::DrawPart(RageColor const* diffuse, RageColor const& stroke,
 	BitmapText::DrawPrimitives();
 }
 
-void RollingNumbers::DrawPrimitives()
+void RollingNumbers::DrawPrimitives() noexcept
 {
 	if(!m_metrics_loaded)
 	{

--- a/src/RollingNumbers.h
+++ b/src/RollingNumbers.h
@@ -15,7 +15,7 @@ public:
 
 	void DrawPart(RageColor const* diffuse, RageColor const& stroke,
 		float crop_left, float crop_right);
-	virtual void DrawPrimitives();
+	virtual void DrawPrimitives() noexcept;
 	virtual void Update( float fDeltaTime );
 
 	/** 


### PR DESCRIPTION
We found that slowing down BitmapText affects the amount of audio latency before a sound is played. Due to the way the code base is designed, DrawPrimitives are called constantly in gameplay, especially in time-sensitive ways, and this needs to be able to complete quickly to prevent unwanted audio latency from being added. This really tightens up overall audio latency in the game.

A few commits are here.

1. BitmapText::DrawPrimitives noexcept (although really, it also defines several constexpr functions in an anonymous namespace to help with repeated functions called within DrawPrimitives). It also declares DrawPrimitives in RollingNumbers noexcept, since it can't be a different level than the BitmapText variant.

2. Undefine a few macros in the constructor related to rainbow coloring

3. Undefine a useless macro called `CPY` used in the assignment operator.

4. Undefine a useless macro in `BitmapText::UpdateBaseZoom()`

5. Standardize use of `size_t` instead of `std::size_t`. Just using `size_t` is more idiomatic in modern C++. So all `std::size_t` have been changed to `size_t`.