### PR TITLE
TimingData.h & NoteField.cpp/.h: macro removal

### DIFF
--- a/src/TimingData.cpp
+++ b/src/TimingData.cpp
@@ -1427,6 +1427,238 @@ std::vector<RString> TimingData::ToVectorString(TimingSegmentType tst, int dec) 
 	return ret;
 }
 
+// Segment adders, getters, and other functions
+const BPMSegment* TimingData::GetBPMSegmentAtRow(int iNoteRow) const {
+	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_BPM);
+	return ToBPM(t);
+}
+
+BPMSegment* TimingData::GetBPMSegmentAtRow(int iNoteRow) {
+	return const_cast<BPMSegment*>(((const TimingData*)this)->GetBPMSegmentAtRow(iNoteRow));
+}
+
+const BPMSegment* TimingData::GetBPMSegmentAtBeat(float fBeat) const {
+	return GetBPMSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+BPMSegment* TimingData::GetBPMSegmentAtBeat(float fBeat) {
+	return const_cast<BPMSegment*>(((const TimingData*)this)->GetBPMSegmentAtBeat(fBeat));
+}
+
+void TimingData::AddSegment(const BPMSegment& seg) {
+	AddSegment(&seg);
+}
+
+const StopSegment* TimingData::GetStopSegmentAtRow(int iNoteRow) const {
+	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_STOP);
+	return ToStop(t);
+}
+
+StopSegment* TimingData::GetStopSegmentAtRow(int iNoteRow) {
+	return const_cast<StopSegment*>(((const TimingData*)this)->GetStopSegmentAtRow(iNoteRow));
+}
+
+const StopSegment* TimingData::GetStopSegmentAtBeat(float fBeat) const {
+	return GetStopSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+StopSegment* TimingData::GetStopSegmentAtBeat(float fBeat) {
+	return const_cast<StopSegment*>(((const TimingData*)this)->GetStopSegmentAtBeat(fBeat));
+}
+
+void TimingData::AddSegment(const StopSegment& seg) {
+	AddSegment(&seg);
+}
+
+const DelaySegment* TimingData::GetDelaySegmentAtRow(int iNoteRow) const {
+	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_DELAY);
+	return ToDelay(t);
+}
+
+DelaySegment* TimingData::GetDelaySegmentAtRow(int iNoteRow) {
+	return const_cast<DelaySegment*>(((const TimingData*)this)->GetDelaySegmentAtRow(iNoteRow));
+}
+
+const DelaySegment* TimingData::GetDelaySegmentAtBeat(float fBeat) const {
+	return GetDelaySegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+DelaySegment* TimingData::GetDelaySegmentAtBeat(float fBeat) {
+	return const_cast<DelaySegment*>(((const TimingData*)this)->GetDelaySegmentAtBeat(fBeat));
+}
+
+void TimingData::AddSegment(const DelaySegment& seg) {
+	AddSegment(&seg);
+}
+
+const WarpSegment* TimingData::GetWarpSegmentAtRow(int iNoteRow) const {
+	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_WARP);
+	return ToWarp(t);
+}
+
+WarpSegment* TimingData::GetWarpSegmentAtRow(int iNoteRow) {
+	return const_cast<WarpSegment*>(((const TimingData*)this)->GetWarpSegmentAtRow(iNoteRow));
+}
+
+const WarpSegment* TimingData::GetWarpSegmentAtBeat(float fBeat) const {
+	return GetWarpSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+WarpSegment* TimingData::GetWarpSegmentAtBeat(float fBeat) {
+	return const_cast<WarpSegment*>(((const TimingData*)this)->GetWarpSegmentAtBeat(fBeat));
+}
+
+void TimingData::AddSegment(const WarpSegment& seg) {
+	AddSegment(&seg);
+}
+
+const LabelSegment* TimingData::GetLabelSegmentAtRow(int iNoteRow) const {
+	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_LABEL);
+	return ToLabel(t);
+}
+
+LabelSegment* TimingData::GetLabelSegmentAtRow(int iNoteRow) {
+	return const_cast<LabelSegment*>(((const TimingData*)this)->GetLabelSegmentAtRow(iNoteRow));
+}
+
+const LabelSegment* TimingData::GetLabelSegmentAtBeat(float fBeat) const {
+	return GetLabelSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+LabelSegment* TimingData::GetLabelSegmentAtBeat(float fBeat) {
+	return const_cast<LabelSegment*>(((const TimingData*)this)->GetLabelSegmentAtBeat(fBeat));
+}
+
+void TimingData::AddSegment(const LabelSegment& seg) {
+	AddSegment(&seg);
+}
+
+const TickcountSegment* TimingData::GetTickcountSegmentAtRow(int iNoteRow) const {
+	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_TICKCOUNT);
+	return ToTickcount(t);
+}
+
+TickcountSegment* TimingData::GetTickcountSegmentAtRow(int iNoteRow) {
+	return const_cast<TickcountSegment*>(((const TimingData*)this)->GetTickcountSegmentAtRow(iNoteRow));
+}
+
+const TickcountSegment* TimingData::GetTickcountSegmentAtBeat(float fBeat) const {
+	return GetTickcountSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+TickcountSegment* TimingData::GetTickcountSegmentAtBeat(float fBeat) {
+	return const_cast<TickcountSegment*>(((const TimingData*)this)->GetTickcountSegmentAtBeat(fBeat));
+}
+
+void TimingData::AddSegment(const TickcountSegment& seg) {
+	AddSegment(&seg);
+}
+
+const ComboSegment* TimingData::GetComboSegmentAtRow(int iNoteRow) const {
+	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_COMBO);
+	return ToCombo(t);
+}
+
+ComboSegment* TimingData::GetComboSegmentAtRow(int iNoteRow) {
+	return const_cast<ComboSegment*>(((const TimingData*)this)->GetComboSegmentAtRow(iNoteRow));
+}
+
+const ComboSegment* TimingData::GetComboSegmentAtBeat(float fBeat) const {
+	return GetComboSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+ComboSegment* TimingData::GetComboSegmentAtBeat(float fBeat) {
+	return const_cast<ComboSegment*>(((const TimingData*)this)->GetComboSegmentAtBeat(fBeat));
+}
+
+void TimingData::AddSegment(const ComboSegment& seg) {
+	AddSegment(&seg);
+}
+
+const SpeedSegment* TimingData::GetSpeedSegmentAtRow(int iNoteRow) const {
+	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_SPEED);
+	return ToSpeed(t);
+}
+
+SpeedSegment* TimingData::GetSpeedSegmentAtRow(int iNoteRow) {
+	return const_cast<SpeedSegment*>(((const TimingData*)this)->GetSpeedSegmentAtRow(iNoteRow));
+}
+
+const SpeedSegment* TimingData::GetSpeedSegmentAtBeat(float fBeat) const {
+	return GetSpeedSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+SpeedSegment* TimingData::GetSpeedSegmentAtBeat(float fBeat) {
+	return const_cast<SpeedSegment*>(((const TimingData*)this)->GetSpeedSegmentAtBeat(fBeat));
+}
+
+void TimingData::AddSegment(const SpeedSegment& seg) {
+	AddSegment(&seg);
+}
+
+const ScrollSegment* TimingData::GetScrollSegmentAtRow(int iNoteRow) const {
+	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_SCROLL);
+	return ToScroll(t);
+}
+
+ScrollSegment* TimingData::GetScrollSegmentAtRow(int iNoteRow) {
+	return const_cast<ScrollSegment*>(((const TimingData*)this)->GetScrollSegmentAtRow(iNoteRow));
+}
+
+const ScrollSegment* TimingData::GetScrollSegmentAtBeat(float fBeat) const {
+	return GetScrollSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+ScrollSegment* TimingData::GetScrollSegmentAtBeat(float fBeat) {
+	return const_cast<ScrollSegment*>(((const TimingData*)this)->GetScrollSegmentAtBeat(fBeat));
+}
+
+void TimingData::AddSegment(const ScrollSegment& seg) {
+	AddSegment(&seg);
+}
+
+const FakeSegment* TimingData::GetFakeSegmentAtRow(int iNoteRow) const {
+	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_FAKE);
+	return ToFake(t);
+}
+
+FakeSegment* TimingData::GetFakeSegmentAtRow(int iNoteRow) {
+	return const_cast<FakeSegment*>(((const TimingData*)this)->GetFakeSegmentAtRow(iNoteRow));
+}
+
+const FakeSegment* TimingData::GetFakeSegmentAtBeat(float fBeat) const {
+	return GetFakeSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+FakeSegment* TimingData::GetFakeSegmentAtBeat(float fBeat) {
+	return const_cast<FakeSegment*>(((const TimingData*)this)->GetFakeSegmentAtBeat(fBeat));
+}
+
+void TimingData::AddSegment(const FakeSegment& seg) {
+	AddSegment(&seg);
+}
+
+const TimeSignatureSegment* TimingData::GetTimeSignatureSegmentAtRow(int iNoteRow) const {
+	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_TIME_SIG);
+	return ToTimeSignature(t);
+}
+
+TimeSignatureSegment* TimingData::GetTimeSignatureSegmentAtRow(int iNoteRow) {
+	return const_cast<TimeSignatureSegment*>(((const TimingData*)this)->GetTimeSignatureSegmentAtRow(iNoteRow));
+}
+
+const TimeSignatureSegment* TimingData::GetTimeSignatureSegmentAtBeat(float fBeat) const {
+	return GetTimeSignatureSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+TimeSignatureSegment* TimingData::GetTimeSignatureSegmentAtBeat(float fBeat) {
+	return const_cast<TimeSignatureSegment*>(((const TimingData*)this)->GetTimeSignatureSegmentAtBeat(fBeat));
+}
+
+void TimingData::AddSegment(const TimeSignatureSegment& seg) {
+	AddSegment(&seg);
+}
+
 // lua start
 #include "LuaBinding.h"
 

--- a/src/TimingData.cpp
+++ b/src/TimingData.cpp
@@ -12,6 +12,7 @@
 #include <cstddef>
 #include <vector>
 
+
 static void EraseSegment(std::vector<TimingSegment*> &vSegs, int index, TimingSegment *cur);
 static const int INVALID_INDEX = -1;
 
@@ -19,138 +20,6 @@ TimingSegment* GetSegmentAtRow( int iNoteRow, TimingSegmentType tst );
 
 TimingData::TimingData(float fOffset) : m_fBeat0OffsetInSeconds(fOffset)
 {
-}
-
-const BPMSegment* ToBPM(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_BPM);
-    return static_cast<const BPMSegment*>(t);
-}
-
-BPMSegment* ToBPM(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_BPM);
-    return static_cast<BPMSegment*>(t);
-}
-
-const StopSegment* ToStop(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_STOP);
-    return static_cast<const StopSegment*>(t);
-}
-
-StopSegment* ToStop(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_STOP);
-    return static_cast<StopSegment*>(t);
-}
-
-const DelaySegment* ToDelay(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_DELAY);
-    return static_cast<const DelaySegment*>(t);
-}
-
-DelaySegment* ToDelay(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_DELAY);
-    return static_cast<DelaySegment*>(t);
-}
-
-const TimeSignatureSegment* ToTimeSignature(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_TIME_SIG);
-    return static_cast<const TimeSignatureSegment*>(t);
-}
-
-TimeSignatureSegment* ToTimeSignature(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_TIME_SIG);
-    return static_cast<TimeSignatureSegment*>(t);
-}
-
-const WarpSegment* ToWarp(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_WARP);
-    return static_cast<const WarpSegment*>(t);
-}
-
-WarpSegment* ToWarp(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_WARP);
-    return static_cast<WarpSegment*>(t);
-}
-
-const LabelSegment* ToLabel(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_LABEL);
-    return static_cast<const LabelSegment*>(t);
-}
-
-LabelSegment* ToLabel(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_LABEL);
-    return static_cast<LabelSegment*>(t);
-}
-
-const TickcountSegment* ToTickcount(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_TICKCOUNT);
-    return static_cast<const TickcountSegment*>(t);
-}
-
-TickcountSegment* ToTickcount(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_TICKCOUNT);
-    return static_cast<TickcountSegment*>(t);
-}
-
-const ComboSegment* ToCombo(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_COMBO);
-    return static_cast<const ComboSegment*>(t);
-}
-
-ComboSegment* ToCombo(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_COMBO);
-    return static_cast<ComboSegment*>(t);
-}
-
-const SpeedSegment* ToSpeed(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_SPEED);
-    return static_cast<const SpeedSegment*>(t);
-}
-
-SpeedSegment* ToSpeed(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_SPEED);
-    return static_cast<SpeedSegment*>(t);
-}
-
-const ScrollSegment* ToScroll(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_SCROLL);
-    return static_cast<const ScrollSegment*>(t);
-}
-
-ScrollSegment* ToScroll(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_SCROLL);
-    return static_cast<ScrollSegment*>(t);
-}
-
-const FakeSegment* ToFake(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_FAKE);
-    return static_cast<const FakeSegment*>(t);
-}
-
-FakeSegment* ToFake(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_FAKE);
-    return static_cast<FakeSegment*>(t);
 }
 
 void TimingData::Copy( const TimingData& cpy )
@@ -1428,6 +1297,138 @@ std::vector<RString> TimingData::ToVectorString(TimingSegmentType tst, int dec) 
 }
 
 // Segment adders, getters, and other functions
+const BPMSegment* ToBPM(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_BPM);
+    return static_cast<const BPMSegment*>(t);
+}
+
+BPMSegment* ToBPM(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_BPM);
+    return static_cast<BPMSegment*>(t);
+}
+
+const StopSegment* ToStop(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_STOP);
+    return static_cast<const StopSegment*>(t);
+}
+
+StopSegment* ToStop(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_STOP);
+    return static_cast<StopSegment*>(t);
+}
+
+const DelaySegment* ToDelay(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_DELAY);
+    return static_cast<const DelaySegment*>(t);
+}
+
+DelaySegment* ToDelay(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_DELAY);
+    return static_cast<DelaySegment*>(t);
+}
+
+const TimeSignatureSegment* ToTimeSignature(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_TIME_SIG);
+    return static_cast<const TimeSignatureSegment*>(t);
+}
+
+TimeSignatureSegment* ToTimeSignature(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_TIME_SIG);
+    return static_cast<TimeSignatureSegment*>(t);
+}
+
+const WarpSegment* ToWarp(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_WARP);
+    return static_cast<const WarpSegment*>(t);
+}
+
+WarpSegment* ToWarp(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_WARP);
+    return static_cast<WarpSegment*>(t);
+}
+
+const LabelSegment* ToLabel(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_LABEL);
+    return static_cast<const LabelSegment*>(t);
+}
+
+LabelSegment* ToLabel(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_LABEL);
+    return static_cast<LabelSegment*>(t);
+}
+
+const TickcountSegment* ToTickcount(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_TICKCOUNT);
+    return static_cast<const TickcountSegment*>(t);
+}
+
+TickcountSegment* ToTickcount(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_TICKCOUNT);
+    return static_cast<TickcountSegment*>(t);
+}
+
+const ComboSegment* ToCombo(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_COMBO);
+    return static_cast<const ComboSegment*>(t);
+}
+
+ComboSegment* ToCombo(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_COMBO);
+    return static_cast<ComboSegment*>(t);
+}
+
+const SpeedSegment* ToSpeed(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_SPEED);
+    return static_cast<const SpeedSegment*>(t);
+}
+
+SpeedSegment* ToSpeed(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_SPEED);
+    return static_cast<SpeedSegment*>(t);
+}
+
+const ScrollSegment* ToScroll(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_SCROLL);
+    return static_cast<const ScrollSegment*>(t);
+}
+
+ScrollSegment* ToScroll(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_SCROLL);
+    return static_cast<ScrollSegment*>(t);
+}
+
+const FakeSegment* ToFake(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_FAKE);
+    return static_cast<const FakeSegment*>(t);
+}
+
+FakeSegment* ToFake(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_FAKE);
+    return static_cast<FakeSegment*>(t);
+}
+
 const BPMSegment* TimingData::GetBPMSegmentAtRow(int iNoteRow) const {
 	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_BPM);
 	return ToBPM(t);

--- a/src/TimingData.cpp
+++ b/src/TimingData.cpp
@@ -1297,138 +1297,95 @@ std::vector<RString> TimingData::ToVectorString(TimingSegmentType tst, int dec) 
 }
 
 // Segment adders, getters, and other functions
-const BPMSegment* ToBPM(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_BPM);
+const BPMSegment* ToBPM(const TimingSegment* t) {
     return static_cast<const BPMSegment*>(t);
 }
 
-BPMSegment* ToBPM(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_BPM);
+BPMSegment* ToBPM(TimingSegment* t) {
     return static_cast<BPMSegment*>(t);
 }
 
-const StopSegment* ToStop(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_STOP);
+const StopSegment* ToStop(const TimingSegment* t) {
     return static_cast<const StopSegment*>(t);
 }
 
-StopSegment* ToStop(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_STOP);
+StopSegment* ToStop(TimingSegment* t) {
     return static_cast<StopSegment*>(t);
 }
 
-const DelaySegment* ToDelay(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_DELAY);
+const DelaySegment* ToDelay(const TimingSegment* t) {
     return static_cast<const DelaySegment*>(t);
 }
 
-DelaySegment* ToDelay(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_DELAY);
+DelaySegment* ToDelay(TimingSegment* t) {
     return static_cast<DelaySegment*>(t);
 }
 
-const TimeSignatureSegment* ToTimeSignature(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_TIME_SIG);
+const TimeSignatureSegment* ToTimeSignature(const TimingSegment* t) {
     return static_cast<const TimeSignatureSegment*>(t);
 }
 
-TimeSignatureSegment* ToTimeSignature(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_TIME_SIG);
+TimeSignatureSegment* ToTimeSignature(TimingSegment* t) {
     return static_cast<TimeSignatureSegment*>(t);
 }
 
-const WarpSegment* ToWarp(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_WARP);
+const WarpSegment* ToWarp(const TimingSegment* t) {
     return static_cast<const WarpSegment*>(t);
 }
 
-WarpSegment* ToWarp(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_WARP);
+WarpSegment* ToWarp(TimingSegment* t) {
     return static_cast<WarpSegment*>(t);
 }
 
-const LabelSegment* ToLabel(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_LABEL);
+const LabelSegment* ToLabel(const TimingSegment* t) {
     return static_cast<const LabelSegment*>(t);
 }
 
-LabelSegment* ToLabel(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_LABEL);
+LabelSegment* ToLabel(TimingSegment* t) {
     return static_cast<LabelSegment*>(t);
 }
 
-const TickcountSegment* ToTickcount(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_TICKCOUNT);
+const TickcountSegment* ToTickcount(const TimingSegment* t) {
     return static_cast<const TickcountSegment*>(t);
 }
 
-TickcountSegment* ToTickcount(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_TICKCOUNT);
+TickcountSegment* ToTickcount(TimingSegment* t) {
     return static_cast<TickcountSegment*>(t);
 }
 
-const ComboSegment* ToCombo(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_COMBO);
+const ComboSegment* ToCombo(const TimingSegment* t) {
     return static_cast<const ComboSegment*>(t);
 }
 
-ComboSegment* ToCombo(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_COMBO);
+ComboSegment* ToCombo(TimingSegment* t) {
     return static_cast<ComboSegment*>(t);
 }
 
-const SpeedSegment* ToSpeed(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_SPEED);
+const SpeedSegment* ToSpeed(const TimingSegment* t) {
     return static_cast<const SpeedSegment*>(t);
 }
 
-SpeedSegment* ToSpeed(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_SPEED);
+SpeedSegment* ToSpeed(TimingSegment* t) {
     return static_cast<SpeedSegment*>(t);
 }
 
-const ScrollSegment* ToScroll(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_SCROLL);
+const ScrollSegment* ToScroll(const TimingSegment* t) {
     return static_cast<const ScrollSegment*>(t);
 }
 
-ScrollSegment* ToScroll(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_SCROLL);
+ScrollSegment* ToScroll(TimingSegment* t) {
     return static_cast<ScrollSegment*>(t);
 }
 
-const FakeSegment* ToFake(const TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_FAKE);
+const FakeSegment* ToFake(const TimingSegment* t) {
     return static_cast<const FakeSegment*>(t);
 }
 
-FakeSegment* ToFake(TimingSegment* t)
-{
-    ASSERT(t->GetType() == SEGMENT_FAKE);
+FakeSegment* ToFake(TimingSegment* t) {
     return static_cast<FakeSegment*>(t);
 }
 
+// Get*SegmentAtRow methods
 const BPMSegment* TimingData::GetBPMSegmentAtRow(int iNoteRow) const {
 	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_BPM);
 	return ToBPM(t);
@@ -1436,18 +1393,6 @@ const BPMSegment* TimingData::GetBPMSegmentAtRow(int iNoteRow) const {
 
 BPMSegment* TimingData::GetBPMSegmentAtRow(int iNoteRow) {
 	return const_cast<BPMSegment*>(((const TimingData*)this)->GetBPMSegmentAtRow(iNoteRow));
-}
-
-const BPMSegment* TimingData::GetBPMSegmentAtBeat(float fBeat) const {
-	return GetBPMSegmentAtRow(BeatToNoteRow(fBeat));
-}
-
-BPMSegment* TimingData::GetBPMSegmentAtBeat(float fBeat) {
-	return const_cast<BPMSegment*>(((const TimingData*)this)->GetBPMSegmentAtBeat(fBeat));
-}
-
-void TimingData::AddSegment(const BPMSegment& seg) {
-	AddSegment(&seg);
 }
 
 const StopSegment* TimingData::GetStopSegmentAtRow(int iNoteRow) const {
@@ -1459,18 +1404,6 @@ StopSegment* TimingData::GetStopSegmentAtRow(int iNoteRow) {
 	return const_cast<StopSegment*>(((const TimingData*)this)->GetStopSegmentAtRow(iNoteRow));
 }
 
-const StopSegment* TimingData::GetStopSegmentAtBeat(float fBeat) const {
-	return GetStopSegmentAtRow(BeatToNoteRow(fBeat));
-}
-
-StopSegment* TimingData::GetStopSegmentAtBeat(float fBeat) {
-	return const_cast<StopSegment*>(((const TimingData*)this)->GetStopSegmentAtBeat(fBeat));
-}
-
-void TimingData::AddSegment(const StopSegment& seg) {
-	AddSegment(&seg);
-}
-
 const DelaySegment* TimingData::GetDelaySegmentAtRow(int iNoteRow) const {
 	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_DELAY);
 	return ToDelay(t);
@@ -1478,18 +1411,6 @@ const DelaySegment* TimingData::GetDelaySegmentAtRow(int iNoteRow) const {
 
 DelaySegment* TimingData::GetDelaySegmentAtRow(int iNoteRow) {
 	return const_cast<DelaySegment*>(((const TimingData*)this)->GetDelaySegmentAtRow(iNoteRow));
-}
-
-const DelaySegment* TimingData::GetDelaySegmentAtBeat(float fBeat) const {
-	return GetDelaySegmentAtRow(BeatToNoteRow(fBeat));
-}
-
-DelaySegment* TimingData::GetDelaySegmentAtBeat(float fBeat) {
-	return const_cast<DelaySegment*>(((const TimingData*)this)->GetDelaySegmentAtBeat(fBeat));
-}
-
-void TimingData::AddSegment(const DelaySegment& seg) {
-	AddSegment(&seg);
 }
 
 const WarpSegment* TimingData::GetWarpSegmentAtRow(int iNoteRow) const {
@@ -1501,18 +1422,6 @@ WarpSegment* TimingData::GetWarpSegmentAtRow(int iNoteRow) {
 	return const_cast<WarpSegment*>(((const TimingData*)this)->GetWarpSegmentAtRow(iNoteRow));
 }
 
-const WarpSegment* TimingData::GetWarpSegmentAtBeat(float fBeat) const {
-	return GetWarpSegmentAtRow(BeatToNoteRow(fBeat));
-}
-
-WarpSegment* TimingData::GetWarpSegmentAtBeat(float fBeat) {
-	return const_cast<WarpSegment*>(((const TimingData*)this)->GetWarpSegmentAtBeat(fBeat));
-}
-
-void TimingData::AddSegment(const WarpSegment& seg) {
-	AddSegment(&seg);
-}
-
 const LabelSegment* TimingData::GetLabelSegmentAtRow(int iNoteRow) const {
 	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_LABEL);
 	return ToLabel(t);
@@ -1520,18 +1429,6 @@ const LabelSegment* TimingData::GetLabelSegmentAtRow(int iNoteRow) const {
 
 LabelSegment* TimingData::GetLabelSegmentAtRow(int iNoteRow) {
 	return const_cast<LabelSegment*>(((const TimingData*)this)->GetLabelSegmentAtRow(iNoteRow));
-}
-
-const LabelSegment* TimingData::GetLabelSegmentAtBeat(float fBeat) const {
-	return GetLabelSegmentAtRow(BeatToNoteRow(fBeat));
-}
-
-LabelSegment* TimingData::GetLabelSegmentAtBeat(float fBeat) {
-	return const_cast<LabelSegment*>(((const TimingData*)this)->GetLabelSegmentAtBeat(fBeat));
-}
-
-void TimingData::AddSegment(const LabelSegment& seg) {
-	AddSegment(&seg);
 }
 
 const TickcountSegment* TimingData::GetTickcountSegmentAtRow(int iNoteRow) const {
@@ -1543,18 +1440,6 @@ TickcountSegment* TimingData::GetTickcountSegmentAtRow(int iNoteRow) {
 	return const_cast<TickcountSegment*>(((const TimingData*)this)->GetTickcountSegmentAtRow(iNoteRow));
 }
 
-const TickcountSegment* TimingData::GetTickcountSegmentAtBeat(float fBeat) const {
-	return GetTickcountSegmentAtRow(BeatToNoteRow(fBeat));
-}
-
-TickcountSegment* TimingData::GetTickcountSegmentAtBeat(float fBeat) {
-	return const_cast<TickcountSegment*>(((const TimingData*)this)->GetTickcountSegmentAtBeat(fBeat));
-}
-
-void TimingData::AddSegment(const TickcountSegment& seg) {
-	AddSegment(&seg);
-}
-
 const ComboSegment* TimingData::GetComboSegmentAtRow(int iNoteRow) const {
 	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_COMBO);
 	return ToCombo(t);
@@ -1562,18 +1447,6 @@ const ComboSegment* TimingData::GetComboSegmentAtRow(int iNoteRow) const {
 
 ComboSegment* TimingData::GetComboSegmentAtRow(int iNoteRow) {
 	return const_cast<ComboSegment*>(((const TimingData*)this)->GetComboSegmentAtRow(iNoteRow));
-}
-
-const ComboSegment* TimingData::GetComboSegmentAtBeat(float fBeat) const {
-	return GetComboSegmentAtRow(BeatToNoteRow(fBeat));
-}
-
-ComboSegment* TimingData::GetComboSegmentAtBeat(float fBeat) {
-	return const_cast<ComboSegment*>(((const TimingData*)this)->GetComboSegmentAtBeat(fBeat));
-}
-
-void TimingData::AddSegment(const ComboSegment& seg) {
-	AddSegment(&seg);
 }
 
 const SpeedSegment* TimingData::GetSpeedSegmentAtRow(int iNoteRow) const {
@@ -1585,18 +1458,6 @@ SpeedSegment* TimingData::GetSpeedSegmentAtRow(int iNoteRow) {
 	return const_cast<SpeedSegment*>(((const TimingData*)this)->GetSpeedSegmentAtRow(iNoteRow));
 }
 
-const SpeedSegment* TimingData::GetSpeedSegmentAtBeat(float fBeat) const {
-	return GetSpeedSegmentAtRow(BeatToNoteRow(fBeat));
-}
-
-SpeedSegment* TimingData::GetSpeedSegmentAtBeat(float fBeat) {
-	return const_cast<SpeedSegment*>(((const TimingData*)this)->GetSpeedSegmentAtBeat(fBeat));
-}
-
-void TimingData::AddSegment(const SpeedSegment& seg) {
-	AddSegment(&seg);
-}
-
 const ScrollSegment* TimingData::GetScrollSegmentAtRow(int iNoteRow) const {
 	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_SCROLL);
 	return ToScroll(t);
@@ -1604,18 +1465,6 @@ const ScrollSegment* TimingData::GetScrollSegmentAtRow(int iNoteRow) const {
 
 ScrollSegment* TimingData::GetScrollSegmentAtRow(int iNoteRow) {
 	return const_cast<ScrollSegment*>(((const TimingData*)this)->GetScrollSegmentAtRow(iNoteRow));
-}
-
-const ScrollSegment* TimingData::GetScrollSegmentAtBeat(float fBeat) const {
-	return GetScrollSegmentAtRow(BeatToNoteRow(fBeat));
-}
-
-ScrollSegment* TimingData::GetScrollSegmentAtBeat(float fBeat) {
-	return const_cast<ScrollSegment*>(((const TimingData*)this)->GetScrollSegmentAtBeat(fBeat));
-}
-
-void TimingData::AddSegment(const ScrollSegment& seg) {
-	AddSegment(&seg);
 }
 
 const FakeSegment* TimingData::GetFakeSegmentAtRow(int iNoteRow) const {
@@ -1627,18 +1476,6 @@ FakeSegment* TimingData::GetFakeSegmentAtRow(int iNoteRow) {
 	return const_cast<FakeSegment*>(((const TimingData*)this)->GetFakeSegmentAtRow(iNoteRow));
 }
 
-const FakeSegment* TimingData::GetFakeSegmentAtBeat(float fBeat) const {
-	return GetFakeSegmentAtRow(BeatToNoteRow(fBeat));
-}
-
-FakeSegment* TimingData::GetFakeSegmentAtBeat(float fBeat) {
-	return const_cast<FakeSegment*>(((const TimingData*)this)->GetFakeSegmentAtBeat(fBeat));
-}
-
-void TimingData::AddSegment(const FakeSegment& seg) {
-	AddSegment(&seg);
-}
-
 const TimeSignatureSegment* TimingData::GetTimeSignatureSegmentAtRow(int iNoteRow) const {
 	const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_TIME_SIG);
 	return ToTimeSignature(t);
@@ -1648,12 +1485,134 @@ TimeSignatureSegment* TimingData::GetTimeSignatureSegmentAtRow(int iNoteRow) {
 	return const_cast<TimeSignatureSegment*>(((const TimingData*)this)->GetTimeSignatureSegmentAtRow(iNoteRow));
 }
 
+// Get*SegmentAtBeat methods
+const BPMSegment* TimingData::GetBPMSegmentAtBeat(float fBeat) const {
+	return GetBPMSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+BPMSegment* TimingData::GetBPMSegmentAtBeat(float fBeat) {
+	return const_cast<BPMSegment*>(((const TimingData*)this)->GetBPMSegmentAtBeat(fBeat));
+}
+
+const StopSegment* TimingData::GetStopSegmentAtBeat(float fBeat) const {
+	return GetStopSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+StopSegment* TimingData::GetStopSegmentAtBeat(float fBeat) {
+	return const_cast<StopSegment*>(((const TimingData*)this)->GetStopSegmentAtBeat(fBeat));
+}
+
+const DelaySegment* TimingData::GetDelaySegmentAtBeat(float fBeat) const {
+	return GetDelaySegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+DelaySegment* TimingData::GetDelaySegmentAtBeat(float fBeat) {
+	return const_cast<DelaySegment*>(((const TimingData*)this)->GetDelaySegmentAtBeat(fBeat));
+}
+
+const WarpSegment* TimingData::GetWarpSegmentAtBeat(float fBeat) const {
+	return GetWarpSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+WarpSegment* TimingData::GetWarpSegmentAtBeat(float fBeat) {
+	return const_cast<WarpSegment*>(((const TimingData*)this)->GetWarpSegmentAtBeat(fBeat));
+}
+
+const LabelSegment* TimingData::GetLabelSegmentAtBeat(float fBeat) const {
+	return GetLabelSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+LabelSegment* TimingData::GetLabelSegmentAtBeat(float fBeat) {
+	return const_cast<LabelSegment*>(((const TimingData*)this)->GetLabelSegmentAtBeat(fBeat));
+}
+
+const TickcountSegment* TimingData::GetTickcountSegmentAtBeat(float fBeat) const {
+	return GetTickcountSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+TickcountSegment* TimingData::GetTickcountSegmentAtBeat(float fBeat) {
+	return const_cast<TickcountSegment*>(((const TimingData*)this)->GetTickcountSegmentAtBeat(fBeat));
+}
+
+const ComboSegment* TimingData::GetComboSegmentAtBeat(float fBeat) const {
+	return GetComboSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+ComboSegment* TimingData::GetComboSegmentAtBeat(float fBeat) {
+	return const_cast<ComboSegment*>(((const TimingData*)this)->GetComboSegmentAtBeat(fBeat));
+}
+
+const SpeedSegment* TimingData::GetSpeedSegmentAtBeat(float fBeat) const {
+	return GetSpeedSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+SpeedSegment* TimingData::GetSpeedSegmentAtBeat(float fBeat) {
+	return const_cast<SpeedSegment*>(((const TimingData*)this)->GetSpeedSegmentAtBeat(fBeat));
+}
+
+const ScrollSegment* TimingData::GetScrollSegmentAtBeat(float fBeat) const {
+	return GetScrollSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+ScrollSegment* TimingData::GetScrollSegmentAtBeat(float fBeat) {
+	return const_cast<ScrollSegment*>(((const TimingData*)this)->GetScrollSegmentAtBeat(fBeat));
+}
+
+const FakeSegment* TimingData::GetFakeSegmentAtBeat(float fBeat) const {
+	return GetFakeSegmentAtRow(BeatToNoteRow(fBeat));
+}
+
+FakeSegment* TimingData::GetFakeSegmentAtBeat(float fBeat) {
+	return const_cast<FakeSegment*>(((const TimingData*)this)->GetFakeSegmentAtBeat(fBeat));
+}
+
 const TimeSignatureSegment* TimingData::GetTimeSignatureSegmentAtBeat(float fBeat) const {
 	return GetTimeSignatureSegmentAtRow(BeatToNoteRow(fBeat));
 }
 
 TimeSignatureSegment* TimingData::GetTimeSignatureSegmentAtBeat(float fBeat) {
 	return const_cast<TimeSignatureSegment*>(((const TimingData*)this)->GetTimeSignatureSegmentAtBeat(fBeat));
+}
+
+// AddSegment methods
+void TimingData::AddSegment(const BPMSegment& seg) {
+	AddSegment(&seg);
+}
+
+void TimingData::AddSegment(const StopSegment& seg) {
+	AddSegment(&seg);
+}
+
+void TimingData::AddSegment(const DelaySegment& seg) {
+	AddSegment(&seg);
+}
+
+void TimingData::AddSegment(const WarpSegment& seg) {
+	AddSegment(&seg);
+}
+
+void TimingData::AddSegment(const LabelSegment& seg) {
+	AddSegment(&seg);
+}
+
+void TimingData::AddSegment(const TickcountSegment& seg) {
+	AddSegment(&seg);
+}
+
+void TimingData::AddSegment(const ComboSegment& seg) {
+	AddSegment(&seg);
+}
+
+void TimingData::AddSegment(const SpeedSegment& seg) {
+	AddSegment(&seg);
+}
+
+void TimingData::AddSegment(const ScrollSegment& seg) {
+	AddSegment(&seg);
+}
+
+void TimingData::AddSegment(const FakeSegment& seg) {
+	AddSegment(&seg);
 }
 
 void TimingData::AddSegment(const TimeSignatureSegment& seg) {

--- a/src/TimingData.cpp
+++ b/src/TimingData.cpp
@@ -12,7 +12,6 @@
 #include <cstddef>
 #include <vector>
 
-
 static void EraseSegment(std::vector<TimingSegment*> &vSegs, int index, TimingSegment *cur);
 static const int INVALID_INDEX = -1;
 
@@ -20,6 +19,138 @@ TimingSegment* GetSegmentAtRow( int iNoteRow, TimingSegmentType tst );
 
 TimingData::TimingData(float fOffset) : m_fBeat0OffsetInSeconds(fOffset)
 {
+}
+
+const BPMSegment* ToBPM(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_BPM);
+    return static_cast<const BPMSegment*>(t);
+}
+
+BPMSegment* ToBPM(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_BPM);
+    return static_cast<BPMSegment*>(t);
+}
+
+const StopSegment* ToStop(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_STOP);
+    return static_cast<const StopSegment*>(t);
+}
+
+StopSegment* ToStop(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_STOP);
+    return static_cast<StopSegment*>(t);
+}
+
+const DelaySegment* ToDelay(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_DELAY);
+    return static_cast<const DelaySegment*>(t);
+}
+
+DelaySegment* ToDelay(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_DELAY);
+    return static_cast<DelaySegment*>(t);
+}
+
+const TimeSignatureSegment* ToTimeSignature(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_TIME_SIG);
+    return static_cast<const TimeSignatureSegment*>(t);
+}
+
+TimeSignatureSegment* ToTimeSignature(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_TIME_SIG);
+    return static_cast<TimeSignatureSegment*>(t);
+}
+
+const WarpSegment* ToWarp(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_WARP);
+    return static_cast<const WarpSegment*>(t);
+}
+
+WarpSegment* ToWarp(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_WARP);
+    return static_cast<WarpSegment*>(t);
+}
+
+const LabelSegment* ToLabel(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_LABEL);
+    return static_cast<const LabelSegment*>(t);
+}
+
+LabelSegment* ToLabel(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_LABEL);
+    return static_cast<LabelSegment*>(t);
+}
+
+const TickcountSegment* ToTickcount(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_TICKCOUNT);
+    return static_cast<const TickcountSegment*>(t);
+}
+
+TickcountSegment* ToTickcount(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_TICKCOUNT);
+    return static_cast<TickcountSegment*>(t);
+}
+
+const ComboSegment* ToCombo(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_COMBO);
+    return static_cast<const ComboSegment*>(t);
+}
+
+ComboSegment* ToCombo(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_COMBO);
+    return static_cast<ComboSegment*>(t);
+}
+
+const SpeedSegment* ToSpeed(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_SPEED);
+    return static_cast<const SpeedSegment*>(t);
+}
+
+SpeedSegment* ToSpeed(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_SPEED);
+    return static_cast<SpeedSegment*>(t);
+}
+
+const ScrollSegment* ToScroll(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_SCROLL);
+    return static_cast<const ScrollSegment*>(t);
+}
+
+ScrollSegment* ToScroll(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_SCROLL);
+    return static_cast<ScrollSegment*>(t);
+}
+
+const FakeSegment* ToFake(const TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_FAKE);
+    return static_cast<const FakeSegment*>(t);
+}
+
+FakeSegment* ToFake(TimingSegment* t)
+{
+    ASSERT(t->GetType() == SEGMENT_FAKE);
+    return static_cast<FakeSegment*>(t);
 }
 
 void TimingData::Copy( const TimingData& cpy )

--- a/src/TimingData.h
+++ b/src/TimingData.h
@@ -192,50 +192,127 @@ public:
 		return GetSegmentAtRow( BeatToNoteRow(fBeat), tst );
 	}
 
-	#define DefineSegmentWithName(Seg, SegName, SegType) \
-		const Seg* Get##Seg##AtRow( int iNoteRow ) const \
-		{ \
-			const TimingSegment *t = GetSegmentAtRow( iNoteRow, SegType ); \
-			return To##SegName( t ); \
-		} \
-		Seg* Get##Seg##AtRow( int iNoteRow ) \
-		{ \
-			return const_cast<Seg*> (((const TimingData*)this)->Get##Seg##AtRow(iNoteRow) ); \
-		} \
-		const Seg* Get##Seg##AtBeat( float fBeat ) const \
-		{ \
-			return Get##Seg##AtRow( BeatToNoteRow(fBeat) ); \
-		} \
-		Seg* Get##Seg##AtBeat( float fBeat ) \
-		{ \
-			return const_cast<Seg*> (((const TimingData*)this)->Get##Seg##AtBeat(fBeat) ); \
-		} \
-		void AddSegment( const Seg &seg ) \
-		{ \
-			AddSegment( &seg ); \
-		}
-
-	// "XXX: this comment (and quote mark) exists so nano won't
-	// display the rest of this file as one giant string
-
-	// (TimeSignature,TIME_SIG) -> (TimeSignatureSegment,SEGMENT_TIME_SIG)
-	#define DefineSegment(Seg, SegType ) \
-		DefineSegmentWithName( Seg##Segment, Seg, SEGMENT_##SegType )
-
-	DefineSegment( BPM, BPM );
-	DefineSegment( Stop, STOP );
-	DefineSegment( Delay, DELAY );
-	DefineSegment( Warp, WARP );
-	DefineSegment( Label, LABEL );
-	DefineSegment( Tickcount, TICKCOUNT );
-	DefineSegment( Combo, COMBO );
-	DefineSegment( Speed, SPEED );
-	DefineSegment( Scroll, SCROLL );
-	DefineSegment( Fake, FAKE );
-	DefineSegment( TimeSignature, TIME_SIG );
-
-	#undef DefineSegmentWithName
-	#undef DefineSegment
+	const BPMSegment* GetBPMSegmentAtRow(int iNoteRow) const {
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_BPM); return ToBPM(t);
+	} BPMSegment* GetBPMSegmentAtRow(int iNoteRow) {
+		return const_cast<BPMSegment*> (((const TimingData*)this)->GetBPMSegmentAtRow(iNoteRow));
+	} const BPMSegment* GetBPMSegmentAtBeat(float fBeat) const {
+		return GetBPMSegmentAtRow(BeatToNoteRow(fBeat));
+	} BPMSegment* GetBPMSegmentAtBeat(float fBeat) {
+		return const_cast<BPMSegment*> (((const TimingData*)this)->GetBPMSegmentAtBeat(fBeat));
+	} void AddSegment(const BPMSegment& seg) {
+		AddSegment(&seg);
+	};
+	const StopSegment* GetStopSegmentAtRow(int iNoteRow) const {
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_STOP); return ToStop(t);
+	} StopSegment* GetStopSegmentAtRow(int iNoteRow) {
+		return const_cast<StopSegment*> (((const TimingData*)this)->GetStopSegmentAtRow(iNoteRow));
+	} const StopSegment* GetStopSegmentAtBeat(float fBeat) const {
+		return GetStopSegmentAtRow(BeatToNoteRow(fBeat));
+	} StopSegment* GetStopSegmentAtBeat(float fBeat) {
+		return const_cast<StopSegment*> (((const TimingData*)this)->GetStopSegmentAtBeat(fBeat));
+	} void AddSegment(const StopSegment& seg) {
+		AddSegment(&seg);
+	};
+	const DelaySegment* GetDelaySegmentAtRow(int iNoteRow) const {
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_DELAY); return ToDelay(t);
+	} DelaySegment* GetDelaySegmentAtRow(int iNoteRow) {
+		return const_cast<DelaySegment*> (((const TimingData*)this)->GetDelaySegmentAtRow(iNoteRow));
+	} const DelaySegment* GetDelaySegmentAtBeat(float fBeat) const {
+		return GetDelaySegmentAtRow(BeatToNoteRow(fBeat));
+	} DelaySegment* GetDelaySegmentAtBeat(float fBeat) {
+		return const_cast<DelaySegment*> (((const TimingData*)this)->GetDelaySegmentAtBeat(fBeat));
+	} void AddSegment(const DelaySegment& seg) {
+		AddSegment(&seg);
+	};
+	const WarpSegment* GetWarpSegmentAtRow(int iNoteRow) const {
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_WARP); return ToWarp(t);
+	} WarpSegment* GetWarpSegmentAtRow(int iNoteRow) {
+		return const_cast<WarpSegment*> (((const TimingData*)this)->GetWarpSegmentAtRow(iNoteRow));
+	} const WarpSegment* GetWarpSegmentAtBeat(float fBeat) const {
+		return GetWarpSegmentAtRow(BeatToNoteRow(fBeat));
+	} WarpSegment* GetWarpSegmentAtBeat(float fBeat) {
+		return const_cast<WarpSegment*> (((const TimingData*)this)->GetWarpSegmentAtBeat(fBeat));
+	} void AddSegment(const WarpSegment& seg) {
+		AddSegment(&seg);
+	};
+	const LabelSegment* GetLabelSegmentAtRow(int iNoteRow) const {
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_LABEL); return ToLabel(t);
+	} LabelSegment* GetLabelSegmentAtRow(int iNoteRow) {
+		return const_cast<LabelSegment*> (((const TimingData*)this)->GetLabelSegmentAtRow(iNoteRow));
+	} const LabelSegment* GetLabelSegmentAtBeat(float fBeat) const {
+		return GetLabelSegmentAtRow(BeatToNoteRow(fBeat));
+	} LabelSegment* GetLabelSegmentAtBeat(float fBeat) {
+		return const_cast<LabelSegment*> (((const TimingData*)this)->GetLabelSegmentAtBeat(fBeat));
+	} void AddSegment(const LabelSegment& seg) {
+		AddSegment(&seg);
+	};
+	const TickcountSegment* GetTickcountSegmentAtRow(int iNoteRow) const {
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_TICKCOUNT); return ToTickcount(t);
+	} TickcountSegment* GetTickcountSegmentAtRow(int iNoteRow) {
+		return const_cast<TickcountSegment*> (((const TimingData*)this)->GetTickcountSegmentAtRow(iNoteRow));
+	} const TickcountSegment* GetTickcountSegmentAtBeat(float fBeat) const {
+		return GetTickcountSegmentAtRow(BeatToNoteRow(fBeat));
+	} TickcountSegment* GetTickcountSegmentAtBeat(float fBeat) {
+		return const_cast<TickcountSegment*> (((const TimingData*)this)->GetTickcountSegmentAtBeat(fBeat));
+	} void AddSegment(const TickcountSegment& seg) {
+		AddSegment(&seg);
+	};
+	const ComboSegment* GetComboSegmentAtRow(int iNoteRow) const {
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_COMBO); return ToCombo(t);
+	} ComboSegment* GetComboSegmentAtRow(int iNoteRow) {
+		return const_cast<ComboSegment*> (((const TimingData*)this)->GetComboSegmentAtRow(iNoteRow));
+	} const ComboSegment* GetComboSegmentAtBeat(float fBeat) const {
+		return GetComboSegmentAtRow(BeatToNoteRow(fBeat));
+	} ComboSegment* GetComboSegmentAtBeat(float fBeat) {
+		return const_cast<ComboSegment*> (((const TimingData*)this)->GetComboSegmentAtBeat(fBeat));
+	} void AddSegment(const ComboSegment& seg) {
+		AddSegment(&seg);
+	};
+	const SpeedSegment* GetSpeedSegmentAtRow(int iNoteRow) const {
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_SPEED); return ToSpeed(t);
+	} SpeedSegment* GetSpeedSegmentAtRow(int iNoteRow) {
+		return const_cast<SpeedSegment*> (((const TimingData*)this)->GetSpeedSegmentAtRow(iNoteRow));
+	} const SpeedSegment* GetSpeedSegmentAtBeat(float fBeat) const {
+		return GetSpeedSegmentAtRow(BeatToNoteRow(fBeat));
+	} SpeedSegment* GetSpeedSegmentAtBeat(float fBeat) {
+		return const_cast<SpeedSegment*> (((const TimingData*)this)->GetSpeedSegmentAtBeat(fBeat));
+	} void AddSegment(const SpeedSegment& seg) {
+		AddSegment(&seg);
+	};
+	const ScrollSegment* GetScrollSegmentAtRow(int iNoteRow) const {
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_SCROLL); return ToScroll(t);
+	} ScrollSegment* GetScrollSegmentAtRow(int iNoteRow) {
+		return const_cast<ScrollSegment*> (((const TimingData*)this)->GetScrollSegmentAtRow(iNoteRow));
+	} const ScrollSegment* GetScrollSegmentAtBeat(float fBeat) const {
+		return GetScrollSegmentAtRow(BeatToNoteRow(fBeat));
+	} ScrollSegment* GetScrollSegmentAtBeat(float fBeat) {
+		return const_cast<ScrollSegment*> (((const TimingData*)this)->GetScrollSegmentAtBeat(fBeat));
+	} void AddSegment(const ScrollSegment& seg) {
+		AddSegment(&seg);
+	};
+	const FakeSegment* GetFakeSegmentAtRow(int iNoteRow) const {
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_FAKE); return ToFake(t);
+	} FakeSegment* GetFakeSegmentAtRow(int iNoteRow) {
+		return const_cast<FakeSegment*> (((const TimingData*)this)->GetFakeSegmentAtRow(iNoteRow));
+	} const FakeSegment* GetFakeSegmentAtBeat(float fBeat) const {
+		return GetFakeSegmentAtRow(BeatToNoteRow(fBeat));
+	} FakeSegment* GetFakeSegmentAtBeat(float fBeat) {
+		return const_cast<FakeSegment*> (((const TimingData*)this)->GetFakeSegmentAtBeat(fBeat));
+	} void AddSegment(const FakeSegment& seg) {
+		AddSegment(&seg);
+	};
+	const TimeSignatureSegment* GetTimeSignatureSegmentAtRow(int iNoteRow) const {
+		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_TIME_SIG); return ToTimeSignature(t);
+	} TimeSignatureSegment* GetTimeSignatureSegmentAtRow(int iNoteRow) {
+		return const_cast<TimeSignatureSegment*> (((const TimingData*)this)->GetTimeSignatureSegmentAtRow(iNoteRow));
+	} const TimeSignatureSegment* GetTimeSignatureSegmentAtBeat(float fBeat) const {
+		return GetTimeSignatureSegmentAtRow(BeatToNoteRow(fBeat));
+	} TimeSignatureSegment* GetTimeSignatureSegmentAtBeat(float fBeat) {
+		return const_cast<TimeSignatureSegment*> (((const TimingData*)this)->GetTimeSignatureSegmentAtBeat(fBeat));
+	} void AddSegment(const TimeSignatureSegment& seg) {
+		AddSegment(&seg);
+	};
 
 	/* convenience aliases (Set functions are deprecated) */
 	float GetBPMAtRow( int iNoteRow ) const { return GetBPMSegmentAtRow(iNoteRow)->GetBPM(); }

--- a/src/TimingData.h
+++ b/src/TimingData.h
@@ -192,127 +192,71 @@ public:
 		return GetSegmentAtRow( BeatToNoteRow(fBeat), tst );
 	}
 
-	const BPMSegment* GetBPMSegmentAtRow(int iNoteRow) const {
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_BPM); return ToBPM(t);
-	} BPMSegment* GetBPMSegmentAtRow(int iNoteRow) {
-		return const_cast<BPMSegment*> (((const TimingData*)this)->GetBPMSegmentAtRow(iNoteRow));
-	} const BPMSegment* GetBPMSegmentAtBeat(float fBeat) const {
-		return GetBPMSegmentAtRow(BeatToNoteRow(fBeat));
-	} BPMSegment* GetBPMSegmentAtBeat(float fBeat) {
-		return const_cast<BPMSegment*> (((const TimingData*)this)->GetBPMSegmentAtBeat(fBeat));
-	} void AddSegment(const BPMSegment& seg) {
-		AddSegment(&seg);
-	};
-	const StopSegment* GetStopSegmentAtRow(int iNoteRow) const {
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_STOP); return ToStop(t);
-	} StopSegment* GetStopSegmentAtRow(int iNoteRow) {
-		return const_cast<StopSegment*> (((const TimingData*)this)->GetStopSegmentAtRow(iNoteRow));
-	} const StopSegment* GetStopSegmentAtBeat(float fBeat) const {
-		return GetStopSegmentAtRow(BeatToNoteRow(fBeat));
-	} StopSegment* GetStopSegmentAtBeat(float fBeat) {
-		return const_cast<StopSegment*> (((const TimingData*)this)->GetStopSegmentAtBeat(fBeat));
-	} void AddSegment(const StopSegment& seg) {
-		AddSegment(&seg);
-	};
-	const DelaySegment* GetDelaySegmentAtRow(int iNoteRow) const {
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_DELAY); return ToDelay(t);
-	} DelaySegment* GetDelaySegmentAtRow(int iNoteRow) {
-		return const_cast<DelaySegment*> (((const TimingData*)this)->GetDelaySegmentAtRow(iNoteRow));
-	} const DelaySegment* GetDelaySegmentAtBeat(float fBeat) const {
-		return GetDelaySegmentAtRow(BeatToNoteRow(fBeat));
-	} DelaySegment* GetDelaySegmentAtBeat(float fBeat) {
-		return const_cast<DelaySegment*> (((const TimingData*)this)->GetDelaySegmentAtBeat(fBeat));
-	} void AddSegment(const DelaySegment& seg) {
-		AddSegment(&seg);
-	};
-	const WarpSegment* GetWarpSegmentAtRow(int iNoteRow) const {
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_WARP); return ToWarp(t);
-	} WarpSegment* GetWarpSegmentAtRow(int iNoteRow) {
-		return const_cast<WarpSegment*> (((const TimingData*)this)->GetWarpSegmentAtRow(iNoteRow));
-	} const WarpSegment* GetWarpSegmentAtBeat(float fBeat) const {
-		return GetWarpSegmentAtRow(BeatToNoteRow(fBeat));
-	} WarpSegment* GetWarpSegmentAtBeat(float fBeat) {
-		return const_cast<WarpSegment*> (((const TimingData*)this)->GetWarpSegmentAtBeat(fBeat));
-	} void AddSegment(const WarpSegment& seg) {
-		AddSegment(&seg);
-	};
-	const LabelSegment* GetLabelSegmentAtRow(int iNoteRow) const {
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_LABEL); return ToLabel(t);
-	} LabelSegment* GetLabelSegmentAtRow(int iNoteRow) {
-		return const_cast<LabelSegment*> (((const TimingData*)this)->GetLabelSegmentAtRow(iNoteRow));
-	} const LabelSegment* GetLabelSegmentAtBeat(float fBeat) const {
-		return GetLabelSegmentAtRow(BeatToNoteRow(fBeat));
-	} LabelSegment* GetLabelSegmentAtBeat(float fBeat) {
-		return const_cast<LabelSegment*> (((const TimingData*)this)->GetLabelSegmentAtBeat(fBeat));
-	} void AddSegment(const LabelSegment& seg) {
-		AddSegment(&seg);
-	};
-	const TickcountSegment* GetTickcountSegmentAtRow(int iNoteRow) const {
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_TICKCOUNT); return ToTickcount(t);
-	} TickcountSegment* GetTickcountSegmentAtRow(int iNoteRow) {
-		return const_cast<TickcountSegment*> (((const TimingData*)this)->GetTickcountSegmentAtRow(iNoteRow));
-	} const TickcountSegment* GetTickcountSegmentAtBeat(float fBeat) const {
-		return GetTickcountSegmentAtRow(BeatToNoteRow(fBeat));
-	} TickcountSegment* GetTickcountSegmentAtBeat(float fBeat) {
-		return const_cast<TickcountSegment*> (((const TimingData*)this)->GetTickcountSegmentAtBeat(fBeat));
-	} void AddSegment(const TickcountSegment& seg) {
-		AddSegment(&seg);
-	};
-	const ComboSegment* GetComboSegmentAtRow(int iNoteRow) const {
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_COMBO); return ToCombo(t);
-	} ComboSegment* GetComboSegmentAtRow(int iNoteRow) {
-		return const_cast<ComboSegment*> (((const TimingData*)this)->GetComboSegmentAtRow(iNoteRow));
-	} const ComboSegment* GetComboSegmentAtBeat(float fBeat) const {
-		return GetComboSegmentAtRow(BeatToNoteRow(fBeat));
-	} ComboSegment* GetComboSegmentAtBeat(float fBeat) {
-		return const_cast<ComboSegment*> (((const TimingData*)this)->GetComboSegmentAtBeat(fBeat));
-	} void AddSegment(const ComboSegment& seg) {
-		AddSegment(&seg);
-	};
-	const SpeedSegment* GetSpeedSegmentAtRow(int iNoteRow) const {
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_SPEED); return ToSpeed(t);
-	} SpeedSegment* GetSpeedSegmentAtRow(int iNoteRow) {
-		return const_cast<SpeedSegment*> (((const TimingData*)this)->GetSpeedSegmentAtRow(iNoteRow));
-	} const SpeedSegment* GetSpeedSegmentAtBeat(float fBeat) const {
-		return GetSpeedSegmentAtRow(BeatToNoteRow(fBeat));
-	} SpeedSegment* GetSpeedSegmentAtBeat(float fBeat) {
-		return const_cast<SpeedSegment*> (((const TimingData*)this)->GetSpeedSegmentAtBeat(fBeat));
-	} void AddSegment(const SpeedSegment& seg) {
-		AddSegment(&seg);
-	};
-	const ScrollSegment* GetScrollSegmentAtRow(int iNoteRow) const {
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_SCROLL); return ToScroll(t);
-	} ScrollSegment* GetScrollSegmentAtRow(int iNoteRow) {
-		return const_cast<ScrollSegment*> (((const TimingData*)this)->GetScrollSegmentAtRow(iNoteRow));
-	} const ScrollSegment* GetScrollSegmentAtBeat(float fBeat) const {
-		return GetScrollSegmentAtRow(BeatToNoteRow(fBeat));
-	} ScrollSegment* GetScrollSegmentAtBeat(float fBeat) {
-		return const_cast<ScrollSegment*> (((const TimingData*)this)->GetScrollSegmentAtBeat(fBeat));
-	} void AddSegment(const ScrollSegment& seg) {
-		AddSegment(&seg);
-	};
-	const FakeSegment* GetFakeSegmentAtRow(int iNoteRow) const {
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_FAKE); return ToFake(t);
-	} FakeSegment* GetFakeSegmentAtRow(int iNoteRow) {
-		return const_cast<FakeSegment*> (((const TimingData*)this)->GetFakeSegmentAtRow(iNoteRow));
-	} const FakeSegment* GetFakeSegmentAtBeat(float fBeat) const {
-		return GetFakeSegmentAtRow(BeatToNoteRow(fBeat));
-	} FakeSegment* GetFakeSegmentAtBeat(float fBeat) {
-		return const_cast<FakeSegment*> (((const TimingData*)this)->GetFakeSegmentAtBeat(fBeat));
-	} void AddSegment(const FakeSegment& seg) {
-		AddSegment(&seg);
-	};
-	const TimeSignatureSegment* GetTimeSignatureSegmentAtRow(int iNoteRow) const {
-		const TimingSegment* t = GetSegmentAtRow(iNoteRow, SEGMENT_TIME_SIG); return ToTimeSignature(t);
-	} TimeSignatureSegment* GetTimeSignatureSegmentAtRow(int iNoteRow) {
-		return const_cast<TimeSignatureSegment*> (((const TimingData*)this)->GetTimeSignatureSegmentAtRow(iNoteRow));
-	} const TimeSignatureSegment* GetTimeSignatureSegmentAtBeat(float fBeat) const {
-		return GetTimeSignatureSegmentAtRow(BeatToNoteRow(fBeat));
-	} TimeSignatureSegment* GetTimeSignatureSegmentAtBeat(float fBeat) {
-		return const_cast<TimeSignatureSegment*> (((const TimingData*)this)->GetTimeSignatureSegmentAtBeat(fBeat));
-	} void AddSegment(const TimeSignatureSegment& seg) {
-		AddSegment(&seg);
-	};
+	const BPMSegment* GetBPMSegmentAtRow(int iNoteRow) const;
+	BPMSegment* GetBPMSegmentAtRow(int iNoteRow);
+	const BPMSegment* GetBPMSegmentAtBeat(float fBeat) const;
+	BPMSegment* GetBPMSegmentAtBeat(float fBeat);
+	void AddSegment(const BPMSegment& seg);
+
+	const StopSegment* GetStopSegmentAtRow(int iNoteRow) const;
+	StopSegment* GetStopSegmentAtRow(int iNoteRow);
+	const StopSegment* GetStopSegmentAtBeat(float fBeat) const;
+	StopSegment* GetStopSegmentAtBeat(float fBeat);
+	void AddSegment(const StopSegment& seg);
+
+	const DelaySegment* GetDelaySegmentAtRow(int iNoteRow) const;
+	DelaySegment* GetDelaySegmentAtRow(int iNoteRow);
+	const DelaySegment* GetDelaySegmentAtBeat(float fBeat) const;
+	DelaySegment* GetDelaySegmentAtBeat(float fBeat);
+	void AddSegment(const DelaySegment& seg);
+
+	const WarpSegment* GetWarpSegmentAtRow(int iNoteRow) const;
+	WarpSegment* GetWarpSegmentAtRow(int iNoteRow);
+	const WarpSegment* GetWarpSegmentAtBeat(float fBeat) const;
+	WarpSegment* GetWarpSegmentAtBeat(float fBeat);
+	void AddSegment(const WarpSegment& seg);
+
+	const LabelSegment* GetLabelSegmentAtRow(int iNoteRow) const;
+	LabelSegment* GetLabelSegmentAtRow(int iNoteRow);
+	const LabelSegment* GetLabelSegmentAtBeat(float fBeat) const;
+	LabelSegment* GetLabelSegmentAtBeat(float fBeat);
+	void AddSegment(const LabelSegment& seg);
+
+	const TickcountSegment* GetTickcountSegmentAtRow(int iNoteRow) const;
+	TickcountSegment* GetTickcountSegmentAtRow(int iNoteRow);
+	const TickcountSegment* GetTickcountSegmentAtBeat(float fBeat) const;
+	TickcountSegment* GetTickcountSegmentAtBeat(float fBeat);
+	void AddSegment(const TickcountSegment& seg);
+
+	const ComboSegment* GetComboSegmentAtRow(int iNoteRow) const;
+	ComboSegment* GetComboSegmentAtRow(int iNoteRow);
+	const ComboSegment* GetComboSegmentAtBeat(float fBeat) const;
+	ComboSegment* GetComboSegmentAtBeat(float fBeat);
+	void AddSegment(const ComboSegment& seg);
+
+	const SpeedSegment* GetSpeedSegmentAtRow(int iNoteRow) const;
+	SpeedSegment* GetSpeedSegmentAtRow(int iNoteRow);
+	const SpeedSegment* GetSpeedSegmentAtBeat(float fBeat) const;
+	SpeedSegment* GetSpeedSegmentAtBeat(float fBeat);
+	void AddSegment(const SpeedSegment& seg);
+
+	const ScrollSegment* GetScrollSegmentAtRow(int iNoteRow) const;
+	ScrollSegment* GetScrollSegmentAtRow(int iNoteRow);
+	const ScrollSegment* GetScrollSegmentAtBeat(float fBeat) const;
+	ScrollSegment* GetScrollSegmentAtBeat(float fBeat);
+	void AddSegment(const ScrollSegment& seg);
+
+	const FakeSegment* GetFakeSegmentAtRow(int iNoteRow) const;
+	FakeSegment* GetFakeSegmentAtRow(int iNoteRow);
+	const FakeSegment* GetFakeSegmentAtBeat(float fBeat) const;
+	FakeSegment* GetFakeSegmentAtBeat(float fBeat);
+	void AddSegment(const FakeSegment& seg);
+
+	const TimeSignatureSegment* GetTimeSignatureSegmentAtRow(int iNoteRow) const;
+	TimeSignatureSegment* GetTimeSignatureSegmentAtRow(int iNoteRow);
+	const TimeSignatureSegment* GetTimeSignatureSegmentAtBeat(float fBeat) const;
+	TimeSignatureSegment* GetTimeSignatureSegmentAtBeat(float fBeat);
+	void AddSegment(const TimeSignatureSegment& seg);
 
 	/* convenience aliases (Set functions are deprecated) */
 	float GetBPMAtRow( int iNoteRow ) const { return GetBPMSegmentAtRow(iNoteRow)->GetBPM(); }

--- a/src/TimingData.h
+++ b/src/TimingData.h
@@ -14,46 +14,48 @@ struct lua_State;
 
 /* convenience functions to handle static casting */
 template<class T>
-inline T ToDerived( const TimingSegment *t, TimingSegmentType tst )
+inline T ToDerived(const TimingSegment* t, TimingSegmentType tst)
 {
-	ASSERT_M( t && tst == t->GetType(),
+	ASSERT_M(t && tst == t->GetType(),
 		ssprintf("type mismatch (expected %s, got %s)",
-		TimingSegmentTypeToString(tst).c_str(),
-		TimingSegmentTypeToString(t->GetType()).c_str() ) );
+			TimingSegmentTypeToString(tst).c_str(),
+			TimingSegmentTypeToString(t->GetType()).c_str()));
 
-	return static_cast<T>( t );
+	return static_cast<T>(t);
 }
 
-#define TimingSegmentToXWithName(Seg, SegName, SegType) \
-	inline const Seg* To##SegName( const TimingSegment *t ) \
-	{ \
-		ASSERT( t->GetType() == SegType ); \
-		return static_cast<const Seg*>( t ); \
-	} \
-	inline Seg* To##SegName( TimingSegment *t ) \
-	{ \
-		ASSERT( t->GetType() == SegType ); \
-		return static_cast<Seg*>( t ); \
-	}
+const BPMSegment* ToBPM(const TimingSegment* t);
+BPMSegment* ToBPM(TimingSegment* t);
 
-#define TimingSegmentToX(Seg, SegType) \
-	TimingSegmentToXWithName(Seg##Segment, Seg, SEGMENT_##SegType)
+const StopSegment* ToStop(const TimingSegment* t);
+StopSegment* ToStop(TimingSegment* t);
 
-/* ToBPM(TimingSegment*), ToTimeSignature(TimingSegment*), etc. */
-TimingSegmentToX( BPM, BPM );
-TimingSegmentToX( Stop, STOP );
-TimingSegmentToX( Delay, DELAY );
-TimingSegmentToX( TimeSignature, TIME_SIG );
-TimingSegmentToX( Warp, WARP );
-TimingSegmentToX( Label, LABEL );
-TimingSegmentToX( Tickcount, TICKCOUNT );
-TimingSegmentToX( Combo, COMBO );
-TimingSegmentToX( Speed, SPEED );
-TimingSegmentToX( Scroll, SCROLL );
-TimingSegmentToX( Fake, FAKE );
+const DelaySegment* ToDelay(const TimingSegment* t);
+DelaySegment* ToDelay(TimingSegment* t);
 
-#undef TimingSegmentToXWithName
-#undef TimingSegmentToX
+const TimeSignatureSegment* ToTimeSignature(const TimingSegment* t);
+TimeSignatureSegment* ToTimeSignature(TimingSegment* t);
+
+const WarpSegment* ToWarp(const TimingSegment* t);
+WarpSegment* ToWarp(TimingSegment* t);
+
+const LabelSegment* ToLabel(const TimingSegment* t);
+LabelSegment* ToLabel(TimingSegment* t);
+
+const TickcountSegment* ToTickcount(const TimingSegment* t);
+TickcountSegment* ToTickcount(TimingSegment* t);
+
+const ComboSegment* ToCombo(const TimingSegment* t);
+ComboSegment* ToCombo(TimingSegment* t);
+
+const SpeedSegment* ToSpeed(const TimingSegment* t);
+SpeedSegment* ToSpeed(TimingSegment* t);
+
+const ScrollSegment* ToScroll(const TimingSegment* t);
+ScrollSegment* ToScroll(TimingSegment* t);
+
+const FakeSegment* ToFake(const TimingSegment* t);
+FakeSegment* ToFake(TimingSegment* t);
 
 /**
  * @brief Holds data for translating beats<->seconds.


### PR DESCRIPTION
The first block of macros (`TimingSegmentToX`, `TimingSegmentToXWithName`) get a set of helper templates and are moved into an anonymous namespace for added security.

The second block of macros (`DefineSegment` / `DefineSegmentWithName`) is inlined and made as compact as possible since there's no further optimization to make here to reduce code - it's already as minimal as it can be.