### PR TITLE
Add centering back into edit/practice mode playback.

### DIFF
--- a/src/EditModePlayerManager.cpp
+++ b/src/EditModePlayerManager.cpp
@@ -22,6 +22,10 @@ void EditModePlayerManager::AddPlayers(const NoteData& note_data) {
 		player->SetY(SCREEN_CENTER_Y);
 		player->SetZoom(SCREEN_HEIGHT / 480);
 		StyleType style_type = GAMESTATE->GetCurrentStyle(pn)->m_StyleType;
+		if (center_) {
+			// Use the doubles style positioning for centering.
+			style_type = StyleType_OnePlayerTwoSides;
+		}
 		player->SetX(THEME->GetMetricF("ScreenGameplay", ssprintf("PlayerP%d%sX", pn + 1, StyleTypeToString(style_type).c_str())));
 	}
 

--- a/src/EditModePlayerManager.h
+++ b/src/EditModePlayerManager.h
@@ -16,7 +16,6 @@
 class EditModePlayerManager
 {
 public:
-
 	// Adds players based on the current gamestate.
 	void AddPlayers(const NoteData& note_data);
 
@@ -43,7 +42,11 @@ public:
 	// Play assist ticks.
 	void PlayTicks(GameplayAssist& gameplay_assist);
 
+	// Sets the "center" boolean, for centering the notefield.
+	void SetCenter(bool center) { center_ = center;  }
+
 private:
 	// All players that the manager is looking at. Indexable by PlayerNumber.
 	std::unordered_map<PlayerNumber, std::shared_ptr<PlayerPlus>> players_;
+	bool center_;
 };

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -1526,6 +1526,27 @@ void ScreenEdit::Init()
 		SetDirty(true);
 	}
 
+
+	// There are two conditions for centering the notefield.
+	// 1. We're in EditMode
+	// 2. We're in PracticeMode, the preference is enabled,
+	//      sylte is OnePlayerOneSide, and the theme allows it.
+	//
+	// If the "center_enabled" check is modified, also modify
+	// ScreenGameplay::Center1Player().
+	ThemeMetric<bool> allow_center;
+	allow_center.Load("ScreenGameplay", "AllowCenter1Player");
+	bool center_enabled = (Preference<bool>::GetPreferenceByName("Center1Player")->Get()
+		&& GAMESTATE->GetCurrentStyle(PLAYER_INVALID)->m_StyleType
+			== StyleType_OnePlayerOneSide)
+		&& GAMESTATE->m_PlayMode != PLAY_MODE_BATTLE
+		&& GAMESTATE->m_PlayMode != PLAY_MODE_RAVE
+		&& allow_center;
+
+	bool edit_mode_screen = (m_sName == "ScreenEdit");
+
+	player_manager_.SetCenter(edit_mode_screen || center_enabled);
+
 	player_manager_.AddPlayers(m_NoteDataEdit);
 	player_manager_.AddPlayersToActorFrame(*this);
 

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -882,7 +882,11 @@ bool ScreenGameplay::Center1Player() const
 	/* Perhaps this should be handled better by defining a new
 	 * StyleType for ONE_PLAYER_ONE_CREDIT_AND_ONE_COMPUTER,
 	 * but for now just ignore Center1Player when it's Battle or Rave
-	 * Mode. This doesn't begin to address two-player solo (6 arrows) */
+	 * Mode. This doesn't begin to address two-player solo (6 arrows)
+	 *
+	 * If this check is modified, also modify the center check in
+	 * ScreenEdit::Init().
+	 */
 	return g_bCenter1Player &&
 		(bool)ALLOW_CENTER_1_PLAYER &&
 		GAMESTATE->m_PlayMode != PLAY_MODE_BATTLE &&


### PR DESCRIPTION
Loosely based on how `ScreenGameplay` handles centering.

The left and right NoteFields cut off a little information on timing measures, but that's orthogonal to this fix.