### PR TITLE
Scale the global offset more accurately when rate modding (Obsoleted by pack.ini PR)

### DIFF
--- a/src/TimingData.cpp
+++ b/src/TimingData.cpp
@@ -994,8 +994,22 @@ float TimingData::GetElapsedTimeInternal(GetBeatStarts& start, float beat,
 
 float TimingData::GetElapsedTimeFromBeat( float fBeat ) const
 {
-	return TimingData::GetElapsedTimeFromBeatNoOffset( fBeat )
-		- GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate * PREFSMAN->m_fGlobalOffsetSeconds;
+	// Calculate the elapsed time from the beat without any offsets
+	float fElapsedTime = TimingData::GetElapsedTimeFromBeatNoOffset(fBeat);
+	float fMusicRate = GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate;
+	float fGlobalOffset = PREFSMAN->m_fGlobalOffsetSeconds;
+
+	if (fMusicRate == 1.0f)
+	{
+		// If the music rate is NOT applied, directly apply the global offset
+		return fElapsedTime - fGlobalOffset;
+	}
+	else
+	{
+		// Find the median of the unscaled and scaled global offsets
+		float medianGlobalOffset = 0.5f * (fGlobalOffset + (fGlobalOffset * fMusicRate));
+		return fElapsedTime - medianGlobalOffset;
+	}
 }
 
 float TimingData::GetElapsedTimeFromBeatNoOffset( float fBeat ) const


### PR DESCRIPTION
## Note: this is most likely irrelevant now that the pack.ini PR is open. I will likely close this if pack.ini changes can fix this bug.



Please feel free to criticize this, maybe this approach is off-base. The goal of this change is to provide a more accurate offset when using extreme rate mods.  Currently, the farther the rate mod gets from the default value of 1.0, a more drastic offset appears. This aims to mitigate that issue by using the median of the unscaled and scaled global offsets to minimize the offset calculation error.

I've been playing with higher rate mods a lot lately (close to, and around, 2.0x) and I have been getting a lot of timing scatter plots that aren't centered.

This led me to start thinking about the "Fix interaction between music rate and global offset" commit again and how I could  make it more accurate. Eventually the idea popped into my head to implement some math to continue scaling the global offset to the music rate, but factor in the unscaled global offset value to find a median.

I've been getting more centered timing plots on high rate mods like 1.5x or 2.0x, so I think this helps, but would like to know what others think of this?

Here's an example. I picked this song as an example because i have been getting very consistent 2.0x scores on it.
current beta
![2024-09-08_010914__1105___07__What_s_Going_](https://github.com/user-attachments/assets/75036d2d-8d91-4e02-9637-52221ed3938c)
vs. current beta + this commit
![2024-09-25_173939__1105___07__What_s_Going_](https://github.com/user-attachments/assets/e3bad3e4-9aef-4cb6-9339-4b9ac2b6c8a7)