### PR TITLE
New LinuxPacDrive lights driver [CI will fail until 495 is merged in]

### DIFF
--- a/src/arch/Lights/LightsDriver_LinuxPacDrive.h
+++ b/src/arch/Lights/LightsDriver_LinuxPacDrive.h
@@ -4,12 +4,46 @@
 #include "LightsDriver.h"
 
 #include <cstdint>
-
-extern "C" {
-#include <usb.h>
-}
+#include <libusb/libusb.h>
 
 #define BIT(i) (1<<(i))
+
+class USBContext
+{
+public:
+    static USBContext& getInstance()
+    {
+        static USBContext instance;
+        return instance;
+    }
+
+    libusb_context* getContext() { return context; }
+
+private:
+    USBContext()
+    {
+        int result = libusb_init(&context);
+        if (result < 0)
+        {
+            // initialization error
+            context = nullptr;
+        }
+    }
+
+    ~USBContext()
+    {
+        if (context)
+        {
+            libusb_exit(context);
+        }
+    }
+
+    libusb_context* context;
+
+    // prevent copying
+    USBContext(const USBContext&) = delete;
+    USBContext& operator=(const USBContext&) = delete;
+};
 
 class LightsDriver_LinuxPacDrive: public LightsDriver
 {
@@ -25,8 +59,8 @@ private:
 	void WriteDevice(std::uint16_t out);
 	void CloseDevice();
 
-	struct usb_device *Device;
-	usb_dev_handle *DeviceHandle;
+	struct libusb_device *Device;
+	libusb_device_handle *DeviceHandle;
 };
 
 #endif // LIGHTSDRIVER_LINUXPACDRIVE_H


### PR DESCRIPTION
This driver was rewritten for libusb 1.0,  so we can drop the libusb 0.1 dependency.

( this PR is just the driver files from #248 , so that we can instead use the new CMake etc from #495 - I made a separate PR because 248 is based on a five-month old beta, and would be a pain to rebase )

**CI will fail until 495 is merged in**