### PR TITLE
Undefine macros in RageUtil.h (huge) (SPLITTING INTO SMALLER PR'S, WON'T REOPEN)

### DIFF
--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -520,8 +520,7 @@ void Actor::PreDraw() // calculate actor properties
 		const float rupathrdown_plus_atf= rupath_plus_rdown + m_effect_hold_at_full;
 		if(fTimeIntoEffect < m_effect_ramp_to_half)
 		{
-			fPercentThroughEffect = SCALE(fTimeIntoEffect,
-				0, m_effect_ramp_to_half, 0.0f, 0.5f);
+			fPercentThroughEffect = (((fTimeIntoEffect)-(0)) * ((0.5f) - (0.0f)) / ((m_effect_ramp_to_half)-(0)) + (0.0f));
 		}
 		else if(fTimeIntoEffect < rup_plus_ath)
 		{
@@ -529,8 +528,7 @@ void Actor::PreDraw() // calculate actor properties
 		}
 		else if(fTimeIntoEffect < rupath_plus_rdown)
 		{
-			fPercentThroughEffect = SCALE(fTimeIntoEffect,
-				rup_plus_ath, rupath_plus_rdown, 0.5f, 1.0f);
+			fPercentThroughEffect = (((fTimeIntoEffect)-(rup_plus_ath)) * ((1.0f) - (0.5f)) / ((rupath_plus_rdown)-(rup_plus_ath)) + (0.5f));
 		}
 		else if(fTimeIntoEffect < rupathrdown_plus_atf)
 		{
@@ -625,11 +623,11 @@ void Actor::PreDraw() // calculate actor properties
 				float fMinZoom = m_vEffectMagnitude[0];
 				float fMaxZoom = m_vEffectMagnitude[1];
 				float fPercentOffset = std::sin( fPercentThroughEffect*PI );
-				float fZoom = SCALE( fPercentOffset, 0.f, 1.f, fMinZoom, fMaxZoom );
+				float fZoom = (((fPercentOffset)-(0.f)) * ((fMaxZoom)-(fMinZoom)) / ((1.f) - (0.f)) + (fMinZoom));
 				m_current_with_effects.scale *= fZoom;
 
 				// Use the color as a Vector3 to scale the effect for added control
-				RageColor c = SCALE( fPercentOffset, 0.f, 1.f, m_effectColor1, m_effectColor2 );
+				RageColor c = (((fPercentOffset)-(0.f)) * ((m_effectColor2)-(m_effectColor1)) / ((1.f) - (0.f)) + (m_effectColor1));
 				m_current_with_effects.scale.x *= c.r;
 				m_current_with_effects.scale.y *= c.g;
 				m_current_with_effects.scale.z *= c.b;
@@ -717,8 +715,8 @@ void Actor::BeginDraw()
 	// Adjust the alignment of the actor
 	if (unlikely(m_fHorizAlign != 0.5f || m_fVertAlign != 0.5f))
 	{
-		float fX = SCALE(m_fHorizAlign, 0.0f, 1.0f, +m_size.x / 2.0f, -m_size.x / 2.0f);
-		float fY = SCALE(m_fVertAlign, 0.0f, 1.0f, +m_size.y / 2.0f, -m_size.y / 2.0f);
+		float fX = (((m_fHorizAlign)-(0.0f)) * ((-m_size.x / 2.0f) - (+m_size.x / 2.0f)) / ((1.0f) - (0.0f)) + (+m_size.x / 2.0f));
+		float fY = (((m_fVertAlign)-(0.0f)) * ((-m_size.y / 2.0f) - (+m_size.y / 2.0f)) / ((1.0f) - (0.0f)) + (+m_size.y / 2.0f));
 		RageMatrix m;
 		RageMatrixTranslate(&m, fX, fY, 0);
 		DISPLAY->PreMultMatrix(m);

--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -1433,20 +1433,25 @@ void Actor::TweenState::Init()
 
 bool Actor::TweenState::operator==( const TweenState &other ) const
 {
-#define COMPARE( x )	if( x != other.x ) return false;
-	COMPARE( pos );
-	COMPARE( rotation );
-	COMPARE( quat );
-	COMPARE( scale );
-	COMPARE( fSkewX );
-	COMPARE( fSkewY );
-	COMPARE( crop );
-	COMPARE( fade );
-	for( unsigned i=0; i<ARRAYLEN(diffuse); i++ )
-		COMPARE( diffuse[i] );
-	COMPARE( glow );
-	COMPARE( aux );
-#undef COMPARE
+	if (pos != other.pos) return false;
+	if (rotation != other.rotation) return false;
+	if (quat != other.quat) return false;
+	if (scale != other.scale) return false;
+	if (fSkewX != other.fSkewX) return false;
+	if (fSkewY != other.fSkewY) return false;
+	if (crop != other.crop) return false;
+	if (fade != other.fade) return false;
+
+	const std::size_t iArrayLen = ArrayLenSizeT(diffuse);
+
+	for (std::size_t i = 0; i < iArrayLen; ++i)
+	{
+		if (diffuse[i] != other.diffuse[i]) return false;
+	}
+
+	if (glow != other.glow) return false;
+	if (aux != other.aux) return false;
+
 	return true;
 }
 

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -292,8 +292,9 @@ void BitmapText::BuildChars()
 			reverse( sLine.begin(), sLine.end() );
 		const int iLineWidth = m_iLineWidths[i];
 
-		float fX = SCALE( m_fHorizAlign, 0.0f, 1.0f, -m_size.x/2.0f, +m_size.x/2.0f - iLineWidth );
-		int iX = std::lrint( fX );
+		int iX = std::lrint(
+			((m_fHorizAlign - 0.0f) * ((+m_size.x / 2.0f - iLineWidth) - (-m_size.x / 2.0f)) / (1.0f - 0.0f) + (-m_size.x / 2.0f))
+		);
 
 		for( unsigned j = 0; j < sLine.size(); ++j )
 		{
@@ -351,10 +352,12 @@ void BitmapText::DrawChars( bool bUseStrokeTexture )
 		return;
 
 	const int iNumGlyphs = m_vpFontPageTextures.size();
-	int iStartGlyph = std::lrint( SCALE( m_pTempState->crop.left, 0.f, 1.f, 0, (float) iNumGlyphs ) );
-	int iEndGlyph = std::lrint( SCALE( m_pTempState->crop.right, 0.f, 1.f, (float) iNumGlyphs, 0 ) );
-	iStartGlyph = std::clamp( iStartGlyph, 0, iNumGlyphs );
-	iEndGlyph = std::clamp( iEndGlyph, 0, iNumGlyphs );
+	//int iStartGlyph = std::lrint((((m_pTempState->crop.left) - (0.f)) * (((float)iNumGlyphs) - (0)) / ((1.f) - (0.f)) + (0)));
+	//int iEndGlyph = std::lrint((((m_pTempState->crop.right) - (0.f)) * ((0) - ((float)iNumGlyphs)) / ((1.f) - (0.f)) + ((float)iNumGlyphs)));
+	//iStartGlyph = std::clamp( iStartGlyph, 0, iNumGlyphs );
+	//iEndGlyph = std::clamp( iEndGlyph, 0, iNumGlyphs );
+	int iStartGlyph = std::max(0, std::min(static_cast<int>(std::lrint(m_pTempState->crop.left * iNumGlyphs)), iNumGlyphs));
+	int iEndGlyph = std::max(0, std::min(static_cast<int>(std::lrint((1.0f - m_pTempState->crop.right) * iNumGlyphs)), iNumGlyphs));
 
 	if( m_pTempState->fade.top > 0 ||
 		m_pTempState->fade.bottom > 0 ||
@@ -379,18 +382,18 @@ void BitmapText::DrawChars( bool bUseStrokeTexture )
 
 		/* We fade from 0 to LeftColor, then from RightColor to 0. (We won't fade
 		 * all the way to 0 if the crop is beyond the outer edge.) */
-		const float fRightAlpha  = SCALE( FadeSize.right,  FadeDist.right,  0, 1, 0 );
-		const float fLeftAlpha   = SCALE( FadeSize.left,   FadeDist.left,   0, 1, 0 );
+		const float fRightAlpha = (((FadeSize.right) - (FadeDist.right)) * ((0) - (1)) / ((0) - (FadeDist.right)) + (1));
+		const float fLeftAlpha = (((FadeSize.left) - (FadeDist.left)) * ((0) - (1)) / ((0) - (FadeDist.left)) + (1));
 
 		const float fStartFadeLeftPercent = m_pTempState->crop.left;
 		const float fStopFadeLeftPercent = m_pTempState->crop.left + FadeSize.left;
-		const float fLeftFadeStartGlyph = SCALE( fStartFadeLeftPercent, 0.f, 1.f, 0, (float) iNumGlyphs );
-		const float fLeftFadeStopGlyph = SCALE( fStopFadeLeftPercent, 0.f, 1.f, 0, (float) iNumGlyphs );
+		const float fLeftFadeStartGlyph = (((fStartFadeLeftPercent)-(0.f)) * (((float)iNumGlyphs) - (0)) / ((1.f) - (0.f)) + (0));
+		const float fLeftFadeStopGlyph = (((fStopFadeLeftPercent)-(0.f)) * (((float)iNumGlyphs) - (0)) / ((1.f) - (0.f)) + (0));
 
 		const float fStartFadeRightPercent = 1-(m_pTempState->crop.right + FadeSize.right);
 		const float fStopFadeRightPercent = 1-(m_pTempState->crop.right);
-		const float fRightFadeStartGlyph = SCALE( fStartFadeRightPercent, 0.f, 1.f, 0, (float) iNumGlyphs );
-		const float fRightFadeStopGlyph = SCALE( fStopFadeRightPercent, 0.f, 1.f, 0, (float) iNumGlyphs );
+		const float fRightFadeStartGlyph = (((fStartFadeRightPercent)-(0.f)) * (((float)iNumGlyphs) - (0)) / ((1.f) - (0.f)) + (0));
+		const float fRightFadeStopGlyph = (((fStopFadeRightPercent)-(0.f)) * (((float)iNumGlyphs) - (0)) / ((1.f) - (0.f)) + (0));
 
 		for( int start = iStartGlyph; start < iEndGlyph; ++start )
 		{
@@ -400,14 +403,14 @@ void BitmapText::DrawChars( bool bUseStrokeTexture )
 			if( FadeSize.left > 0.001f )
 			{
 				// Add .5, so we fade wrt. the center of the vert, not the left side.
-				float fPercent = SCALE( start+0.5f, fLeftFadeStartGlyph, fLeftFadeStopGlyph, 0.0f, 1.0f );
+				float fPercent = (((start + 0.5f) - (fLeftFadeStartGlyph)) * ((1.0f) - (0.0f)) / ((fLeftFadeStopGlyph)-(fLeftFadeStartGlyph)) + (0.0f));
 				fPercent = std::clamp( fPercent, 0.0f, 1.0f );
 				fAlpha *= fPercent * fLeftAlpha;
 			}
 
 			if( FadeSize.right > 0.001f )
 			{
-				float fPercent = SCALE( start+0.5f, fRightFadeStartGlyph, fRightFadeStopGlyph, 1.0f, 0.0f );
+				float fPercent = (((start + 0.5f) - (fRightFadeStartGlyph)) * ((0.0f) - (1.0f)) / ((fRightFadeStopGlyph)-(fRightFadeStartGlyph)) + (1.0f));
 				fPercent = std::clamp( fPercent, 0.0f, 1.0f );
 				fAlpha *= fPercent * fRightAlpha;
 			}

--- a/src/CodeDetector.cpp
+++ b/src/CodeDetector.cpp
@@ -231,11 +231,11 @@ bool CodeDetector::DetectAndAdjustMusicOptions( GameController controller )
 			case CODE_DARK:				FLOAT_TOGGLE( po.m_fDark );				break;
 			case CODE_CANCEL_ALL:			GAMESTATE->GetDefaultPlayerOptions( po );		break;
 			case CODE_HIDDEN:
-				ZERO(po.m_fAppearances);
+				ZeroArray(po.m_fAppearances);
 				po.m_fAppearances[PlayerOptions::APPEARANCE_HIDDEN] = 1;
 				break;
 			case CODE_RANDOMVANISH:
-				ZERO(po.m_fAppearances);
+				ZeroArray(po.m_fAppearances);
 				po.m_fAppearances[PlayerOptions::APPEARANCE_RANDOMVANISH] = 1;
 				break;
 			default:	break;

--- a/src/CombinedLifeMeterTug.cpp
+++ b/src/CombinedLifeMeterTug.cpp
@@ -64,7 +64,7 @@ void CombinedLifeMeterTug::Update( float fDelta )
 	m_Stream[PLAYER_1].SetPercent( fPercentToShow );
 	m_Stream[PLAYER_2].SetPercent( 1-fPercentToShow );
 
-	float fSeparatorX = SCALE( fPercentToShow, 0.f, 1.f, -METER_WIDTH/2.f, +METER_WIDTH/2.f );
+	float fSeparatorX = (((fPercentToShow)-(0.f)) * ((+METER_WIDTH / 2.f) - (-METER_WIDTH / 2.f)) / ((1.f) - (0.f)) + (-METER_WIDTH / 2.f));
 
 	m_sprSeparator->SetX( fSeparatorX );
 
@@ -127,7 +127,7 @@ void CombinedLifeMeterTug::ChangeLife( PlayerNumber pn, float fPercentToMove )
 
 		/* Clamp the life meter only for calculating the multiplier. */
 		fLifePercentage = std::clamp( fLifePercentage, 0.0f, 1.0f );
-		fPercentToMove *= SCALE( fLifePercentage, 0.f, 1.f, 0.2f, 1.f);
+		fPercentToMove *= (((fLifePercentage)-(0.f)) * ((1.f) - (0.2f)) / ((1.f) - (0.f)) + (0.2f));
 	}
 
 	switch( pn )

--- a/src/ComboGraph.cpp
+++ b/src/ComboGraph.cpp
@@ -86,10 +86,10 @@ void ComboGraph::Set( const StageStats &s, const PlayerStageStats &pss )
 		LOG->Trace( "combo %i is %f+%f of %f", i, combo.m_fStartSecond, combo.m_fSizeSeconds, fLastSecond );
 		Actor *pSprite = bIsMax? m_pMaxCombo->Copy() : m_pNormalCombo->Copy();
 
-		const float fStart = SCALE( combo.m_fStartSecond, fFirstSecond, fLastSecond, 0.0f, 1.0f );
-		const float fSize = SCALE( combo.m_fSizeSeconds, 0, fLastSecond-fFirstSecond, 0.0f, 1.0f );
-		pSprite->SetCropLeft ( SCALE( fSize, 0.0f, 1.0f, 0.5f, 0.0f ) );
-		pSprite->SetCropRight( SCALE( fSize, 0.0f, 1.0f, 0.5f, 0.0f ) );
+		const float fStart = (((combo.m_fStartSecond) - (fFirstSecond)) * ((1.0f) - (0.0f)) / ((fLastSecond)-(fFirstSecond)) + (0.0f));
+		const float fSize = (((combo.m_fSizeSeconds) - (0)) * ((1.0f) - (0.0f)) / ((fLastSecond - fFirstSecond) - (0)) + (0.0f));
+		pSprite->SetCropLeft((((fSize)-(0.0f)) * ((0.0f) - (0.5f)) / ((1.0f) - (0.0f)) + (0.5f)));
+		pSprite->SetCropRight((((fSize)-(0.0f)) * ((0.0f) - (0.5f)) / ((1.0f) - (0.0f)) + (0.5f)));
 
 		pSprite->SetCropLeft( fStart );
 		pSprite->SetCropRight( 1 - (fSize + fStart) );
@@ -112,11 +112,11 @@ void ComboGraph::Set( const StageStats &s, const PlayerStageStats &pss )
 
 		BitmapText *pText = m_pComboNumber->Copy();
 
-		const float fStart = SCALE( combo.m_fStartSecond, fFirstSecond, fLastSecond, 0.0f, 1.0f );
-		const float fSize = SCALE( combo.m_fSizeSeconds, 0, fLastSecond-fFirstSecond, 0.0f, 1.0f );
+		const float fStart = (((combo.m_fStartSecond) - (fFirstSecond)) * ((1.0f) - (0.0f)) / ((fLastSecond)-(fFirstSecond)) + (0.0f));
+		const float fSize = (((combo.m_fSizeSeconds) - (0)) * ((1.0f) - (0.0f)) / ((fLastSecond - fFirstSecond) - (0)) + (0.0f));
 
 		const float fCenterPercent = fStart + fSize/2;
-		const float fCenterXPos = SCALE( fCenterPercent, 0.0f, 1.0f, -BODY_WIDTH/2.0f, BODY_WIDTH/2.0f );
+		const float fCenterXPos = (((fCenterPercent)-(0.0f)) * ((BODY_WIDTH / 2.0f) - (-BODY_WIDTH / 2.0f)) / ((1.0f) - (0.0f)) + (-BODY_WIDTH / 2.0f));
 		pText->SetX( fCenterXPos );
 
 		pText->SetText( ssprintf("%i",combo.GetStageCnt()) );

--- a/src/DancingCharacters.cpp
+++ b/src/DancingCharacters.cpp
@@ -209,7 +209,7 @@ void DancingCharacters::Update( float fDelta )
 	{
 		// make the characters move
 		float fBPM = GAMESTATE->m_Position.m_fCurBPS*60;
-		float fUpdateScale = SCALE( fBPM, 60.f, 300.f, 0.75f, 1.5f );
+		float fUpdateScale = (((fBPM)-(60.f)) * ((1.5f) - (0.75f)) / ((300.f) - (60.f)) + (0.75f));
 		CLAMP( fUpdateScale, 0.75f, 1.5f );
 
 		/* It's OK for the animation to go slower than natural when we're
@@ -340,9 +340,9 @@ void DancingCharacters::DrawPrimitives()
 	if(m_fThisCameraStartBeat == m_fThisCameraEndBeat)
 		fPercentIntoSweep = 0;
 	else 
-		fPercentIntoSweep = SCALE(GAMESTATE->m_Position.m_fSongBeat, m_fThisCameraStartBeat, m_fThisCameraEndBeat, 0.f, 1.f );
-	float fCameraPanY = SCALE( fPercentIntoSweep, 0.f, 1.f, m_CameraPanYStart, m_CameraPanYEnd );
-	float fCameraHeight = SCALE( fPercentIntoSweep, 0.f, 1.f, m_fCameraHeightStart, m_fCameraHeightEnd );
+		fPercentIntoSweep = (((GAMESTATE->m_Position.m_fSongBeat) - (m_fThisCameraStartBeat)) * ((1.f) - (0.f)) / ((m_fThisCameraEndBeat)-(m_fThisCameraStartBeat)) + (0.f));
+	float fCameraPanY = (((fPercentIntoSweep)-(0.f)) * ((m_CameraPanYEnd)-(m_CameraPanYStart)) / ((1.f) - (0.f)) + (m_CameraPanYStart));
+	float fCameraHeight = (((fPercentIntoSweep)-(0.f)) * ((m_fCameraHeightEnd)-(m_fCameraHeightStart)) / ((1.f) - (0.f)) + (m_fCameraHeightStart));
 
 	RageVector3 m_CameraPoint( 0, fCameraHeight, -m_CameraDistance );
 	RageMatrix CameraRot;

--- a/src/DateTime.cpp
+++ b/src/DateTime.cpp
@@ -12,46 +12,45 @@ DateTime::DateTime()
 
 void DateTime::Init()
 {
-	ZeroArray( *this );
+	tm_year = 0;
+	tm_mon = 0;
+	tm_mday = 0;
+	tm_hour = 0;
+	tm_min = 0;
+	tm_sec = 0;
 }
 
 bool DateTime::operator<( const DateTime& other ) const
 {
-#define COMPARE( v ) if(v!=other.v) return v<other.v;
-	COMPARE( tm_year );
-	COMPARE( tm_mon );
-	COMPARE( tm_mday );
-	COMPARE( tm_hour );
-	COMPARE( tm_min );
-	COMPARE( tm_sec );
-#undef COMPARE
+	if (tm_year != other.tm_year) return tm_year < other.tm_year;
+	if (tm_mon != other.tm_mon) return tm_mon < other.tm_mon;
+	if (tm_mday != other.tm_mday) return tm_mday < other.tm_mday;
+	if (tm_hour != other.tm_hour) return tm_hour < other.tm_hour;
+	if (tm_min != other.tm_min) return tm_min < other.tm_min;
+	if (tm_sec != other.tm_sec) return tm_sec < other.tm_sec;
 	// they're equal
 	return false;
 }
 
 bool DateTime::operator==( const DateTime& other ) const 
 {
-#define COMPARE(x)	if( x!=other.x )	return false;
-	COMPARE( tm_year );
-	COMPARE( tm_mon );
-	COMPARE( tm_mday );
-	COMPARE( tm_hour );
-	COMPARE( tm_min );
-	COMPARE( tm_sec );
-#undef COMPARE
+	if (tm_year != other.tm_year) return false;
+	if (tm_mon != other.tm_mon) return false;
+	if (tm_mday != other.tm_mday) return false;
+	if (tm_hour != other.tm_hour) return false;
+	if (tm_min != other.tm_min) return false;
+	if (tm_sec != other.tm_sec) return false;
 	return true;
 }
 
 bool DateTime::operator>( const DateTime& other ) const
 {
-#define COMPARE( v ) if(v!=other.v) return v>other.v;
-	COMPARE( tm_year );
-	COMPARE( tm_mon );
-	COMPARE( tm_mday );
-	COMPARE( tm_hour );
-	COMPARE( tm_min );
-	COMPARE( tm_sec );
-#undef COMPARE
+	if (tm_year != other.tm_year) return tm_year > other.tm_year;
+	if (tm_mon != other.tm_mon) return tm_mon > other.tm_mon;
+	if (tm_mday != other.tm_mday) return tm_mday > other.tm_mday;
+	if (tm_hour != other.tm_hour) return tm_hour > other.tm_hour;
+	if (tm_min != other.tm_min) return tm_min > other.tm_min;
+	if (tm_sec != other.tm_sec) return tm_sec > other.tm_sec;
 	// they're equal
 	return false;
 }
@@ -60,16 +59,14 @@ DateTime DateTime::GetNowDateTime()
 {
 	time_t now = time(nullptr);
 	tm tNow;
-	localtime_r( &now, &tNow );
+	localtime_r(&now, &tNow);
 	DateTime dtNow;
-#define COPY_M( v ) dtNow.v = tNow.v;
-	COPY_M( tm_year );
-	COPY_M( tm_mon );
-	COPY_M( tm_mday );
-	COPY_M( tm_hour );
-	COPY_M( tm_min );
-	COPY_M( tm_sec );
-#undef COPY_M
+	dtNow.tm_year = tNow.tm_year;
+	dtNow.tm_mon = tNow.tm_mon;
+	dtNow.tm_mday = tNow.tm_mday;
+	dtNow.tm_hour = tNow.tm_hour;
+	dtNow.tm_min = tNow.tm_min;
+	dtNow.tm_sec = tNow.tm_sec;
 	return dtNow;
 }
 

--- a/src/DateTime.cpp
+++ b/src/DateTime.cpp
@@ -12,7 +12,7 @@ DateTime::DateTime()
 
 void DateTime::Init()
 {
-	ZERO( *this );
+	ZeroArray( *this );
 }
 
 bool DateTime::operator<( const DateTime& other ) const
@@ -305,7 +305,7 @@ tm GetDayInYearAndYear( int iDayInYearIndex, int iYear )
 	 * round it.  This shouldn't suffer from the macOS mktime() issue described
 	 * above, since we're not giving it negative values. */
 	tm when;
-	ZERO( when );
+	ZeroArray( when );
 	when.tm_mon = 0;
 	when.tm_mday = iDayInYearIndex+1;
 	when.tm_year = iYear - 1900;

--- a/src/DualScrollBar.cpp
+++ b/src/DualScrollBar.cpp
@@ -51,11 +51,11 @@ void DualScrollBar::SetPercentage( PlayerNumber pn, float fPercent )
 	/* Position both thumbs. */
 	m_sprScrollThumbUnderHalf[pn]->StopTweening();
 	m_sprScrollThumbUnderHalf[pn]->BeginTweening( m_fBarTime );
-	m_sprScrollThumbUnderHalf[pn]->SetY( SCALE( fPercent, 0, 1, top, bottom ) );
+	m_sprScrollThumbUnderHalf[pn]->SetY((((fPercent)-(0)) * ((bottom)-(top)) / ((1) - (0)) + (top)));
 
 	m_sprScrollThumbOverHalf[pn]->StopTweening();
 	m_sprScrollThumbOverHalf[pn]->BeginTweening( m_fBarTime );
-	m_sprScrollThumbOverHalf[pn]->SetY( SCALE( fPercent, 0, 1, top, bottom ) );
+	m_sprScrollThumbOverHalf[pn]->SetY((((fPercent)-(0)) * ((bottom)-(top)) / ((1) - (0)) + (top)));
 }
 
 /*

--- a/src/EditMenu.cpp
+++ b/src/EditMenu.cpp
@@ -130,7 +130,7 @@ void EditMenu::Load( const RString &sType )
 
 	m_SelectedRow = GetFirstRow();
 
-	ZERO( m_iSelection );
+	ZeroArray( m_iSelection );
 
 	FOREACH_EditMenuRow( r )
 	{

--- a/src/EnumHelper.h
+++ b/src/EnumHelper.h
@@ -80,7 +80,7 @@ const RString &EnumToString( int iVal, int iMax, const char **szNameArray, std::
 
 #define XToString(X) \
 const RString& X##ToString(X x); \
-static_assert( NUM_##X == ARRAYLEN(X##Names) ); \
+static_assert( NUM_##X == (sizeof(X##Names) / sizeof((X##Names)[0])) ); \
 const RString& X##ToString( X x ) \
 {	\
 	static std::unique_ptr<RString> as_##X##Name[NUM_##X+2]; \
@@ -107,7 +107,7 @@ const RString &X##ToLocalizedString( X x ) \
 X StringTo##X(const RString&); \
 X StringTo##X( const RString& s ) \
 {	\
-	for( unsigned i = 0; i < ARRAYLEN(X##Names); ++i )	\
+	for( unsigned i = 0; i < (sizeof(X##Names) / sizeof((X##Names)[0])); ++i )	\
 		if( !s.CompareNoCase(X##Names[i]) )	\
 			return (X)i;	\
 	return X##_Invalid;	\

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -364,7 +364,7 @@ const glyph &Font::GetGlyph( wchar_t c ) const
 	}
 
 	// Fast path:
-	if( c < (int) ARRAYLEN(m_iCharToGlyphCache) && m_iCharToGlyphCache[c] )
+	if( c < (int) ArrayLenInt(m_iCharToGlyphCache) && m_iCharToGlyphCache[c] )
 		return *m_iCharToGlyphCache[c];
 
 	// Try the regular character.
@@ -904,10 +904,10 @@ void Font::Load( const RString &sIniPath, RString sChars )
 	if( LoadStack.empty() )
 	{
 		// Cache ASCII glyphs.
-		ZERO( m_iCharToGlyphCache );
+		ZeroArray( m_iCharToGlyphCache );
 		std::map<wchar_t,glyph*>::iterator it;
 		for( it = m_iCharToGlyph.begin(); it != m_iCharToGlyph.end(); ++it )
-			if( it->first < (int) ARRAYLEN(m_iCharToGlyphCache) )
+			if( it->first < (int) ArrayLenInt(m_iCharToGlyphCache) )
 				m_iCharToGlyphCache[it->first] = it->second;
 	}
 }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -33,7 +33,7 @@ static const Game::PerButtonInfo g_CommonButtonInfo[] =
 
 const Game::PerButtonInfo *Game::GetPerButtonInfo( GameButton gb ) const
 {
-	static_assert( GAME_BUTTON_NEXT == ARRAYLEN(g_CommonButtonInfo) );
+	static_assert(GAME_BUTTON_NEXT == (sizeof(g_CommonButtonInfo) / sizeof((g_CommonButtonInfo)[0])));
 	if( gb < GAME_BUTTON_NEXT )
 		return &g_CommonButtonInfo[gb];
 	else

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -102,7 +102,7 @@ static const StepsTypeInfo g_StepsTypeInfos[] = {
 	{ "kickbox-insect", 6, true, StepsTypeCategory_Single },
 	{ "kickbox-arachnid", 8, true, StepsTypeCategory_Single },
 };
-static_assert( ARRAYLEN(g_StepsTypeInfos) == NUM_StepsType, "ARRAYLEN(g_StepsTypeInfos) != NUM_StepsType" );
+static_assert((sizeof(g_StepsTypeInfos) / sizeof((g_StepsTypeInfos)[0])) == NUM_StepsType, "ARRAYLEN(g_StepsTypeInfos) != NUM_StepsType");
 
 // Important:  Every game must define the buttons: "Start", "Back", "MenuLeft", "Operator" and "MenuRight"
 static const AutoMappings g_AutoKeyMappings_Dance = AutoMappings (
@@ -3270,7 +3270,8 @@ void GameManager::GetStylesForGame( const Game *pGame, std::vector<const Style*>
 
 const Game *GameManager::GetGameForStyle( const Style *pStyle )
 {
-	for( std::size_t g=0; g<ARRAYLEN(g_Games); ++g )
+	const std::size_t iArrayLen = ArrayLenSizeT(g_Games);
+	for( std::size_t g=0; g<iArrayLen; ++g )
 	{
 		const Game *pGame = g_Games[g];
 		for( int s=0; pGame->m_apStyles[s]; ++s )
@@ -3284,7 +3285,8 @@ const Game *GameManager::GetGameForStyle( const Style *pStyle )
 
 const Style* GameManager::GetEditorStyleForStepsType( StepsType st )
 {
-	for( std::size_t g=0; g<ARRAYLEN(g_Games); ++g )
+	const std::size_t iArrayLen = ArrayLenSizeT(g_Games);
+	for( std::size_t g=0; g<iArrayLen; ++g )
 	{
 		const Game *pGame = g_Games[g];
 		for( int s=0; pGame->m_apStyles[s]; ++s )
@@ -3395,7 +3397,8 @@ const Style *GameManager::GetFirstCompatibleStyle( const Game *pGame, int iNumPl
 
 void GameManager::GetEnabledGames( std::vector<const Game*>& aGamesOut )
 {
-	for( std::size_t g=0; g<ARRAYLEN(g_Games); ++g )
+	const std::size_t iArrayLen = ArrayLenSizeT(g_Games);
+	for( std::size_t g=0; g<iArrayLen; ++g )
 	{
 		const Game *pGame = g_Games[g];
 		if( IsGameEnabled( pGame ) )
@@ -3408,7 +3411,8 @@ const Game* GameManager::GetDefaultGame()
 	const Game *pDefault = nullptr;
 	if( pDefault == nullptr )
 	{
-		for( std::size_t i=0; pDefault == nullptr && i < ARRAYLEN(g_Games); ++i )
+		const std::size_t iArrayLen = ArrayLenSizeT(g_Games);
+		for( std::size_t i=0; pDefault == nullptr && i < iArrayLen; ++i )
 		{
 			if( IsGameEnabled(g_Games[i]) )
 				pDefault = g_Games[i];
@@ -3423,7 +3427,8 @@ const Game* GameManager::GetDefaultGame()
 
 int GameManager::GetIndexFromGame( const Game* pGame )
 {
-	for( std::size_t g=0; g<ARRAYLEN(g_Games); ++g )
+	const std::size_t iArrayLen = ArrayLenSizeT(g_Games);
+	for( std::size_t g=0; g<iArrayLen; ++g )
 	{
 		if( g_Games[g] == pGame )
 			return g;
@@ -3434,7 +3439,7 @@ int GameManager::GetIndexFromGame( const Game* pGame )
 const Game* GameManager::GetGameFromIndex( int index )
 {
 	ASSERT( index >= 0 );
-	ASSERT( index < (int) ARRAYLEN(g_Games) );
+	ASSERT( index < ArrayLenInt(g_Games) );
 	return g_Games[index];
 }
 
@@ -3472,7 +3477,8 @@ RString GameManager::StyleToLocalizedString( const Style* style )
 
 const Game* GameManager::StringToGame( RString sGame )
 {
-	for( std::size_t i=0; i<ARRAYLEN(g_Games); ++i )
+	const std::size_t iArrayLen = ArrayLenSizeT(g_Games);
+	for( std::size_t i=0; i<iArrayLen; ++i )
 		if( !sGame.CompareNoCase(g_Games[i]->m_szName) )
 			return g_Games[i];
 

--- a/src/GraphDisplay.cpp
+++ b/src/GraphDisplay.cpp
@@ -144,7 +144,7 @@ public:
 		Actor::SetTextureRenderStates();
 
 		DISPLAY->SetTextureMode( TextureUnit_1, TextureMode_Modulate );
-		DISPLAY->DrawQuadStrip( m_Slices, ARRAYLEN(m_Slices) );
+		DISPLAY->DrawQuadStrip(m_Slices, (sizeof(m_Slices) / sizeof((m_Slices)[0])));
 	}
 
 	RageTexture* m_pTexture;
@@ -174,7 +174,8 @@ void GraphDisplay::Set( const StageStats &ss, const PlayerStageStats &pss )
 
 	m_Values.resize( VALUE_RESOLUTION );
 	pss.GetLifeRecord( &m_Values[0], VALUE_RESOLUTION, ss.GetTotalPossibleStepsSeconds() );
-	for( unsigned i=0; i<ARRAYLEN(m_Values); i++ )
+	const unsigned iArrayLen = m_Values.size();
+	for( unsigned i=0; i<iArrayLen; i++ )
 		CLAMP( m_Values[i], 0.f, 1.f );
 
 	UpdateVerts();

--- a/src/GraphDisplay.cpp
+++ b/src/GraphDisplay.cpp
@@ -188,7 +188,7 @@ void GraphDisplay::Set( const StageStats &ss, const PlayerStageStats &pss )
 
 		Actor *p = m_sprSongBoundary->Copy();
 		m_vpSongBoundaries.push_back( p );
-		float fX = SCALE( fSec, 0, fTotalStepSeconds, m_quadVertices.left, m_quadVertices.right );
+		float fX = (((fSec)-(0)) * ((m_quadVertices.right) - (m_quadVertices.left)) / ((fTotalStepSeconds)-(0)) + (m_quadVertices.left));
 		p->SetX( fX );
 		this->AddChild( p );
 	});
@@ -211,7 +211,7 @@ void GraphDisplay::Set( const StageStats &ss, const PlayerStageStats &pss )
 
 		if( fMinLifeSoFar > 0.0f  &&  fMinLifeSoFar < 0.1f )
 		{
-			float fX = SCALE( float(iMinLifeSoFarAt), 0.0f, float(VALUE_RESOLUTION-1), m_quadVertices.left, m_quadVertices.right );
+			float fX = (((float(iMinLifeSoFarAt)) - (0.0f)) * ((m_quadVertices.right) - (m_quadVertices.left)) / ((float(VALUE_RESOLUTION - 1)) - (0.0f)) + (m_quadVertices.left));
 			m_sprBarely->SetX( fX );
 		}
 		else
@@ -255,16 +255,16 @@ void GraphDisplay::UpdateVerts()
 	RageSpriteVertex LineStrip[VALUE_RESOLUTION];
 	for( int i = 0; i < VALUE_RESOLUTION; ++i )
 	{
-		const float fX = SCALE( float(i), 0.0f, float(VALUE_RESOLUTION-1), m_quadVertices.left, m_quadVertices.right );
-		const float fY = SCALE( m_Values[i], 0.0f, 1.0f, m_quadVertices.bottom, m_quadVertices.top );
+		const float fX = (((float(i)) - (0.0f)) * ((m_quadVertices.right) - (m_quadVertices.left)) / ((float(VALUE_RESOLUTION - 1)) - (0.0f)) + (m_quadVertices.left));
+		const float fY = (((m_Values[i]) - (0.0f)) * ((m_quadVertices.top) - (m_quadVertices.bottom)) / ((1.0f) - (0.0f)) + (m_quadVertices.bottom));
 
 		m_pGraphBody->m_Slices[i*2+0].p = RageVector3( fX, fY, 0 );
 		m_pGraphBody->m_Slices[i*2+1].p = RageVector3( fX, m_quadVertices.bottom, 0 );
 
 		const RectF *pRect = m_pGraphBody->m_pTexture->GetTextureCoordRect( 0 );
 
-		const float fU = SCALE( fX, m_quadVertices.left, m_quadVertices.right, pRect->left, pRect->right );
-		const float fV = SCALE( fY, m_quadVertices.top, m_quadVertices.bottom, pRect->top, pRect->bottom );
+		const float fU = (((fX)-(m_quadVertices.left)) * ((pRect->right) - (pRect->left)) / ((m_quadVertices.right) - (m_quadVertices.left)) + (pRect->left));
+		const float fV = (((fY)-(m_quadVertices.top)) * ((pRect->bottom) - (pRect->top)) / ((m_quadVertices.bottom) - (m_quadVertices.top)) + (pRect->top));
 		m_pGraphBody->m_Slices[i*2+0].t = RageVector2( fU, fV );
 		m_pGraphBody->m_Slices[i*2+1].t = RageVector2( fU, pRect->bottom );
 

--- a/src/HighScore.cpp
+++ b/src/HighScore.cpp
@@ -87,8 +87,8 @@ HighScoreImpl::HighScoreImpl()
 	sPlayerGuid = "";
 	sMachineGuid = "";
 	iProductID = 0;
-	ZERO( iTapNoteScores );
-	ZERO( iHoldNoteScores );
+	ZeroArray( iTapNoteScores );
+	ZeroArray( iHoldNoteScores );
 	radarValues.MakeUnknown();
 	fLifeRemainingSeconds = 0;
 }

--- a/src/InputFilter.cpp
+++ b/src/InputFilter.cpp
@@ -490,14 +490,14 @@ public:
 	static int GetMouseX( T* p, lua_State *L ){
 		float fX = p->GetCursorX();
 		// Scale input to the theme's dimensions
-		fX = SCALE( fX, 0, (PREFSMAN->m_iDisplayHeight * PREFSMAN->m_fDisplayAspectRatio), SCREEN_LEFT, SCREEN_RIGHT );
+		fX = (((fX)-(0)) * (((ScreenDimensions::GetScreenWidth())) - ((0))) / (((PREFSMAN->m_iDisplayHeight * PREFSMAN->m_fDisplayAspectRatio)) - (0)) + ((0)));
 		lua_pushnumber( L, fX );
 		return 1;
 	}
 	static int GetMouseY( T* p, lua_State *L ){
 		float fY = p->GetCursorY();
 		// Scale input to the theme's dimensions
-		fY = SCALE( fY, 0, PREFSMAN->m_iDisplayHeight, SCREEN_TOP, SCREEN_BOTTOM );
+		fY = (((fY)-(0)) * (((ScreenDimensions::GetScreenHeight())) - ((0))) / ((PREFSMAN->m_iDisplayHeight) - (0)) + ((0)));
 		lua_pushnumber( L, fY );
 		return 1;
 	}

--- a/src/InputMapper.cpp
+++ b/src/InputMapper.cpp
@@ -666,7 +666,8 @@ void InputMapper::AutoMapJoysticksForCurrentGame()
 		}
 
 		// hard-coded automaps
-		for( unsigned j=0; j<ARRAYLEN(g_AutoMappings); j++ )
+		const unsigned iArrayLen = ArrayLenUnsigned(g_AutoMappings);
+		for( unsigned j=0; j<iArrayLen; j++ )
 		{
 			const AutoMappings& mapping = g_AutoMappings[j];
 			if( mapping.m_sGame.EqualsNoCase(m_pInputScheme->m_szName) )
@@ -1217,7 +1218,7 @@ static const InputScheme::GameButtonInfo g_CommonGameButtonInfo[] =
 
 const InputScheme::GameButtonInfo *InputScheme::GetGameButtonInfo( GameButton gb ) const
 {
-	static_assert( GAME_BUTTON_NEXT == ARRAYLEN(g_CommonGameButtonInfo) );
+	static_assert(GAME_BUTTON_NEXT == (sizeof(g_CommonGameButtonInfo) / sizeof((g_CommonGameButtonInfo)[0])));
 	if( gb < GAME_BUTTON_NEXT )
 		return &g_CommonGameButtonInfo[gb];
 	else

--- a/src/LifeMeterBar.cpp
+++ b/src/LifeMeterBar.cpp
@@ -198,7 +198,7 @@ void LifeMeterBar::ChangeLife( float fDeltaLife )
 {
 	bool bUseMercifulDrain = m_bMercifulBeginnerInEffect || PREFSMAN->m_bMercifulDrain;
 	if( bUseMercifulDrain  &&  fDeltaLife < 0 )
-		fDeltaLife *= SCALE( m_fLifePercentage, 0.f, 1.f, 0.5f, 1.f);
+		fDeltaLife *= (((m_fLifePercentage)-(0.f)) * ((1.f) - (0.5f)) / ((1.f) - (0.f)) + (0.5f));
 
 	// handle progressiveness and ComboToRegainLife here
 	if( fDeltaLife >= 0 )

--- a/src/LifeMeterTime.cpp
+++ b/src/LifeMeterTime.cpp
@@ -37,7 +37,7 @@ static const float g_fTimeMeterSecondsChangeInit[] =
 	-4.0f, // SE_LetGo
 	-0.0f, // SE_Missed
 };
-static_assert( ARRAYLEN(g_fTimeMeterSecondsChangeInit) == NUM_ScoreEvent );
+static_assert((sizeof(g_fTimeMeterSecondsChangeInit) / sizeof((g_fTimeMeterSecondsChangeInit)[0])) == NUM_ScoreEvent);
 
 static void TimeMeterSecondsChangeInit( std::size_t /*ScoreEvent*/ i, RString &sNameOut, float &defaultValueOut )
 {

--- a/src/LightsManager.cpp
+++ b/src/LightsManager.cpp
@@ -106,10 +106,10 @@ LightsManager*	LIGHTSMAN = nullptr;	// global and accessible from anywhere in ou
 
 LightsManager::LightsManager()
 {
-	ZERO( m_fSecsLeftInCabinetLightBlink );
-	ZERO( m_fSecsLeftInGameButtonBlink );
-	ZERO( m_fActorLights );
-	ZERO( m_fSecsLeftInActorLightBlink );
+	ZeroArray( m_fSecsLeftInCabinetLightBlink );
+	ZeroArray( m_fSecsLeftInGameButtonBlink );
+	ZeroArray( m_fActorLights );
+	ZeroArray( m_fSecsLeftInActorLightBlink );
 	m_iQueuedCoinCounterPulses = 0;
 	m_CoinCounterTimer.SetZero();
 
@@ -184,8 +184,8 @@ void LightsManager::Update( float fDeltaTime )
 
 	// Set new lights state cabinet lights
 	{
-		ZERO( m_LightsState.m_bCabinetLights );
-		ZERO( m_LightsState.m_bGameButtonLights );
+		ZeroArray( m_LightsState.m_bCabinetLights );
+		ZeroArray( m_LightsState.m_bGameButtonLights );
 	}
 
 	{
@@ -415,7 +415,7 @@ void LightsManager::Update( float fDeltaTime )
 			GetUsedGameInputs( vGI );
 			wrap( index, vGI.size() );
 
-			ZERO( m_LightsState.m_bGameButtonLights );
+			ZeroArray( m_LightsState.m_bGameButtonLights );
 
 			GameController gc = vGI[index].controller;
 			GameButton gb = vGI[index].button;
@@ -426,7 +426,7 @@ void LightsManager::Update( float fDeltaTime )
 
 		case LIGHTSMODE_TEST_MANUAL_CYCLE:
 		{
-			ZERO( m_LightsState.m_bGameButtonLights );
+			ZeroArray( m_LightsState.m_bGameButtonLights );
 
 			std::vector<GameInput> vGI;
 			GetUsedGameInputs( vGI );

--- a/src/LuaExpressionTransform.cpp
+++ b/src/LuaExpressionTransform.cpp
@@ -59,7 +59,7 @@ void LuaExpressionTransform::TransformItemCached( Actor &a, float fPositionOffse
 		const Actor::TweenState &tsFloor = GetTransformCached( fFloor, iItemIndex, iNumItems );
 		const Actor::TweenState &tsCeil = GetTransformCached( fCeil, iItemIndex, iNumItems );
 
-		float fPercentTowardCeil = SCALE( fPositionOffsetFromCenter, fFloor, fCeil, 0.0f, 1.0f );
+		float fPercentTowardCeil = (((fPositionOffsetFromCenter)-(fFloor)) * ((1.0f) - (0.0f)) / ((fCeil)-(fFloor)) + (0.0f));
 		Actor::TweenState::MakeWeightedAverage( a.DestTweenState(), tsFloor, tsCeil, fPercentTowardCeil );
 	}
 }

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -1051,7 +1051,7 @@ LuaFunction( VersionTime, (RString) version_time );
 
 static float scale( float x, float l1, float h1, float l2, float h2 )
 {
-	return SCALE( x, l1, h1, l2, h2 );
+	return (((x)-(l1)) * ((h2)-(l2)) / ((h1)-(l1)) + (l2));
 }
 LuaFunction( scale, scale(FArg(1), FArg(2), FArg(3), FArg(4), FArg(5)) );
 

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -655,7 +655,7 @@ XNode *LuaHelpers::GetLuaInformation()
 
 	//const RString BuiltInPackages[] = { "_G", "coroutine", "debug", "math", "package", "string", "table" };
 	const RString BuiltInPackages[] = { "_G", "coroutine", "debug", "math", "package", "string", "table" };
-	const RString *const end = BuiltInPackages+ARRAYLEN(BuiltInPackages);
+	const RString* const end = BuiltInPackages + (sizeof(BuiltInPackages) / sizeof((BuiltInPackages)[0]));
 	FOREACH_LUATABLE( L, -1 )
 	{
 		RString sNamespace;

--- a/src/MeterDisplay.cpp
+++ b/src/MeterDisplay.cpp
@@ -67,7 +67,7 @@ void MeterDisplay::SetPercent( float fPercent )
 	m_sprStream->SetCropRight( 1-fPercent );
 
 	if( m_sprTip.IsLoaded() )
-		m_sprTip->SetX( SCALE(fPercent, 0.f, 1.f, -m_fStreamWidth/2, m_fStreamWidth/2) );
+		m_sprTip->SetX((((fPercent)-(0.f)) * ((m_fStreamWidth / 2) - (-m_fStreamWidth / 2)) / ((1.f) - (0.f)) + (-m_fStreamWidth / 2)));
 }
 
 void MeterDisplay::SetStreamWidth( float fStreamWidth )
@@ -82,7 +82,7 @@ void SongMeterDisplay::Update( float fDeltaTime )
 	{
 		float fSongStartSeconds = GAMESTATE->m_pCurSong->GetFirstSecond();
 		float fSongEndSeconds = GAMESTATE->m_pCurSong->GetLastSecond();
-		float fPercentPositionSong = SCALE( GAMESTATE->m_Position.m_fMusicSeconds, fSongStartSeconds, fSongEndSeconds, 0.0f, 1.0f );
+		float fPercentPositionSong = (((GAMESTATE->m_Position.m_fMusicSeconds) - (fSongStartSeconds)) * ((1.0f) - (0.0f)) / ((fSongEndSeconds)-(fSongStartSeconds)) + (0.0f));
 		CLAMP( fPercentPositionSong, 0, 1 );
 
 		SetPercent( fPercentPositionSong );

--- a/src/ModIconRow.cpp
+++ b/src/ModIconRow.cpp
@@ -48,7 +48,7 @@ void ModIconRow::Load( const RString &sMetricsGroup, PlayerNumber pn )
 	{
 		ModIcon *p = new ModIcon;
 		p->SetName( "ModIcon" );
-		float fOffset = SCALE( i, 0, NUM_OPTION_ICONS-1, -(NUM_OPTION_ICONS-1)/2.0f, (float)(NUM_OPTION_ICONS-1)/2.0f );
+		float fOffset = (((i)-(0)) * (((float)(NUM_OPTION_ICONS - 1) / 2.0f) - (-(NUM_OPTION_ICONS - 1) / 2.0f)) / ((NUM_OPTION_ICONS - 1) - (0)) + (-(NUM_OPTION_ICONS - 1) / 2.0f));
 		p->SetXY( fOffset*SPACING_X, fOffset*SPACING_Y );
 		p->Load( OPTION_ICON_METRICS_GROUP );
 		ActorUtil::LoadAllCommands( p, sMetricsGroup );

--- a/src/ModIconRow.cpp
+++ b/src/ModIconRow.cpp
@@ -132,9 +132,14 @@ int OptionToPreferredColumn( RString sOptionText )
 		return 0;
 	}
 
-	for( unsigned i=0; i<ARRAYLEN(g_OptionColumnEntries); i++ )
-		if( g_OptionColumnEntries[i].szString == sOptionText )
-			return g_OptionColumnEntries[i].iSlotIndex;
+	const unsigned iArrayLen = ArrayLenUnsigned(g_OptionColumnEntries);
+    for (unsigned i = 0; i < iArrayLen; i++)
+    {
+        if (g_OptionColumnEntries[i].szString == sOptionText)
+        {
+            return g_OptionColumnEntries[i].iSlotIndex;
+        }
+    }
 
 	// This warns about C1234 and noteskins.
 //	LOG->Warn("Unknown option: '%s'", sOptionText.c_str() );

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -630,7 +630,7 @@ void Model::SetBones( const msAnimation* pAnimation, float fFrame, std::vector<m
 		RageVector3 vPos;
 		if( pLastPositionKey != nullptr && pThisPositionKey != nullptr )
 		{
-			const float s = SCALE( fFrame, pLastPositionKey->fTime, pThisPositionKey->fTime, 0, 1 );
+			const float s = (((fFrame)-(pLastPositionKey->fTime)) * ((1) - (0)) / ((pThisPositionKey->fTime) - (pLastPositionKey->fTime)) + (0));
 			vPos = pLastPositionKey->Position + (pThisPositionKey->Position - pLastPositionKey->Position) * s;
 		}
 		else if( pLastPositionKey == nullptr )
@@ -654,7 +654,7 @@ void Model::SetBones( const msAnimation* pAnimation, float fFrame, std::vector<m
 		RageVector4 vRot;
 		if( pLastRotationKey != nullptr && pThisRotationKey != nullptr )
 		{
-			const float s = SCALE( fFrame, pLastRotationKey->fTime, pThisRotationKey->fTime, 0, 1 );
+			const float s = (((fFrame)-(pLastRotationKey->fTime)) * ((1) - (0)) / ((pThisRotationKey->fTime) - (pLastRotationKey->fTime)) + (0));
 			RageQuatSlerp( &vRot, pLastRotationKey->Rotation, pThisRotationKey->Rotation, s );
 		}
 		else if( pLastRotationKey == nullptr )

--- a/src/NoteDataUtil.cpp
+++ b/src/NoteDataUtil.cpp
@@ -2952,7 +2952,8 @@ const ValidRow g_ValidRows[] =
 void NoteDataUtil::RemoveStretch( NoteData &inout, StepsType st, int iStartIndex, int iEndIndex )
 {
 	std::vector<const ValidRow*> vpValidRowsToCheck;
-	for( unsigned i=0; i<ARRAYLEN(g_ValidRows); i++ )
+	const unsigned iArrayLen = ArrayLenUnsigned(g_ValidRows);
+	for( unsigned i=0; i<iArrayLen; i++ )
 	{
 		if( g_ValidRows[i].st == st )
 			vpValidRowsToCheck.push_back( &g_ValidRows[i] );
@@ -3104,7 +3105,7 @@ void NoteDataUtil::AddTapAttacks( NoteData &nd, Song* pSong )
 			TapNoteType_Attack,
 			TapNoteSubType_Invalid,
 			TapNoteSource_Original,
-			szAttacks[RandomInt(ARRAYLEN(szAttacks))],
+			szAttacks[RandomInt((sizeof(szAttacks) / sizeof((szAttacks)[0])))],
 			15.0f,
 			-1 );
 		nd.SetTapNote( iTrack, BeatToNoteRow(fBeat), tn );

--- a/src/NoteDataWithScoring.cpp
+++ b/src/NoteDataWithScoring.cpp
@@ -162,7 +162,7 @@ float GetActualVoltageRadarValue( const NoteData &in, float fSongSeconds, const 
 	 * length of the longest recorded combo. This is only subtly different:
 	 * it's the percent of the song the longest combo took to get. */
 	const PlayerStageStats::Combo_t MaxCombo = pss.GetMaxCombo();
-	float fComboPercent = SCALE(MaxCombo.m_fSizeSeconds, 0, fSongSeconds, 0.0f, 1.0f);
+	float fComboPercent = (((MaxCombo.m_fSizeSeconds) - (0)) * ((1.0f) - (0.0f)) / ((fSongSeconds)-(0)) + (0.0f));
 	return std::clamp( fComboPercent, 0.0f, 1.0f );
 }
 

--- a/src/NoteDisplay.cpp
+++ b/src/NoteDisplay.cpp
@@ -803,8 +803,7 @@ void NoteDisplay::DrawHoldPart(std::vector<Sprite*> &vpSpr,
 	{
 		if (!part_args.anchor_to_top)
 		{
-			float tex_coord_bottom= SCALE(part_args.y_bottom - part_args.y_top,
-				0, unzoomed_frame_height, rect.top, rect.bottom);
+			float tex_coord_bottom = (((part_args.y_bottom - part_args.y_top) - (0)) * ((rect.bottom) - (rect.top)) / ((unzoomed_frame_height)-(0)) + (rect.top));
 			float want_tex_coord_bottom	= std::ceil(tex_coord_bottom - 0.0001f);
 			add_to_tex_coord = want_tex_coord_bottom - tex_coord_bottom;
 		}
@@ -814,7 +813,7 @@ void NoteDisplay::DrawHoldPart(std::vector<Sprite*> &vpSpr,
 			/* For very large hold notes, shift the texture coordinates to be near 0, so we
 			 * don't send very large values to the renderer. */
 			const float fDistFromTop = y_start_pos - part_args.y_top;
-			float fTexCoordTop = SCALE(fDistFromTop, 0, unzoomed_frame_height, rect.top, rect.bottom);
+			float fTexCoordTop = (((fDistFromTop)-(0)) * ((rect.bottom) - (rect.top)) / ((unzoomed_frame_height)-(0)) + (rect.top));
 			fTexCoordTop += add_to_tex_coord;
 			add_to_tex_coord -= std::floor(fTexCoordTop);
 		}
@@ -831,7 +830,7 @@ void NoteDisplay::DrawHoldPart(std::vector<Sprite*> &vpSpr,
 			// Shift texture coord to fit hold length If hold length is less than
 			// bottomcap frame height. (translated by hanubeki)
 			if (offset>0){
-				add_to_tex_coord = SCALE(offset, 0.0f, unzoomed_frame_height, 0.0f, 1.0f);
+				add_to_tex_coord = (((offset)-(0.0f)) * ((1.0f) - (0.0f)) / ((unzoomed_frame_height)-(0.0f)) + (0.0f));
 			}
 			else{
 				add_to_tex_coord = 0.0f;
@@ -864,7 +863,7 @@ void NoteDisplay::DrawHoldPart(std::vector<Sprite*> &vpSpr,
 		float cur_beat= part_args.top_beat;
 		if(part_args.top_beat != part_args.bottom_beat)
 		{
-			cur_beat= SCALE(fY, part_args.y_top, part_args.y_bottom, part_args.top_beat, part_args.bottom_beat);
+			cur_beat = (((fY)-(part_args.y_top)) * ((part_args.bottom_beat) - (part_args.top_beat)) / ((part_args.y_bottom) - (part_args.y_top)) + (part_args.top_beat));
 		}
 
 		// Fun times ahead with vector math.  If the notes are being moved by the
@@ -1013,7 +1012,7 @@ void NoteDisplay::DrawHoldPart(std::vector<Sprite*> &vpSpr,
 		const float fVariableZoom	= ArrowEffects::GetZoomVariable(fYOffset, column_args.column, 1) / fPulseInnerAdj;
 
 		const float fDistFromTop	= (fY - y_start_pos) / ae_zoom;
-		float fTexCoordTop		= SCALE(fDistFromTop, 0, unzoomed_frame_height, rect.top, rect.bottom * fVariableZoom);
+		float fTexCoordTop = (((fDistFromTop)-(0)) * ((rect.bottom * fVariableZoom) - (rect.top)) / ((unzoomed_frame_height)-(0)) + (rect.top));
 		fTexCoordTop += add_to_tex_coord;
 
 		const float fAlpha		= ArrowGetAlphaOrGlow(glow, m_pPlayerState, column_args.column, fYOffset, part_args.percent_fade_to_fail, m_fYReverseOffsetPixels, field_args.draw_pixels_before_targets, field_args.fade_before_targets);
@@ -1223,7 +1222,7 @@ void NoteDisplay::DrawHold(const TapNote& tn,
 	const float fYHead= ArrowEffects::GetYPos(m_pPlayerState, column_args.column, fStartYOffset, m_fYReverseOffsetPixels);
 	const float fYTail= ArrowEffects::GetYPos(m_pPlayerState, column_args.column, fEndYOffset, m_fYReverseOffsetPixels);
 
-	const float fColorScale		= SCALE( tn.HoldResult.fLife, 0.0f, 1.0f, cache->m_fHoldLetGoGrayPercent, 1.0f );
+	const float fColorScale = (((tn.HoldResult.fLife) - (0.0f)) * ((1.0f) - (cache->m_fHoldLetGoGrayPercent)) / ((1.0f) - (0.0f)) + (cache->m_fHoldLetGoGrayPercent));
 
 	bool bFlipHeadAndTail = bReverse && cache->m_bFlipHeadAndTailWhenReverse;
 

--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -432,11 +432,11 @@ void NoteField::DrawBeatBar( const float fBeat, BeatBarType type, int iMeasureIn
 				iState = 1;
 				break;
 			case half_beat:
-				fAlpha = SCALE(fScrollSpeed,1.0f,2.0f,0.0f,m_fBar8thAlpha);
+				fAlpha = (fScrollSpeed - 1.0f) * m_fBar8thAlpha;
 				iState = 2;
 				break;
 			case quarter_beat:
-				fAlpha = SCALE(fScrollSpeed,2.0f,4.0f,0.0f,m_fBar16thAlpha);
+				fAlpha = (fScrollSpeed - 2.0f) * m_fBar16thAlpha / 2.0f;
 				iState = 3;
 				break;
 		}
@@ -450,7 +450,12 @@ void NoteField::DrawBeatBar( const float fBeat, BeatBarType type, int iMeasureIn
 	m_sprBeatBars.SetY( fYPos );
 	m_sprBeatBars.SetDiffuse( RageColor(1,1,1,fAlpha) );
 	m_sprBeatBars.SetState( iState );
-	m_sprBeatBars.SetCustomTextureRect( RectF(0,SCALE(iState,0.f,4.f,0.f,1.f), fWidth/fFrameWidth, SCALE(iState+1,0.f,4.f,0.f,1.f)) );
+	m_sprBeatBars.SetCustomTextureRect(RectF(
+		0,
+		iState / 4.0f,
+		fWidth / fFrameWidth,
+		(iState + 1) / 4.0f
+	));
 	m_sprBeatBars.SetZoomX( fWidth/m_sprBeatBars.GetUnzoomedWidth() );
 	m_sprBeatBars.Draw();
 
@@ -757,7 +762,7 @@ void NoteField::CalcPixelsBeforeAndAfterTargets()
 		curr_options.m_fScrolls[PlayerOptions::SCROLL_CENTERED] *
 		curr_options.m_fAccels[PlayerOptions::ACCEL_BOOMERANG];
 	m_FieldRenderArgs.draw_pixels_after_targets +=
-		int(SCALE(centered_times_boomerang, 0.f, 1.f, 0.f, -SCREEN_HEIGHT/2));
+		int((((centered_times_boomerang)-(0.f)) * ((-ScreenDimensions::GetScreenHeight() / 2) - (0.f)) / ((1.f) - (0.f)) + (0.f)));
 	m_FieldRenderArgs.draw_pixels_before_targets =
 		m_iDrawDistanceBeforeTargetsPixels * (1.f + curr_options.m_fDrawSize);
 
@@ -1061,8 +1066,7 @@ void NoteField::DrawPrimitives()
 	if(*m_FieldRenderArgs.selection_begin_marker != -1 &&
 		*m_FieldRenderArgs.selection_end_marker != -1)
 	{
-		m_FieldRenderArgs.selection_glow= SCALE(
-			std::cos(RageTimer::GetTimeSinceStartFast()*2), -1, 1, 0.1f, 0.3f);
+		m_FieldRenderArgs.selection_glow = (((std::cos(RageTimer::GetTimeSinceStartFast() * 2)) - (-1)) * ((0.3f) - (0.1f)) / ((1) - (-1)) + (0.1f));
 	}
 	m_FieldRenderArgs.fade_before_targets= FADE_BEFORE_TARGETS_PERCENT;
 

--- a/src/NotesLoader.cpp
+++ b/src/NotesLoader.cpp
@@ -16,7 +16,9 @@ void NotesLoader::GetMainAndSubTitlesFromFullTitle( const RString &sFullTitle, R
 {
 	const RString sLeftSeps[]  = { "\t", " -", " ~", " (", " [" };
 
-	for( unsigned i=0; i<ARRAYLEN(sLeftSeps); i++ )
+	const unsigned iArrayLen = ArrayLenUnsigned(sLeftSeps);
+	unsigned i = 0;
+	for( i = 0; i<iArrayLen; i++ )
 	{
 		std::size_t iBeginIndex = sFullTitle.find( sLeftSeps[i] );
 		if( iBeginIndex == std::string::npos )

--- a/src/OptionRow.cpp
+++ b/src/OptionRow.cpp
@@ -41,7 +41,7 @@ OptionRow::OptionRow( const OptionRowType *pSource )
 	m_pHand = nullptr;
 
 	m_textTitle = nullptr;
-	ZERO( m_ModIcons );
+	ZeroArray( m_ModIcons );
 
 	Clear();
 	this->AddChild( &m_Frame );
@@ -74,8 +74,8 @@ void OptionRow::Clear()
 	SAFE_DELETE( m_pHand );
 
 	m_bFirstItemGoesDown = false;
-	ZERO( m_bRowHasFocus );
-	ZERO( m_iChoiceInRowWithFocus );
+	ZeroArray( m_bRowHasFocus );
+	ZeroArray( m_iChoiceInRowWithFocus );
 }
 
 void OptionRowType::Load( const RString &sMetricsGroup, Actor *pParent )
@@ -842,7 +842,7 @@ void OptionRow::Reload()
 	if( m_pHand->m_Def.m_bExportOnChange )
 	{
 		bool bRowHasFocus[NUM_PLAYERS];
-		ZERO( bRowHasFocus );
+		ZeroArray( bRowHasFocus );
 		ExportOptions( vpns, bRowHasFocus );
 	}
 	*/
@@ -880,7 +880,7 @@ void OptionRow::Reload()
 	if( m_pHand->m_Def.m_bExportOnChange )
 	{
 		bool bRowHasFocus[NUM_PLAYERS];
-		ZERO( bRowHasFocus );
+		ZeroArray( bRowHasFocus );
 		ExportOptions( vpns, bRowHasFocus );
 	}
 	*/

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -906,7 +906,7 @@ void Player::Update( float fDeltaTime )
 			for( int c=0; c<GAMESTATE->GetCurrentStyle(GetPlayerState()->m_PlayerNumber)->m_iColsPerPlayer; c++ )
 			{
 				float fPercentReverse = m_pPlayerState->m_PlayerOptions.GetCurrent().GetReversePercentForColumn(c);
-				float fHoldJudgeYPos = SCALE( fPercentReverse, 0.f, 1.f, HOLD_JUDGMENT_Y_STANDARD, HOLD_JUDGMENT_Y_REVERSE );
+				float fHoldJudgeYPos = (((fPercentReverse)-(0.f)) * ((HOLD_JUDGMENT_Y_REVERSE)-(HOLD_JUDGMENT_Y_STANDARD)) / ((1.f) - (0.f)) + (HOLD_JUDGMENT_Y_STANDARD));
 				//float fGrayYPos = SCALE( fPercentReverse, 0.f, 1.f, GRAY_ARROWS_Y_STANDARD, GRAY_ARROWS_Y_REVERSE );
 
 				float fX = ArrowEffects::GetXPos( m_pPlayerState, c, 0 );
@@ -1687,7 +1687,7 @@ void Player::PushPlayerMatrix(float x, float skew, float center_y)
 	DISPLAY->CameraPushMatrix();
 	DISPLAY->PushMatrix();
 	DISPLAY->LoadMenuPerspective(45, SCREEN_WIDTH, SCREEN_HEIGHT,
-		SCALE(skew, 0.1f, 1.0f, x, SCREEN_CENTER_X), center_y);
+		(((skew)-(0.1f)) * ((((0) + ((ScreenDimensions::GetScreenWidth()) - (0)) / 2.0f)) - (x)) / ((1.0f) - (0.1f)) + (x)), center_y);
 }
 
 void Player::PopPlayerMatrix()
@@ -1710,21 +1710,21 @@ Player::PlayerNoteFieldPositioner::PlayerNoteFieldPositioner(
 	player->PushPlayerMatrix(x, skew, center_y);
 	float reverse_mult= (reverse ? -1 : 1);
 	original_y= player->m_pNoteField->GetY();
-	float tilt_degrees= SCALE(tilt, -1.f, +1.f, +30, -30) * reverse_mult;
-	float zoom= SCALE(mini, 0.f, 1.f, 1.f, .5f);
+	float tilt_degrees = (((tilt)-(-1.f)) * ((-30) - (+30)) / ((+1.f) - (-1.f)) + (+30)) * reverse_mult;
+	float zoom = (((mini)-(0.f)) * ((.5f) - (1.f)) / ((1.f) - (0.f)) + (1.f));
 	// Something strange going on here.  Notice that the range for tilt's
 	// effect on y_offset goes to -45 when positive, but -20 when negative.
 	// I don't know why it's done this why, simply preserving old behavior.
 	// -Kyz
 	if(tilt > 0)
 	{
-		zoom*= SCALE(tilt, 0.f, 1.f, 1.f, 0.9f);
-		y_offset= SCALE(tilt, 0.f, 1.f, 0.f, -45.f) * reverse_mult;
+		zoom *= (((tilt)-(0.f)) * ((0.9f) - (1.f)) / ((1.f) - (0.f)) + (1.f));
+		y_offset = (((tilt)-(0.f)) * ((-45.f) - (0.f)) / ((1.f) - (0.f)) + (0.f)) * reverse_mult;
 	}
 	else
 	{
-		zoom*= SCALE(tilt, 0.f, -1.f, 1.f, 0.9f);
-		y_offset= SCALE(tilt, 0.f, -1.f, 0.f, -20.f) * reverse_mult;
+		zoom *= (((tilt)-(0.f)) * ((0.9f) - (1.f)) / ((-1.f) - (0.f)) + (1.f));
+		y_offset = (((tilt)-(0.f)) * ((-20.f) - (0.f)) / ((-1.f) - (0.f)) + (0.f)) * reverse_mult;
 	}
 	player->m_pNoteField->SetY(original_y + y_offset);
 	if(player->m_oitg_zoom_mode)
@@ -2199,9 +2199,9 @@ void Player::Step( int col, int row, const RageTimer &tm, bool bHeld, bool bRele
 			[[fallthrough]];
 		default:
 			{
-				float fCalsFor100Lbs = SCALE( iNumTracksHeld, 1, 2, 0.023f, 0.077f );
-				float fCalsFor200Lbs = SCALE( iNumTracksHeld, 1, 2, 0.041f, 0.133f );
-				fCals = SCALE( pProfile->GetCalculatedWeightPounds(), 100.f, 200.f, fCalsFor100Lbs, fCalsFor200Lbs );
+			float fCalsFor100Lbs = (((iNumTracksHeld)-(1)) * ((0.077f) - (0.023f)) / ((2) - (1)) + (0.023f));
+			float fCalsFor200Lbs = (((iNumTracksHeld)-(1)) * ((0.133f) - (0.041f)) / ((2) - (1)) + (0.041f));
+			fCals = (((pProfile->GetCalculatedWeightPounds()) - (100.f)) * ((fCalsFor200Lbs)-(fCalsFor100Lbs)) / ((200.f) - (100.f)) + (fCalsFor100Lbs));
 			}
 			break;
 		}

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -73,10 +73,10 @@ void PlayerOptions::Init()
 	m_fTimeSpacing = 0;		m_SpeedfTimeSpacing = 1.0f;
 	m_fScrollSpeed = 1.0f;		m_SpeedfScrollSpeed = 1.0f;
 	m_fScrollBPM = CMOD_DEFAULT;		m_SpeedfScrollBPM = 1.0f;
-	ZERO( m_fAccels );		ONE( m_SpeedfAccels );
-	ZERO( m_fEffects );		ONE( m_SpeedfEffects );
-	ZERO( m_fAppearances );		ONE( m_SpeedfAppearances );
-	ZERO( m_fScrolls );		ONE( m_SpeedfScrolls );
+	ZeroArray( m_fAccels );		SetArrayToOne( m_SpeedfAccels );
+	ZeroArray( m_fEffects );		SetArrayToOne( m_SpeedfEffects );
+	ZeroArray( m_fAppearances );		SetArrayToOne( m_SpeedfAppearances );
+	ZeroArray( m_fScrolls );		SetArrayToOne( m_SpeedfScrolls );
 	m_fDark = 0;			m_SpeedfDark = 1.0f;
 	m_fBlind = 0;			m_SpeedfBlind = 1.0f;
 	m_fCover = 0;			m_SpeedfCover = 1.0f;
@@ -91,8 +91,8 @@ void PlayerOptions::Init()
 	m_fModTimerOffset = 0;		m_SpeedfModTimerOffset = 1.0f;
 	m_fDrawSize = 0;		m_SpeedfDrawSize = 1.0f;
 	m_fDrawSizeBack = 0;		m_SpeedfDrawSizeBack = 1.0f;
-	ZERO( m_bTurns );
-	ZERO( m_bTransforms );
+	ZeroArray( m_bTurns );
+	ZeroArray( m_bTransforms );
 	m_bMuteOnError = false;
 	m_bStealthType = false;
 	m_bStealthPastReceptors = false;
@@ -102,17 +102,17 @@ void PlayerOptions::Init()
 	m_sNoteSkin = "";
 	m_fVisualDelay = 0.0f;
 	m_twDisabledWindows.reset();
-	ZERO( m_fMovesX );		ONE( m_SpeedfMovesX );
-	ZERO( m_fMovesY );		ONE( m_SpeedfMovesY );
-	ZERO( m_fMovesZ );		ONE( m_SpeedfMovesZ );
-	ZERO( m_fConfusionX );		ONE( m_SpeedfConfusionX );
-	ZERO( m_fConfusionY );		ONE( m_SpeedfConfusionY );
-	ZERO( m_fConfusionZ );		ONE( m_SpeedfConfusionZ );
-	ZERO( m_fDarks );		ONE( m_SpeedfDarks );
-	ZERO( m_fStealth );		ONE( m_SpeedfStealth );
-	ZERO( m_fTiny );		ONE( m_SpeedfTiny );
-	ZERO( m_fBumpy );		ONE( m_SpeedfBumpy );
-	ZERO( m_fReverse );		ONE( m_SpeedfReverse );
+	ZeroArray( m_fMovesX );		SetArrayToOne( m_SpeedfMovesX );
+	ZeroArray( m_fMovesY );		SetArrayToOne( m_SpeedfMovesY );
+	ZeroArray( m_fMovesZ );		SetArrayToOne( m_SpeedfMovesZ );
+	ZeroArray( m_fConfusionX );		SetArrayToOne( m_SpeedfConfusionX );
+	ZeroArray( m_fConfusionY );		SetArrayToOne( m_SpeedfConfusionY );
+	ZeroArray( m_fConfusionZ );		SetArrayToOne( m_SpeedfConfusionZ );
+	ZeroArray( m_fDarks );		SetArrayToOne( m_SpeedfDarks );
+	ZeroArray( m_fStealth );		SetArrayToOne( m_SpeedfStealth );
+	ZeroArray( m_fTiny );		SetArrayToOne( m_SpeedfTiny );
+	ZeroArray( m_fBumpy );		SetArrayToOne( m_SpeedfBumpy );
+	ZeroArray( m_fReverse );		SetArrayToOne( m_SpeedfReverse );
 
 }
 
@@ -1026,7 +1026,7 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 	}
 	else if( sBit == "blink" )				SET_FLOAT( fAppearances[APPEARANCE_BLINK] )
 	else if( sBit == "randomvanish" )			SET_FLOAT( fAppearances[APPEARANCE_RANDOMVANISH] )
-	else if( sBit == "turn" && !on )			ZERO( m_bTurns ); /* "no turn" */
+	else if( sBit == "turn" && !on )			ZeroArray( m_bTurns ); /* "no turn" */
 	else if( sBit == "mirror" )				m_bTurns[TURN_MIRROR] = on;
 	else if( sBit == "lrmirror" )				m_bTurns[TURN_LRMIRROR] = on;
 	else if( sBit == "udmirror" )				m_bTurns[TURN_UDMIRROR] = on;
@@ -1350,32 +1350,32 @@ PlayerOptions::Scroll PlayerOptions::GetFirstScroll()
 
 void PlayerOptions::SetOneAccel( Accel a )
 {
-	ZERO( m_fAccels );
+	ZeroArray( m_fAccels );
 	m_fAccels[a] = 1;
 }
 
 void PlayerOptions::SetOneEffect( Effect e )
 {
-	ZERO( m_fEffects );
+	ZeroArray( m_fEffects );
 	m_fEffects[e] = 1;
 }
 
 void PlayerOptions::SetOneAppearance( Appearance a )
 {
-	ZERO( m_fAppearances );
+	ZeroArray( m_fAppearances );
 	m_fAppearances[a] = 1;
 }
 
 void PlayerOptions::SetOneScroll( Scroll s )
 {
-	ZERO( m_fScrolls );
+	ZeroArray( m_fScrolls );
 	m_fScrolls[s] = 1;
 }
 
 void PlayerOptions::ToggleOneTurn( Turn t )
 {
 	bool bWasOn = m_bTurns[t];
-	ZERO( m_bTurns );
+	ZeroArray( m_bTurns );
 	m_bTurns[t] = !bWasOn;
 }
 

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -1403,7 +1403,7 @@ float PlayerOptions::GetReversePercentForColumn( int iCol ) const
 	if( f > 2 )
 		f = std::fmod( f, 2 );
 	if( f > 1 )
-		f = SCALE( f, 1.f, 2.f, 1.f, 0.f );
+		f = (((f)-(1.f)) * ((0.f) - (1.f)) / ((2.f) - (1.f)) + (1.f)); // f = SCALE( f, 1.f, 2.f, 1.f, 0.f )
 	return f;
 }
 

--- a/src/PlayerOptions.h
+++ b/src/PlayerOptions.h
@@ -7,15 +7,12 @@ class Steps;
 class Trail;
 struct lua_State;
 
-#define ONE( arr ) { for( unsigned Z = 0; Z < ARRAYLEN(arr); ++Z ) arr[Z]=1.0f; }
-
 #include "GameConstantsAndTypes.h"
 #include "PlayerNumber.h"
 #include "PrefsManager.h"
 
 #include <bitset>
 #include <vector>
-
 
 enum LifeType
 {
@@ -53,6 +50,13 @@ enum ModTimerType
 const RString& ModTimerTypeToString( ModTimerType cat );
 const RString& ModTimerTypeToLocalizedString( ModTimerType cat );
 LuaDeclareType( ModTimerType );
+
+template <typename T, std::size_t N>
+constexpr void SetArrayToOne(T (&arr)[N]) noexcept {
+	for (std::size_t i = 0; i < (sizeof(arr) / sizeof((arr)[0])); ++i) {
+        arr[i] = 1.0f;
+    }
+}
 
 /** @brief Per-player options that are not saved between sessions. */
 class PlayerOptions
@@ -93,22 +97,22 @@ public:
 	{
 		m_sNoteSkin = "";
 		m_fVisualDelay = 0.0f;
-		ZERO( m_fAccels );	ONE( m_SpeedfAccels );
-		ZERO( m_fEffects );	ONE( m_SpeedfEffects );
-		ZERO( m_fAppearances );	ONE( m_SpeedfAppearances );
-		ZERO( m_fScrolls );	ONE( m_SpeedfScrolls );
-		ZERO( m_bTurns );	ZERO( m_bTransforms );
-		ZERO( m_fMovesX );	ONE( m_SpeedfMovesX );
-		ZERO( m_fMovesY );	ONE( m_SpeedfMovesY );
-		ZERO( m_fMovesZ );	ONE( m_SpeedfMovesZ );
-		ZERO( m_fConfusionX );	ONE( m_SpeedfConfusionX );
-		ZERO( m_fConfusionY );	ONE( m_SpeedfConfusionY );
-		ZERO( m_fConfusionZ );	ONE( m_SpeedfConfusionZ );
-		ZERO( m_fDarks );	ONE( m_SpeedfDarks );
-		ZERO( m_fStealth );	ONE( m_SpeedfStealth );
-		ZERO( m_fTiny );	ONE( m_SpeedfTiny );
-		ZERO( m_fBumpy );	ONE( m_SpeedfBumpy );
-		ZERO( m_fReverse );	ONE( m_SpeedfReverse );
+		ZeroArray( m_fAccels );	SetArrayToOne( m_SpeedfAccels );
+		ZeroArray( m_fEffects );	SetArrayToOne( m_SpeedfEffects );
+		ZeroArray( m_fAppearances );	SetArrayToOne( m_SpeedfAppearances );
+		ZeroArray( m_fScrolls );	SetArrayToOne( m_SpeedfScrolls );
+		ZeroArray( m_bTurns );	ZeroArray( m_bTransforms );
+		ZeroArray( m_fMovesX );	SetArrayToOne( m_SpeedfMovesX );
+		ZeroArray( m_fMovesY );	SetArrayToOne( m_SpeedfMovesY );
+		ZeroArray( m_fMovesZ );	SetArrayToOne( m_SpeedfMovesZ );
+		ZeroArray( m_fConfusionX );	SetArrayToOne( m_SpeedfConfusionX );
+		ZeroArray( m_fConfusionY );	SetArrayToOne( m_SpeedfConfusionY );
+		ZeroArray( m_fConfusionZ );	SetArrayToOne( m_SpeedfConfusionZ );
+		ZeroArray( m_fDarks );	SetArrayToOne( m_SpeedfDarks );
+		ZeroArray( m_fStealth );	SetArrayToOne( m_SpeedfStealth );
+		ZeroArray( m_fTiny );	SetArrayToOne( m_SpeedfTiny );
+		ZeroArray( m_fBumpy );	SetArrayToOne( m_SpeedfBumpy );
+		ZeroArray( m_fReverse );	SetArrayToOne( m_SpeedfReverse );
 	};
 	void Init();
 	void Approach( const PlayerOptions& other, float fDeltaSeconds );

--- a/src/PlayerStageStats.cpp
+++ b/src/PlayerStageStats.cpp
@@ -58,8 +58,8 @@ void PlayerStageStats::InternalInit()
 	m_iNumControllerSteps = 0;
 	m_fCaloriesBurned = 0;
 
-	ZERO( m_iTapNoteScores );
-	ZERO( m_iHoldNoteScores );
+	ZeroArray( m_iTapNoteScores );
+	ZeroArray( m_iHoldNoteScores );
 	m_radarPossible.Zero();
 	m_radarActual.Zero();
 

--- a/src/PlayerStageStats.cpp
+++ b/src/PlayerStageStats.cpp
@@ -456,14 +456,14 @@ float PlayerStageStats::GetLifeRecordLerpAt( float fStepsSecond ) const
 		return earlier->second;
 
 	// earlier <= pos <= later
-	return SCALE( fStepsSecond, earlier->first, later->first, earlier->second, later->second );
+	return (((fStepsSecond)-(earlier->first)) * ((later->second) - (earlier->second)) / ((later->first) - (earlier->first)) + (earlier->second));
 }
 
 void PlayerStageStats::GetLifeRecord( float *fLifeOut, int iNumSamples, float fStepsEndSecond ) const
 {
 	for( int i = 0; i < iNumSamples; ++i )
 	{
-		float from = SCALE( i, 0, (float)iNumSamples, 0.0f, fStepsEndSecond );
+		float from = (((i)-(0)) * ((fStepsEndSecond)-(0.0f)) / (((float)iNumSamples) - (0)) + (0.0f));
 		fLifeOut[i] = GetLifeRecordLerpAt( from );
 	}
 }
@@ -835,7 +835,7 @@ public:
 		for(int i= 0; i < samples; ++i)
 		{
 			// The scale from range is [0, samples-1] because that is i's range.
-			float from= SCALE(i, 0, (float)samples-1.0f, 0.0f, last_second);
+			float from = (((i)-(0)) * ((last_second)-(0.0f)) / (((float)samples - 1.0f) - (0)) + (0.0f));
 			float curr= p->GetLifeRecordLerpAt(from);
 			lua_pushnumber(L, curr);
 			lua_rawseti(L, -2, i+1);

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -191,8 +191,8 @@ void Profile::InitGeneralData()
 	for( int i=0; i<MAX_METER+1; i++ )
 		m_iNumSongsPlayedByMeter[i] = 0;
 	m_iNumTotalSongsPlayed = 0;
-	ZERO( m_iNumStagesPassedByPlayMode );
-	ZERO( m_iNumStagesPassedByGrade );
+	ZeroArray( m_iNumStagesPassedByPlayMode );
+	ZeroArray( m_iNumStagesPassedByGrade );
 
 	m_UserTable.Unset();
 }

--- a/src/Profile.h
+++ b/src/Profile.h
@@ -129,8 +129,8 @@ public:
 		for( int i=0; i<MAX_METER+1; i++ )
 			m_iNumSongsPlayedByMeter[i] = 0;
 
-		ZERO( m_iNumStagesPassedByPlayMode );
-		ZERO( m_iNumStagesPassedByGrade );
+		ZeroArray( m_iNumStagesPassedByPlayMode );
+		ZeroArray( m_iNumStagesPassedByGrade );
 		m_UserTable.Unset();
 
 		FOREACH_ENUM( StepsType,st )

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -586,8 +586,8 @@ void RageDisplay::LoadMenuPerspective( float fovDegrees, float fWidth, float fHe
 		float theta = fovRadians/2;
 		float fDistCameraFromImage = fWidth/2 / std::tan( theta );
 
-		fVanishPointX = SCALE( fVanishPointX, 0, fWidth, fWidth, 0 );
-		fVanishPointY = SCALE( fVanishPointY, 0, fHeight, fHeight, 0 );
+		fVanishPointX = (((fVanishPointX)-(0)) * ((0) - (fWidth)) / ((fWidth)-(0)) + (fWidth));
+		fVanishPointY = (((fVanishPointY)-(0)) * ((0) - (fHeight)) / ((fHeight)-(0)) + (fHeight));
 
 		fVanishPointX -= fWidth/2;
 		fVanishPointY -= fHeight/2;
@@ -738,10 +738,10 @@ RageMatrix RageDisplay::GetCenteringMatrix( float fTranslateX, float fTranslateY
 	// in screen space, left edge = -1, right edge = 1, bottom edge = -1. top edge = 1
 	float fWidth = (float) GetActualVideoModeParams().windowWidth;
 	float fHeight = (float) GetActualVideoModeParams().windowHeight;
-	float fPercentShiftX = SCALE( fTranslateX, 0, fWidth, 0, +2.0f );
-	float fPercentShiftY = SCALE( fTranslateY, 0, fHeight, 0, -2.0f );
-	float fPercentScaleX = SCALE( fAddWidth, 0, fWidth, 1.0f, 2.0f );
-	float fPercentScaleY = SCALE( fAddHeight, 0, fHeight, 1.0f, 2.0f );
+	float fPercentShiftX = (((fTranslateX)-(0)) * ((+2.0f) - (0)) / ((fWidth)-(0)) + (0));
+	float fPercentShiftY = (((fTranslateY)-(0)) * ((-2.0f) - (0)) / ((fHeight)-(0)) + (0));
+	float fPercentScaleX = (((fAddWidth)-(0)) * ((2.0f) - (1.0f)) / ((fWidth)-(0)) + (1.0f));
+	float fPercentScaleY = (((fAddHeight)-(0)) * ((2.0f) - (1.0f)) / ((fHeight)-(0)) + (1.0f));
 
 	RageMatrix m1;
 	RageMatrix m2;

--- a/src/RageDisplay_D3D.cpp
+++ b/src/RageDisplay_D3D.cpp
@@ -1216,8 +1216,8 @@ void RageDisplay_D3D::SetZBias( float f )
 {
 	D3DVIEWPORT9 viewData;
 	g_pd3dDevice->GetViewport( &viewData );
-	viewData.MinZ = SCALE( f, 0.0f, 1.0f, 0.05f, 0.0f );
-	viewData.MaxZ = SCALE( f, 0.0f, 1.0f, 1.0f, 0.95f );
+	viewData.MinZ = (((f)-(0.0f)) * ((0.0f) - (0.05f)) / ((1.0f) - (0.0f)) + (0.05f));
+	viewData.MaxZ = (((f)-(0.0f)) * ((0.95f) - (1.0f)) / ((1.0f) - (0.0f)) + (1.0f));
 	g_pd3dDevice->SetViewport( &viewData );
 }
 

--- a/src/RageDisplay_D3D.cpp
+++ b/src/RageDisplay_D3D.cpp
@@ -477,7 +477,7 @@ static bool D3DReduceParams( D3DPRESENT_PARAMETERS *pp )
 
 static void SetPresentParametersFromVideoModeParams( const VideoModeParams &p, D3DPRESENT_PARAMETERS *pD3Dpp )
 {
-	ZERO( *pD3Dpp );
+	ZeroArray( *pD3Dpp );
 
 	pD3Dpp->BackBufferWidth		= p.width;
 	pD3Dpp->BackBufferHeight	= p.height;
@@ -1321,7 +1321,7 @@ void RageDisplay_D3D::SetLightDirectional(
 	g_pd3dDevice->LightEnable( index, true );
 
 	D3DLIGHT9 light;
-	ZERO( light );
+	ZeroArray( light );
 	light.Type = D3DLIGHT_DIRECTIONAL;
 
 	/* Z for lighting is flipped for D3D compared to OpenGL.

--- a/src/RageDisplay_GLES2.cpp
+++ b/src/RageDisplay_GLES2.cpp
@@ -704,8 +704,8 @@ RageDisplay_GLES2::SetZWrite( bool b )
 void
 RageDisplay_GLES2::SetZBias( float f )
 {
-	float fNear = SCALE( f, 0.0f, 1.0f, 0.05f, 0.0f );
-	float fFar = SCALE( f, 0.0f, 1.0f, 1.0f, 0.95f );
+	float fNear = (((f)-(0.0f)) * ((0.0f) - (0.05f)) / ((1.0f) - (0.0f)) + (0.05f));
+	float fFar = (((f)-(0.0f)) * ((0.95f) - (1.0f)) / ((1.0f) - (0.0f)) + (1.0f));
 
 	glDepthRange( fNear, fFar );
 }

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -1962,8 +1962,8 @@ void RageDisplay_Legacy::SetZWrite( bool b )
 
 void RageDisplay_Legacy::SetZBias( float f )
 {
-	float fNear = SCALE( f, 0.0f, 1.0f, 0.05f, 0.0f );
-	float fFar = SCALE( f, 0.0f, 1.0f, 1.0f, 0.95f );
+	float fNear = (f - 0.0f) * (0.0f - 0.05f) / (1.0f - 0.0f) + 0.05f;
+	float fFar = (f - 0.0f) * (0.95f - 1.0f) / (1.0f - 0.0f) + 1.0f;
 
 	glDepthRange( fNear, fFar );
 }
@@ -2184,10 +2184,10 @@ void SetPixelMapForSurface( int glImageFormat, int glTexFormat, const RageSurfac
 
 	for( int i = 0; i < palette->ncolors; ++i )
 	{
-		buf[0][i] = SCALE( palette->colors[i].r, 0, 255, 0, 65535 );
-		buf[1][i] = SCALE( palette->colors[i].g, 0, 255, 0, 65535 );
-		buf[2][i] = SCALE( palette->colors[i].b, 0, 255, 0, 65535 );
-		buf[3][i] = SCALE( palette->colors[i].a, 0, 255, 0, 65535 );
+		buf[0][i] = (((palette->colors[i].r) - (0)) * ((65535) - (0)) / ((255) - (0)) + (0));
+		buf[1][i] = (((palette->colors[i].g) - (0)) * ((65535) - (0)) / ((255) - (0)) + (0));
+		buf[2][i] = (((palette->colors[i].b) - (0)) * ((65535) - (0)) / ((255) - (0)) + (0));
+		buf[3][i] = (((palette->colors[i].a) - (0)) * ((65535) - (0)) / ((255) - (0)) + (0));
 	}
 
 	DebugFlushGLErrors();

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -983,7 +983,8 @@ static bool PathUsesSlowFlush( const RString &sPath )
 		"Save/"
 	};
 
-	for( unsigned i = 0; i < ARRAYLEN(FlushPaths); ++i )
+	const unsigned iArrayLen = ArrayLenUnsigned(FlushPaths);
+	for( unsigned i = 0; i < iArrayLen; ++i )
 		if( !strncmp( sPath, FlushPaths[i], strlen(FlushPaths[i]) ) )
 			return true;
 	return false;

--- a/src/RageMath.cpp
+++ b/src/RageMath.cpp
@@ -681,7 +681,7 @@ float RageBezier2D::EvaluateYFromX( float fX ) const
 	/* Quickly approximate T using Newton-Raphelson successive optimization (see
 	 * http://www.tinaja.com/text/bezmath.html).  This usually finds T within an
 	 * acceptable error margin in a few steps. */
-	float fT = SCALE( fX, m_X.GetBezierStart(), m_X.GetBezierEnd(), 0, 1 );
+	float fT = (((fX)-(m_X.GetBezierStart())) * ((1) - (0)) / ((m_X.GetBezierEnd()) - (m_X.GetBezierStart())) + (0));
 	// Don't try more than 100 times, the curve might be a bit nonsensical. -Kyz
 	for(int i= 0; i < 100; ++i)
 	{

--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -353,7 +353,7 @@ int RageSoundReader_Chain::Read( float *pBuffer, int iFrames )
 	RageSoundMixBuffer mix;
 	/* Read iFrames from each sound. */
 	float Buffer[2048];
-	iFrames = std::min( iFrames, (int) (ARRAYLEN(Buffer) / m_iChannels) );
+    iFrames = FastMin(iFrames, static_cast<int>(ArrayLenInt(Buffer) / m_iChannels));
 	for( unsigned i = 0; i < m_apActiveSounds.size(); )
 	{
 		RageSoundReader *pSound = m_apActiveSounds[i]->pSound;

--- a/src/RageSoundReader_Extend.cpp
+++ b/src/RageSoundReader_Extend.cpp
@@ -124,8 +124,8 @@ int RageSoundReader_Extend::Read( float *pBuffer, int iFrames )
 		{
 			const int iStartSecond = m_iPositionFrames;
 			const int iEndSecond = m_iPositionFrames + iFramesRead;
-			const float fStartVolume = SCALE( iStartSecond, iFullVolumePositionFrames, iSilencePositionFrames, 1.0f, 0.0f );
-			const float fEndVolume = SCALE( iEndSecond, iFullVolumePositionFrames, iSilencePositionFrames, 1.0f, 0.0f );
+			const float fStartVolume = (((iStartSecond)-(iFullVolumePositionFrames)) * ((0.0f) - (1.0f)) / ((iSilencePositionFrames)-(iFullVolumePositionFrames)) + (1.0f));
+			const float fEndVolume = (((iEndSecond)-(iFullVolumePositionFrames)) * ((0.0f) - (1.0f)) / ((iSilencePositionFrames)-(iFullVolumePositionFrames)) + (1.0f));
 			RageSoundUtil::Fade( pBuffer, iFramesRead, this->GetNumChannels(), fStartVolume, fEndVolume );
 		}
 

--- a/src/RageSoundReader_Merge.cpp
+++ b/src/RageSoundReader_Merge.cpp
@@ -235,7 +235,7 @@ int RageSoundReader_Merge::Read( float *pBuffer, int iFrames )
 
 	RageSoundMixBuffer mix;
 	float Buffer[2048];
-	iFrames = std::min( iFrames, (int) (ARRAYLEN(Buffer) / m_iChannels) );
+	iFrames = FastMin(iFrames, static_cast<int>(ArrayLenInt(Buffer) / m_iChannels));
 
 	/* Read iFrames from each sound. */
 	for( unsigned i = 0; i < m_aSounds.size(); ++i )

--- a/src/RageSoundReader_Preload.cpp
+++ b/src/RageSoundReader_Preload.cpp
@@ -80,7 +80,7 @@ bool RageSoundReader_Preload::Open( RageSoundReader *pSource )
 			return false; /* Don't bother trying to preload it. */
 		}
 		float buffer[1024];
-		int iCnt = pSource->Read( buffer, ARRAYLEN(buffer) / m_iChannels );
+		int iCnt = pSource->Read( buffer, ArrayLenInt(buffer) / m_iChannels );
 
 		if( iCnt == END_OF_FILE )
 		{

--- a/src/RageSoundReader_Resample_Good.cpp
+++ b/src/RageSoundReader_Resample_Good.cpp
@@ -638,9 +638,9 @@ RageSoundReader_Resample_Good::~RageSoundReader_Resample_Good()
 /* iFrame is in the destination rate.  Seek the source in its own sample rate. */
 int RageSoundReader_Resample_Good::SetPosition( int iFrame )
 {
-	Reset();
-	iFrame = (int) SCALE( iFrame, 0, (std::int64_t) m_iSampleRate, 0, (std::int64_t) m_pSource->GetSampleRate() );
-	return m_pSource->SetPosition( iFrame );
+    Reset();
+    std::int64_t iFrame64 = static_cast<std::int64_t>(iFrame) * m_pSource->GetSampleRate() / m_iSampleRate;
+    return m_pSource->SetPosition(static_cast<int>(iFrame64));
 }
 
 int RageSoundReader_Resample_Good::Read( float *pBuf, int iFrames )

--- a/src/RageSoundReader_SpeedChange.cpp
+++ b/src/RageSoundReader_SpeedChange.cpp
@@ -280,7 +280,7 @@ int RageSoundReader_SpeedChange::Read( float *pBuf, int iFrames )
 				ChannelInfo &c = m_Channels[i];
 				float i1 = c.m_DataBuffer[c.m_iCorrelatedPos+m_iPos];
 				float i2 = c.m_DataBuffer[c.m_iLastCorrelatedPos+m_iPos];
-				*pBuf++ = SCALE( m_iPos, 0, iWindowSizeFrames, i2, i1 );
+				*pBuf++ = (((m_iPos)-(0)) * ((i1)-(i2)) / ((iWindowSizeFrames)-(0)) + (i2));
 			}
 
 			++m_iPos;

--- a/src/RageSoundUtil.cpp
+++ b/src/RageSoundUtil.cpp
@@ -27,8 +27,8 @@ void RageSoundUtil::Pan( float *buffer, int frames, float fPos )
 	float fLeftFactors[2] ={ 1-fPos, 0 };
 	float fRightFactors[2] =
 	{
-		SCALE( fPos, 0, 1, 0.5f, 0 ),
-		SCALE( fPos, 0, 1, 0.5f, 1 )
+		(((fPos)-(0)) * ((0) - (0.5f)) / ((1) - (0)) + (0.5f)),
+		(((fPos)-(0)) * ((1) - (0.5f)) / ((1) - (0)) + (0.5f))
 	};
 
 	if( bSwap )
@@ -55,7 +55,7 @@ void RageSoundUtil::Fade( float *pBuffer, int iFrames, int iChannels, float fSta
 
 	for( int iFrame = 0; iFrame < iFrames; ++iFrame )
 	{
-		float fVolPercent = SCALE( iFrame, 0, iFrames, fStartVolume, fEndVolume );
+		float fVolPercent = (((iFrame)-(0)) * ((fEndVolume)-(fStartVolume)) / ((iFrames)-(0)) + (fStartVolume));
 
 		fVolPercent = std::clamp( fVolPercent, 0.f, 1.f );
 		for( int i = 0; i < iChannels; ++i )

--- a/src/RageSurface.cpp
+++ b/src/RageSurface.cpp
@@ -188,11 +188,11 @@ void SetupFormat( RageSurfaceFormat &fmt,
 	fmt.BytesPerPixel = BitsPerPixel/8;
 	if( fmt.BytesPerPixel == 1 )
 	{
-		ZERO( fmt.Mask );
-		ZERO( fmt.Shift );
+		ZeroArray( fmt.Mask );
+		ZeroArray( fmt.Shift );
 
 		// Loss for paletted textures is zero; the actual palette entries are 8-bit.
-		ZERO( fmt.Loss );
+		ZeroArray( fmt.Loss );
 
 		fmt.palette = std::make_unique<RageSurfacePalette>();
 		fmt.palette->ncolors = 256;

--- a/src/RageSurfaceUtils.cpp
+++ b/src/RageSurfaceUtils.cpp
@@ -572,10 +572,10 @@ static bool blit_rgba_to_rgba( const RageSurface *src_surf, const RageSurface *d
 			 * strange; what's wrong here? */
 			if( max_src_val > max_dst_val )
 				for( std::uint32_t i = 0; i <= max_src_val; ++i )
-					lookup[c][i] = (std::uint8_t) SCALE( i, 0, max_src_val+1, 0, max_dst_val+1 );
+					lookup[c][i] = (std::uint8_t)(((i)-(0)) * ((max_dst_val + 1) - (0)) / ((max_src_val + 1) - (0)) + (0));
 			else
 				for( std::uint32_t i = 0; i <= max_src_val; ++i )
-					lookup[c][i] = (std::uint8_t) SCALE( i, 0, max_src_val, 0, max_dst_val );
+					lookup[c][i] = (std::uint8_t)(((i)-(0)) * ((max_dst_val)-(0)) / ((max_src_val)-(0)) + (0));
 		}
 	}
 

--- a/src/RageSurfaceUtils_Palettize.cpp
+++ b/src/RageSurfaceUtils_Palettize.cpp
@@ -42,7 +42,7 @@ struct acolorhash_hash
 	acolorhist_list hash[HASH_SIZE];
 	acolorhash_hash()
 	{
-		ZERO( hash );
+		ZeroArray( hash );
 	}
 
 	~acolorhash_hash()

--- a/src/RageSurface_Load_BMP.cpp
+++ b/src/RageSurface_Load_BMP.cpp
@@ -120,7 +120,7 @@ static RageSurfaceUtils::OpenResult LoadBMP( RageFile &f, RageSurface *&img, RSt
 	if( iBPP == 8 )
 	{
 		RageSurfaceColor Palette[256];
-		ZERO( Palette );
+		ZeroArray( Palette );
 
 		if( iColors > 256 )
 			FATAL_ERROR( ssprintf( "unexpected colors %i", iColors ) );

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -637,13 +637,15 @@ static const LanguageInfo g_langs[] =
 
 void GetLanguageInfos( std::vector<const LanguageInfo*> &vAddTo )
 {
-	for( unsigned i=0; i<ARRAYLEN(g_langs); ++i )
+	const unsigned iArrayLen = ArrayLenUnsigned(g_langs);
+	for( unsigned i=0; i<iArrayLen; ++i )
 		vAddTo.push_back( &g_langs[i] );
 }
 
 const LanguageInfo *GetLanguageInfo( const RString &sIsoCode )
 {
-	for( unsigned i=0; i<ARRAYLEN(g_langs); ++i )
+	const unsigned iArrayLen = ArrayLenUnsigned(g_langs);
+	for( unsigned i=0; i<iArrayLen; ++i )
 	{
 		if( sIsoCode.EqualsNoCase(g_langs[i].szIsoCode) )
 			return &g_langs[i];

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -21,12 +21,39 @@ class RageFileDriver;
 /** @brief Safely delete array pointers. */
 #define SAFE_DELETE_ARRAY(p) do { delete[] (p);   (p)=nullptr; } while( false )
 
-/** @brief Zero out the memory. */
-#define ZERO(x)	memset(&(x), 0, sizeof(x))
-/** @brief Copy from a to b. */
-#define COPY(a,b) do { ASSERT(sizeof(a)==sizeof(b)); memcpy(&(a), &(b), sizeof(a)); } while( false )
-/** @brief Get the length of the array. */
-#define ARRAYLEN(a) (sizeof(a) / sizeof((a)[0]))
+// A constexpr function to initialize an array to zero.
+template <typename T>
+constexpr void ZeroArray(T& x) noexcept
+{
+    std::memset(&x, 0, sizeof(x));
+}
+
+// Get the length of an array without using .size() as a size_t
+template <typename T, std::size_t N>
+constexpr std::size_t ArrayLenSizeT(const T (&)[N]) noexcept
+{
+    return N;
+}
+
+// Get the length of an array without using .size() as an unsigned int
+template <typename T, std::size_t N>
+constexpr unsigned ArrayLenUnsigned(const T (&)[N]) noexcept
+{
+    return static_cast<unsigned>(N);
+}
+
+// Get the length of an array without using .size() as an int
+template <typename T, std::size_t N>
+constexpr int ArrayLenInt(const T (&)[N]) noexcept
+{
+    return static_cast<int>(N);
+}
+
+// A constexpr function to use where std::min might fail due to being different types.
+constexpr int FastMin(int a, int b)
+{
+    return (a < b) ? a : b;
+}
 
 extern const RString CUSTOM_SONG_PATH;
 

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -16,10 +16,21 @@
 
 class RageFileDriver;
 
-/** @brief Safely delete pointers. */
-#define SAFE_DELETE(p)       do { delete (p);     (p)=nullptr; } while( false )
-/** @brief Safely delete array pointers. */
-#define SAFE_DELETE_ARRAY(p) do { delete[] (p);   (p)=nullptr; } while( false )
+// Safely delete pointers.
+template <typename T>
+inline void SAFE_DELETE(T*& p) noexcept
+{
+    delete p;
+    p = nullptr;
+}
+
+// Safely delete array pointers.
+template <typename T>
+inline void SAFE_DELETE_ARRAY(T*& p) noexcept
+{
+    delete[] p;
+    p = nullptr;
+}
 
 // A constexpr function to initialize an array to zero.
 template <typename T>
@@ -56,16 +67,6 @@ constexpr int FastMin(int a, int b)
 }
 
 extern const RString CUSTOM_SONG_PATH;
-
-/**
- * @brief Scales x so that l1 corresponds to l2 and h1 corresponds to h2.
- *
- * This does not modify x, so it MUST assign the result to something!
- * Do the multiply before the divide to that integer scales have more precision.
- *
- * One such example: SCALE(x, 0, 1, L, H); interpolate between L and H.
- */
-//#define SCALE(x, l1, h1, l2, h2)	(((x) - (l1)) * ((h2) - (l2)) / ((h1) - (l1)) + (l2))
 
 template<typename T, typename U>
 inline U lerp( T x, U l, U h )

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -38,7 +38,7 @@ extern const RString CUSTOM_SONG_PATH;
  *
  * One such example: SCALE(x, 0, 1, L, H); interpolate between L and H.
  */
-#define SCALE(x, l1, h1, l2, h2)	(((x) - (l1)) * ((h2) - (l2)) / ((h1) - (l1)) + (l2))
+//#define SCALE(x, l1, h1, l2, h2)	(((x) - (l1)) * ((h2) - (l2)) / ((h1) - (l1)) + (l2))
 
 template<typename T, typename U>
 inline U lerp( T x, U l, U h )

--- a/src/ScoreKeeperRave.cpp
+++ b/src/ScoreKeeperRave.cpp
@@ -119,7 +119,7 @@ void ScoreKeeperRave::AddSuperMeterDelta( float fUnscaledPercentChange )
 	if( PREFSMAN->m_bMercifulDrain  &&  fUnscaledPercentChange<0 )
 	{
 		float fSuperPercentage = m_pPlayerState->m_fSuperMeter / Enum::to_integral(NUM_ATTACK_LEVELS);
-		fUnscaledPercentChange *= SCALE( fSuperPercentage, 0.f, 1.f, 0.5f, 1.f);
+		fUnscaledPercentChange *= (((fSuperPercentage)-(0.f)) * ((1.f) - (0.5f)) / ((1.f) - (0.f)) + (0.5f));
 	}
 
 	// more mercy: Grow super meter slower or faster depending on life.
@@ -135,14 +135,14 @@ void ScoreKeeperRave::AddSuperMeterDelta( float fUnscaledPercentChange )
 		}
 		CLAMP( fLifePercentage, 0.f, 1.f );
 		if( fUnscaledPercentChange > 0 )
-			fUnscaledPercentChange *= SCALE( fLifePercentage, 0.f, 1.f, 1.7f, 0.3f);
+			fUnscaledPercentChange *= (((fLifePercentage)-(0.f)) * ((0.3f) - (1.7f)) / ((1.f) - (0.f)) + (1.7f));
 		else	// fUnscaledPercentChange <= 0
-			fUnscaledPercentChange /= SCALE( fLifePercentage, 0.f, 1.f, 1.7f, 0.3f);
+			fUnscaledPercentChange /= (((fLifePercentage)-(0.f)) * ((0.3f) - (1.7f)) / ((1.f) - (0.f)) + (1.7f));
 	}
 
 	// mercy: drop super meter faster if at a higher level
 	if( fUnscaledPercentChange < 0 )
-		fUnscaledPercentChange *= SCALE( m_pPlayerState->m_fSuperMeter, 0.f, 1.f, 0.01f, 1.f );
+		fUnscaledPercentChange *= (((m_pPlayerState->m_fSuperMeter) - (0.f)) * ((1.f) - (0.01f)) / ((1.f) - (0.f)) + (0.01f));
 
 	AttackLevel oldAL = (AttackLevel)(int)m_pPlayerState->m_fSuperMeter;
 

--- a/src/ScreenBookkeeping.cpp
+++ b/src/ScreenBookkeeping.cpp
@@ -48,7 +48,7 @@ void ScreenBookkeeping::Init()
 		m_textData[i].LoadFromFont( THEME->GetPathF(m_sName,"data") );
 		m_textData[i].SetName( "Data" );
 		LOAD_ALL_COMMANDS_AND_SET_XY( m_textData[i] );
-		float fX = SCALE( i, 0.f, NUM_BOOKKEEPING_COLS-1, SCREEN_LEFT+50, SCREEN_RIGHT-160 );
+		float fX = (((i)-(0.f)) * (((ScreenDimensions::GetScreenWidth()) - 160) - ((0) + 50)) / ((NUM_BOOKKEEPING_COLS - 1) - (0.f)) + ((0) + 50));
 		m_textData[i].SetX( fX );
 		this->AddChild( &m_textData[i] );
 	}

--- a/src/ScreenDebugOverlay.cpp
+++ b/src/ScreenDebugOverlay.cpp
@@ -869,7 +869,7 @@ static HighScore MakeRandomHighScore( float fPercentDP )
 {
 	HighScore hs;
 	hs.SetName( "FAKE" );
-	Grade g = (Grade)SCALE( RandomInt(6), 0, 4, Grade_Tier01, Grade_Tier06 );
+	Grade g = (Grade)(((RandomInt(6)) - (0)) * ((Grade_Tier06)-(Grade_Tier01)) / ((4) - (0)) + (Grade_Tier01));
 	if( g == Grade_Tier06 )
 		g = Grade_Failed;
 	hs.SetGrade( g );

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -2243,8 +2243,9 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 			float fScrollSpeed = pPlayerState->m_PlayerOptions.GetSong().m_fScrollSpeed;
 
 			const float fSpeeds[] = { 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f, 8.0f };
+			const unsigned iArrayLen = ArrayLenUnsigned(fSpeeds);
 			int iSpeed = 0;
-			for( unsigned i = 0; i < ARRAYLEN(fSpeeds); ++i )
+			for( unsigned i = 0; i < iArrayLen; ++i )
 			{
 				if( fSpeeds[i] == fScrollSpeed )
 				{
@@ -2263,7 +2264,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 				INVERT_SCROLL_BUTTONS ? --iSpeed : ++iSpeed;
 				break;
 			}
-			iSpeed = std::clamp( iSpeed, 0, (int) ARRAYLEN(fSpeeds)-1 );
+			iSpeed = std::clamp( iSpeed, 0, ArrayLenInt(fSpeeds)-1 );
 
 			if( fSpeeds[iSpeed] != fScrollSpeed )
 			{
@@ -6532,7 +6533,8 @@ void ScreenEdit::DoHelp()
 {
 	g_EditHelp.rows.clear();
 
-	for( unsigned i=0; i<ARRAYLEN(g_EditHelpLines); ++i )
+	const unsigned iArrayLen = ArrayLenUnsigned(g_EditHelpLines);
+	for( unsigned i=0; i<iArrayLen; ++i )
 	{
 		const EditHelpLine &hl = g_EditHelpLines[i];
 

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -231,7 +231,7 @@ void ScreenEvaluation::Init()
 	}
 	m_pStageStats = &STATSMAN->m_vPlayedStageStats.back();
 
-	ZERO( m_bSavedScreenshot );
+	ZeroArray( m_bSavedScreenshot );
 
 	// Figure out which statistics and songs we're going to display
 	SUMMARY.Load( m_sName, "Summary" );

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -2154,8 +2154,8 @@ void ScreenGameplay::UpdateLights()
 
 	bool bBlinkCabinetLight[NUM_CabinetLight];
 	bool bBlinkGameButton[NUM_GameController][NUM_GameButton];
-	ZERO( bBlinkCabinetLight );
-	ZERO( bBlinkGameButton );
+	ZeroArray( bBlinkCabinetLight );
+	ZeroArray( bBlinkGameButton );
 	{
 		const float fSongBeat = GAMESTATE->m_Position.m_fLightSongBeat;
 		const int iSongRow = BeatToNoteRowNotRounded( fSongBeat );

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1241,7 +1241,7 @@ void ScreenGameplay::LoadNextSong()
 			{
 				pi->GetPlayerState()->m_PlayerController = PC_CPU;
 				int iMeter = pSteps->GetMeter();
-				int iNewSkill = SCALE( iMeter, MIN_METER, MAX_METER, 0, NUM_SKILL_LEVELS-1 );
+				int iNewSkill = (((iMeter)-(MIN_METER)) * ((NUM_SKILL_LEVELS - 1) - (0)) / ((MAX_METER)-(MIN_METER)) + (0));
 				/* Watch out: songs aren't actually bound by MAX_METER. */
 				iNewSkill = std::clamp( iNewSkill, 0, NUM_SKILL_LEVELS-1 );
 				pi->GetPlayerState()->m_iCpuSkill = iNewSkill;
@@ -2080,7 +2080,7 @@ void ScreenGameplay::UpdateHasteRate()
 		}
 	}
 	if( fMaxLife <= m_fHasteLifeSwitchPoint )
-		GAMESTATE->m_fHasteRate = SCALE( fMaxLife, 0.0f, m_fHasteLifeSwitchPoint, -1.0f, 0.0f );
+		GAMESTATE->m_fHasteRate = (((fMaxLife)-(0.0f)) * ((0.0f) - (-1.0f)) / ((m_fHasteLifeSwitchPoint)-(0.0f)) + (-1.0f));
 	CLAMP( GAMESTATE->m_fHasteRate, -1.0f, +1.0f );
 
 	float fSpeed = 1.0f;
@@ -2111,7 +2111,7 @@ void ScreenGameplay::UpdateHasteRate()
 		scale_to_low= m_HasteAddAmounts[turning_point];
 	}
 	// If negative haste is being used, the game instead slows down when the player does well.
-	float speed_add= SCALE(GAMESTATE->m_fHasteRate, scale_from_low, scale_from_high, scale_to_low, scale_to_high) * options_haste;
+	float speed_add = (((GAMESTATE->m_fHasteRate) - (scale_from_low)) * ((scale_to_high)-(scale_to_low)) / ((scale_from_high)-(scale_from_low)) + (scale_to_low)) * options_haste;
 	if(scale_from_low == scale_from_high)
 	{
 		speed_add= scale_to_high * options_haste;

--- a/src/ScreenManager.cpp
+++ b/src/ScreenManager.cpp
@@ -109,7 +109,7 @@ namespace ScreenManagerUtil
 		{
 			m_pScreen = nullptr;
 			m_bDeleteWhenDone = true;
-			ZERO( m_input_redirected );
+			ZeroArray( m_input_redirected );
 			m_SendOnPop = SM_None;
 		}
 	};
@@ -400,7 +400,7 @@ ScreenMessage ScreenManager::PopTopScreenInternal( bool bSendLoseFocus )
 	if( bSendLoseFocus )
 		ls.m_pScreen->HandleScreenMessage( SM_LoseFocus );
 	ls.m_pScreen->EndScreen();
-	ZERO( ls.m_input_redirected );
+	ZeroArray( ls.m_input_redirected );
 
 	if( g_setPersistantScreens.find(ls.m_pScreen->GetName()) != g_setPersistantScreens.end() )
 	{

--- a/src/ScreenNameEntry.cpp
+++ b/src/ScreenNameEntry.cpp
@@ -79,11 +79,11 @@ void ScreenNameEntry::ScrollingText::DrawPrimitives()
 		float fAlpha = 1.f;
 
 		if( iCharIndex == iClosestIndex )
-			fZoom = SCALE( std::abs(fClosestYOffset), 0, 0.5f, g_fCharsZoomLarge, g_fCharsZoomSmall );
+			fZoom = (((std::abs(fClosestYOffset)) - (0)) * ((g_fCharsZoomSmall)-(g_fCharsZoomLarge)) / ((0.5f) - (0)) + (g_fCharsZoomLarge));
 		if( i == 0 )
-			fAlpha *= SCALE( fClosestYOffset, -0.5f, 0.f, 0.f, 1.f );
+			fAlpha *= (((fClosestYOffset)-(-0.5f)) * ((1.f) - (0.f)) / ((0.f) - (-0.5f)) + (0.f));
 		if( i == g_iNumCharsToDrawTotal-1 )
-			fAlpha *= SCALE( fClosestYOffset, 0.f, 0.5f, 1.f, 0.f );
+			fAlpha *= (((fClosestYOffset)-(0.f)) * ((0.f) - (1.f)) / ((0.5f) - (0.f)) + (1.f));
 
 		m_Stamp.SetZoom( fZoom );
 		m_Stamp.SetDiffuseAlpha( fAlpha );

--- a/src/ScreenOptionsMaster.cpp
+++ b/src/ScreenOptionsMaster.cpp
@@ -90,7 +90,7 @@ void ScreenOptionsMaster::ExportOptions( int r, const std::vector<PlayerNumber> 
 
 	OptionRow &row = *m_pRows[r];
 	bool bRowHasFocus[NUM_PLAYERS];
-	ZERO( bRowHasFocus );
+	ZeroArray( bRowHasFocus );
 	for (PlayerNumber const &p : vpns)
 	{
 		int iCurRow = m_iCurrentRow[p];

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -390,19 +390,19 @@ static void BGBrightness( int &sel, bool ToSel, const ConfOption *pConfOption )
 	// option is created. Try to find a way to only use the same list once.
 	// Do that for all of these float and int lists.
 	const float mapping[] = { 0.0f,0.1f,0.2f,0.3f,0.4f,0.5f,0.6f,0.7f,0.8f,0.9f,1.0f };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 static void BGBrightnessNoZero( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const float mapping[] = { 0.1f,0.2f,0.3f,0.4f,0.5f,0.6f,0.7f,0.8f,0.9f,1.0f };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 static void BGBrightnessOrStatic( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const float mapping[] = { 0.5f,0.25f,0.5f,0.75f };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 
 	IPreference *pSongBackgroundsPref = IPreference::GetPreferenceByName( "SongBackgrounds" );
 	if( ToSel && pSongBackgroundsPref->ToString() == "0" )
@@ -414,20 +414,20 @@ static void BGBrightnessOrStatic( int &sel, bool ToSel, const ConfOption *pConfO
 static void NumBackgrounds( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const int mapping[] = { 1,5,10,15,20 };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 // Input options
 static void MusicWheelSwitchSpeed( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const int mapping[] = { 5, 10, 15, 25 };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 static void InputDebounceTime(int& sel, bool to_sel, ConfOption const* conf_option)
 {
 	float const mapping[]= {0.0f, 0.01f, 0.02f, 0.03f, 0.04f, 0.05f, 0.06f, 0.07f, 0.08f, 0.09f, 0.1f};
-	MoveMap(sel, conf_option, to_sel, mapping, ARRAYLEN(mapping));
+	MoveMap(sel, conf_option, to_sel, mapping, ArrayLenUnsigned(mapping));
 }
 
 // Machine options
@@ -469,25 +469,25 @@ static void CoinsPerCredit( int &sel, bool ToSel, const ConfOption *pConfOption 
 static void MaxNumCredits( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	int const mapping[]= {20, 40, 60, 80, 100};
-	MoveMap(sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping));
+	MoveMap(sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping));
 }
 
 static void JointPremium( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const Premium mapping[] = { Premium_DoubleFor1Credit, Premium_2PlayersFor1Credit };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 static void SongsPerPlay( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const int mapping[] = { 1,2,3,4,5 };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 static void SongsPerPlayOrEventMode( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const int mapping[] = { 1,2,3,4,5,6 };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 
 	if( ToSel && PREFSMAN->m_bEventMode )
 		sel = 5;
@@ -504,7 +504,7 @@ static void TimingWindowScale( int &sel, bool ToSel, const ConfOption *pConfOpti
 
 	// StepMania 3.9 and 4.0 values:
 	const float mapping[] = { 1.50f,1.33f,1.16f,1.00f,0.84f,0.66f,0.50f,0.33f,0.20f };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 /** @brief Life Difficulty scale */
@@ -517,19 +517,19 @@ static void LifeDifficulty( int &sel, bool ToSel, const ConfOption *pConfOption 
 
 	// StepMania 3.9 and 4.0 values:
 	const float mapping[] = { 1.60f,1.40f,1.20f,1.00f,0.80f,0.60f,0.40f };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 static void MaxHighScoresPerListForMachine(int& sel, bool to_sel, ConfOption const* conf_option)
 {
 	int const mapping[]= {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
-	MoveMap(sel, conf_option, to_sel, mapping, ARRAYLEN(mapping));
+	MoveMap(sel, conf_option, to_sel, mapping, ArrayLenUnsigned(mapping));
 }
 
 static void MaxHighScoresPerListForPlayer(int& sel, bool to_sel, ConfOption const* conf_option)
 {
 	int const mapping[]= {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
-	MoveMap(sel, conf_option, to_sel, mapping, ARRAYLEN(mapping));
+	MoveMap(sel, conf_option, to_sel, mapping, ArrayLenUnsigned(mapping));
 }
 
 
@@ -626,37 +626,37 @@ static void DisplayResolutionM( int &sel, bool ToSel, const ConfOption *pConfOpt
 static void DisplayColorDepth( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const int mapping[] = { 16,32 };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 static void MaxTextureResolution( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const int mapping[] = { 256,512,1024,2048 };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 static void TextureColorDepth( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const int mapping[] = { 16,32 };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 static void MovieColorDepth( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const int mapping[] = { 16,32 };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 static void RefreshRate( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const int mapping[] = { (int) REFRESH_DEFAULT,60,70,72,75,80,85,90,100,120,150 };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 static void DisplayAspectRatio( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const float mapping[] = { 3/4.f, 1, 4/3.0f, 5/4.0f, 16/10.0f, 16/9.f, 8/3.f };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 /* Simpler DisplayAspectRatio setting, which only offers "on" and "off".
@@ -664,13 +664,13 @@ static void DisplayAspectRatio( int &sel, bool ToSel, const ConfOption *pConfOpt
 static void WideScreen16_10( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const float mapping[] = { 4/3.0f, 16/10.0f };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 static void WideScreen16_9( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const float mapping[] = { 4/3.0f, 16/9.0f };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 // BackgroundCache code isn't live yet -aj
@@ -678,7 +678,7 @@ static void WideScreen16_9( int &sel, bool ToSel, const ConfOption *pConfOption 
 static void BackgroundCache( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const BackgroundCache mapping[] = { BackgroundCacheMode_Off, BackgroundCacheMode_LowResPreload, BackgroundCacheMode_LowResLoadOnDemand, BackgroundCacheMode_Full };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 */
 
@@ -686,19 +686,19 @@ static void BackgroundCache( int &sel, bool ToSel, const ConfOption *pConfOption
 static void SoundVolume( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const float mapping[] = { 0.0f,0.1f,0.2f,0.3f,0.4f,0.5f,0.6f,0.7f,0.8f,0.9f,1.0f };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 static void SoundVolumeAttract( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const float mapping[] = { 0.0f,0.1f,0.2f,0.3f,0.4f,0.5f,0.6f,0.7f,0.8f,0.9f,1.0f };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 static void VisualDelaySeconds( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const float mapping[] = { -0.125f,-0.1f,-0.075f,-0.05f,-0.025f,0.0f,0.025f,0.05f,0.075f,0.1f,0.125f };
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 static void GlobalOffsetSeconds( int &sel, bool ToSel, const ConfOption *pConfOption )
@@ -707,7 +707,7 @@ static void GlobalOffsetSeconds( int &sel, bool ToSel, const ConfOption *pConfOp
 	for( int i = 0; i < 41; ++i )
 		mapping[i] = (((i)-(0.0f)) * ((+0.1f) - (-0.1f)) / ((40.0f) - (0.0f)) + (-0.1f));
 
-	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
+	MoveMap( sel, pConfOption, ToSel, mapping, ArrayLenUnsigned(mapping) );
 }
 
 static void EditRecordModeLeadIn(int &sel, bool to_sel, const ConfOption* conf_option)
@@ -717,37 +717,37 @@ static void EditRecordModeLeadIn(int &sel, bool to_sel, const ConfOption* conf_o
 	{
 		mapping[i]= static_cast<float>(i);
 	}
-	MoveMap(sel, conf_option, to_sel, mapping, ARRAYLEN(mapping));
+	MoveMap(sel, conf_option, to_sel, mapping, ArrayLenUnsigned(mapping));
 }
 
 static void EditClearPromptThreshold(int& sel, bool to_sel, const ConfOption* conf_option)
 {
 	int mapping[]= {-1, 10, 50, 100, 1000, 1000000};
-	MoveMap(sel, conf_option, to_sel, mapping, ARRAYLEN(mapping));
+	MoveMap(sel, conf_option, to_sel, mapping, ArrayLenUnsigned(mapping));
 }
 
 static void CustomSongsCount(int& sel, bool to_sel, const ConfOption* conf_option)
 {
 	int mapping[]= {10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 1000};
-	MoveMap(sel, conf_option, to_sel, mapping, ARRAYLEN(mapping));
+	MoveMap(sel, conf_option, to_sel, mapping, ArrayLenUnsigned(mapping));
 }
 
 static void CustomSongsLoadTimeout(int& sel, bool to_sel, const ConfOption* conf_option)
 {
 	int mapping[]= {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 1000};
-	MoveMap(sel, conf_option, to_sel, mapping, ARRAYLEN(mapping));
+	MoveMap(sel, conf_option, to_sel, mapping, ArrayLenUnsigned(mapping));
 }
 
 static void CustomSongsMaxSeconds(int& sel, bool to_sel, const ConfOption* conf_option)
 {
 	int mapping[]= {60, 90, 120, 150, 180, 210, 240, 10000};
-	MoveMap(sel, conf_option, to_sel, mapping, ARRAYLEN(mapping));
+	MoveMap(sel, conf_option, to_sel, mapping, ArrayLenUnsigned(mapping));
 }
 
 static void CustomSongsMaxMegabytes(int& sel, bool to_sel, const ConfOption* conf_option)
 {
 	int mapping[]= {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 1000};
-	MoveMap(sel, conf_option, to_sel, mapping, ARRAYLEN(mapping));
+	MoveMap(sel, conf_option, to_sel, mapping, ArrayLenUnsigned(mapping));
 }
 static std::vector<ConfOption> g_ConfOptions;
 static void InitializeConfOptions()

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -705,7 +705,7 @@ static void GlobalOffsetSeconds( int &sel, bool ToSel, const ConfOption *pConfOp
 {
 	float mapping[41];
 	for( int i = 0; i < 41; ++i )
-		mapping[i] = SCALE( i, 0.0f, 40.0f, -0.1f, +0.1f );
+		mapping[i] = (((i)-(0.0f)) * ((+0.1f) - (-0.1f)) / ((40.0f) - (0.0f)) + (-0.1f));
 
 	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
 }

--- a/src/ScreenSelectCharacter.cpp
+++ b/src/ScreenSelectCharacter.cpp
@@ -261,7 +261,7 @@ void ScreenSelectCharacter::AfterValueChange( PlayerNumber pn )
 				Banner &banner = m_sprIcons[pnAffected][i];
 				banner.LoadIconFromCharacter( pCharacter );
 				float fX = (pnAffected==PLAYER_1) ? 320-ICON_WIDTH : 320+ICON_WIDTH;
-				float fY = SCALE( i, 0.f, MAX_CHAR_ICONS_TO_SHOW-1.f, 240-(MAX_CHAR_ICONS_TO_SHOW/2*ICON_HEIGHT), 240+(MAX_CHAR_ICONS_TO_SHOW/2*ICON_HEIGHT));
+				float fY = (((i)-(0.f)) * ((240 + (11 / 2 * THEME->GetMetricF("ScreenSelectCharacter", "IconHeight"))) - (240 - (11 / 2 * THEME->GetMetricF("ScreenSelectCharacter", "IconHeight")))) / ((11 - 1.f) - (0.f)) + (240 - (11 / 2 * THEME->GetMetricF("ScreenSelectCharacter", "IconHeight"))));
 				banner.SetXY( fX, fY );
 			}
 		}

--- a/src/ScreenSelectMaster.cpp
+++ b/src/ScreenSelectMaster.cpp
@@ -43,9 +43,9 @@ if( SHARED_SELECTION ) { \
 
 ScreenSelectMaster::ScreenSelectMaster()
 {
-	ZERO( m_iChoice );
-	ZERO( m_bChosen );
-	ZERO( m_bDoubleChoice );
+	ZeroArray( m_iChoice );
+	ZeroArray( m_bChosen );
+	ZeroArray( m_bDoubleChoice );
 }
 
 void ScreenSelectMaster::Init()

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -275,10 +275,10 @@ void ScreenSelectMusic::BeginScreen()
 	m_MusicWheel.BeginScreen();
 
 	m_SelectionState = SelectionState_SelectingSong;
-	ZERO( m_bStepsChosen );
+	ZeroArray( m_bStepsChosen );
 	m_bGoToOptions = false;
 	m_bAllowOptionsMenu = m_bAllowOptionsMenuRepeat = false;
-	ZERO( m_iSelection );
+	ZeroArray( m_iSelection );
 
 	if( USE_OPTIONS_LIST )
 		FOREACH_PlayerNumber( pn )

--- a/src/ScreenStatsOverlay.cpp
+++ b/src/ScreenStatsOverlay.cpp
@@ -48,9 +48,7 @@ void ScreenStatsOverlay::Init()
 			 * doesn't obscure something, and it's just a diagnostic. */
 			m_textSkips[i].LoadFromFont( THEME->GetPathF("Common","normal") );
 			m_textSkips[i].SetX( SKIP_X );
-			m_textSkips[i].SetY( 
-				SCALE( i, 0, NUM_SKIPS_TO_SHOW-1, rectSkips.top + 10, rectSkips.bottom - 10 ) 
-				);
+			m_textSkips[i].SetY( (((i)-(0)) * ((rectSkips.bottom - 10) - (rectSkips.top + 10)) / ((NUM_SKIPS_TO_SHOW - 1) - (0)) + (rectSkips.top + 10)) );
 			m_textSkips[i].SetDiffuse( RageColor(1,1,1,0) );
 			m_textSkips[i].SetShadowLength( 0 );
 			this->AddChild( &m_textSkips[i] );

--- a/src/ScreenTextEntry.cpp
+++ b/src/ScreenTextEntry.cpp
@@ -686,8 +686,8 @@ void ScreenTextEntryVisual::BeginScreen()
 		for( int x=0; x<KEYS_PER_ROW; ++x )
 		{
 			BitmapText &bt = *m_ptextKeys[r][x];
-			float fX = std::round( SCALE( x, 0, KEYS_PER_ROW-1, ROW_START_X, ROW_END_X ) );
-			float fY = std::round( SCALE( r, 0, NUM_KeyboardRow-1, ROW_START_Y, ROW_END_Y ) );
+			float fX = std::round((((x)-(0)) * ((ROW_END_X)-(ROW_START_X)) / ((KEYS_PER_ROW - 1) - (0)) + (ROW_START_X)));
+			float fY = std::round((((r)-(0)) * ((ROW_END_Y)-(ROW_START_Y)) / ((NUM_KeyboardRow - 1) - (0)) + (ROW_START_Y)));
 			bt.SetXY( fX, fY );
 		}
 	}

--- a/src/ScrollBar.cpp
+++ b/src/ScrollBar.cpp
@@ -24,7 +24,8 @@ ScrollBar::ScrollBar()
 	m_sprScrollTickThumb.Load( THEME->GetPathG(sMetricsGroup,"TickThumb") );
 	this->AddChild( m_sprScrollTickThumb );
 
-	for( unsigned i=0; i<ARRAYLEN(m_sprScrollStretchThumb); i++ )
+	const unsigned iArrayLen = ArrayLenUnsigned(m_sprScrollStretchThumb);
+	for( unsigned i=0; i<iArrayLen; i++ )
 	{
 		m_sprScrollStretchThumb[i].Load( THEME->GetPathG(sMetricsGroup,"StretchThumb") );
 		this->AddChild( m_sprScrollStretchThumb[i] );
@@ -40,7 +41,8 @@ void ScrollBar::SetBarHeight( int iHeight )
 	m_sprTop->SetY( -m_iBarHeight/2.0f );
 	m_sprBottom->SetY( +m_iBarHeight/2.0f );
 	m_sprScrollTickThumb->SetY( 0 );
-	for( unsigned i=0; i<ARRAYLEN(m_sprScrollStretchThumb); i++ )
+	const unsigned iArrayLen = ArrayLenUnsigned(m_sprScrollStretchThumb);
+	for( unsigned i=0; i<iArrayLen; i++ )
 		m_sprScrollStretchThumb[i]->SetY( 0 );
 }
 
@@ -84,7 +86,8 @@ void ScrollBar::SetPercentage( float fCenterPercent, float fSizePercent )
 		fPartBottomY[1] = (((1.0f) - (0.0f)) * ((+iBarContentHeight / 2.0f) - (-iBarContentHeight / 2.0f)) / ((1.0f) - (0.0f)) + (-iBarContentHeight / 2.0f));
 	}
 
-	for( unsigned i=0; i<ARRAYLEN(m_sprScrollStretchThumb); i++ )
+	const unsigned iArrayLen = ArrayLenUnsigned(m_sprScrollStretchThumb);
+	for( unsigned i=0; i<iArrayLen; i++ )
 	{
 		RectF rect(
 			-m_sprScrollStretchThumb[i]->GetUnzoomedWidth()/2,

--- a/src/ScrollBar.cpp
+++ b/src/ScrollBar.cpp
@@ -53,7 +53,7 @@ void ScrollBar::SetPercentage( float fCenterPercent, float fSizePercent )
 
 	/* Set tick thumb */
 	{
-		float fY = SCALE( fCenterPercent, 0.0f, 1.0f, -iBarContentHeight/2.0f, iBarContentHeight/2.0f );
+		float fY = (((fCenterPercent)-(0.0f)) * ((iBarContentHeight / 2.0f) - (-iBarContentHeight / 2.0f)) / ((1.0f) - (0.0f)) + (-iBarContentHeight / 2.0f));
 		fY = std::round( fY );
 		m_sprScrollTickThumb->SetY( fY );
 	}
@@ -71,17 +71,17 @@ void ScrollBar::SetPercentage( float fCenterPercent, float fSizePercent )
 
 	if( fStartPercent < fEndPercent )	// we only need to one 1 stretch thumb part
 	{
-		fPartTopY[0]	= SCALE( fStartPercent,0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
-		fPartBottomY[0]	= SCALE( fEndPercent,  0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
+		fPartTopY[0] = (((fStartPercent)-(0.0f)) * ((+iBarContentHeight / 2.0f) - (-iBarContentHeight / 2.0f)) / ((1.0f) - (0.0f)) + (-iBarContentHeight / 2.0f));
+		fPartBottomY[0] = (((fEndPercent)-(0.0f)) * ((+iBarContentHeight / 2.0f) - (-iBarContentHeight / 2.0f)) / ((1.0f) - (0.0f)) + (-iBarContentHeight / 2.0f));
 		fPartTopY[1]	= 0;
 		fPartBottomY[1]	= 0;
 	}
 	else	// we need two stretch thumb parts
 	{
-		fPartTopY[0]	= SCALE( 0.0f,		0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
-		fPartBottomY[0]	= SCALE( fEndPercent,	0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
-		fPartTopY[1]	= SCALE( fStartPercent,	0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
-		fPartBottomY[1]	= SCALE( 1.0f,		0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
+		fPartTopY[0] = (((0.0f) - (0.0f)) * ((+iBarContentHeight / 2.0f) - (-iBarContentHeight / 2.0f)) / ((1.0f) - (0.0f)) + (-iBarContentHeight / 2.0f));
+		fPartBottomY[0] = (((fEndPercent)-(0.0f)) * ((+iBarContentHeight / 2.0f) - (-iBarContentHeight / 2.0f)) / ((1.0f) - (0.0f)) + (-iBarContentHeight / 2.0f));
+		fPartTopY[1] = (((fStartPercent)-(0.0f)) * ((+iBarContentHeight / 2.0f) - (-iBarContentHeight / 2.0f)) / ((1.0f) - (0.0f)) + (-iBarContentHeight / 2.0f));
+		fPartBottomY[1] = (((1.0f) - (0.0f)) * ((+iBarContentHeight / 2.0f) - (-iBarContentHeight / 2.0f)) / ((1.0f) - (0.0f)) + (-iBarContentHeight / 2.0f));
 	}
 
 	for( unsigned i=0; i<ARRAYLEN(m_sprScrollStretchThumb); i++ )

--- a/src/SoundEffectControl.cpp
+++ b/src/SoundEffectControl.cpp
@@ -76,9 +76,9 @@ void SoundEffectControl::Update( float fDeltaTime )
 
 	float fCurrent;
 	if( m_fSample < 0 )
-		fCurrent = SCALE( m_fSample, 0.0f, -1.0f, fPropertyCenter, fPropertyMin );
+		fCurrent = (((m_fSample)-(0.0f)) * ((fPropertyMin)-(fPropertyCenter)) / ((-1.0f) - (0.0f)) + (fPropertyCenter));
 	else
-		fCurrent = SCALE( m_fSample, 0.0f, +1.0f, fPropertyCenter, fPropertyMax );
+		fCurrent = (((m_fSample)-(0.0f)) * ((fPropertyMax)-(fPropertyCenter)) / ((+1.0f) - (0.0f)) + (fPropertyCenter));
 
 	if( m_pSoundReader )
 		m_pSoundReader->SetProperty( SOUND_PROPERTY, fCurrent );

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -525,8 +525,9 @@ bool CheckVideoDefaultSettings()
 
 	VideoCardDefaults defaults;
 
-	unsigned i;
-	for( i=0; i<ARRAYLEN(g_VideoCardDefaults); i++ )
+	const unsigned iArrayLen = ArrayLenUnsigned(g_VideoCardDefaults);
+	unsigned i = 0;
+	for( i=0; i<iArrayLen; i++ )
 	{
 		defaults = g_VideoCardDefaults[i];
 
@@ -538,7 +539,7 @@ bool CheckVideoDefaultSettings()
 			break;
 		}
 	}
-	if (i >= ARRAYLEN(g_VideoCardDefaults))
+	if (i >= iArrayLen)
 	{
 		FAIL_M("Failed to match video driver");
 	}

--- a/src/StreamDisplay.cpp
+++ b/src/StreamDisplay.cpp
@@ -109,7 +109,7 @@ void StreamDisplay::Update( float fDeltaSecs )
 		for( int i=0; i<(int)m_vpSprPill[st].size(); i++ )
 		{
 			Sprite *pSpr = m_vpSprPill[st][i];
-			float fPercentFilledThisPill = SCALE( m_fTrailingPercent, fPillWidthPercent*i, fPillWidthPercent*(i+1), 0.0f, 1.0f );
+			float fPercentFilledThisPill = (((m_fTrailingPercent)-(fPillWidthPercent * i)) * ((1.0f) - (0.0f)) / ((fPillWidthPercent * (i + 1)) - (fPillWidthPercent * i)) + (0.0f));
 			CLAMP( fPercentFilledThisPill, 0.0f, 1.0f );
 
 			// XXX scale by current song speed

--- a/src/UnlockManager.cpp
+++ b/src/UnlockManager.cpp
@@ -674,7 +674,7 @@ void UnlockManager::Reload()
 float UnlockManager::PointsUntilNextUnlock( UnlockRequirement t ) const
 {
 	float fScores[NUM_UnlockRequirement];
-	ZERO( fScores );
+	ZeroArray( fScores );
 	GetPoints( PROFILEMAN->GetMachineProfile(), fScores );
 
 	float fSmallestPoints = FLT_MAX;   // or an arbitrarily large value

--- a/src/UnlockManager.h
+++ b/src/UnlockManager.h
@@ -69,7 +69,7 @@ public:
 		m_bRequirePassChallengeSteps(false), m_bRoulette(false),
 		m_sEntryID(RString(""))
 	{
-		ZERO( m_fRequirement );
+		ZeroArray( m_fRequirement );
 	}
 
 	UnlockRewardType m_Type;

--- a/src/WorkoutGraph.cpp
+++ b/src/WorkoutGraph.cpp
@@ -74,11 +74,11 @@ void WorkoutGraph::SetInternal( int iMinSongsPlayed )
 	int iBlocksHigh = MAX_METER;
 
 	const float fMaxWidth = 300;
-	float fTotalWidth = SCALE( iBlocksWide, 1.0f, 10.0f, 50.0f, fMaxWidth );
+	float fTotalWidth = (((iBlocksWide)-(1.0f)) * ((fMaxWidth)-(50.0f)) / ((10.0f) - (1.0f)) + (50.0f));
 	CLAMP( fTotalWidth, 50, fMaxWidth );
 
 	const float fMaxHeight = 130;
-	float fTotalHeight = SCALE( iBlocksHigh, 1.0f, 10.0f, 50.0f, fMaxHeight );
+	float fTotalHeight = (((iBlocksHigh)-(1.0f)) * ((fMaxHeight)-(50.0f)) / ((10.0f) - (1.0f)) + (50.0f));
 	CLAMP( fTotalHeight, 50, fMaxHeight );
 
 	float fBlockSize = std::min( fTotalWidth / iBlocksWide, fTotalHeight / iBlocksHigh );

--- a/src/XmlFileUtil.cpp
+++ b/src/XmlFileUtil.cpp
@@ -75,7 +75,7 @@ static void InitEntities()
 		{ '>',  "gt", }
 	};
 
-	for( unsigned i = 0; i < ARRAYLEN(EntityTable); ++i )
+	for (unsigned i = 0; i < (sizeof(EntityTable) / sizeof((EntityTable)[0])); ++i)
 	{
 		const Entity &ent = EntityTable[i];
 		g_mapEntitiesToChars[ent.pEntity] = RString(1, ent.c);

--- a/src/arch/ArchHooks/ArchHooks_Win32.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32.cpp
@@ -137,7 +137,7 @@ void ArchHooks_Win32::RestartProgram()
 void ArchHooks_Win32::SetTime( tm newtime )
 {
 	SYSTEMTIME st;
-	ZERO( st );
+	ZeroArray( st );
 	st.wYear = (WORD)newtime.tm_year+1900;
 	st.wMonth = (WORD)newtime.tm_mon+1;
 	st.wDay = (WORD)newtime.tm_mday;
@@ -172,7 +172,7 @@ bool ArchHooks_Win32::GoToURL( RString sUrl )
 float ArchHooks_Win32::GetDisplayAspectRatio()
 {
 	DEVMODE dm;
-	ZERO( dm );
+	ZeroArray( dm );
 	dm.dmSize = sizeof(dm);
 	BOOL bResult = EnumDisplaySettings( nullptr, ENUM_REGISTRY_SETTINGS, &dm );
 	ASSERT( bResult != 0 );

--- a/src/arch/InputHandler/InputHandler_DirectInput.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInput.cpp
@@ -516,7 +516,7 @@ void InputHandler_DInput::UpdatePolled( DIDevice &device, const RageTimer &tm )
 
 						if( neg != DeviceButton_Invalid )
 						{
-							float l = SCALE( int(val), 0.0f, 100.0f, 0.0f, 1.0f );
+							float l = (((int(val)) - (0.0f)) * ((1.0f) - (0.0f)) / ((100.0f) - (0.0f)) + (0.0f));
 							ButtonPressed( DeviceInput(dev, neg, std::max(-l, 0.0f), tm) );
 							ButtonPressed( DeviceInput(dev, pos, std::max(+l, 0.0f), tm) );
 						}
@@ -693,6 +693,8 @@ void InputHandler_DInput::UpdateBuffered( DIDevice &device, const RageTimer &tm 
 								up = MOUSE_WHEELUP; down = MOUSE_WHEELDOWN;
 								float fWheelDelta = l;
 								//l = SCALE( int(evtbuf[i].dwData), -WHEEL_DELTA, WHEEL_DELTA, 1.0f, -1.0f );
+								// note: the SCALE macro is removed, for reference the macro was as follows:
+								// (((x)-(l1))* ((h2)-(l2)) / ((h1)-(l1)) + (l2))
 								if( l > 0 )
 								{
 									DeviceInput diUp = DeviceInput(dev, up, 1.0f, tm);
@@ -753,7 +755,7 @@ void InputHandler_DInput::UpdateBuffered( DIDevice &device, const RageTimer &tm 
 										 "Controller '%s' is returning an unknown joystick offset, %i",
 										 device.m_sName.c_str(), in.ofs );
 
-						float l = SCALE( int(evtbuf[i].dwData), 0.0f, 100.0f, 0.0f, 1.0f );
+						float l = (((int(evtbuf[i].dwData)) - (0.0f)) * ((1.0f) - (0.0f)) / ((100.0f) - (0.0f)) + (0.0f));
 						if(GamePreferences::m_AxisFix)
 						{
 						  ButtonPressed( DeviceInput(dev, up, (l == 0) || (l == -1), tm) );
@@ -796,8 +798,8 @@ void InputHandler_DInput::UpdateXInput( XIDevice &device, const RageTimer &tm )
 		float ly = 0.f;
 		if (std::sqrt(std::pow(state.Gamepad.sThumbLX, 2) + std::pow(state.Gamepad.sThumbLY, 2)) > XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE)
 		{
-			lx = SCALE(state.Gamepad.sThumbLX + 0.f, XINPUT_GAMEPAD_THUMB_MIN + 0.f, XINPUT_GAMEPAD_THUMB_MAX + 0.f, -1.0f, 1.0f);
-			ly = SCALE(state.Gamepad.sThumbLY + 0.f, XINPUT_GAMEPAD_THUMB_MIN + 0.f, XINPUT_GAMEPAD_THUMB_MAX + 0.f, -1.0f, 1.0f);
+			lx = (((state.Gamepad.sThumbLX + 0.f) - (XINPUT_GAMEPAD_THUMB_MIN + 0.f)) * ((1.0f) - (-1.0f)) / ((XINPUT_GAMEPAD_THUMB_MAX + 0.f) - (XINPUT_GAMEPAD_THUMB_MIN + 0.f)) + (-1.0f));
+			ly = (((state.Gamepad.sThumbLY + 0.f) - (XINPUT_GAMEPAD_THUMB_MIN + 0.f)) * ((1.0f) - (-1.0f)) / ((XINPUT_GAMEPAD_THUMB_MAX + 0.f) - (XINPUT_GAMEPAD_THUMB_MIN + 0.f)) + (-1.0f));
 		}
 		ButtonPressed(DeviceInput(device.dev, JOY_LEFT, std::max(-lx, 0.f), tm));
 		ButtonPressed(DeviceInput(device.dev, JOY_RIGHT, std::max(+lx, 0.f), tm));
@@ -808,8 +810,8 @@ void InputHandler_DInput::UpdateXInput( XIDevice &device, const RageTimer &tm )
 		float ry = 0.f;
 		if (std::sqrt(std::pow(state.Gamepad.sThumbRX, 2) + std::pow(state.Gamepad.sThumbRY, 2)) > XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE)
 		{
-			rx = SCALE(state.Gamepad.sThumbRX + 0.f, XINPUT_GAMEPAD_THUMB_MIN + 0.f, XINPUT_GAMEPAD_THUMB_MAX + 0.f, -1.0f, 1.0f);
-			ry = SCALE(state.Gamepad.sThumbRY + 0.f, XINPUT_GAMEPAD_THUMB_MIN + 0.f, XINPUT_GAMEPAD_THUMB_MAX + 0.f, -1.0f, 1.0f);
+			rx = (((state.Gamepad.sThumbRX + 0.f) - (XINPUT_GAMEPAD_THUMB_MIN + 0.f)) * ((1.0f) - (-1.0f)) / ((XINPUT_GAMEPAD_THUMB_MAX + 0.f) - (XINPUT_GAMEPAD_THUMB_MIN + 0.f)) + (-1.0f));
+			ry = (((state.Gamepad.sThumbRY + 0.f) - (XINPUT_GAMEPAD_THUMB_MIN + 0.f)) * ((1.0f) - (-1.0f)) / ((XINPUT_GAMEPAD_THUMB_MAX + 0.f) - (XINPUT_GAMEPAD_THUMB_MIN + 0.f)) + (-1.0f));
 		}
 		ButtonPressed(DeviceInput(device.dev, JOY_LEFT_2, std::max(-rx, 0.f), tm));
 		ButtonPressed(DeviceInput(device.dev, JOY_RIGHT_2, std::max(+rx, 0.f), tm));

--- a/src/arch/InputHandler/InputHandler_DirectInput.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInput.cpp
@@ -1039,7 +1039,7 @@ static wchar_t ScancodeAndKeysToChar( DWORD scancode, unsigned char keys[256] )
 	}
 
 	unsigned short result[2]; // ToAscii writes a max of 2 chars
-	ZERO( result );
+	ZeroArray( result );
 
 	if( pToUnicodeEx != nullptr )
 	{
@@ -1084,7 +1084,7 @@ wchar_t InputHandler_DInput::DeviceButtonToChar( DeviceButton button, bool bUseC
 				continue;
 
 			unsigned char keys[256];
-			ZERO( keys );
+			ZeroArray( keys );
 			if( bUseCurrentKeyModifiers )
 				GetKeyboardState(keys);
 			// todo: handle Caps Lock -freem

--- a/src/arch/InputHandler/InputHandler_Linux_Event.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Event.cpp
@@ -245,7 +245,7 @@ bool EventDevice::Open( RString sFile, InputDevice dev )
 		}
 		else
 		{
-			if( iNextExtraAxis < (int) ARRAYLEN(iExtraAxes) )
+			if( iNextExtraAxis < ArrayLenInt(iExtraAxes) )
 			{
 				aiAbsMappingLow[i] = iExtraAxes[iNextExtraAxis];
 				aiAbsMappingHigh[i] = enum_add2( aiAbsMappingLow[i], 1 );

--- a/src/arch/InputHandler/InputHandler_Linux_Event.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Event.cpp
@@ -411,7 +411,7 @@ void InputHandler_Linux_Event::InputThread()
 				DeviceButton neg = g_apEventDevices[i]->aiAbsMappingLow[event.code];
 				DeviceButton pos = g_apEventDevices[i]->aiAbsMappingHigh[event.code];
 
-				float l = SCALE( int(event.value), (float) g_apEventDevices[i]->aiAbsMin[event.code], (float) g_apEventDevices[i]->aiAbsMax[event.code], -1.0f, 1.0f );
+				float l = (int(event.value) - (float) g_apEventDevices[i]->aiAbsMin[event.code]) * (1.0f - (-1.0f)) / ((float) g_apEventDevices[i]->aiAbsMax[event.code] - (float) g_apEventDevices[i]->aiAbsMin[event.code]) + (-1.0f);
 				if (GamePreferences::m_AxisFix)
 				{
 				  ButtonPressed( DeviceInput(g_apEventDevices[i]->m_Dev, neg, (l < -0.5)||((l > 0.0001)&&(l < 0.5)), now) ); //Up if between 0.0001 and 0.5 or if less than -0.5

--- a/src/arch/InputHandler/InputHandler_Linux_Joystick.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Joystick.cpp
@@ -174,7 +174,7 @@ void InputHandler_Linux_Joystick::InputThread()
 			case JS_EVENT_AXIS: {
 				DeviceButton neg = enum_add2(JOY_LEFT, 2*event.number);
 				DeviceButton pos = enum_add2(JOY_RIGHT, 2*event.number);
-                                float l = SCALE( int(event.value), 0.0f, 32767, 0.0f, 1.0f );
+                                float l = (int(event.value) - 0.0f) * (1.0f - 0.0f) / (32767 - 0.0f) + 0.0f;
 				ButtonPressed( DeviceInput(id, neg, std::max(-l, 0.0f), now) );
 				ButtonPressed( DeviceInput(id, pos, std::max(+l, 0.0f), now) );
 				break;

--- a/src/arch/InputHandler/InputHandler_Linux_Joystick.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Joystick.cpp
@@ -81,7 +81,7 @@ bool InputHandler_Linux_Joystick::TryDevice(RString dev)
 		if(f.fd != -1)
 		{
 			char szName[1024];
-			ZERO( szName );
+			ZeroArray( szName );
 			if( ioctl(f.fd, JSIOCGNAME(sizeof(szName)), szName) < 0 )
 				f.description = ssprintf( "Unknown joystick at %s", dev.c_str() );
 			else

--- a/src/arch/InputHandler/InputHandler_MonkeyKeyboard.cpp
+++ b/src/arch/InputHandler/InputHandler_MonkeyKeyboard.cpp
@@ -53,7 +53,7 @@ static const DeviceButton g_keys[] =
 
 static DeviceButton GetRandomKeyboardKey()
 {
-	int index = RandomInt( ARRAYLEN(g_keys) );
+	int index = RandomInt( ArrayLenInt(g_keys) );
 	return g_keys[index];
 }
 

--- a/src/arch/InputHandler/InputHandler_Win32_Pump.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_Pump.cpp
@@ -71,7 +71,9 @@ void InputHandler_Win32_Pump::HandleInput( int iDevice, int iEvent )
 
 	InputDevice id = InputDevice( DEVICE_PUMP1 + iDevice );
 
-	for( int iButton = 0; iButton < ARRAYLEN(bits); ++iButton )
+	const int iArrayLen = ArrayLenInt(bits);
+
+	for( int iButton = 0; iButton < iArrayLen; ++iButton )
 	{
 		DeviceInput di( id, enum_add2(JOY_BUTTON_1, iButton), !(iEvent & bits[iButton]) );
 

--- a/src/arch/InputHandler/InputHandler_X11.cpp
+++ b/src/arch/InputHandler/InputHandler_X11.cpp
@@ -50,7 +50,8 @@ static DeviceButton XSymToDeviceButton( int key )
 	};
 
 	/* 32...127: */
-	if( key < int(ARRAYLEN(ASCIIKeySyms)))
+	int iArrayLen = ArrayLenInt(ASCIIKeySyms);
+	if( key < iArrayLen )
 		return ASCIIKeySyms[key];
 
 	/* XK_KP_0 ... XK_KP_9 to KEY_KP_C0 ... KEY_KP_C9 */

--- a/src/arch/Lights/LightsDriver.cpp
+++ b/src/arch/Lights/LightsDriver.cpp
@@ -45,9 +45,9 @@ void LightsDriver::Create( const RString &sDrivers, std::vector<LightsDriver *> 
 void LightsDriver::Reset()
 {
 	LightsState state;
-	ZERO( state.m_bCabinetLights );
-	ZERO( state.m_bGameButtonLights );
-	ZERO( state.m_bCoinCounter );
+	ZeroArray( state.m_bCabinetLights );
+	ZeroArray( state.m_bGameButtonLights );
+	ZeroArray( state.m_bCoinCounter );
 	Set( &state );
 }
 

--- a/src/arch/LowLevelWindow/LowLevelWindow_Win32.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_Win32.cpp
@@ -35,7 +35,7 @@ static void DestroyGraphicsWindowAndOpenGLContext()
 		g_HGLRC_Background = nullptr;
 	}
 
-	ZERO( g_CurrentPixelFormat );
+	ZeroArray( g_CurrentPixelFormat );
 
 	GraphicsWindow::DestroyGraphicsWindow();
 }
@@ -82,7 +82,7 @@ int ChooseWindowPixelFormat( const VideoModeParams &p, PIXELFORMATDESCRIPTOR *pi
 	ASSERT( GraphicsWindow::GetHwnd() != nullptr );
 	ASSERT( GraphicsWindow::GetHDC() != nullptr );
 
-	ZERO( *pixfmt );
+	ZeroArray( *pixfmt );
 	pixfmt->nSize		= sizeof(PIXELFORMATDESCRIPTOR);
 	pixfmt->nVersion		= 1;
 	pixfmt->dwFlags		= PFD_DRAW_TO_WINDOW | PFD_DOUBLEBUFFER | PFD_SUPPORT_OPENGL;
@@ -175,7 +175,7 @@ RString LowLevelWindow_Win32::TryVideoMode( const VideoModeParams &p, bool &bNew
 		/* We'll need to recreate it if the pixel format is going to change.  We
 		 * aren't allowed to change the pixel format twice. */
 		PIXELFORMATDESCRIPTOR DestPixelFormat;
-		ZERO( DestPixelFormat );
+		ZeroArray( DestPixelFormat );
 		DescribePixelFormat( GraphicsWindow::GetHDC(), iPixelFormat, sizeof(PIXELFORMATDESCRIPTOR), &DestPixelFormat );
 		if( memcmp( &DestPixelFormat, &g_CurrentPixelFormat, sizeof(PIXELFORMATDESCRIPTOR) ) )
 		{

--- a/src/arch/MovieTexture/MovieTexture_Generic.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Generic.cpp
@@ -402,7 +402,9 @@ static EffectMode EffectModes[] =
 {
 	EffectMode_YUYV422,
 };
-static_assert( ARRAYLEN(EffectModes) == NUM_PixelFormatYCbCr );
+// Ensure that the number of EffectModes matches the number of PixelFormatYCbCr formats
+constexpr std::size_t NumEffectModes = sizeof(EffectModes) / sizeof(EffectModes[0]);
+static_assert( NumEffectModes == NUM_PixelFormatYCbCr );
 
 EffectMode MovieTexture_Generic::GetEffectMode( MovieDecoderPixelFormatYCbCr fmt )
 {

--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -182,7 +182,7 @@ RString DSoundBuf::Init( DSound &ds, DSoundBuf::hw hardware,
 	m_iExtraWriteahead = 0;
 	m_iLastPosition = 0;
 	m_bPlaying = false;
-	ZERO( m_iLastCursors );
+	ZeroArray( m_iLastCursors );
 
 	/* The size of the actual DSound buffer.  This can be large; we generally
 	 * won't fill it completely. */

--- a/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
@@ -72,7 +72,9 @@ RageSoundMixBuffer &RageSoundDriver::MixIntoBuffer( int iFrames, std::int64_t iF
 
 	static RageSoundMixBuffer mix;
 
-	for( unsigned i = 0; i < ARRAYLEN(m_Sounds); ++i )
+	unsigned iArrayLen = ArrayLenUnsigned(m_Sounds);
+	unsigned i = 0;
+	for( i = 0; i < iArrayLen; ++i )
 	{
 		/* s.m_pSound can not safely be accessed from here. */
 		Sound &s = m_Sounds[i];
@@ -206,7 +208,9 @@ void RageSoundDriver::DecodeThread()
 		LockMut( m_Mutex );
 //		LOG->Trace("begin mix");
 
-		for( unsigned i = 0; i < ARRAYLEN(m_Sounds); ++i )
+		unsigned iArrayLen = ArrayLenUnsigned(m_Sounds);
+		unsigned i = 0;
+		for( i = 0; i < iArrayLen; ++i )
 		{
 			if( m_Sounds[i].m_State != Sound::PLAYING )
 				continue;
@@ -244,7 +248,7 @@ int RageSoundDriver::GetDataForSound( Sound &s )
 	ASSERT( psize[0] > 0 );
 
 	sound_block *pBlock = p[0];
-	int size = ARRAYLEN(pBlock->m_Buffer)/channels;
+	int size = ArrayLenInt(pBlock->m_Buffer)/channels;
 	int iRet = s.m_pSound->GetDataToPlay( pBlock->m_Buffer, size, pBlock->m_iPosition, pBlock->m_FramesInBuffer );
 	if( iRet > 0 )
 	{
@@ -262,7 +266,9 @@ int RageSoundDriver::GetDataForSound( Sound &s )
 void RageSoundDriver::Update()
 {
 	m_Mutex.Lock();
-	for( unsigned i = 0; i < ARRAYLEN(m_Sounds); ++i )
+	unsigned iArrayLen = ArrayLenUnsigned(m_Sounds);
+	unsigned i = 0;
+	for( i = 0; i < iArrayLen; ++i )
 	{
 		{
 			Sound::QueuedPosMap p;
@@ -326,11 +332,13 @@ void RageSoundDriver::StartMixing( RageSoundBase *pSound )
 	/* Lock available m_Sounds[], and reserve a slot. */
 	m_SoundListMutex.Lock();
 
-	unsigned i;
-	for( i = 0; i < ARRAYLEN(m_Sounds); ++i )
+	const unsigned iArrayLen = ArrayLenUnsigned(m_Sounds);
+
+	unsigned i = 0;
+	for( i = 0; i < iArrayLen; ++i )
 		if( m_Sounds[i].m_State == Sound::AVAILABLE )
 			break;
-	if( i == ARRAYLEN(m_Sounds) )
+	if( i == iArrayLen )
 	{
 		m_SoundListMutex.Unlock();
 		return;
@@ -374,11 +382,13 @@ void RageSoundDriver::StopMixing( RageSoundBase *pSound )
 	m_Mutex.Lock();
 
 	/* Find the sound. */
-	unsigned i;
-	for( i = 0; i < ARRAYLEN(m_Sounds); ++i )
+	const unsigned iArrayLen = ArrayLenUnsigned(m_Sounds);
+
+	unsigned i = 0;
+	for( i = 0; i < iArrayLen; ++i )
 		if( m_Sounds[i].m_State != Sound::AVAILABLE && m_Sounds[i].m_pSound == pSound )
 			break;
-	if( i == ARRAYLEN(m_Sounds) )
+	if( i == iArrayLen )
 	{
 		m_Mutex.Unlock();
 		LOG->Trace( "not stopping a sound because it's not playing" );
@@ -415,15 +425,17 @@ bool RageSoundDriver::PauseMixing( RageSoundBase *pSound, bool bStop )
 	LockMut( m_Mutex );
 
 	/* Find the sound. */
-	unsigned i;
-	for( i = 0; i < ARRAYLEN(m_Sounds); ++i )
+	const unsigned iArrayLen = ArrayLenUnsigned(m_Sounds);
+
+	unsigned i = 0;
+	for( i = 0; i < iArrayLen; ++i )
 		if( m_Sounds[i].m_State != Sound::AVAILABLE && m_Sounds[i].m_pSound == pSound )
 			break;
 
 	/* A sound can be paused in PLAYING or STOPPING.  (STOPPING means the sound
 	 * has been decoded to the end, and we're waiting for that data to finish, so
 	 * externally it looks and acts like PLAYING.) */
-	if( i == ARRAYLEN(m_Sounds) ||
+	if( i == iArrayLen ||
 		(m_Sounds[i].m_State != Sound::PLAYING && m_Sounds[i].m_State != Sound::STOPPING) )
 	{
 		LOG->Trace( "not pausing a sound because it's not playing" );

--- a/src/arch/Sound/RageSoundDriver_WDMKS.cpp
+++ b/src/arch/Sound/RageSoundDriver_WDMKS.cpp
@@ -1075,7 +1075,7 @@ namespace
 		{
 			float *pOutBuf = (float *) pOut;
 			for( int i = 0; i < iSamples; ++i )
-				pOutBuf[i] = SCALE( pIn[i], -32768, +32767, -1.0f, +1.0f ); // [-32768, 32767] -> [-1,+1]
+				pOutBuf[i] = (((pIn[i]) - (-32768)) * ((+1.0f) - (-1.0f)) / ((+32767) - (-32768)) + (-1.0f)); // [-32768, 32767] -> [-1,+1]
 			break;
 		}
 		case DeviceSampleFormat_Int24:

--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -161,7 +161,7 @@ RString RageSoundDriver_WaveOut::Init()
 	}
 
 
-	ZERO( m_aBuffers );
+	ZeroArray( m_aBuffers );
 	for(int b = 0; b < NUM_CHUNKS; ++b)
 	{
 		m_aBuffers[b].dwBufferLength = CHUNKSIZE;

--- a/src/archutils/Darwin/JoystickDevice.cpp
+++ b/src/archutils/Darwin/JoystickDevice.cpp
@@ -160,7 +160,7 @@ void JoystickDevice::GetButtonPresses( std::vector<DeviceInput>& vPresses, IOHID
 	{
 		if( js.x_axis == cookie )
 		{
-			float level = SCALE( value, js.x_min, js.x_max, -1.0f, 1.0f );
+			float level = (value - js.ry_min) * (1.0f - (-1.0f)) / (js.ry_max - js.ry_min) + (-1.0f);
 
 			vPresses.push_back( DeviceInput(js.id, JOY_LEFT, std::max(-level, 0.0f), now) );
 			vPresses.push_back( DeviceInput(js.id, JOY_RIGHT, std::max(level, 0.0f), now) );
@@ -168,7 +168,7 @@ void JoystickDevice::GetButtonPresses( std::vector<DeviceInput>& vPresses, IOHID
 		}
 		else if( js.y_axis == cookie )
 		{
-			float level = SCALE( value, js.y_min, js.y_max, -1.0f, 1.0f );
+			float level = (value - js.ry_min) * (1.0f - (-1.0f)) / (js.ry_max - js.ry_min) + (-1.0f);
 
 			vPresses.push_back( DeviceInput(js.id, JOY_UP, std::max(-level, 0.0f), now) );
 			vPresses.push_back( DeviceInput(js.id, JOY_DOWN, std::max(level, 0.0f), now) );
@@ -176,7 +176,7 @@ void JoystickDevice::GetButtonPresses( std::vector<DeviceInput>& vPresses, IOHID
 		}
 		else if( js.z_axis == cookie )
 		{
-			float level = SCALE( value, js.z_min, js.z_max, -1.0f, 1.0f );
+			float level = (value - js.ry_min) * (1.0f - (-1.0f)) / (js.ry_max - js.ry_min) + (-1.0f);
 
 			vPresses.push_back( DeviceInput(js.id, JOY_Z_UP, std::max(-level, 0.0f), now) );
 			vPresses.push_back( DeviceInput(js.id, JOY_Z_DOWN, std::max(level, 0.0f), now) );
@@ -184,7 +184,7 @@ void JoystickDevice::GetButtonPresses( std::vector<DeviceInput>& vPresses, IOHID
 		}
 		else if( js.x_rot == cookie )
 		{
-			float level = SCALE( value, js.rx_min, js.rx_max, -1.0f, 1.0f );
+			float level = (value - js.ry_min) * (1.0f - (-1.0f)) / (js.ry_max - js.ry_min) + (-1.0f);
 
 			vPresses.push_back( DeviceInput(js.id, JOY_ROT_LEFT, std::max(-level, 0.0f), now) );
 			vPresses.push_back( DeviceInput(js.id, JOY_ROT_RIGHT, std::max(level, 0.0f), now) );
@@ -192,7 +192,7 @@ void JoystickDevice::GetButtonPresses( std::vector<DeviceInput>& vPresses, IOHID
 		}
 		else if( js.y_rot == cookie )
 		{
-			float level = SCALE( value, js.ry_min, js.ry_max, -1.0f, 1.0f );
+			float level = (value - js.ry_min) * (1.0f - (-1.0f)) / (js.ry_max - js.ry_min) + (-1.0f);
 
 			vPresses.push_back( DeviceInput(js.id, JOY_ROT_UP, std::max(-level, 0.0f), now) );
 			vPresses.push_back( DeviceInput(js.id, JOY_ROT_DOWN, std::max(level, 0.0f), now) );
@@ -200,7 +200,7 @@ void JoystickDevice::GetButtonPresses( std::vector<DeviceInput>& vPresses, IOHID
 		}
 		else if( js.z_rot == cookie )
 		{
-			float level = SCALE( value, js.rz_min, js.rz_max, -1.0f, 1.0f );
+			float level = (value - js.ry_min) * (1.0f - (-1.0f)) / (js.ry_max - js.ry_min) + (-1.0f);
 
 			vPresses.push_back( DeviceInput(js.id, JOY_ROT_Z_UP, std::max(-level, 0.0f), now) );
 			vPresses.push_back( DeviceInput(js.id, JOY_ROT_Z_DOWN, std::max(level, 0.0f), now) );

--- a/src/archutils/Darwin/MouseDevice.cpp
+++ b/src/archutils/Darwin/MouseDevice.cpp
@@ -119,7 +119,7 @@ void MouseDevice::GetButtonPresses( std::vector<DeviceInput>& vPresses, IOHIDEle
 	}
 	else if( m.z_axis == cookie )
 	{
-		float level = SCALE( value, m.z_min, m.z_max, -1.0f, 1.0f );
+		float level = (value - m.z_min) * (1.0f - (-1.0f)) / (m.z_max - m.z_min) + (-1.0f);
 		INPUTFILTER->ButtonPressed( DeviceInput(DEVICE_MOUSE, MOUSE_WHEELUP, std::max(-level, 0.0f), now) );
 		INPUTFILTER->ButtonPressed( DeviceInput(DEVICE_MOUSE, MOUSE_WHEELDOWN, std::max(+level, 0.0f), now) );
 	}

--- a/src/archutils/Unix/EmergencyShutdown.cpp
+++ b/src/archutils/Unix/EmergencyShutdown.cpp
@@ -8,7 +8,8 @@ static unsigned g_iNumEmergencyFuncs = 0;
 
 void RegisterEmergencyShutdownCallback( void (*pFunc)() )
 {
-	ASSERT( g_iNumEmergencyFuncs+1 < ARRAYLEN(g_pEmergencyFunc) );
+	unsigned iArrayLen = ArrayLenUnsigned(g_pEmergencyFunc);
+	ASSERT( g_iNumEmergencyFuncs+1 < iArrayLen );
 	g_pEmergencyFunc[ g_iNumEmergencyFuncs++ ] = pFunc;
 }
 

--- a/src/archutils/Win32/CrashHandlerChild.cpp
+++ b/src/archutils/Win32/CrashHandlerChild.cpp
@@ -135,7 +135,7 @@ namespace VDDebugInfo
 
 		pctx->sRawBlock = RString();
 		pctx->pRVAHeap = nullptr;
-		GetVDIPath( pctx->sFilename, ARRAYLEN(pctx->sFilename) );
+		GetVDIPath( pctx->sFilename, ArrayLenInt(pctx->sFilename) );
 		pctx->sError = RString();
 
 		HANDLE h = CreateFile( pctx->sFilename, GENERIC_READ, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr );

--- a/src/archutils/Win32/DialogUtil.cpp
+++ b/src/archutils/Win32/DialogUtil.cpp
@@ -65,7 +65,7 @@ void DialogUtil::LocalizeDialogAndContents( HWND hdlg )
 	RString sGroup;
 
 	{
-		::GetWindowText( hdlg, szTemp, ARRAYLEN(szTemp) );
+		::GetWindowText(hdlg, szTemp, (sizeof(szTemp) / sizeof((szTemp)[0])));
 		RString s = szTemp;
 		sGroup = "Dialog-"+s;
 		s = THEME->GetString( sGroup, s );
@@ -74,7 +74,7 @@ void DialogUtil::LocalizeDialogAndContents( HWND hdlg )
 
 	for( HWND hwndChild = ::GetTopWindow(hdlg); hwndChild != nullptr; hwndChild = ::GetNextWindow(hwndChild,GW_HWNDNEXT) )
 	{
-		::GetWindowText( hwndChild, szTemp, ARRAYLEN(szTemp) );
+		::GetWindowText(hwndChild, szTemp, (sizeof(szTemp) / sizeof((szTemp)[0])));
 		RString s = szTemp;
 		if( s.empty() )
 			continue;

--- a/src/archutils/Win32/GetFileInformation.cpp
+++ b/src/archutils/Win32/GetFileInformation.cpp
@@ -102,7 +102,7 @@ bool GetProcessFileName( std::uint32_t iProcessID, RString &sName )
 		}
 
 		MODULEENTRY32 me;
-		ZERO( me );
+		ZeroArray( me );
 		me.dwSize = sizeof(MODULEENTRY32);
 		bool bRet = !!Module32First( hSnap, &me );
 		CloseHandle( hSnap );

--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -189,7 +189,7 @@ static LRESULT CALLBACK GraphicsWindow_WndProc( HWND hWnd, UINT msg, WPARAM wPar
 static void AdjustVideoModeParams( VideoModeParams &p )
 {
 	DEVMODE dm;
-	ZERO( dm );
+	ZeroArray( dm );
 	dm.dmSize = sizeof(dm);
 	if( !EnumDisplaySettings(nullptr, ENUM_CURRENT_SETTINGS, &dm) )
 	{
@@ -233,7 +233,7 @@ RString GraphicsWindow::SetScreenMode( const VideoModeParams &p )
 	}
 
 	DEVMODE DevMode;
-	ZERO( DevMode );
+	ZeroArray( DevMode );
 	DevMode.dmSize = sizeof(DEVMODE);
 	DevMode.dmPelsWidth = p.width;
 	DevMode.dmPelsHeight = p.height;

--- a/src/archutils/Win32/VideoDriverInfo.cpp
+++ b/src/archutils/Win32/VideoDriverInfo.cpp
@@ -31,7 +31,7 @@ RString GetPrimaryVideoName()
 	for( int i=0; true; ++i )
 	{
 		DISPLAY_DEVICE dd;
-		ZERO( dd );
+		ZeroArray( dd );
 		dd.cb = sizeof(dd);
 		if( !EnumDisplayDevices(nullptr, i, &dd, 0) )
 			break;

--- a/src/smpackage/CreateLanguageDlg.cpp
+++ b/src/smpackage/CreateLanguageDlg.cpp
@@ -45,7 +45,8 @@ BOOL CreateLanguageDlg::OnInitDialog()
 	// TODO: Add extra initialization here
 	DialogUtil::LocalizeDialogAndContents( *this );
 
-	for( int i = 0; i < ARRAYLEN(g_aListedLanguageCodes); ++i )
+	const int iArrayLen = ArrayLenInt(g_aListedLanguageCodes);
+	for( int i = 0; i < iArrayLen); ++i )
 	{
 		RString s = SMPackageUtil::GetLanguageDisplayString(g_aListedLanguageCodes[i]);
 		RString sLanguage = ConvertUTF8ToACP( s );

--- a/src/smpackage/MainMenuDlg.cpp
+++ b/src/smpackage/MainMenuDlg.cpp
@@ -177,7 +177,7 @@ BOOL MainMenuDlg::OnInitDialog()
 	//DialogUtil::SetDlgItemHeader( *this, IDC_STATIC_HEADER_TEXT, "header" );
 
 	TCHAR szCurDir[MAX_PATH];
-	GetCurrentDirectory( ARRAYLEN(szCurDir), szCurDir );
+	GetCurrentDirectory( ArrayLenInt(szCurDir), szCurDir );
 	GetDlgItem( IDC_EDIT_INSTALLATION )->SetWindowText( szCurDir );
 
 	return TRUE;  // return TRUE unless you set the focus to a control

--- a/src/smpackage/smpackage.cpp
+++ b/src/smpackage/smpackage.cpp
@@ -60,7 +60,7 @@ BOOL CSmpackageApp::InitInstance()
 
 
 	TCHAR szCurrentDirectory[MAX_PATH];
-	GetCurrentDirectory( ARRAYLEN(szCurrentDirectory), szCurrentDirectory );
+	GetCurrentDirectory( ArrayLenInt(szCurrentDirectory), szCurrentDirectory );
 	if( CAN_INSTALL_PACKAGES && SMPackageUtil::IsValidInstallDir(szCurrentDirectory) )
 	{
 		SMPackageUtil::AddGameInstallDir( szCurrentDirectory );	// add this if it doesn't already exist

--- a/src/tests/test_audio_readers.cpp
+++ b/src/tests/test_audio_readers.cpp
@@ -355,7 +355,7 @@ bool RunTests( RageSoundReader *snd, const TestFile &tf )
 		if( !Identical )
 		{
 			LOG->Trace("Expected data:");
-			dump( tf.initial, ARRAYLEN(tf.initial) );
+			dump( tf.initial, sizeof(tf.initial) / sizeof(tf.initial[0]) );
 			LOG->Trace(" ");
 			bFailed = true;
 		}
@@ -373,7 +373,7 @@ bool RunTests( RageSoundReader *snd, const TestFile &tf )
 		if( !Identical )
 		{
 			LOG->Trace("Expected half second data:");
-                        dump( tf.later, ARRAYLEN(tf.later) );
+                        dump( tf.later, sizeof(tf.later) / sizeof(tf.later[0]) );
 			LOG->Trace("Got half second data:");
 			dump( LaterData, 16 );
 
@@ -416,7 +416,7 @@ bool RunTests( RageSoundReader *snd, const TestFile &tf )
 	while(1)
 	{
 		float buf[4096];
-		int got = snd->Read( buf, ARRAYLEN(buf) / snd->GetNumChannels() );
+		int got = snd->Read( buf, sizeof(buf) / sizeof(buf[0]) / snd->GetNumChannels() );
 		if( got == RageSoundReader::END_OF_FILE )
 			break;
 		ASSERT( got >= 0 );


### PR DESCRIPTION
`RageUtil` has a few macros which were used very heavily in the code base.  These macros see hundreds of usages in the code base so there is a LOT of changes here. These functions were inlined automatically by VS2022 so there is absolutely no functional change and they are guaranteed correct. Only a few functions had redundancy removed to increase readability but are functionally identical, most remain exactly as VS2022 inlined them.

 It is recommended to view the PR one commit at a time.

`SCALE` is NOT CHANGED due to impacting sync and many other aspects of the game directly;  we depend on the strange behavior of this macro unfortunately.

`ARRAYLEN` was straightforward to replace with constexpr functions. There is a series of them now since the code base will call `ARRAYLEN` to be used in conjunction with `int`, `unsigned`, or `size_t`. This is why there's a function for each of those three data types here. There are a few places I opted to simply inline `ARRAYLEN`'s original behavior, if it made sense to do that. In many places I decided to cast the array length to a variable and use that, though it isn't needed for everything to work as-is.

`ZERO` and `ONE` are not used many places, they were respectively renamed `ZeroArray` and `SetArrayToOne` to make the intent of the function more clear. No changes were needed besides renaming the function calls, everything worked as expected without having to change anything.

Changing `SAFE_DELETE` and `SAFE_DELETE_ARRAY` was easy because it worked as expected without having to change anything.