### PR TITLE
Remove low_sample_count_workaround

### DIFF
--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -296,13 +296,6 @@ void GameLoop::UpdateAllButDraw(bool bRunningFromVBLANK)
 	 * acting on song beat from last frame */
 	HandleInputEvents(fDeltaTime);
 
-	// Legacy hack to work around low sample count in some sound drivers.
-	// This is a workaround for a bug in the Windows sound system that causes
-	// the sound to be cut off if the sample count is too low. This is a
-	// workaround for the bug, but it's not a fix. It should probably be
-	// removed or localized to the DirectSound driver. --sukibaby
-	SOUNDMAN->low_sample_count_workaround();
-
 	// Update the lights
 	LIGHTSMAN->Update(fDeltaTime);
 }

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -284,7 +284,6 @@ PrefsManager::PrefsManager() :
 	m_bSmoothLines			( "SmoothLines",			true ),
 	m_iSoundWriteAhead		( "SoundWriteAhead",			0 ),
 	m_iSoundDevice			( "SoundDevice",			"" ),
-	m_iRageSoundSampleCountClamp	("RageSoundSampleCountClamp", 0), //some sound drivers mask the sample location number, the most popular number for this is 2^27, this causes lockup after ~50 minutes at 44.1khz sample rate
 	m_iSoundPreferredSampleRate	( "SoundPreferredSampleRate",		0 ),
 	m_sLightsStepsDifficulty	( "LightsStepsDifficulty",		"hard,medium" ),
 	m_bLightsSimplifyBass		( "LightsSimplifyBass",		false),

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -310,7 +310,6 @@ public:
 	Preference<bool>	m_bSmoothLines;
 	Preference<int>	m_iSoundWriteAhead;
 	Preference<RString>	m_iSoundDevice;
-	Preference<int> m_iRageSoundSampleCountClamp;
 	Preference<int>	m_iSoundPreferredSampleRate;
 	Preference<RString>	m_sLightsStepsDifficulty;
 	Preference<bool>	m_bLightsSimplifyBass;

--- a/src/RageSoundManager.cpp
+++ b/src/RageSoundManager.cpp
@@ -57,12 +57,6 @@ RageSoundManager::~RageSoundManager()
 	m_mapPreloadedSounds.clear();
 }
 
-
-void RageSoundManager::low_sample_count_workaround()
-{
-	m_pDriver->low_sample_count_workaround();
-}
-
 /*
  * Previously, we went to some lengths to shut down sounds before exiting threads.
  * The only other thread that actually starts sounds is SOUND.  Doing this was ugly;

--- a/src/RageSoundManager.h
+++ b/src/RageSoundManager.h
@@ -46,8 +46,6 @@ public:
 	RageSoundReader *GetLoadedSound( const RString &sPath );
 	void AddLoadedSound( const RString &sPath, RageSoundReader_Preload *pSound );
 
-	void low_sample_count_workaround();
-
 private:
 	std::map<RString, RageSoundReader_Preload *> m_mapPreloadedSounds;
 

--- a/src/arch/Sound/RageSoundDriver.h
+++ b/src/arch/Sound/RageSoundDriver.h
@@ -52,7 +52,6 @@ public:
 	 * RageSound::CommitPlayingPosition. */
 	std::int64_t GetHardwareFrame( RageTimer *pTimer ) const;
 	virtual std::int64_t GetPosition() const = 0;
-	void low_sample_count_workaround();
 
 	/* When a sound is finished playing (GetDataToPlay returns 0) and the sound has
 	 * been completely flushed (so GetPosition is no longer meaningful), call
@@ -205,7 +204,6 @@ private:
 	std::int64_t ClampHardwareFrame( std::int64_t iHardwareFrame ) const;
 	mutable std::int64_t m_iMaxHardwareFrame;
 	mutable std::int64_t m_iVMaxHardwareFrame;
-	mutable std::int32_t soundDriverMaxSamples = 0;
 
 	bool m_bShutdownDecodeThread;
 

--- a/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
@@ -450,11 +450,6 @@ void RageSoundDriver::SetDecodeBufferSize( int iFrames )
 	frames_to_buffer = iFrames;
 }
 
-void RageSoundDriver::low_sample_count_workaround()
-{
-	if (soundDriverMaxSamples != 0) GetHardwareFrame(nullptr);
-}
-
 RageSoundDriver::RageSoundDriver():
 	m_Mutex("RageSoundDriver"),
 	m_SoundListMutex("SoundListMutex")
@@ -463,7 +458,6 @@ RageSoundDriver::RageSoundDriver():
 	m_iMaxHardwareFrame = 0;
 	m_iVMaxHardwareFrame = 0;
 	SetDecodeBufferSize( 4096 );
-	soundDriverMaxSamples = PREFSMAN->m_iRageSoundSampleCountClamp;
 	m_DecodeThread.SetName("Decode thread");
 }
 


### PR DESCRIPTION
Not needed any longer, now that hardware clamping methods are corrected, so we can get rid of this and its associated variable.