### PR TITLE
Removing the SCALE macro (messes with sync - abandoned!)

### DIFF
--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -520,7 +520,7 @@ void Actor::PreDraw() // calculate actor properties
 		const float rupathrdown_plus_atf= rupath_plus_rdown + m_effect_hold_at_full;
 		if(fTimeIntoEffect < m_effect_ramp_to_half)
 		{
-			fPercentThroughEffect = SCALE(fTimeIntoEffect,
+			fPercentThroughEffect = RageUtil::ScaleFloat(fTimeIntoEffect,
 				0, m_effect_ramp_to_half, 0.0f, 0.5f);
 		}
 		else if(fTimeIntoEffect < rup_plus_ath)
@@ -529,7 +529,7 @@ void Actor::PreDraw() // calculate actor properties
 		}
 		else if(fTimeIntoEffect < rupath_plus_rdown)
 		{
-			fPercentThroughEffect = SCALE(fTimeIntoEffect,
+			fPercentThroughEffect = RageUtil::ScaleFloat(fTimeIntoEffect,
 				rup_plus_ath, rupath_plus_rdown, 0.5f, 1.0f);
 		}
 		else if(fTimeIntoEffect < rupathrdown_plus_atf)
@@ -625,11 +625,11 @@ void Actor::PreDraw() // calculate actor properties
 				float fMinZoom = m_vEffectMagnitude[0];
 				float fMaxZoom = m_vEffectMagnitude[1];
 				float fPercentOffset = std::sin( fPercentThroughEffect*PI );
-				float fZoom = SCALE( fPercentOffset, 0.f, 1.f, fMinZoom, fMaxZoom );
+				float fZoom = RageUtil::ScaleFloat( fPercentOffset, 0.f, 1.f, fMinZoom, fMaxZoom );
 				m_current_with_effects.scale *= fZoom;
 
 				// Use the color as a Vector3 to scale the effect for added control
-				RageColor c = SCALE( fPercentOffset, 0.f, 1.f, m_effectColor1, m_effectColor2 );
+				RageColor c = fPercentOffset * (m_effectColor2 - m_effectColor1) / 1.f + m_effectColor1;
 				m_current_with_effects.scale.x *= c.r;
 				m_current_with_effects.scale.y *= c.g;
 				m_current_with_effects.scale.z *= c.b;
@@ -717,8 +717,8 @@ void Actor::BeginDraw()
 	// Adjust the alignment of the actor
 	if (unlikely(m_fHorizAlign != 0.5f || m_fVertAlign != 0.5f))
 	{
-		float fX = SCALE(m_fHorizAlign, 0.0f, 1.0f, +m_size.x / 2.0f, -m_size.x / 2.0f);
-		float fY = SCALE(m_fVertAlign, 0.0f, 1.0f, +m_size.y / 2.0f, -m_size.y / 2.0f);
+		float fX = RageUtil::ScaleFloat(m_fHorizAlign, 0.0f, 1.0f, +m_size.x / 2.0f, -m_size.x / 2.0f);
+		float fY = RageUtil::ScaleFloat(m_fVertAlign, 0.0f, 1.0f, +m_size.y / 2.0f, -m_size.y / 2.0f);
 		RageMatrix m;
 		RageMatrixTranslate(&m, fX, fY, 0);
 		DISPLAY->PreMultMatrix(m);

--- a/src/ArrowEffects.cpp
+++ b/src/ArrowEffects.cpp
@@ -158,7 +158,7 @@ static float CalculateTornadoOffsetFromMagnitude(int dimension, int col_id,
 	PerPlayerData& data, float y_offset, bool is_tan)
 {
 	float const real_pixel_offset= pCols[col_id].fXOffset * field_zoom;
-	float const position_between= SCALE(real_pixel_offset,
+	float const position_between= RageUtil::ScaleFloat(real_pixel_offset,
 		data.m_MinTornado[dimension][col_id] * field_zoom,
 		data.m_MaxTornado[dimension][col_id] * field_zoom,
 		tornado_position_scale_to_low[dimension],
@@ -168,7 +168,7 @@ static float CalculateTornadoOffsetFromMagnitude(int dimension, int col_id,
 	rads+= (y_offset + effect_offset) * ((period * frequency) + frequency) / SCREEN_HEIGHT;
 	float processed_rads = is_tan ? SelectTanType(rads, curr_options->m_bCosecant) : std::cos(rads);
 
-	float const adjusted_pixel_offset= SCALE(processed_rads,
+	float const adjusted_pixel_offset= RageUtil::ScaleFloat(processed_rads,
 		tornado_offset_scale_from_low[dimension],
 		tornado_offset_scale_from_high[dimension],
 		data.m_MinTornado[dimension][col_id] * field_zoom,
@@ -215,10 +215,10 @@ static void UpdateBeat(int dimension, PerPlayerData &data, const SongPosition &p
 
 	if( fBeat < fAccelTime )
 	{
-		data.m_fBeatFactor[dimension] = SCALE( fBeat, 0.0f, fAccelTime, 0.0f, 1.0f);
+		data.m_fBeatFactor[dimension] = RageUtil::ScaleFloat( fBeat, 0.0f, fAccelTime, 0.0f, 1.0f);
 		data.m_fBeatFactor[dimension] *= data.m_fBeatFactor[dimension];
 	} else /* fBeat < fTotalTime */ {
-		data.m_fBeatFactor[dimension] = SCALE( fBeat, fAccelTime, fTotalTime, 1.0f, 0.0f);
+		data.m_fBeatFactor[dimension] = RageUtil::ScaleFloat( fBeat, fAccelTime, fTotalTime, 1.0f, 0.0f);
 		data.m_fBeatFactor[dimension] = 1 - (1-data.m_fBeatFactor[dimension]) * (1-data.m_fBeatFactor[dimension]);
 	}
 
@@ -379,7 +379,7 @@ void ArrowEffects::Update()
 			if( iFirstColOnSide == iLastColOnSide )
 				iNewColOnSide = 0;
 			else
-				iNewColOnSide = SCALE( iColOnSide, iFirstColOnSide, iLastColOnSide, iLastColOnSide, iFirstColOnSide );
+				iNewColOnSide = RageUtil::ScaleInt( iColOnSide, iFirstColOnSide, iLastColOnSide, iLastColOnSide, iFirstColOnSide );
 			const int iNewCol = iSideIndex*iNumColsPerSide + iNewColOnSide;
 
 			const float fOldPixelOffset = pCols[iColNum].fXOffset;
@@ -539,7 +539,7 @@ float ArrowEffects::GetYOffset( const PlayerState* pPlayerState, int iCol, float
 	if( fAccels[PlayerOptions::ACCEL_BRAKE] != 0 )
 	{
 		float fEffectHeight = GetNoteFieldHeight();
-		float fScale = SCALE( fYOffset, 0.f, fEffectHeight, 0, 1.f );
+		float fScale = RageUtil::ScaleFloat( fYOffset, 0.f, fEffectHeight, 0, 1.f );
 		float fNewYOffset = fYOffset * fScale;
 		float fBrakeYAdjust = fAccels[PlayerOptions::ACCEL_BRAKE] * (fNewYOffset - fYOffset);
 		// TRICKY: Clamp this value the same way as BOOST so that in BOOST+BRAKE, BRAKE doesn't overpower BOOST
@@ -576,27 +576,27 @@ float ArrowEffects::GetYOffset( const PlayerState* pPlayerState, int iCol, float
 		/* Random speed always increases speed: a random speed of 10 indicates
 		 * [1,11]. This keeps it consistent with other mods: 0 means no effect. */
 		fScrollSpeed *=
-				SCALE( fRandom,
+				RageUtil::ScaleFloat( fRandom,
 						0.0f, 1.0f,
 						1.0f, curr_options->m_fRandomSpeed + 1.0f );
 	}
 
 	if( fAccels[PlayerOptions::ACCEL_EXPAND] != 0 )
 	{
-		float fExpandMultiplier = SCALE( std::cos(data.m_fExpandSeconds*EXPAND_MULTIPLIER_FREQUENCY*(fAccels[PlayerOptions::ACCEL_EXPAND_PERIOD]+1)),
+		float fExpandMultiplier = RageUtil::ScaleFloat( std::cos(data.m_fExpandSeconds*EXPAND_MULTIPLIER_FREQUENCY*(fAccels[PlayerOptions::ACCEL_EXPAND_PERIOD]+1)),
 						EXPAND_MULTIPLIER_SCALE_FROM_LOW, EXPAND_MULTIPLIER_SCALE_FROM_HIGH,
 						EXPAND_MULTIPLIER_SCALE_TO_LOW, EXPAND_MULTIPLIER_SCALE_TO_HIGH );
-		fScrollSpeed *=	SCALE( fAccels[PlayerOptions::ACCEL_EXPAND],
+		fScrollSpeed *=	RageUtil::ScaleFloat( fAccels[PlayerOptions::ACCEL_EXPAND],
 				      EXPAND_SPEED_SCALE_FROM_LOW, EXPAND_SPEED_SCALE_FROM_HIGH,
 				      EXPAND_SPEED_SCALE_TO_LOW, fExpandMultiplier );
 	}
 
 	if( fAccels[PlayerOptions::ACCEL_TAN_EXPAND] != 0 )
 	{
-		float fTanExpandMultiplier = SCALE( SelectTanType(data.m_fTanExpandSeconds*EXPAND_MULTIPLIER_FREQUENCY*(fAccels[PlayerOptions::ACCEL_TAN_EXPAND_PERIOD]+1), curr_options->m_bCosecant),
+		float fTanExpandMultiplier = RageUtil::ScaleFloat( SelectTanType(data.m_fTanExpandSeconds*EXPAND_MULTIPLIER_FREQUENCY*(fAccels[PlayerOptions::ACCEL_TAN_EXPAND_PERIOD]+1), curr_options->m_bCosecant),
 						EXPAND_MULTIPLIER_SCALE_FROM_LOW, EXPAND_MULTIPLIER_SCALE_FROM_HIGH,
 						EXPAND_MULTIPLIER_SCALE_TO_LOW, EXPAND_MULTIPLIER_SCALE_TO_HIGH );
-		fScrollSpeed *=	SCALE( fAccels[PlayerOptions::ACCEL_TAN_EXPAND],
+		fScrollSpeed *=	RageUtil::ScaleFloat( fAccels[PlayerOptions::ACCEL_TAN_EXPAND],
 				      EXPAND_SPEED_SCALE_FROM_LOW, EXPAND_SPEED_SCALE_FROM_HIGH,
 				      EXPAND_SPEED_SCALE_TO_LOW, fTanExpandMultiplier );
 	}
@@ -618,11 +618,11 @@ static void ArrowGetReverseShiftAndScale(int iCol, float fYReverseOffsetPixels, 
 		fZoom = 0.01f;
 
 	float fPercentReverse = curr_options->GetReversePercentForColumn(iCol);
-	fShiftOut = SCALE( fPercentReverse, 0.f, 1.f, -fYReverseOffsetPixels/fZoom/2, fYReverseOffsetPixels/fZoom/2 );
+	fShiftOut = RageUtil::ScaleFloat( fPercentReverse, 0.f, 1.f, -fYReverseOffsetPixels/fZoom/2, fYReverseOffsetPixels/fZoom/2 );
 	float fPercentCentered = curr_options->m_fScrolls[PlayerOptions::SCROLL_CENTERED];
-	fShiftOut = SCALE( fPercentCentered, 0.f, 1.f, fShiftOut, 0.0f );
+	fShiftOut = RageUtil::ScaleFloat( fPercentCentered, 0.f, 1.f, fShiftOut, 0.0f );
 
-	fScaleOut = SCALE( fPercentReverse, 0.f, 1.f, 1.f, -1.f );
+	fScaleOut = RageUtil::ScaleFloat( fPercentReverse, 0.f, 1.f, 1.f, -1.f );
 }
 
 float ArrowEffects::GetYPos( const PlayerState* pPlayerState, int iCol, float fYOffset, float fYReverseOffsetPixels, bool WithReverse)
@@ -754,7 +754,7 @@ float ArrowEffects::GetXPos( const PlayerState* pPlayerState, int iColNum, float
 	{
 		const int iFirstCol = 0;
 		const int iLastCol = pStyle->m_iColsPerPlayer-1;
-		const int iNewCol = SCALE( iColNum, iFirstCol, iLastCol, iLastCol, iFirstCol );
+		const int iNewCol = RageUtil::ScaleInt( iColNum, iFirstCol, iLastCol, iLastCol, iFirstCol );
 		const float fOldPixelOffset = pCols[iColNum].fXOffset * pPlayerState->m_NotefieldZoom;
 		const float fNewPixelOffset = pCols[iNewCol].fXOffset * pPlayerState->m_NotefieldZoom;
 		const float fDistance = fNewPixelOffset - fOldPixelOffset;
@@ -1049,28 +1049,28 @@ static float GetHiddenSudden()
 static float GetHiddenEndLine()
 {
 	return GetCenterLine() +
-		FADE_DIST_Y * SCALE( GetHiddenSudden(), 0.f, 1.f, -1.0f, -1.25f ) +
+		FADE_DIST_Y * RageUtil::ScaleFloat( GetHiddenSudden(), 0.f, 1.f, -1.0f, -1.25f ) +
 		GetCenterLine() * curr_options->m_fAppearances[PlayerOptions::APPEARANCE_HIDDEN_OFFSET];
 }
 
 static float GetHiddenStartLine()
 {
 	return GetCenterLine() +
-		FADE_DIST_Y * SCALE( GetHiddenSudden(), 0.f, 1.f, +0.0f, -0.25f ) +
+		FADE_DIST_Y * RageUtil::ScaleFloat( GetHiddenSudden(), 0.f, 1.f, +0.0f, -0.25f ) +
 		GetCenterLine() * curr_options->m_fAppearances[PlayerOptions::APPEARANCE_HIDDEN_OFFSET];
 }
 
 static float GetSuddenEndLine()
 {
 	return GetCenterLine() +
-		FADE_DIST_Y * SCALE( GetHiddenSudden(), 0.f, 1.f, -0.0f, +0.25f ) +
+		FADE_DIST_Y * RageUtil::ScaleFloat( GetHiddenSudden(), 0.f, 1.f, -0.0f, +0.25f ) +
 		GetCenterLine() * curr_options->m_fAppearances[PlayerOptions::APPEARANCE_SUDDEN_OFFSET];
 }
 
 static float GetSuddenStartLine()
 {
 	return GetCenterLine() +
-		FADE_DIST_Y * SCALE( GetHiddenSudden(), 0.f, 1.f, +1.0f, +1.25f ) +
+		FADE_DIST_Y * RageUtil::ScaleFloat( GetHiddenSudden(), 0.f, 1.f, +1.0f, +1.25f ) +
 		GetCenterLine() * curr_options->m_fAppearances[PlayerOptions::APPEARANCE_SUDDEN_OFFSET];
 }
 
@@ -1095,13 +1095,13 @@ float ArrowGetPercentVisible(float fYPosWithoutReverse, int iCol, float fYOffset
 
 	if( fAppearances[PlayerOptions::APPEARANCE_HIDDEN] != 0 )
 	{
-		float fHiddenVisibleAdjust = SCALE( fYPos, GetHiddenStartLine(), GetHiddenEndLine(), 0, -1 );
+		float fHiddenVisibleAdjust = RageUtil::ScaleFloat( fYPos, GetHiddenStartLine(), GetHiddenEndLine(), 0, -1 );
 		CLAMP( fHiddenVisibleAdjust, -1, 0 );
 		fVisibleAdjust += fAppearances[PlayerOptions::APPEARANCE_HIDDEN] * fHiddenVisibleAdjust;
 	}
 	if( fAppearances[PlayerOptions::APPEARANCE_SUDDEN] != 0 )
 	{
-		float fSuddenVisibleAdjust = SCALE( fYPos, GetSuddenStartLine(), GetSuddenEndLine(), -1, 0 );
+		float fSuddenVisibleAdjust = RageUtil::ScaleFloat( fYPos, GetSuddenStartLine(), GetSuddenEndLine(), -1, 0 );
 		CLAMP( fSuddenVisibleAdjust, -1, 0 );
 		fVisibleAdjust += fAppearances[PlayerOptions::APPEARANCE_SUDDEN] * fSuddenVisibleAdjust;
 	}
@@ -1115,12 +1115,12 @@ float ArrowGetPercentVisible(float fYPosWithoutReverse, int iCol, float fYOffset
 	{
 		float f = std::sin(ArrowEffects::GetTime()*10);
 		f = Quantize( f, BLINK_MOD_FREQUENCY );
-		fVisibleAdjust += SCALE( f, 0, 1, -1, 0 );
+		fVisibleAdjust += RageUtil::ScaleFloat( f, 0, 1, -1, 0 );
 	}
 	if( fAppearances[PlayerOptions::APPEARANCE_RANDOMVANISH] != 0 )
 	{
 		const float fRealFadeDist = 80;
-		fVisibleAdjust += SCALE( std::abs(fDistFromCenterLine), fRealFadeDist, 2*fRealFadeDist, -1, 0 )
+		fVisibleAdjust += RageUtil::ScaleFloat( std::abs(fDistFromCenterLine), fRealFadeDist, 2*fRealFadeDist, -1, 0 )
 			* fAppearances[PlayerOptions::APPEARANCE_RANDOMVANISH];
 	}
 
@@ -1141,7 +1141,7 @@ float ArrowEffects::GetAlpha( const PlayerState* pPlayerState, int iCol, float f
 	float fFullAlphaY = fDrawDistanceBeforeTargetsPixels*(1-fFadeInPercentOfDrawFar);
 	if( fYPosWithoutReverse > fFullAlphaY )
 	{
-		float f = SCALE( fYPosWithoutReverse, fFullAlphaY, fDrawDistanceBeforeTargetsPixels, 1.0f, 0.0f );
+		float f = RageUtil::ScaleFloat( fYPosWithoutReverse, fFullAlphaY, fDrawDistanceBeforeTargetsPixels, 1.0f, 0.0f );
 		return f;
 	}
 	return (fPercentVisible>0.5f) ? 1.0f : 0.0f;
@@ -1158,7 +1158,7 @@ float ArrowEffects::GetGlow( const PlayerState* pPlayerState, int iCol, float fY
 		fPercentVisible = 1 - fPercentFadeToFail;
 
 	const float fDistFromHalf = std::abs( fPercentVisible - 0.5f );
-	return SCALE( fDistFromHalf, 0, 0.5f, 1.3f, 0 );
+	return RageUtil::ScaleFloat( fDistFromHalf, 0, 0.5f, 1.3f, 0 );
 }
 
 float ArrowEffects::GetBrightness( const PlayerState* pPlayerState, float fNoteBeat )
@@ -1169,7 +1169,7 @@ float ArrowEffects::GetBrightness( const PlayerState* pPlayerState, float fNoteB
 	float fSongBeat = pPlayerState->m_Position.m_fSongBeatVisible;
 	float fBeatsUntilStep = fNoteBeat - fSongBeat;
 
-	float fBrightness = SCALE( fBeatsUntilStep, 0, -1, 1.f, 0.f );
+	float fBrightness = RageUtil::ScaleFloat( fBeatsUntilStep, 0, -1, 1.f, 0.f );
 	CLAMP( fBrightness, 0, 1 );
 	return fBrightness;
 }
@@ -1410,15 +1410,15 @@ float ArrowEffects::GetFrameWidthScale( const PlayerState* pPlayerState, float f
 		float fFromEndOfOverlapped = fOverlappedTime - fSecond;
 		float fTrailingPixels = FRAME_WIDTH_LOCK_EFFECTS_TWEEN_PIXELS;
 		float fTrailingSeconds = fTrailingPixels / fPixelsPerSecond;
-		float fScaleEffect = SCALE( fFromEndOfOverlapped, 0.0f, fTrailingSeconds, 0.0f, 1.0f );
+		float fScaleEffect = RageUtil::ScaleFloat( fFromEndOfOverlapped, 0.0f, fTrailingSeconds, 0.0f, 1.0f );
 		CLAMP( fScaleEffect, 0.0f, 1.0f );
 		fWidthEffect *= fScaleEffect;
 	}
 
 	if( fWidthEffect > 0 )
-		fFrameWidthMultiplier *= SCALE( fWidthEffect, 0.0f, 1.0f, 1.0f, FRAME_WIDTH_EFFECTS_MAX_MULTIPLIER );
+		fFrameWidthMultiplier *= RageUtil::ScaleFloat( fWidthEffect, 0.0f, 1.0f, 1.0f, FRAME_WIDTH_EFFECTS_MAX_MULTIPLIER );
 	else if( fWidthEffect < 0 )
-		fFrameWidthMultiplier *= SCALE( fWidthEffect, 0.0f, -1.0f, 1.0f, FRAME_WIDTH_EFFECTS_MIN_MULTIPLIER );
+		fFrameWidthMultiplier *= RageUtil::ScaleFloat( fWidthEffect, 0.0f, -1.0f, 1.0f, FRAME_WIDTH_EFFECTS_MIN_MULTIPLIER );
 
 	return fFrameWidthMultiplier;
 }

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -322,7 +322,7 @@ void BitmapText::BuildChars()
 			reverse( sLine.begin(), sLine.end() );
 		const int iLineWidth = m_iLineWidths[i];
 
-		float fX = SCALE( m_fHorizAlign, 0.0f, 1.0f, -m_size.x/2.0f, +m_size.x/2.0f - iLineWidth );
+		float fX = RageUtil::ScaleFloat( m_fHorizAlign, 0.0f, 1.0f, -m_size.x/2.0f, +m_size.x/2.0f - iLineWidth );
 		int iX = std::lrint( fX );
 
 		for( unsigned j = 0; j < sLine.size(); ++j )
@@ -381,8 +381,8 @@ void BitmapText::DrawChars( bool bUseStrokeTexture )
 		return;
 
 	const int iNumGlyphs = m_vpFontPageTextures.size();
-	int iStartGlyph = std::lrint( SCALE( m_pTempState->crop.left, 0.f, 1.f, 0, (float) iNumGlyphs ) );
-	int iEndGlyph = std::lrint( SCALE( m_pTempState->crop.right, 0.f, 1.f, (float) iNumGlyphs, 0 ) );
+	int iStartGlyph = std::lrint( RageUtil::ScaleFloat( m_pTempState->crop.left, 0.f, 1.f, 0, (float) iNumGlyphs ) );
+	int iEndGlyph = std::lrint( RageUtil::ScaleFloat( m_pTempState->crop.right, 0.f, 1.f, (float) iNumGlyphs, 0 ) );
 	iStartGlyph = std::clamp( iStartGlyph, 0, iNumGlyphs );
 	iEndGlyph = std::clamp( iEndGlyph, 0, iNumGlyphs );
 
@@ -409,18 +409,18 @@ void BitmapText::DrawChars( bool bUseStrokeTexture )
 
 		/* We fade from 0 to LeftColor, then from RightColor to 0. (We won't fade
 		 * all the way to 0 if the crop is beyond the outer edge.) */
-		const float fRightAlpha  = SCALE( FadeSize.right,  FadeDist.right,  0, 1, 0 );
-		const float fLeftAlpha   = SCALE( FadeSize.left,   FadeDist.left,   0, 1, 0 );
+		const float fRightAlpha  = RageUtil::ScaleFloat( FadeSize.right,  FadeDist.right,  0, 1, 0 );
+		const float fLeftAlpha   = RageUtil::ScaleFloat( FadeSize.left,   FadeDist.left,   0, 1, 0 );
 
 		const float fStartFadeLeftPercent = m_pTempState->crop.left;
 		const float fStopFadeLeftPercent = m_pTempState->crop.left + FadeSize.left;
-		const float fLeftFadeStartGlyph = SCALE( fStartFadeLeftPercent, 0.f, 1.f, 0, (float) iNumGlyphs );
-		const float fLeftFadeStopGlyph = SCALE( fStopFadeLeftPercent, 0.f, 1.f, 0, (float) iNumGlyphs );
+		const float fLeftFadeStartGlyph = RageUtil::ScaleFloat( fStartFadeLeftPercent, 0.f, 1.f, 0, static_cast<float>(iNumGlyphs) );
+		const float fLeftFadeStopGlyph = RageUtil::ScaleFloat( fStopFadeLeftPercent, 0.f, 1.f, 0, static_cast<float>(iNumGlyphs) );
 
 		const float fStartFadeRightPercent = 1-(m_pTempState->crop.right + FadeSize.right);
 		const float fStopFadeRightPercent = 1-(m_pTempState->crop.right);
-		const float fRightFadeStartGlyph = SCALE( fStartFadeRightPercent, 0.f, 1.f, 0, (float) iNumGlyphs );
-		const float fRightFadeStopGlyph = SCALE( fStopFadeRightPercent, 0.f, 1.f, 0, (float) iNumGlyphs );
+		const float fRightFadeStartGlyph = RageUtil::ScaleFloat( fStartFadeRightPercent, 0.f, 1.f, 0, static_cast<float>(iNumGlyphs) );
+		const float fRightFadeStopGlyph = RageUtil::ScaleFloat( fStopFadeRightPercent, 0.f, 1.f, 0, static_cast<float>(iNumGlyphs) );
 
 		for( int start = iStartGlyph; start < iEndGlyph; ++start )
 		{
@@ -430,14 +430,14 @@ void BitmapText::DrawChars( bool bUseStrokeTexture )
 			if( FadeSize.left > 0.001f )
 			{
 				// Add .5, so we fade wrt. the center of the vert, not the left side.
-				float fPercent = SCALE( start+0.5f, fLeftFadeStartGlyph, fLeftFadeStopGlyph, 0.0f, 1.0f );
+				float fPercent = RageUtil::ScaleFloat( start+0.5f, fLeftFadeStartGlyph, fLeftFadeStopGlyph, 0.0f, 1.0f );
 				fPercent = std::clamp( fPercent, 0.0f, 1.0f );
 				fAlpha *= fPercent * fLeftAlpha;
 			}
 
 			if( FadeSize.right > 0.001f )
 			{
-				float fPercent = SCALE( start+0.5f, fRightFadeStartGlyph, fRightFadeStopGlyph, 1.0f, 0.0f );
+				float fPercent = RageUtil::ScaleFloat( start+0.5f, fRightFadeStartGlyph, fRightFadeStopGlyph, 1.0f, 0.0f );
 				fPercent = std::clamp( fPercent, 0.0f, 1.0f );
 				fAlpha *= fPercent * fRightAlpha;
 			}

--- a/src/CombinedLifeMeterTug.cpp
+++ b/src/CombinedLifeMeterTug.cpp
@@ -64,7 +64,7 @@ void CombinedLifeMeterTug::Update( float fDelta )
 	m_Stream[PLAYER_1].SetPercent( fPercentToShow );
 	m_Stream[PLAYER_2].SetPercent( 1-fPercentToShow );
 
-	float fSeparatorX = SCALE( fPercentToShow, 0.f, 1.f, -METER_WIDTH/2.f, +METER_WIDTH/2.f );
+	float fSeparatorX = RageUtil::ScaleFloat( fPercentToShow, 0.f, 1.f, -METER_WIDTH/2.f, +METER_WIDTH/2.f );
 
 	m_sprSeparator->SetX( fSeparatorX );
 
@@ -127,7 +127,7 @@ void CombinedLifeMeterTug::ChangeLife( PlayerNumber pn, float fPercentToMove )
 
 		/* Clamp the life meter only for calculating the multiplier. */
 		fLifePercentage = std::clamp( fLifePercentage, 0.0f, 1.0f );
-		fPercentToMove *= SCALE( fLifePercentage, 0.f, 1.f, 0.2f, 1.f);
+		fPercentToMove *= RageUtil::ScaleFloat( fLifePercentage, 0.f, 1.f, 0.2f, 1.f);
 	}
 
 	switch( pn )

--- a/src/ComboGraph.cpp
+++ b/src/ComboGraph.cpp
@@ -86,10 +86,10 @@ void ComboGraph::Set( const StageStats &s, const PlayerStageStats &pss )
 		LOG->Trace( "combo %i is %f+%f of %f", i, combo.m_fStartSecond, combo.m_fSizeSeconds, fLastSecond );
 		Actor *pSprite = bIsMax? m_pMaxCombo->Copy() : m_pNormalCombo->Copy();
 
-		const float fStart = SCALE( combo.m_fStartSecond, fFirstSecond, fLastSecond, 0.0f, 1.0f );
-		const float fSize = SCALE( combo.m_fSizeSeconds, 0, fLastSecond-fFirstSecond, 0.0f, 1.0f );
-		pSprite->SetCropLeft ( SCALE( fSize, 0.0f, 1.0f, 0.5f, 0.0f ) );
-		pSprite->SetCropRight( SCALE( fSize, 0.0f, 1.0f, 0.5f, 0.0f ) );
+		const float fStart = RageUtil::ScaleFloat( combo.m_fStartSecond, fFirstSecond, fLastSecond, 0.0f, 1.0f );
+		const float fSize = RageUtil::ScaleFloat( combo.m_fSizeSeconds, 0, fLastSecond-fFirstSecond, 0.0f, 1.0f );
+		pSprite->SetCropLeft ( RageUtil::ScaleFloat( fSize, 0.0f, 1.0f, 0.5f, 0.0f ) );
+		pSprite->SetCropRight( RageUtil::ScaleFloat( fSize, 0.0f, 1.0f, 0.5f, 0.0f ) );
 
 		pSprite->SetCropLeft( fStart );
 		pSprite->SetCropRight( 1 - (fSize + fStart) );
@@ -112,11 +112,11 @@ void ComboGraph::Set( const StageStats &s, const PlayerStageStats &pss )
 
 		BitmapText *pText = m_pComboNumber->Copy();
 
-		const float fStart = SCALE( combo.m_fStartSecond, fFirstSecond, fLastSecond, 0.0f, 1.0f );
-		const float fSize = SCALE( combo.m_fSizeSeconds, 0, fLastSecond-fFirstSecond, 0.0f, 1.0f );
+		const float fStart = RageUtil::ScaleFloat( combo.m_fStartSecond, fFirstSecond, fLastSecond, 0.0f, 1.0f );
+		const float fSize = RageUtil::ScaleFloat( combo.m_fSizeSeconds, 0, fLastSecond-fFirstSecond, 0.0f, 1.0f );
 
 		const float fCenterPercent = fStart + fSize/2;
-		const float fCenterXPos = SCALE( fCenterPercent, 0.0f, 1.0f, -BODY_WIDTH/2.0f, BODY_WIDTH/2.0f );
+		const float fCenterXPos = RageUtil::ScaleFloat( fCenterPercent, 0.0f, 1.0f, -BODY_WIDTH/2.0f, BODY_WIDTH/2.0f );
 		pText->SetX( fCenterXPos );
 
 		pText->SetText( ssprintf("%i",combo.GetStageCnt()) );

--- a/src/DancingCharacters.cpp
+++ b/src/DancingCharacters.cpp
@@ -209,7 +209,7 @@ void DancingCharacters::Update( float fDelta )
 	{
 		// make the characters move
 		float fBPM = GAMESTATE->m_Position.m_fCurBPS*60;
-		float fUpdateScale = SCALE( fBPM, 60.f, 300.f, 0.75f, 1.5f );
+		float fUpdateScale = RageUtil::ScaleFloat( fBPM, 60.f, 300.f, 0.75f, 1.5f );
 		CLAMP( fUpdateScale, 0.75f, 1.5f );
 
 		/* It's OK for the animation to go slower than natural when we're
@@ -340,9 +340,9 @@ void DancingCharacters::DrawPrimitives()
 	if(m_fThisCameraStartBeat == m_fThisCameraEndBeat)
 		fPercentIntoSweep = 0;
 	else 
-		fPercentIntoSweep = SCALE(GAMESTATE->m_Position.m_fSongBeat, m_fThisCameraStartBeat, m_fThisCameraEndBeat, 0.f, 1.f );
-	float fCameraPanY = SCALE( fPercentIntoSweep, 0.f, 1.f, m_CameraPanYStart, m_CameraPanYEnd );
-	float fCameraHeight = SCALE( fPercentIntoSweep, 0.f, 1.f, m_fCameraHeightStart, m_fCameraHeightEnd );
+		fPercentIntoSweep = RageUtil::ScaleFloat(GAMESTATE->m_Position.m_fSongBeat, m_fThisCameraStartBeat, m_fThisCameraEndBeat, 0.f, 1.f );
+	float fCameraPanY = RageUtil::ScaleFloat( fPercentIntoSweep, 0.f, 1.f, m_CameraPanYStart, m_CameraPanYEnd );
+	float fCameraHeight = RageUtil::ScaleFloat( fPercentIntoSweep, 0.f, 1.f, m_fCameraHeightStart, m_fCameraHeightEnd );
 
 	RageVector3 m_CameraPoint( 0, fCameraHeight, -m_CameraDistance );
 	RageMatrix CameraRot;

--- a/src/DualScrollBar.cpp
+++ b/src/DualScrollBar.cpp
@@ -51,11 +51,11 @@ void DualScrollBar::SetPercentage( PlayerNumber pn, float fPercent )
 	/* Position both thumbs. */
 	m_sprScrollThumbUnderHalf[pn]->StopTweening();
 	m_sprScrollThumbUnderHalf[pn]->BeginTweening( m_fBarTime );
-	m_sprScrollThumbUnderHalf[pn]->SetY( SCALE( fPercent, 0, 1, top, bottom ) );
+	m_sprScrollThumbUnderHalf[pn]->SetY( RageUtil::ScaleFloat( fPercent, 0, 1, top, bottom ) );
 
 	m_sprScrollThumbOverHalf[pn]->StopTweening();
 	m_sprScrollThumbOverHalf[pn]->BeginTweening( m_fBarTime );
-	m_sprScrollThumbOverHalf[pn]->SetY( SCALE( fPercent, 0, 1, top, bottom ) );
+	m_sprScrollThumbOverHalf[pn]->SetY( RageUtil::ScaleFloat( fPercent, 0, 1, top, bottom ) );
 }
 
 /*

--- a/src/GraphDisplay.cpp
+++ b/src/GraphDisplay.cpp
@@ -188,7 +188,7 @@ void GraphDisplay::Set( const StageStats &ss, const PlayerStageStats &pss )
 
 		Actor *p = m_sprSongBoundary->Copy();
 		m_vpSongBoundaries.push_back( p );
-		float fX = SCALE( fSec, 0, fTotalStepSeconds, m_quadVertices.left, m_quadVertices.right );
+		float fX = RageUtil::ScaleFloat( fSec, 0, fTotalStepSeconds, m_quadVertices.left, m_quadVertices.right );
 		p->SetX( fX );
 		this->AddChild( p );
 	});
@@ -211,7 +211,7 @@ void GraphDisplay::Set( const StageStats &ss, const PlayerStageStats &pss )
 
 		if( fMinLifeSoFar > 0.0f  &&  fMinLifeSoFar < 0.1f )
 		{
-			float fX = SCALE( float(iMinLifeSoFarAt), 0.0f, float(VALUE_RESOLUTION-1), m_quadVertices.left, m_quadVertices.right );
+			float fX = RageUtil::ScaleFloat( float(iMinLifeSoFarAt), 0.0f, float(VALUE_RESOLUTION-1), m_quadVertices.left, m_quadVertices.right );
 			m_sprBarely->SetX( fX );
 		}
 		else
@@ -255,16 +255,16 @@ void GraphDisplay::UpdateVerts()
 	RageSpriteVertex LineStrip[VALUE_RESOLUTION];
 	for( int i = 0; i < VALUE_RESOLUTION; ++i )
 	{
-		const float fX = SCALE( float(i), 0.0f, float(VALUE_RESOLUTION-1), m_quadVertices.left, m_quadVertices.right );
-		const float fY = SCALE( m_Values[i], 0.0f, 1.0f, m_quadVertices.bottom, m_quadVertices.top );
+		const float fX = RageUtil::ScaleFloat( float(i), 0.0f, float(VALUE_RESOLUTION-1), m_quadVertices.left, m_quadVertices.right );
+		const float fY = RageUtil::ScaleFloat( m_Values[i], 0.0f, 1.0f, m_quadVertices.bottom, m_quadVertices.top );
 
 		m_pGraphBody->m_Slices[i*2+0].p = RageVector3( fX, fY, 0 );
 		m_pGraphBody->m_Slices[i*2+1].p = RageVector3( fX, m_quadVertices.bottom, 0 );
 
 		const RectF *pRect = m_pGraphBody->m_pTexture->GetTextureCoordRect( 0 );
 
-		const float fU = SCALE( fX, m_quadVertices.left, m_quadVertices.right, pRect->left, pRect->right );
-		const float fV = SCALE( fY, m_quadVertices.top, m_quadVertices.bottom, pRect->top, pRect->bottom );
+		const float fU = RageUtil::ScaleFloat( fX, m_quadVertices.left, m_quadVertices.right, pRect->left, pRect->right );
+		const float fV = RageUtil::ScaleFloat( fY, m_quadVertices.top, m_quadVertices.bottom, pRect->top, pRect->bottom );
 		m_pGraphBody->m_Slices[i*2+0].t = RageVector2( fU, fV );
 		m_pGraphBody->m_Slices[i*2+1].t = RageVector2( fU, pRect->bottom );
 

--- a/src/InputFilter.cpp
+++ b/src/InputFilter.cpp
@@ -490,14 +490,14 @@ public:
 	static int GetMouseX( T* p, lua_State *L ){
 		float fX = p->GetCursorX();
 		// Scale input to the theme's dimensions
-		fX = SCALE( fX, 0, (PREFSMAN->m_iDisplayHeight * PREFSMAN->m_fDisplayAspectRatio), SCREEN_LEFT, SCREEN_RIGHT );
+		fX = RageUtil::ScaleFloat( fX, 0, (PREFSMAN->m_iDisplayHeight * PREFSMAN->m_fDisplayAspectRatio), SCREEN_LEFT, SCREEN_RIGHT );
 		lua_pushnumber( L, fX );
 		return 1;
 	}
 	static int GetMouseY( T* p, lua_State *L ){
 		float fY = p->GetCursorY();
 		// Scale input to the theme's dimensions
-		fY = SCALE( fY, 0, PREFSMAN->m_iDisplayHeight, SCREEN_TOP, SCREEN_BOTTOM );
+		fY = RageUtil::ScaleFloat( fY, 0, PREFSMAN->m_iDisplayHeight, SCREEN_TOP, SCREEN_BOTTOM );
 		lua_pushnumber( L, fY );
 		return 1;
 	}

--- a/src/LifeMeterBar.cpp
+++ b/src/LifeMeterBar.cpp
@@ -198,7 +198,7 @@ void LifeMeterBar::ChangeLife( float fDeltaLife )
 {
 	bool bUseMercifulDrain = m_bMercifulBeginnerInEffect || PREFSMAN->m_bMercifulDrain;
 	if( bUseMercifulDrain  &&  fDeltaLife < 0 )
-		fDeltaLife *= SCALE( m_fLifePercentage, 0.f, 1.f, 0.5f, 1.f);
+		fDeltaLife *= RageUtil::ScaleFloat( m_fLifePercentage, 0.f, 1.f, 0.5f, 1.f);
 
 	// handle progressiveness and ComboToRegainLife here
 	if( fDeltaLife >= 0 )

--- a/src/LuaExpressionTransform.cpp
+++ b/src/LuaExpressionTransform.cpp
@@ -59,7 +59,7 @@ void LuaExpressionTransform::TransformItemCached( Actor &a, float fPositionOffse
 		const Actor::TweenState &tsFloor = GetTransformCached( fFloor, iItemIndex, iNumItems );
 		const Actor::TweenState &tsCeil = GetTransformCached( fCeil, iItemIndex, iNumItems );
 
-		float fPercentTowardCeil = SCALE( fPositionOffsetFromCenter, fFloor, fCeil, 0.0f, 1.0f );
+		float fPercentTowardCeil = RageUtil::ScaleFloat( fPositionOffsetFromCenter, fFloor, fCeil, 0.0f, 1.0f );
 		Actor::TweenState::MakeWeightedAverage( a.DestTweenState(), tsFloor, tsCeil, fPercentTowardCeil );
 	}
 }

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -1051,7 +1051,7 @@ LuaFunction( VersionTime, (RString) version_time );
 
 static float scale( float x, float l1, float h1, float l2, float h2 )
 {
-	return SCALE( x, l1, h1, l2, h2 );
+	return (((x)-(l1)) * ((h2)-(l2)) / ((h1)-(l1)) + (l2));
 }
 LuaFunction( scale, scale(FArg(1), FArg(2), FArg(3), FArg(4), FArg(5)) );
 

--- a/src/MeterDisplay.cpp
+++ b/src/MeterDisplay.cpp
@@ -67,7 +67,7 @@ void MeterDisplay::SetPercent( float fPercent )
 	m_sprStream->SetCropRight( 1-fPercent );
 
 	if( m_sprTip.IsLoaded() )
-		m_sprTip->SetX( SCALE(fPercent, 0.f, 1.f, -m_fStreamWidth/2, m_fStreamWidth/2) );
+		m_sprTip->SetX( RageUtil::ScaleFloat(fPercent, 0.f, 1.f, -m_fStreamWidth/2, m_fStreamWidth/2) );
 }
 
 void MeterDisplay::SetStreamWidth( float fStreamWidth )
@@ -82,7 +82,7 @@ void SongMeterDisplay::Update( float fDeltaTime )
 	{
 		float fSongStartSeconds = GAMESTATE->m_pCurSong->GetFirstSecond();
 		float fSongEndSeconds = GAMESTATE->m_pCurSong->GetLastSecond();
-		float fPercentPositionSong = SCALE( GAMESTATE->m_Position.m_fMusicSeconds, fSongStartSeconds, fSongEndSeconds, 0.0f, 1.0f );
+		float fPercentPositionSong = RageUtil::ScaleFloat( GAMESTATE->m_Position.m_fMusicSeconds, fSongStartSeconds, fSongEndSeconds, 0.0f, 1.0f );
 		CLAMP( fPercentPositionSong, 0, 1 );
 
 		SetPercent( fPercentPositionSong );

--- a/src/ModIconRow.cpp
+++ b/src/ModIconRow.cpp
@@ -48,7 +48,7 @@ void ModIconRow::Load( const RString &sMetricsGroup, PlayerNumber pn )
 	{
 		ModIcon *p = new ModIcon;
 		p->SetName( "ModIcon" );
-		float fOffset = SCALE( i, 0, NUM_OPTION_ICONS-1, -(NUM_OPTION_ICONS-1)/2.0f, (float)(NUM_OPTION_ICONS-1)/2.0f );
+		float fOffset = RageUtil::ScaleFloat( i, 0, NUM_OPTION_ICONS-1, -(NUM_OPTION_ICONS-1)/2.0f, (float)(NUM_OPTION_ICONS-1)/2.0f );
 		p->SetXY( fOffset*SPACING_X, fOffset*SPACING_Y );
 		p->Load( OPTION_ICON_METRICS_GROUP );
 		ActorUtil::LoadAllCommands( p, sMetricsGroup );

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -630,7 +630,7 @@ void Model::SetBones( const msAnimation* pAnimation, float fFrame, std::vector<m
 		RageVector3 vPos;
 		if( pLastPositionKey != nullptr && pThisPositionKey != nullptr )
 		{
-			const float s = SCALE( fFrame, pLastPositionKey->fTime, pThisPositionKey->fTime, 0, 1 );
+			const float s = RageUtil::ScaleFloat( fFrame, pLastPositionKey->fTime, pThisPositionKey->fTime, 0, 1 );
 			vPos = pLastPositionKey->Position + (pThisPositionKey->Position - pLastPositionKey->Position) * s;
 		}
 		else if( pLastPositionKey == nullptr )
@@ -654,7 +654,7 @@ void Model::SetBones( const msAnimation* pAnimation, float fFrame, std::vector<m
 		RageVector4 vRot;
 		if( pLastRotationKey != nullptr && pThisRotationKey != nullptr )
 		{
-			const float s = SCALE( fFrame, pLastRotationKey->fTime, pThisRotationKey->fTime, 0, 1 );
+			const float s = RageUtil::ScaleFloat( fFrame, pLastRotationKey->fTime, pThisRotationKey->fTime, 0, 1 );
 			RageQuatSlerp( &vRot, pLastRotationKey->Rotation, pThisRotationKey->Rotation, s );
 		}
 		else if( pLastRotationKey == nullptr )

--- a/src/NoteDataWithScoring.cpp
+++ b/src/NoteDataWithScoring.cpp
@@ -162,7 +162,7 @@ float GetActualVoltageRadarValue( const NoteData &in, float fSongSeconds, const 
 	 * length of the longest recorded combo. This is only subtly different:
 	 * it's the percent of the song the longest combo took to get. */
 	const PlayerStageStats::Combo_t MaxCombo = pss.GetMaxCombo();
-	float fComboPercent = SCALE(MaxCombo.m_fSizeSeconds, 0, fSongSeconds, 0.0f, 1.0f);
+	float fComboPercent = RageUtil::ScaleFloat(MaxCombo.m_fSizeSeconds, 0, fSongSeconds, 0.0f, 1.0f);
 	return std::clamp( fComboPercent, 0.0f, 1.0f );
 }
 

--- a/src/NoteDisplay.cpp
+++ b/src/NoteDisplay.cpp
@@ -803,7 +803,7 @@ void NoteDisplay::DrawHoldPart(std::vector<Sprite*> &vpSpr,
 	{
 		if (!part_args.anchor_to_top)
 		{
-			float tex_coord_bottom= SCALE(part_args.y_bottom - part_args.y_top,
+			float tex_coord_bottom= RageUtil::ScaleFloat(part_args.y_bottom - part_args.y_top,
 				0, unzoomed_frame_height, rect.top, rect.bottom);
 			float want_tex_coord_bottom	= std::ceil(tex_coord_bottom - 0.0001f);
 			add_to_tex_coord = want_tex_coord_bottom - tex_coord_bottom;
@@ -814,7 +814,7 @@ void NoteDisplay::DrawHoldPart(std::vector<Sprite*> &vpSpr,
 			/* For very large hold notes, shift the texture coordinates to be near 0, so we
 			 * don't send very large values to the renderer. */
 			const float fDistFromTop = y_start_pos - part_args.y_top;
-			float fTexCoordTop = SCALE(fDistFromTop, 0, unzoomed_frame_height, rect.top, rect.bottom);
+			float fTexCoordTop = RageUtil::ScaleFloat(fDistFromTop, 0, unzoomed_frame_height, rect.top, rect.bottom);
 			fTexCoordTop += add_to_tex_coord;
 			add_to_tex_coord -= std::floor(fTexCoordTop);
 		}
@@ -831,7 +831,7 @@ void NoteDisplay::DrawHoldPart(std::vector<Sprite*> &vpSpr,
 			// Shift texture coord to fit hold length If hold length is less than
 			// bottomcap frame height. (translated by hanubeki)
 			if (offset>0){
-				add_to_tex_coord = SCALE(offset, 0.0f, unzoomed_frame_height, 0.0f, 1.0f);
+				add_to_tex_coord = RageUtil::ScaleFloat(offset, 0.0f, unzoomed_frame_height, 0.0f, 1.0f);
 			}
 			else{
 				add_to_tex_coord = 0.0f;
@@ -864,7 +864,7 @@ void NoteDisplay::DrawHoldPart(std::vector<Sprite*> &vpSpr,
 		float cur_beat= part_args.top_beat;
 		if(part_args.top_beat != part_args.bottom_beat)
 		{
-			cur_beat= SCALE(fY, part_args.y_top, part_args.y_bottom, part_args.top_beat, part_args.bottom_beat);
+			cur_beat= RageUtil::ScaleFloat(fY, part_args.y_top, part_args.y_bottom, part_args.top_beat, part_args.bottom_beat);
 		}
 
 		// Fun times ahead with vector math.  If the notes are being moved by the
@@ -1013,7 +1013,7 @@ void NoteDisplay::DrawHoldPart(std::vector<Sprite*> &vpSpr,
 		const float fVariableZoom	= ArrowEffects::GetZoomVariable(fYOffset, column_args.column, 1) / fPulseInnerAdj;
 
 		const float fDistFromTop	= (fY - y_start_pos) / ae_zoom;
-		float fTexCoordTop		= SCALE(fDistFromTop, 0, unzoomed_frame_height, rect.top, rect.bottom * fVariableZoom);
+		float fTexCoordTop		= RageUtil::ScaleFloat(fDistFromTop, 0, unzoomed_frame_height, rect.top, rect.bottom * fVariableZoom);
 		fTexCoordTop += add_to_tex_coord;
 
 		const float fAlpha		= ArrowGetAlphaOrGlow(glow, m_pPlayerState, column_args.column, fYOffset, part_args.percent_fade_to_fail, m_fYReverseOffsetPixels, field_args.draw_pixels_before_targets, field_args.fade_before_targets);
@@ -1223,7 +1223,7 @@ void NoteDisplay::DrawHold(const TapNote& tn,
 	const float fYHead= ArrowEffects::GetYPos(m_pPlayerState, column_args.column, fStartYOffset, m_fYReverseOffsetPixels);
 	const float fYTail= ArrowEffects::GetYPos(m_pPlayerState, column_args.column, fEndYOffset, m_fYReverseOffsetPixels);
 
-	const float fColorScale		= SCALE( tn.HoldResult.fLife, 0.0f, 1.0f, cache->m_fHoldLetGoGrayPercent, 1.0f );
+	const float fColorScale		= RageUtil::ScaleFloat( tn.HoldResult.fLife, 0.0f, 1.0f, cache->m_fHoldLetGoGrayPercent, 1.0f );
 
 	bool bFlipHeadAndTail = bReverse && cache->m_bFlipHeadAndTailWhenReverse;
 

--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -432,11 +432,11 @@ void NoteField::DrawBeatBar( const float fBeat, BeatBarType type, int iMeasureIn
 				iState = 1;
 				break;
 			case half_beat:
-				fAlpha = SCALE(fScrollSpeed,1.0f,2.0f,0.0f,m_fBar8thAlpha);
+				fAlpha = RageUtil::ScaleFloat(fScrollSpeed,1.0f,2.0f,0.0f,m_fBar8thAlpha);
 				iState = 2;
 				break;
 			case quarter_beat:
-				fAlpha = SCALE(fScrollSpeed,2.0f,4.0f,0.0f,m_fBar16thAlpha);
+				fAlpha = RageUtil::ScaleFloat(fScrollSpeed,2.0f,4.0f,0.0f,m_fBar16thAlpha);
 				iState = 3;
 				break;
 		}
@@ -450,7 +450,7 @@ void NoteField::DrawBeatBar( const float fBeat, BeatBarType type, int iMeasureIn
 	m_sprBeatBars.SetY( fYPos );
 	m_sprBeatBars.SetDiffuse( RageColor(1,1,1,fAlpha) );
 	m_sprBeatBars.SetState( iState );
-	m_sprBeatBars.SetCustomTextureRect( RectF(0,SCALE(iState,0.f,4.f,0.f,1.f), fWidth/fFrameWidth, SCALE(iState+1,0.f,4.f,0.f,1.f)) );
+	m_sprBeatBars.SetCustomTextureRect( RectF(0,RageUtil::ScaleFloat(iState,0.f,4.f,0.f,1.f), fWidth/fFrameWidth, RageUtil::ScaleFloat(iState+1,0.f,4.f,0.f,1.f)) );
 	m_sprBeatBars.SetZoomX( fWidth/m_sprBeatBars.GetUnzoomedWidth() );
 	m_sprBeatBars.Draw();
 
@@ -757,7 +757,7 @@ void NoteField::CalcPixelsBeforeAndAfterTargets()
 		curr_options.m_fScrolls[PlayerOptions::SCROLL_CENTERED] *
 		curr_options.m_fAccels[PlayerOptions::ACCEL_BOOMERANG];
 	m_FieldRenderArgs.draw_pixels_after_targets +=
-		int(SCALE(centered_times_boomerang, 0.f, 1.f, 0.f, -SCREEN_HEIGHT/2));
+		RageUtil::ScaleInt(centered_times_boomerang, 0.f, 1.f, 0.f, -SCREEN_HEIGHT/2);
 	m_FieldRenderArgs.draw_pixels_before_targets =
 		m_iDrawDistanceBeforeTargetsPixels * (1.f + curr_options.m_fDrawSize);
 
@@ -1061,7 +1061,7 @@ void NoteField::DrawPrimitives()
 	if(*m_FieldRenderArgs.selection_begin_marker != -1 &&
 		*m_FieldRenderArgs.selection_end_marker != -1)
 	{
-		m_FieldRenderArgs.selection_glow= SCALE(
+		m_FieldRenderArgs.selection_glow= RageUtil::ScaleFloat(
 			std::cos(RageTimer::GetTimeSinceStartFast()*2), -1, 1, 0.1f, 0.3f);
 	}
 	m_FieldRenderArgs.fade_before_targets= FADE_BEFORE_TARGETS_PERCENT;

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -906,8 +906,7 @@ void Player::Update( float fDeltaTime )
 			for( int c=0; c<GAMESTATE->GetCurrentStyle(GetPlayerState()->m_PlayerNumber)->m_iColsPerPlayer; c++ )
 			{
 				float fPercentReverse = m_pPlayerState->m_PlayerOptions.GetCurrent().GetReversePercentForColumn(c);
-				float fHoldJudgeYPos = SCALE( fPercentReverse, 0.f, 1.f, HOLD_JUDGMENT_Y_STANDARD, HOLD_JUDGMENT_Y_REVERSE );
-				//float fGrayYPos = SCALE( fPercentReverse, 0.f, 1.f, GRAY_ARROWS_Y_STANDARD, GRAY_ARROWS_Y_REVERSE );
+				float fHoldJudgeYPos = RageUtil::ScaleFloat( fPercentReverse, 0.f, 1.f, HOLD_JUDGMENT_Y_STANDARD, HOLD_JUDGMENT_Y_REVERSE );
 
 				float fX = ArrowEffects::GetXPos( m_pPlayerState, c, 0 );
 				const float fZ = ArrowEffects::GetZPos( m_pPlayerState, c, 0);
@@ -1687,7 +1686,7 @@ void Player::PushPlayerMatrix(float x, float skew, float center_y)
 	DISPLAY->CameraPushMatrix();
 	DISPLAY->PushMatrix();
 	DISPLAY->LoadMenuPerspective(45, SCREEN_WIDTH, SCREEN_HEIGHT,
-		SCALE(skew, 0.1f, 1.0f, x, SCREEN_CENTER_X), center_y);
+		RageUtil::ScaleFloat(skew, 0.1f, 1.0f, x, SCREEN_CENTER_X), center_y);
 }
 
 void Player::PopPlayerMatrix()
@@ -1710,21 +1709,21 @@ Player::PlayerNoteFieldPositioner::PlayerNoteFieldPositioner(
 	player->PushPlayerMatrix(x, skew, center_y);
 	float reverse_mult= (reverse ? -1 : 1);
 	original_y= player->m_pNoteField->GetY();
-	float tilt_degrees= SCALE(tilt, -1.f, +1.f, +30, -30) * reverse_mult;
-	float zoom= SCALE(mini, 0.f, 1.f, 1.f, .5f);
+	float tilt_degrees= RageUtil::ScaleFloat(tilt, -1.f, +1.f, +30, -30) * reverse_mult;
+	float zoom= RageUtil::ScaleFloat(mini, 0.f, 1.f, 1.f, .5f);
 	// Something strange going on here.  Notice that the range for tilt's
 	// effect on y_offset goes to -45 when positive, but -20 when negative.
 	// I don't know why it's done this why, simply preserving old behavior.
 	// -Kyz
 	if(tilt > 0)
 	{
-		zoom*= SCALE(tilt, 0.f, 1.f, 1.f, 0.9f);
-		y_offset= SCALE(tilt, 0.f, 1.f, 0.f, -45.f) * reverse_mult;
+		zoom*= RageUtil::ScaleFloat(tilt, 0.f, 1.f, 1.f, 0.9f);
+		y_offset= RageUtil::ScaleFloat(tilt, 0.f, 1.f, 0.f, -45.f) * reverse_mult;
 	}
 	else
 	{
-		zoom*= SCALE(tilt, 0.f, -1.f, 1.f, 0.9f);
-		y_offset= SCALE(tilt, 0.f, -1.f, 0.f, -20.f) * reverse_mult;
+		zoom*= RageUtil::ScaleFloat(tilt, 0.f, -1.f, 1.f, 0.9f);
+		y_offset= RageUtil::ScaleFloat(tilt, 0.f, -1.f, 0.f, -20.f) * reverse_mult;
 	}
 	player->m_pNoteField->SetY(original_y + y_offset);
 	if(player->m_oitg_zoom_mode)
@@ -2199,9 +2198,9 @@ void Player::Step( int col, int row, const RageTimer &tm, bool bHeld, bool bRele
 			[[fallthrough]];
 		default:
 			{
-				float fCalsFor100Lbs = SCALE( iNumTracksHeld, 1, 2, 0.023f, 0.077f );
-				float fCalsFor200Lbs = SCALE( iNumTracksHeld, 1, 2, 0.041f, 0.133f );
-				fCals = SCALE( pProfile->GetCalculatedWeightPounds(), 100.f, 200.f, fCalsFor100Lbs, fCalsFor200Lbs );
+				float fCalsFor100Lbs = RageUtil::ScaleFloat( iNumTracksHeld, 1, 2, 0.023f, 0.077f );
+				float fCalsFor200Lbs = RageUtil::ScaleFloat( iNumTracksHeld, 1, 2, 0.041f, 0.133f );
+				fCals = RageUtil::ScaleFloat( pProfile->GetCalculatedWeightPounds(), 100.f, 200.f, fCalsFor100Lbs, fCalsFor200Lbs );
 			}
 			break;
 		}

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -1403,7 +1403,7 @@ float PlayerOptions::GetReversePercentForColumn( int iCol ) const
 	if( f > 2 )
 		f = std::fmod( f, 2 );
 	if( f > 1 )
-		f = SCALE( f, 1.f, 2.f, 1.f, 0.f );
+		f = RageUtil::ScaleFloat( f, 1.f, 2.f, 1.f, 0.f );
 	return f;
 }
 

--- a/src/PlayerStageStats.cpp
+++ b/src/PlayerStageStats.cpp
@@ -456,14 +456,14 @@ float PlayerStageStats::GetLifeRecordLerpAt( float fStepsSecond ) const
 		return earlier->second;
 
 	// earlier <= pos <= later
-	return SCALE( fStepsSecond, earlier->first, later->first, earlier->second, later->second );
+	return RageUtil::ScaleFloat( fStepsSecond, earlier->first, later->first, earlier->second, later->second );
 }
 
 void PlayerStageStats::GetLifeRecord( float *fLifeOut, int iNumSamples, float fStepsEndSecond ) const
 {
 	for( int i = 0; i < iNumSamples; ++i )
 	{
-		float from = SCALE( i, 0, (float)iNumSamples, 0.0f, fStepsEndSecond );
+		float from = RageUtil::ScaleFloat( i, 0, (float)iNumSamples, 0.0f, fStepsEndSecond );
 		fLifeOut[i] = GetLifeRecordLerpAt( from );
 	}
 }
@@ -835,7 +835,7 @@ public:
 		for(int i= 0; i < samples; ++i)
 		{
 			// The scale from range is [0, samples-1] because that is i's range.
-			float from= SCALE(i, 0, (float)samples-1.0f, 0.0f, last_second);
+			float from= RageUtil::ScaleFloat(i, 0, (float)samples-1.0f, 0.0f, last_second);
 			float curr= p->GetLifeRecordLerpAt(from);
 			lua_pushnumber(L, curr);
 			lua_rawseti(L, -2, i+1);

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -586,8 +586,8 @@ void RageDisplay::LoadMenuPerspective( float fovDegrees, float fWidth, float fHe
 		float theta = fovRadians/2;
 		float fDistCameraFromImage = fWidth/2 / std::tan( theta );
 
-		fVanishPointX = SCALE( fVanishPointX, 0, fWidth, fWidth, 0 );
-		fVanishPointY = SCALE( fVanishPointY, 0, fHeight, fHeight, 0 );
+		fVanishPointX = RageUtil::ScaleFloat( fVanishPointX, 0, fWidth, fWidth, 0 );
+		fVanishPointY = RageUtil::ScaleFloat( fVanishPointY, 0, fHeight, fHeight, 0 );
 
 		fVanishPointX -= fWidth/2;
 		fVanishPointY -= fHeight/2;
@@ -738,10 +738,10 @@ RageMatrix RageDisplay::GetCenteringMatrix( float fTranslateX, float fTranslateY
 	// in screen space, left edge = -1, right edge = 1, bottom edge = -1. top edge = 1
 	float fWidth = (float) GetActualVideoModeParams().windowWidth;
 	float fHeight = (float) GetActualVideoModeParams().windowHeight;
-	float fPercentShiftX = SCALE( fTranslateX, 0, fWidth, 0, +2.0f );
-	float fPercentShiftY = SCALE( fTranslateY, 0, fHeight, 0, -2.0f );
-	float fPercentScaleX = SCALE( fAddWidth, 0, fWidth, 1.0f, 2.0f );
-	float fPercentScaleY = SCALE( fAddHeight, 0, fHeight, 1.0f, 2.0f );
+	float fPercentShiftX = RageUtil::ScaleFloat( fTranslateX, 0, fWidth, 0, +2.0f );
+	float fPercentShiftY = RageUtil::ScaleFloat( fTranslateY, 0, fHeight, 0, -2.0f );
+	float fPercentScaleX = RageUtil::ScaleFloat( fAddWidth, 0, fWidth, 1.0f, 2.0f );
+	float fPercentScaleY = RageUtil::ScaleFloat( fAddHeight, 0, fHeight, 1.0f, 2.0f );
 
 	RageMatrix m1;
 	RageMatrix m2;

--- a/src/RageDisplay_D3D.cpp
+++ b/src/RageDisplay_D3D.cpp
@@ -1216,8 +1216,8 @@ void RageDisplay_D3D::SetZBias( float f )
 {
 	D3DVIEWPORT9 viewData;
 	g_pd3dDevice->GetViewport( &viewData );
-	viewData.MinZ = SCALE( f, 0.0f, 1.0f, 0.05f, 0.0f );
-	viewData.MaxZ = SCALE( f, 0.0f, 1.0f, 1.0f, 0.95f );
+	viewData.MinZ = RageUtil::ScaleFloat( f, 0.0f, 1.0f, 0.05f, 0.0f );
+	viewData.MaxZ = RageUtil::ScaleFloat( f, 0.0f, 1.0f, 1.0f, 0.95f );
 	g_pd3dDevice->SetViewport( &viewData );
 }
 

--- a/src/RageDisplay_GLES2.cpp
+++ b/src/RageDisplay_GLES2.cpp
@@ -704,8 +704,8 @@ RageDisplay_GLES2::SetZWrite( bool b )
 void
 RageDisplay_GLES2::SetZBias( float f )
 {
-	float fNear = SCALE( f, 0.0f, 1.0f, 0.05f, 0.0f );
-	float fFar = SCALE( f, 0.0f, 1.0f, 1.0f, 0.95f );
+	float fNear = RageUtil::ScaleFloat( f, 0.0f, 1.0f, 0.05f, 0.0f );
+	float fFar = RageUtil::ScaleFloat( f, 0.0f, 1.0f, 1.0f, 0.95f );
 
 	glDepthRange( fNear, fFar );
 }

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -1962,8 +1962,8 @@ void RageDisplay_Legacy::SetZWrite( bool b )
 
 void RageDisplay_Legacy::SetZBias( float f )
 {
-	float fNear = SCALE( f, 0.0f, 1.0f, 0.05f, 0.0f );
-	float fFar = SCALE( f, 0.0f, 1.0f, 1.0f, 0.95f );
+	float fNear = RageUtil::ScaleFloat( f, 0.0f, 1.0f, 0.05f, 0.0f );
+	float fFar = RageUtil::ScaleFloat( f, 0.0f, 1.0f, 1.0f, 0.95f );
 
 	glDepthRange( fNear, fFar );
 }
@@ -2184,10 +2184,10 @@ void SetPixelMapForSurface( int glImageFormat, int glTexFormat, const RageSurfac
 
 	for( int i = 0; i < palette->ncolors; ++i )
 	{
-		buf[0][i] = SCALE( palette->colors[i].r, 0, 255, 0, 65535 );
-		buf[1][i] = SCALE( palette->colors[i].g, 0, 255, 0, 65535 );
-		buf[2][i] = SCALE( palette->colors[i].b, 0, 255, 0, 65535 );
-		buf[3][i] = SCALE( palette->colors[i].a, 0, 255, 0, 65535 );
+		buf[0][i] = RageUtil::ScaleInt( palette->colors[i].r, 0, 255, 0, 65535 );
+		buf[1][i] = RageUtil::ScaleInt( palette->colors[i].g, 0, 255, 0, 65535 );
+		buf[2][i] = RageUtil::ScaleInt( palette->colors[i].b, 0, 255, 0, 65535 );
+		buf[3][i] = RageUtil::ScaleInt( palette->colors[i].a, 0, 255, 0, 65535 );
 	}
 
 	DebugFlushGLErrors();

--- a/src/RageMath.cpp
+++ b/src/RageMath.cpp
@@ -681,7 +681,7 @@ float RageBezier2D::EvaluateYFromX( float fX ) const
 	/* Quickly approximate T using Newton-Raphelson successive optimization (see
 	 * http://www.tinaja.com/text/bezmath.html).  This usually finds T within an
 	 * acceptable error margin in a few steps. */
-	float fT = SCALE( fX, m_X.GetBezierStart(), m_X.GetBezierEnd(), 0, 1 );
+	float fT = RageUtil::ScaleFloat( fX, m_X.GetBezierStart(), m_X.GetBezierEnd(), 0, 1 );
 	// Don't try more than 100 times, the curve might be a bit nonsensical. -Kyz
 	for(int i= 0; i < 100; ++i)
 	{

--- a/src/RageSoundReader_Extend.cpp
+++ b/src/RageSoundReader_Extend.cpp
@@ -124,8 +124,8 @@ int RageSoundReader_Extend::Read( float *pBuffer, int iFrames )
 		{
 			const int iStartSecond = m_iPositionFrames;
 			const int iEndSecond = m_iPositionFrames + iFramesRead;
-			const float fStartVolume = SCALE( iStartSecond, iFullVolumePositionFrames, iSilencePositionFrames, 1.0f, 0.0f );
-			const float fEndVolume = SCALE( iEndSecond, iFullVolumePositionFrames, iSilencePositionFrames, 1.0f, 0.0f );
+			const float fStartVolume = RageUtil::ScaleFloat( iStartSecond, iFullVolumePositionFrames, iSilencePositionFrames, 1.0f, 0.0f );
+			const float fEndVolume = RageUtil::ScaleFloat( iEndSecond, iFullVolumePositionFrames, iSilencePositionFrames, 1.0f, 0.0f );
 			RageSoundUtil::Fade( pBuffer, iFramesRead, this->GetNumChannels(), fStartVolume, fEndVolume );
 		}
 

--- a/src/RageSoundReader_Resample_Good.cpp
+++ b/src/RageSoundReader_Resample_Good.cpp
@@ -648,7 +648,7 @@ RageSoundReader_Resample_Good::~RageSoundReader_Resample_Good()
 int RageSoundReader_Resample_Good::SetPosition( int iFrame )
 {
 	Reset();
-	iFrame = (int) SCALE( iFrame, 0, (std::int64_t) m_iSampleRate, 0, (std::int64_t) m_pSource->GetSampleRate() );
+	iFrame = RageUtil::ScaleInt( iFrame, 0, (std::int64_t) m_iSampleRate, 0, (std::int64_t) m_pSource->GetSampleRate() );
 	return m_pSource->SetPosition( iFrame );
 }
 

--- a/src/RageSoundReader_SpeedChange.cpp
+++ b/src/RageSoundReader_SpeedChange.cpp
@@ -280,7 +280,7 @@ int RageSoundReader_SpeedChange::Read( float *pBuf, int iFrames )
 				ChannelInfo &c = m_Channels[i];
 				float i1 = c.m_DataBuffer[c.m_iCorrelatedPos+m_iPos];
 				float i2 = c.m_DataBuffer[c.m_iLastCorrelatedPos+m_iPos];
-				*pBuf++ = SCALE( m_iPos, 0, iWindowSizeFrames, i2, i1 );
+				*pBuf++ = RageUtil::ScaleFloat( m_iPos, 0, iWindowSizeFrames, i2, i1 );
 			}
 
 			++m_iPos;

--- a/src/RageSoundUtil.cpp
+++ b/src/RageSoundUtil.cpp
@@ -27,8 +27,8 @@ void RageSoundUtil::Pan( float *buffer, int frames, float fPos )
 	float fLeftFactors[2] ={ 1-fPos, 0 };
 	float fRightFactors[2] =
 	{
-		SCALE( fPos, 0, 1, 0.5f, 0 ),
-		SCALE( fPos, 0, 1, 0.5f, 1 )
+		RageUtil::ScaleFloat( fPos, 0, 1, 0.5f, 0 ),
+		RageUtil::ScaleFloat( fPos, 0, 1, 0.5f, 1 )
 	};
 
 	if( bSwap )
@@ -55,7 +55,7 @@ void RageSoundUtil::Fade( float *pBuffer, int iFrames, int iChannels, float fSta
 
 	for( int iFrame = 0; iFrame < iFrames; ++iFrame )
 	{
-		float fVolPercent = SCALE( iFrame, 0, iFrames, fStartVolume, fEndVolume );
+		float fVolPercent = RageUtil::ScaleFloat( iFrame, 0, iFrames, fStartVolume, fEndVolume );
 
 		fVolPercent = std::clamp( fVolPercent, 0.f, 1.f );
 		for( int i = 0; i < iChannels; ++i )

--- a/src/RageSurfaceUtils.cpp
+++ b/src/RageSurfaceUtils.cpp
@@ -570,12 +570,21 @@ static bool blit_rgba_to_rgba( const RageSurface *src_surf, const RageSurface *d
 			 *
 			 * Having separate formulas for increasing and decreasing resolution seems
 			 * strange; what's wrong here? */
-			if( max_src_val > max_dst_val )
-				for( std::uint32_t i = 0; i <= max_src_val; ++i )
-					lookup[c][i] = (std::uint8_t) SCALE( i, 0, max_src_val+1, 0, max_dst_val+1 );
+			if (max_src_val > max_dst_val)
+			{
+				for (std::uint32_t i = 0; i <= max_src_val; ++i)
+				{
+					lookup[c][i] = static_cast<std::uint8_t>(i * (max_dst_val + 1) / (max_src_val + 1));
+				}
+			}
 			else
-				for( std::uint32_t i = 0; i <= max_src_val; ++i )
-					lookup[c][i] = (std::uint8_t) SCALE( i, 0, max_src_val, 0, max_dst_val );
+			{
+				for (std::uint32_t i = 0; i <= max_src_val; ++i)
+				{
+					lookup[c][i] = static_cast<std::uint8_t>(i * max_dst_val / max_src_val);
+				}
+			}
+
 		}
 	}
 

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -30,15 +30,25 @@ class RageFileDriver;
 
 extern const RString CUSTOM_SONG_PATH;
 
-/**
- * @brief Scales x so that l1 corresponds to l2 and h1 corresponds to h2.
- *
- * This does not modify x, so it MUST assign the result to something!
- * Do the multiply before the divide to that integer scales have more precision.
- *
- * One such example: SCALE(x, 0, 1, L, H); interpolate between L and H.
- */
-#define SCALE(x, l1, h1, l2, h2)	(((x) - (l1)) * ((h2) - (l2)) / ((h1) - (l1)) + (l2))
+class RageUtil
+{
+public:
+	/**** Linear interpolation / scaling functions. In the old code base this was a macro `SCALE`. ****/
+	// We initialize the variables to 0 to retain the original behavior. 
+	// - Most SCALE calls want to return a float.
+	// - Some SCALE calls added 0.f to a variable to force it to evaluated as a float.
+	inline static float ScaleFloat(float x = 0.f, float l1 = 0.f, float h1 = 0.f, float l2 = 0.f, float h2 = 0.f)
+	{
+		return (((x)-(l1)) * ((h2)-(l2)) / ((h1)-(l1)) + (l2));
+	}
+
+	// Same as the above function, but returns an int.
+	// It's necessary to evaluate the arguments as floats to obtain the correct result.
+	inline static int ScaleInt(float x = 0.f, float l1 = 0.f, float h1 = 0.f, float l2 = 0.f, float h2 = 0.f)
+	{
+		return (((x)-(l1)) * ((h2)-(l2)) / ((h1)-(l1)) + (l2));
+	}
+};
 
 template<typename T, typename U>
 inline U lerp( T x, U l, U h )

--- a/src/ScoreKeeperRave.cpp
+++ b/src/ScoreKeeperRave.cpp
@@ -119,7 +119,7 @@ void ScoreKeeperRave::AddSuperMeterDelta( float fUnscaledPercentChange )
 	if( PREFSMAN->m_bMercifulDrain  &&  fUnscaledPercentChange<0 )
 	{
 		float fSuperPercentage = m_pPlayerState->m_fSuperMeter / Enum::to_integral(NUM_ATTACK_LEVELS);
-		fUnscaledPercentChange *= SCALE( fSuperPercentage, 0.f, 1.f, 0.5f, 1.f);
+		fUnscaledPercentChange *= RageUtil::ScaleFloat( fSuperPercentage, 0.f, 1.f, 0.5f, 1.f);
 	}
 
 	// more mercy: Grow super meter slower or faster depending on life.
@@ -135,14 +135,14 @@ void ScoreKeeperRave::AddSuperMeterDelta( float fUnscaledPercentChange )
 		}
 		CLAMP( fLifePercentage, 0.f, 1.f );
 		if( fUnscaledPercentChange > 0 )
-			fUnscaledPercentChange *= SCALE( fLifePercentage, 0.f, 1.f, 1.7f, 0.3f);
+			fUnscaledPercentChange *= RageUtil::ScaleFloat( fLifePercentage, 0.f, 1.f, 1.7f, 0.3f);
 		else	// fUnscaledPercentChange <= 0
-			fUnscaledPercentChange /= SCALE( fLifePercentage, 0.f, 1.f, 1.7f, 0.3f);
+			fUnscaledPercentChange /= RageUtil::ScaleFloat( fLifePercentage, 0.f, 1.f, 1.7f, 0.3f);
 	}
 
 	// mercy: drop super meter faster if at a higher level
 	if( fUnscaledPercentChange < 0 )
-		fUnscaledPercentChange *= SCALE( m_pPlayerState->m_fSuperMeter, 0.f, 1.f, 0.01f, 1.f );
+		fUnscaledPercentChange *= RageUtil::ScaleFloat( m_pPlayerState->m_fSuperMeter, 0.f, 1.f, 0.01f, 1.f );
 
 	AttackLevel oldAL = (AttackLevel)(int)m_pPlayerState->m_fSuperMeter;
 

--- a/src/ScreenBookkeeping.cpp
+++ b/src/ScreenBookkeeping.cpp
@@ -48,7 +48,7 @@ void ScreenBookkeeping::Init()
 		m_textData[i].LoadFromFont( THEME->GetPathF(m_sName,"data") );
 		m_textData[i].SetName( "Data" );
 		LOAD_ALL_COMMANDS_AND_SET_XY( m_textData[i] );
-		float fX = SCALE( i, 0.f, NUM_BOOKKEEPING_COLS-1, SCREEN_LEFT+50, SCREEN_RIGHT-160 );
+		float fX = RageUtil::ScaleFloat( i, 0.f, NUM_BOOKKEEPING_COLS-1, SCREEN_LEFT+50, SCREEN_RIGHT-160 );
 		m_textData[i].SetX( fX );
 		this->AddChild( &m_textData[i] );
 	}

--- a/src/ScreenDebugOverlay.cpp
+++ b/src/ScreenDebugOverlay.cpp
@@ -869,7 +869,7 @@ static HighScore MakeRandomHighScore( float fPercentDP )
 {
 	HighScore hs;
 	hs.SetName( "FAKE" );
-	Grade g = (Grade)SCALE( RandomInt(6), 0, 4, Grade_Tier01, Grade_Tier06 );
+	Grade g = static_cast<Grade>((RandomInt(6) * (Grade_Tier06 - Grade_Tier01) / 4) + Grade_Tier01);
 	if( g == Grade_Tier06 )
 		g = Grade_Failed;
 	hs.SetGrade( g );

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1241,7 +1241,7 @@ void ScreenGameplay::LoadNextSong()
 			{
 				pi->GetPlayerState()->m_PlayerController = PC_CPU;
 				int iMeter = pSteps->GetMeter();
-				int iNewSkill = SCALE( iMeter, MIN_METER, MAX_METER, 0, NUM_SKILL_LEVELS-1 );
+				int iNewSkill = RageUtil::ScaleInt( iMeter, MIN_METER, MAX_METER, 0, NUM_SKILL_LEVELS-1 );
 				/* Watch out: songs aren't actually bound by MAX_METER. */
 				iNewSkill = std::clamp( iNewSkill, 0, NUM_SKILL_LEVELS-1 );
 				pi->GetPlayerState()->m_iCpuSkill = iNewSkill;
@@ -2080,7 +2080,7 @@ void ScreenGameplay::UpdateHasteRate()
 		}
 	}
 	if( fMaxLife <= m_fHasteLifeSwitchPoint )
-		GAMESTATE->m_fHasteRate = SCALE( fMaxLife, 0.0f, m_fHasteLifeSwitchPoint, -1.0f, 0.0f );
+		GAMESTATE->m_fHasteRate = RageUtil::ScaleFloat( fMaxLife, 0.0f, m_fHasteLifeSwitchPoint, -1.0f, 0.0f );
 	CLAMP( GAMESTATE->m_fHasteRate, -1.0f, +1.0f );
 
 	float fSpeed = 1.0f;
@@ -2111,7 +2111,7 @@ void ScreenGameplay::UpdateHasteRate()
 		scale_to_low= m_HasteAddAmounts[turning_point];
 	}
 	// If negative haste is being used, the game instead slows down when the player does well.
-	float speed_add= SCALE(GAMESTATE->m_fHasteRate, scale_from_low, scale_from_high, scale_to_low, scale_to_high) * options_haste;
+	float speed_add= RageUtil::ScaleFloat(GAMESTATE->m_fHasteRate, scale_from_low, scale_from_high, scale_to_low, scale_to_high) * options_haste;
 	if(scale_from_low == scale_from_high)
 	{
 		speed_add= scale_to_high * options_haste;

--- a/src/ScreenNameEntry.cpp
+++ b/src/ScreenNameEntry.cpp
@@ -79,11 +79,17 @@ void ScreenNameEntry::ScrollingText::DrawPrimitives()
 		float fAlpha = 1.f;
 
 		if( iCharIndex == iClosestIndex )
-			fZoom = SCALE( std::abs(fClosestYOffset), 0, 0.5f, g_fCharsZoomLarge, g_fCharsZoomSmall );
+		{
+			fZoom = RageUtil::ScaleFloat( std::abs(fClosestYOffset), 0, 0.5f, g_fCharsZoomLarge, g_fCharsZoomSmall );
+		}
 		if( i == 0 )
-			fAlpha *= SCALE( fClosestYOffset, -0.5f, 0.f, 0.f, 1.f );
+		{
+			fAlpha *= RageUtil::ScaleFloat( fClosestYOffset, -0.5f, 0.f, 0.f, 1.f );
+		}
 		if( i == g_iNumCharsToDrawTotal-1 )
-			fAlpha *= SCALE( fClosestYOffset, 0.f, 0.5f, 1.f, 0.f );
+		{
+			fAlpha *= RageUtil::ScaleFloat( fClosestYOffset, 0.f, 0.5f, 1.f, 0.f );
+		}
 
 		m_Stamp.SetZoom( fZoom );
 		m_Stamp.SetDiffuseAlpha( fAlpha );

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -705,7 +705,7 @@ static void GlobalOffsetSeconds( int &sel, bool ToSel, const ConfOption *pConfOp
 {
 	float mapping[41];
 	for( int i = 0; i < 41; ++i )
-		mapping[i] = SCALE( i, 0.0f, 40.0f, -0.1f, +0.1f );
+		mapping[i] = RageUtil::ScaleFloat( i, 0.0f, 40.0f, -0.1f, +0.1f );
 
 	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
 }

--- a/src/ScreenSelectCharacter.cpp
+++ b/src/ScreenSelectCharacter.cpp
@@ -261,7 +261,7 @@ void ScreenSelectCharacter::AfterValueChange( PlayerNumber pn )
 				Banner &banner = m_sprIcons[pnAffected][i];
 				banner.LoadIconFromCharacter( pCharacter );
 				float fX = (pnAffected==PLAYER_1) ? 320-ICON_WIDTH : 320+ICON_WIDTH;
-				float fY = SCALE( i, 0.f, MAX_CHAR_ICONS_TO_SHOW-1.f, 240-(MAX_CHAR_ICONS_TO_SHOW/2*ICON_HEIGHT), 240+(MAX_CHAR_ICONS_TO_SHOW/2*ICON_HEIGHT));
+				float fY = RageUtil::ScaleFloat( i, 0.f, MAX_CHAR_ICONS_TO_SHOW-1.f, 240-(MAX_CHAR_ICONS_TO_SHOW/2*ICON_HEIGHT), 240+(MAX_CHAR_ICONS_TO_SHOW/2*ICON_HEIGHT));
 				banner.SetXY( fX, fY );
 			}
 		}

--- a/src/ScreenStatsOverlay.cpp
+++ b/src/ScreenStatsOverlay.cpp
@@ -49,7 +49,7 @@ void ScreenStatsOverlay::Init()
 			m_textSkips[i].LoadFromFont( THEME->GetPathF("Common","normal") );
 			m_textSkips[i].SetX( SKIP_X );
 			m_textSkips[i].SetY( 
-				SCALE( i, 0, NUM_SKIPS_TO_SHOW-1, rectSkips.top + 10, rectSkips.bottom - 10 ) 
+				RageUtil::ScaleFloat( i, 0, NUM_SKIPS_TO_SHOW-1, rectSkips.top + 10, rectSkips.bottom - 10 ) 
 				);
 			m_textSkips[i].SetDiffuse( RageColor(1,1,1,0) );
 			m_textSkips[i].SetShadowLength( 0 );

--- a/src/ScreenTextEntry.cpp
+++ b/src/ScreenTextEntry.cpp
@@ -686,8 +686,8 @@ void ScreenTextEntryVisual::BeginScreen()
 		for( int x=0; x<KEYS_PER_ROW; ++x )
 		{
 			BitmapText &bt = *m_ptextKeys[r][x];
-			float fX = std::round( SCALE( x, 0, KEYS_PER_ROW-1, ROW_START_X, ROW_END_X ) );
-			float fY = std::round( SCALE( r, 0, NUM_KeyboardRow-1, ROW_START_Y, ROW_END_Y ) );
+			float fX = std::round( RageUtil::ScaleFloat( x, 0, KEYS_PER_ROW-1, ROW_START_X, ROW_END_X ) );
+			float fY = std::round( RageUtil::ScaleFloat( r, 0, NUM_KeyboardRow-1, ROW_START_Y, ROW_END_Y ) );
 			bt.SetXY( fX, fY );
 		}
 	}

--- a/src/ScrollBar.cpp
+++ b/src/ScrollBar.cpp
@@ -53,7 +53,7 @@ void ScrollBar::SetPercentage( float fCenterPercent, float fSizePercent )
 
 	/* Set tick thumb */
 	{
-		float fY = SCALE( fCenterPercent, 0.0f, 1.0f, -iBarContentHeight/2.0f, iBarContentHeight/2.0f );
+		float fY = RageUtil::ScaleFloat( fCenterPercent, 0.0f, 1.0f, -iBarContentHeight/2.0f, iBarContentHeight/2.0f );
 		fY = std::round( fY );
 		m_sprScrollTickThumb->SetY( fY );
 	}
@@ -71,17 +71,17 @@ void ScrollBar::SetPercentage( float fCenterPercent, float fSizePercent )
 
 	if( fStartPercent < fEndPercent )	// we only need to one 1 stretch thumb part
 	{
-		fPartTopY[0]	= SCALE( fStartPercent,0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
-		fPartBottomY[0]	= SCALE( fEndPercent,  0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
+		fPartTopY[0]	= RageUtil::ScaleFloat( fStartPercent,0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
+		fPartBottomY[0]	= RageUtil::ScaleFloat( fEndPercent,  0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
 		fPartTopY[1]	= 0;
 		fPartBottomY[1]	= 0;
 	}
 	else	// we need two stretch thumb parts
 	{
-		fPartTopY[0]	= SCALE( 0.0f,		0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
-		fPartBottomY[0]	= SCALE( fEndPercent,	0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
-		fPartTopY[1]	= SCALE( fStartPercent,	0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
-		fPartBottomY[1]	= SCALE( 1.0f,		0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
+		fPartTopY[0]	= RageUtil::ScaleFloat( 0.0f,		0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
+		fPartBottomY[0]	= RageUtil::ScaleFloat( fEndPercent,	0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
+		fPartTopY[1]	= RageUtil::ScaleFloat( fStartPercent,	0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
+		fPartBottomY[1]	= RageUtil::ScaleFloat( 1.0f,		0.0f, 1.0f, -iBarContentHeight/2.0f, +iBarContentHeight/2.0f );
 	}
 
 	for( unsigned i=0; i<ARRAYLEN(m_sprScrollStretchThumb); i++ )

--- a/src/SoundEffectControl.cpp
+++ b/src/SoundEffectControl.cpp
@@ -76,9 +76,9 @@ void SoundEffectControl::Update( float fDeltaTime )
 
 	float fCurrent;
 	if( m_fSample < 0 )
-		fCurrent = SCALE( m_fSample, 0.0f, -1.0f, fPropertyCenter, fPropertyMin );
+		fCurrent = RageUtil::ScaleFloat( m_fSample, 0.0f, -1.0f, fPropertyCenter, fPropertyMin );
 	else
-		fCurrent = SCALE( m_fSample, 0.0f, +1.0f, fPropertyCenter, fPropertyMax );
+		fCurrent = RageUtil::ScaleFloat( m_fSample, 0.0f, +1.0f, fPropertyCenter, fPropertyMax );
 
 	if( m_pSoundReader )
 		m_pSoundReader->SetProperty( SOUND_PROPERTY, fCurrent );

--- a/src/Sprite.cpp
+++ b/src/Sprite.cpp
@@ -241,13 +241,13 @@ void Sprite::LoadFromNode( const XNode* pNode )
 					float fX = 1.0f, fY = 1.0f;
 					pPoints[0]->GetAttrValue( "x", fX );
 					pPoints[0]->GetAttrValue( "y", fY );
-					newState.rect.left = SCALE( fX, 0.0f, 1.0f, r.left, r.right );
-					newState.rect.top = SCALE( fY, 0.0f, 1.0f, r.top, r.bottom );
+					newState.rect.left = RageUtil::ScaleFloat( fX, 0.0f, 1.0f, r.left, r.right );
+					newState.rect.top = RageUtil::ScaleFloat( fY, 0.0f, 1.0f, r.top, r.bottom );
 
 					pPoints[1]->GetAttrValue( "x", fX );
 					pPoints[1]->GetAttrValue( "y", fY );
-					newState.rect.right = SCALE( fX, 0.0f, 1.0f, r.left, r.right );
-					newState.rect.bottom = SCALE( fY, 0.0f, 1.0f, r.top, r.bottom );
+					newState.rect.right = RageUtil::ScaleFloat( fX, 0.0f, 1.0f, r.left, r.right );
+					newState.rect.bottom = RageUtil::ScaleFloat( fY, 0.0f, 1.0f, r.top, r.bottom );
 				}
 
 				aStates.push_back( newState );
@@ -616,13 +616,13 @@ void Sprite::DrawTexture( const TweenState *state )
 			{
 				RageSpriteVertex *pVert = &v[i];
 
-				float fTopX = SCALE( pVert->p.x, quadVerticies.left, quadVerticies.right, texCoords[0].x, texCoords[3].x );
-				float fBottomX = SCALE( pVert->p.x, quadVerticies.left, quadVerticies.right, texCoords[1].x, texCoords[2].x );
-				pVert->t.x = SCALE( pVert->p.y, quadVerticies.top, quadVerticies.bottom, fTopX, fBottomX );
+				float fTopX = RageUtil::ScaleFloat( pVert->p.x, quadVerticies.left, quadVerticies.right, texCoords[0].x, texCoords[3].x );
+				float fBottomX = RageUtil::ScaleFloat( pVert->p.x, quadVerticies.left, quadVerticies.right, texCoords[1].x, texCoords[2].x );
+				pVert->t.x = RageUtil::ScaleFloat( pVert->p.y, quadVerticies.top, quadVerticies.bottom, fTopX, fBottomX );
 
-				float fLeftY = SCALE( pVert->p.y, quadVerticies.top, quadVerticies.bottom, texCoords[0].y, texCoords[1].y );
-				float fRightY = SCALE( pVert->p.y, quadVerticies.top, quadVerticies.bottom, texCoords[3].y, texCoords[2].y );
-				pVert->t.y = SCALE( pVert->p.x, quadVerticies.left, quadVerticies.right, fLeftY, fRightY );
+				float fLeftY = RageUtil::ScaleFloat( pVert->p.y, quadVerticies.top, quadVerticies.bottom, texCoords[0].y, texCoords[1].y );
+				float fRightY = RageUtil::ScaleFloat( pVert->p.y, quadVerticies.top, quadVerticies.bottom, texCoords[3].y, texCoords[2].y );
+				pVert->t.y = RageUtil::ScaleFloat( pVert->p.x, quadVerticies.left, quadVerticies.right, fLeftY, fRightY );
 			}
 		}
 		else
@@ -716,10 +716,10 @@ void Sprite::DrawPrimitives()
 		}
 
 		// Alpha value of the un-faded side of each fade rect:
-		const float RightAlpha  = SCALE( FadeSize.right,  FadeDist.right,  0, 1, 0 );
-		const float LeftAlpha   = SCALE( FadeSize.left,   FadeDist.left,   0, 1, 0 );
-		const float TopAlpha    = SCALE( FadeSize.top,    FadeDist.top,    0, 1, 0 );
-		const float BottomAlpha = SCALE( FadeSize.bottom, FadeDist.bottom, 0, 1, 0 );
+		const float RightAlpha  = RageUtil::ScaleFloat( FadeSize.right,  FadeDist.right,  0, 1, 0 );
+		const float LeftAlpha   = RageUtil::ScaleFloat( FadeSize.left,   FadeDist.left,   0, 1, 0 );
+		const float TopAlpha    = RageUtil::ScaleFloat( FadeSize.top,    FadeDist.top,    0, 1, 0 );
+		const float BottomAlpha = RageUtil::ScaleFloat( FadeSize.bottom, FadeDist.bottom, 0, 1, 0 );
 
 		// Draw the inside:
 		TweenState ts = *m_pTempState;
@@ -1252,10 +1252,10 @@ public:
 				// I have no idea why the points are from 0 to 1 and make it use only
 				// a portion of the state.  This is just copied from LoadFromNode.
 				// -Kyz
-				new_state.rect.left= SCALE(FArg(-1), 0.0f, 1.0f, r.left, r.right);
+				new_state.rect.left= RageUtil::ScaleFloat(FArg(-1), 0.0f, 1.0f, r.left, r.right);
 				lua_pop(L, 1);
 				lua_rawgeti(L, -1, 2);
-				new_state.rect.top= SCALE(FArg(-1), 0.0f, 1.0f, r.top, r.bottom);
+				new_state.rect.top= RageUtil::ScaleFloat(FArg(-1), 0.0f, 1.0f, r.top, r.bottom);
 				lua_pop(L, 1);
 			}
 			lua_pop(L, 1);
@@ -1266,10 +1266,10 @@ public:
 				// I have no idea why the points are from 0 to 1 and make it use only
 				// a portion of the state.  This is just copied from LoadFromNode.
 				// -Kyz
-				new_state.rect.right= SCALE(FArg(-1), 0.0f, 1.0f, r.left, r.right);
+				new_state.rect.right= RageUtil::ScaleFloat(FArg(-1), 0.0f, 1.0f, r.left, r.right);
 				lua_pop(L, 1);
 				lua_rawgeti(L, -1, 2);
-				new_state.rect.bottom= SCALE(FArg(-1), 0.0f, 1.0f, r.top, r.bottom);
+				new_state.rect.bottom= RageUtil::ScaleFloat(FArg(-1), 0.0f, 1.0f, r.top, r.bottom);
 				lua_pop(L, 1);
 			}
 			lua_pop(L, 1);

--- a/src/Sprite.cpp
+++ b/src/Sprite.cpp
@@ -563,14 +563,18 @@ void Sprite::DrawTexture( const TweenState *state )
 	CLAMP( crop.bottom, 0, 1 );
 
 	RectF croppedQuadVerticies = quadVerticies;
-#define IF_CROP_POS(side,opp_side) \
-	if(state->crop.side!=0) \
-		croppedQuadVerticies.side = \
-			SCALE( crop.side, 0.f, 1.f, quadVerticies.side, quadVerticies.opp_side )
-	IF_CROP_POS( left, right );
-	IF_CROP_POS( top, bottom );
-	IF_CROP_POS( right, left );
-	IF_CROP_POS( bottom, top );
+
+	if (state->crop.left != 0) 
+		croppedQuadVerticies.left = crop.left * (quadVerticies.right - quadVerticies.left) / 1.0f + quadVerticies.left;
+
+	if (state->crop.top != 0) 
+		croppedQuadVerticies.top = crop.top * (quadVerticies.bottom - quadVerticies.top) / 1.0f + quadVerticies.top;
+
+	if (state->crop.right != 0) 
+		croppedQuadVerticies.right = crop.right * (quadVerticies.left - quadVerticies.right) / 1.0f + quadVerticies.right;
+
+	if (state->crop.bottom != 0) 
+		croppedQuadVerticies.bottom = crop.bottom * (quadVerticies.top - quadVerticies.bottom) / 1.0f + quadVerticies.bottom;
 
 	static RageSpriteVertex v[4];
 	v[0].p = RageVector3( croppedQuadVerticies.left,	croppedQuadVerticies.top,	0 );	// top left

--- a/src/StreamDisplay.cpp
+++ b/src/StreamDisplay.cpp
@@ -109,7 +109,7 @@ void StreamDisplay::Update( float fDeltaSecs )
 		for( int i=0; i<(int)m_vpSprPill[st].size(); i++ )
 		{
 			Sprite *pSpr = m_vpSprPill[st][i];
-			float fPercentFilledThisPill = SCALE( m_fTrailingPercent, fPillWidthPercent*i, fPillWidthPercent*(i+1), 0.0f, 1.0f );
+			float fPercentFilledThisPill = RageUtil::ScaleFloat( m_fTrailingPercent, fPillWidthPercent*i, fPillWidthPercent*(i+1), 0.0f, 1.0f );
 			CLAMP( fPercentFilledThisPill, 0.0f, 1.0f );
 
 			// XXX scale by current song speed

--- a/src/WorkoutGraph.cpp
+++ b/src/WorkoutGraph.cpp
@@ -74,11 +74,11 @@ void WorkoutGraph::SetInternal( int iMinSongsPlayed )
 	int iBlocksHigh = MAX_METER;
 
 	const float fMaxWidth = 300;
-	float fTotalWidth = SCALE( iBlocksWide, 1.0f, 10.0f, 50.0f, fMaxWidth );
+	float fTotalWidth = RageUtil::ScaleFloat( iBlocksWide, 1.0f, 10.0f, 50.0f, fMaxWidth );
 	CLAMP( fTotalWidth, 50, fMaxWidth );
 
 	const float fMaxHeight = 130;
-	float fTotalHeight = SCALE( iBlocksHigh, 1.0f, 10.0f, 50.0f, fMaxHeight );
+	float fTotalHeight = RageUtil::ScaleFloat( iBlocksHigh, 1.0f, 10.0f, 50.0f, fMaxHeight );
 	CLAMP( fTotalHeight, 50, fMaxHeight );
 
 	float fBlockSize = std::min( fTotalWidth / iBlocksWide, fTotalHeight / iBlocksHigh );

--- a/src/arch/InputHandler/InputHandler_DirectInput.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInput.cpp
@@ -516,7 +516,7 @@ void InputHandler_DInput::UpdatePolled( DIDevice &device, const RageTimer &tm )
 
 						if( neg != DeviceButton_Invalid )
 						{
-							float l = SCALE( int(val), 0.0f, 100.0f, 0.0f, 1.0f );
+							float l = RageUtil::ScaleFloat( static_cast<int>(val), 0.0f, 100.0f, 0.0f, 1.0f );
 							ButtonPressed( DeviceInput(dev, neg, std::max(-l, 0.0f), tm) );
 							ButtonPressed( DeviceInput(dev, pos, std::max(+l, 0.0f), tm) );
 						}
@@ -692,7 +692,6 @@ void InputHandler_DInput::UpdateBuffered( DIDevice &device, const RageTimer &tm 
 							{
 								up = MOUSE_WHEELUP; down = MOUSE_WHEELDOWN;
 								float fWheelDelta = l;
-								//l = SCALE( int(evtbuf[i].dwData), -WHEEL_DELTA, WHEEL_DELTA, 1.0f, -1.0f );
 								if( l > 0 )
 								{
 									DeviceInput diUp = DeviceInput(dev, up, 1.0f, tm);
@@ -753,7 +752,7 @@ void InputHandler_DInput::UpdateBuffered( DIDevice &device, const RageTimer &tm 
 										 "Controller '%s' is returning an unknown joystick offset, %i",
 										 device.m_sName.c_str(), in.ofs );
 
-						float l = SCALE( int(evtbuf[i].dwData), 0.0f, 100.0f, 0.0f, 1.0f );
+						float l = RageUtil::ScaleFloat( static_cast<int>(evtbuf[i].dwData), 0.0f, 100.0f, 0.0f, 1.0f );
 						if(GamePreferences::m_AxisFix)
 						{
 						  ButtonPressed( DeviceInput(dev, up, (l == 0) || (l == -1), tm) );
@@ -796,8 +795,8 @@ void InputHandler_DInput::UpdateXInput( XIDevice &device, const RageTimer &tm )
 		float ly = 0.f;
 		if (std::sqrt(std::pow(state.Gamepad.sThumbLX, 2) + std::pow(state.Gamepad.sThumbLY, 2)) > XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE)
 		{
-			lx = SCALE(state.Gamepad.sThumbLX + 0.f, XINPUT_GAMEPAD_THUMB_MIN + 0.f, XINPUT_GAMEPAD_THUMB_MAX + 0.f, -1.0f, 1.0f);
-			ly = SCALE(state.Gamepad.sThumbLY + 0.f, XINPUT_GAMEPAD_THUMB_MIN + 0.f, XINPUT_GAMEPAD_THUMB_MAX + 0.f, -1.0f, 1.0f);
+			lx = RageUtil::ScaleFloat(state.Gamepad.sThumbLX, XINPUT_GAMEPAD_THUMB_MIN, XINPUT_GAMEPAD_THUMB_MAX, -1.0f, 1.0f);
+			ly = RageUtil::ScaleFloat(state.Gamepad.sThumbLY, XINPUT_GAMEPAD_THUMB_MIN, XINPUT_GAMEPAD_THUMB_MAX, -1.0f, 1.0f);
 		}
 		ButtonPressed(DeviceInput(device.dev, JOY_LEFT, std::max(-lx, 0.f), tm));
 		ButtonPressed(DeviceInput(device.dev, JOY_RIGHT, std::max(+lx, 0.f), tm));
@@ -808,8 +807,8 @@ void InputHandler_DInput::UpdateXInput( XIDevice &device, const RageTimer &tm )
 		float ry = 0.f;
 		if (std::sqrt(std::pow(state.Gamepad.sThumbRX, 2) + std::pow(state.Gamepad.sThumbRY, 2)) > XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE)
 		{
-			rx = SCALE(state.Gamepad.sThumbRX + 0.f, XINPUT_GAMEPAD_THUMB_MIN + 0.f, XINPUT_GAMEPAD_THUMB_MAX + 0.f, -1.0f, 1.0f);
-			ry = SCALE(state.Gamepad.sThumbRY + 0.f, XINPUT_GAMEPAD_THUMB_MIN + 0.f, XINPUT_GAMEPAD_THUMB_MAX + 0.f, -1.0f, 1.0f);
+			rx = RageUtil::ScaleFloat(state.Gamepad.sThumbRX, XINPUT_GAMEPAD_THUMB_MIN, XINPUT_GAMEPAD_THUMB_MAX, -1.0f, 1.0f);
+			ry = RageUtil::ScaleFloat(state.Gamepad.sThumbRY, XINPUT_GAMEPAD_THUMB_MIN, XINPUT_GAMEPAD_THUMB_MAX, -1.0f, 1.0f);
 		}
 		ButtonPressed(DeviceInput(device.dev, JOY_LEFT_2, std::max(-rx, 0.f), tm));
 		ButtonPressed(DeviceInput(device.dev, JOY_RIGHT_2, std::max(+rx, 0.f), tm));

--- a/src/arch/InputHandler/InputHandler_Linux_Event.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Event.cpp
@@ -411,7 +411,7 @@ void InputHandler_Linux_Event::InputThread()
 				DeviceButton neg = g_apEventDevices[i]->aiAbsMappingLow[event.code];
 				DeviceButton pos = g_apEventDevices[i]->aiAbsMappingHigh[event.code];
 
-				float l = SCALE( int(event.value), (float) g_apEventDevices[i]->aiAbsMin[event.code], (float) g_apEventDevices[i]->aiAbsMax[event.code], -1.0f, 1.0f );
+				float l = RageUtil::ScaleFloat( static_cast<int>(event.value), static_cast<float>(g_apEventDevices[i]->aiAbsMin[event.code]), static_cast<float>(g_apEventDevices[i]->aiAbsMax[event.code]), -1.0f, 1.0f );
 				if (GamePreferences::m_AxisFix)
 				{
 				  ButtonPressed( DeviceInput(g_apEventDevices[i]->m_Dev, neg, (l < -0.5)||((l > 0.0001)&&(l < 0.5)), now) ); //Up if between 0.0001 and 0.5 or if less than -0.5

--- a/src/arch/InputHandler/InputHandler_Linux_Joystick.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Joystick.cpp
@@ -174,7 +174,7 @@ void InputHandler_Linux_Joystick::InputThread()
 			case JS_EVENT_AXIS: {
 				DeviceButton neg = enum_add2(JOY_LEFT, 2*event.number);
 				DeviceButton pos = enum_add2(JOY_RIGHT, 2*event.number);
-                                float l = SCALE( int(event.value), 0.0f, 32767, 0.0f, 1.0f );
+                                float l = RageUtil::ScaleFloat( static_cast<int>(event.value), 0.0f, 32767, 0.0f, 1.0f );
 				ButtonPressed( DeviceInput(id, neg, std::max(-l, 0.0f), now) );
 				ButtonPressed( DeviceInput(id, pos, std::max(+l, 0.0f), now) );
 				break;

--- a/src/arch/Sound/RageSoundDriver_WDMKS.cpp
+++ b/src/arch/Sound/RageSoundDriver_WDMKS.cpp
@@ -1074,8 +1074,10 @@ namespace
 		case DeviceSampleFormat_Float32: // untested
 		{
 			float *pOutBuf = (float *) pOut;
-			for( int i = 0; i < iSamples; ++i )
-				pOutBuf[i] = SCALE( pIn[i], -32768, +32767, -1.0f, +1.0f ); // [-32768, 32767] -> [-1,+1]
+			for (int i = 0; i < iSamples; ++i)
+			{
+				pOutBuf[i] = (pIn[i] + 32768) * 2.0f / 65535.0f - 1.0f; // [-32768, 32767] -> [-1, +1]
+			}
 			break;
 		}
 		case DeviceSampleFormat_Int24:

--- a/src/archutils/Darwin/JoystickDevice.cpp
+++ b/src/archutils/Darwin/JoystickDevice.cpp
@@ -160,7 +160,7 @@ void JoystickDevice::GetButtonPresses( std::vector<DeviceInput>& vPresses, IOHID
 	{
 		if( js.x_axis == cookie )
 		{
-			float level = SCALE( value, js.x_min, js.x_max, -1.0f, 1.0f );
+			float level = RageUtil::ScaleFloat( value, js.x_min, js.x_max, -1.0f, 1.0f );
 
 			vPresses.push_back( DeviceInput(js.id, JOY_LEFT, std::max(-level, 0.0f), now) );
 			vPresses.push_back( DeviceInput(js.id, JOY_RIGHT, std::max(level, 0.0f), now) );
@@ -168,7 +168,7 @@ void JoystickDevice::GetButtonPresses( std::vector<DeviceInput>& vPresses, IOHID
 		}
 		else if( js.y_axis == cookie )
 		{
-			float level = SCALE( value, js.y_min, js.y_max, -1.0f, 1.0f );
+			float level = RageUtil::ScaleFloat( value, js.y_min, js.y_max, -1.0f, 1.0f );
 
 			vPresses.push_back( DeviceInput(js.id, JOY_UP, std::max(-level, 0.0f), now) );
 			vPresses.push_back( DeviceInput(js.id, JOY_DOWN, std::max(level, 0.0f), now) );
@@ -176,7 +176,7 @@ void JoystickDevice::GetButtonPresses( std::vector<DeviceInput>& vPresses, IOHID
 		}
 		else if( js.z_axis == cookie )
 		{
-			float level = SCALE( value, js.z_min, js.z_max, -1.0f, 1.0f );
+			float level = RageUtil::ScaleFloat( value, js.z_min, js.z_max, -1.0f, 1.0f );
 
 			vPresses.push_back( DeviceInput(js.id, JOY_Z_UP, std::max(-level, 0.0f), now) );
 			vPresses.push_back( DeviceInput(js.id, JOY_Z_DOWN, std::max(level, 0.0f), now) );
@@ -184,7 +184,7 @@ void JoystickDevice::GetButtonPresses( std::vector<DeviceInput>& vPresses, IOHID
 		}
 		else if( js.x_rot == cookie )
 		{
-			float level = SCALE( value, js.rx_min, js.rx_max, -1.0f, 1.0f );
+			float level = RageUtil::ScaleFloat( value, js.rx_min, js.rx_max, -1.0f, 1.0f );
 
 			vPresses.push_back( DeviceInput(js.id, JOY_ROT_LEFT, std::max(-level, 0.0f), now) );
 			vPresses.push_back( DeviceInput(js.id, JOY_ROT_RIGHT, std::max(level, 0.0f), now) );
@@ -192,7 +192,7 @@ void JoystickDevice::GetButtonPresses( std::vector<DeviceInput>& vPresses, IOHID
 		}
 		else if( js.y_rot == cookie )
 		{
-			float level = SCALE( value, js.ry_min, js.ry_max, -1.0f, 1.0f );
+			float level = RageUtil::ScaleFloat( value, js.ry_min, js.ry_max, -1.0f, 1.0f );
 
 			vPresses.push_back( DeviceInput(js.id, JOY_ROT_UP, std::max(-level, 0.0f), now) );
 			vPresses.push_back( DeviceInput(js.id, JOY_ROT_DOWN, std::max(level, 0.0f), now) );
@@ -200,7 +200,7 @@ void JoystickDevice::GetButtonPresses( std::vector<DeviceInput>& vPresses, IOHID
 		}
 		else if( js.z_rot == cookie )
 		{
-			float level = SCALE( value, js.rz_min, js.rz_max, -1.0f, 1.0f );
+			float level = RageUtil::ScaleFloat( value, js.rz_min, js.rz_max, -1.0f, 1.0f );
 
 			vPresses.push_back( DeviceInput(js.id, JOY_ROT_Z_UP, std::max(-level, 0.0f), now) );
 			vPresses.push_back( DeviceInput(js.id, JOY_ROT_Z_DOWN, std::max(level, 0.0f), now) );

--- a/src/archutils/Darwin/MouseDevice.cpp
+++ b/src/archutils/Darwin/MouseDevice.cpp
@@ -119,7 +119,7 @@ void MouseDevice::GetButtonPresses( std::vector<DeviceInput>& vPresses, IOHIDEle
 	}
 	else if( m.z_axis == cookie )
 	{
-		float level = SCALE( value, m.z_min, m.z_max, -1.0f, 1.0f );
+		float level = RageUtil::ScaleFloat( value, m.z_min, m.z_max, -1.0f, 1.0f );
 		INPUTFILTER->ButtonPressed( DeviceInput(DEVICE_MOUSE, MOUSE_WHEELUP, std::max(-level, 0.0f), now) );
 		INPUTFILTER->ButtonPressed( DeviceInput(DEVICE_MOUSE, MOUSE_WHEELDOWN, std::max(+level, 0.0f), now) );
 	}


### PR DESCRIPTION
## edit: It appears as though we depend on the possibly incorrect behavior of this Macro. Changing it to be "correct" messes up sync very badly and breaks other things too. I would suggest either leaving it alone or inlining it.

- Even making a template that treats each of the 5 arguments as being its own unique type doesn't quite provide the same result as the original calculation.
- Attemping to make variants of the `scale` function that accept and return different values has weird implications throughout the code base, such as sync issues, incorrect song previews in the song wheel, and sounds taking too long to load.
- I strongly think it should be left alone unless a major core rewrite takes place. Changing this will cause regressions all over the place.