### PR TITLE
Replace SAFE_DELETE / SAFE_DELETE_ARRAY macros

### DIFF
--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -177,7 +177,7 @@ Actor::~Actor()
 	UnsubscribeAll();
 	for(std::size_t i= 0; i < m_WrapperStates.size(); ++i)
 	{
-		SAFE_DELETE(m_WrapperStates[i]);
+		RageUtil::SafeDelete(m_WrapperStates[i]);
 	}
 	m_WrapperStates.clear();
 }
@@ -987,7 +987,7 @@ void Actor::AddWrapperState()
 void Actor::RemoveWrapperState(std::size_t i)
 {
 	ASSERT(i < m_WrapperStates.size());
-	SAFE_DELETE(m_WrapperStates[i]);
+	RageUtil::SafeDelete(m_WrapperStates[i]);
 	m_WrapperStates.erase(m_WrapperStates.begin()+i);
 }
 

--- a/src/ActorFrame.cpp
+++ b/src/ActorFrame.cpp
@@ -736,7 +736,7 @@ public:
 		if(child)
 		{
 			p->RemoveChild(child);
-			SAFE_DELETE(child);
+			RageUtil::SafeDelete(child);
 		}
 		COMMON_RETURN_SELF;
 	}

--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -760,7 +760,7 @@ void BackgroundImpl::Layer::UpdateCurBGChange( const Song *pSong, float fLastMus
 			RString xml = XmlFileUtil::GetXML( pNode );
 			Trim( xml );
 			LuaHelpers::ReportScriptErrorFmt( "Tried to switch to a background that was never loaded:\n%s", xml.c_str() );
-			SAFE_DELETE( pNode );
+			RageUtil::SafeDelete( pNode );
 			return;
 		}
 
@@ -984,7 +984,7 @@ void BrightnessOverlay::FadeToActualBrightness()
 }
 
 Background::Background()				{ m_disable_draw= false; m_pImpl = new BackgroundImpl; this->AddChild(m_pImpl); }
-Background::~Background()				{ SAFE_DELETE( m_pImpl ); }
+Background::~Background()				{ RageUtil::SafeDelete( m_pImpl ); }
 void Background::Init()					{ m_pImpl->Init(); }
 void Background::LoadFromSong( const Song *pSong )	{ m_pImpl->LoadFromSong(pSong); }
 void Background::Unload()				{ m_pImpl->Unload(); }

--- a/src/CharacterManager.cpp
+++ b/src/CharacterManager.cpp
@@ -24,7 +24,7 @@ CharacterManager::CharacterManager()
 	}
 
 	for( unsigned i=0; i<m_pCharacters.size(); i++ )
-		SAFE_DELETE( m_pCharacters[i] );
+		RageUtil::SafeDelete( m_pCharacters[i] );
 	m_pCharacters.clear();
 
 	std::vector<RString> as;
@@ -60,7 +60,7 @@ CharacterManager::CharacterManager()
 CharacterManager::~CharacterManager()
 {
 	for( unsigned i=0; i<m_pCharacters.size(); i++ )
-		SAFE_DELETE( m_pCharacters[i] );
+		RageUtil::SafeDelete( m_pCharacters[i] );
 
 	// Unregister with Lua.
 	LUA->UnsetGlobal( "CHARMAN" );

--- a/src/CreateZip.cpp
+++ b/src/CreateZip.cpp
@@ -677,7 +677,7 @@ ZRESULT TZip::open_file(const TCHAR *fn)
 	hfin = new RageFile();
 	if( !hfin->Open(fn) )
 	{
-		SAFE_DELETE( hfin );
+		RageUtil::SafeDelete( hfin );
 		return ZR_NOFILE;
 	}
 	isize = hfin->GetFileSize();
@@ -755,7 +755,7 @@ unsigned TZip::read(char *srcbuf, unsigned size)
 ZRESULT TZip::iclose()
 {
 	if (hfin!=0)
-		SAFE_DELETE( hfin);
+		RageUtil::SafeDelete( hfin);
 	bool mismatch = (isize!=-1 && isize!=ired);
 	isize=ired; // and crc has been being updated anyway
 	if (mismatch)

--- a/src/CryptManager.cpp
+++ b/src/CryptManager.cpp
@@ -138,7 +138,7 @@ void CryptManager::GenerateGlobalKeys()
 
 CryptManager::~CryptManager()
 {
-	SAFE_DELETE( g_pPRNG );
+	RageUtil::SafeDelete( g_pPRNG );
 	// Unregister with Lua.
 	LUA->UnsetGlobal( "CRYPTMAN" );
 }

--- a/src/CubicSpline.cpp
+++ b/src/CubicSpline.cpp
@@ -986,7 +986,7 @@ struct LunaCubicSplineN : Luna<CubicSplineN>
 			luaL_error(L, "This spline cannot be destroyed because it is "
 				"owned by an actor that relies on it existing.");
 		}
-		SAFE_DELETE(p);
+		RageUtil::SafeDelete(p);
 		return 0;
 	}
 	LunaCubicSplineN()

--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -135,7 +135,7 @@ namespace
 
 	void DoChangeTheme()
 	{
-		SAFE_DELETE( SCREENMAN );
+		RageUtil::SafeDelete( SCREENMAN );
 		TEXTUREMAN->DoDelayedDelete();
 
 		// In case the previous theme overloaded class bindings, reinitialize them.
@@ -188,7 +188,7 @@ namespace
 
 		if(theme_changing)
 		{
-			SAFE_DELETE(SCREENMAN);
+			RageUtil::SafeDelete(SCREENMAN);
 			TEXTUREMAN->DoDelayedDelete();
 			LUA->RegisterTypes();
 			THEME->SwitchThemeAndLanguage(g_NewTheme, THEME->GetCurLanguage(),

--- a/src/GameSoundManager.cpp
+++ b/src/GameSoundManager.cpp
@@ -476,8 +476,8 @@ GameSoundManager::~GameSoundManager()
 	MusicThread.Wait();
 	LOG->Trace("Music start thread shut down.");
 
-	SAFE_DELETE( g_Playing );
-	SAFE_DELETE( g_Mutex );
+	RageUtil::SafeDelete( g_Playing );
+	RageUtil::SafeDelete( g_Mutex );
 }
 
 float GameSoundManager::GetFrameTimingAdjustment( float fDeltaTime )

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -197,13 +197,13 @@ GameState::~GameState()
 	LUA->UnsetGlobal( "GAMESTATE" );
 
 	FOREACH_PlayerNumber( p )
-		SAFE_DELETE( m_pPlayerState[p] );
+		RageUtil::SafeDelete( m_pPlayerState[p] );
 	FOREACH_MultiPlayer( p )
-		SAFE_DELETE( m_pMultiPlayerState[p] );
+		RageUtil::SafeDelete( m_pMultiPlayerState[p] );
 
-	SAFE_DELETE( m_Environment );
-	SAFE_DELETE( g_pImpl );
-	SAFE_DELETE( processedTiming );
+	RageUtil::SafeDelete( m_Environment );
+	RageUtil::SafeDelete( g_pImpl );
+	RageUtil::SafeDelete( processedTiming );
 }
 
 PlayerNumber GameState::GetMasterPlayerNumber() const

--- a/src/GraphDisplay.cpp
+++ b/src/GraphDisplay.cpp
@@ -161,11 +161,11 @@ GraphDisplay::~GraphDisplay()
 {
 	for (Actor *p : m_vpSongBoundaries)
 	{
-		SAFE_DELETE( p );
+		RageUtil::SafeDelete( p );
 	}
 	m_vpSongBoundaries.clear();
-	SAFE_DELETE( m_pGraphLine );
-	SAFE_DELETE( m_pGraphBody );
+	RageUtil::SafeDelete( m_pGraphLine );
+	RageUtil::SafeDelete( m_pGraphBody );
 }
 
 void GraphDisplay::Set( const StageStats &ss, const PlayerStageStats &pss )

--- a/src/JsonUtil.h
+++ b/src/JsonUtil.h
@@ -4,6 +4,7 @@
 
 class RageFileBasic;
 #include "json/json.h"
+#include "RageUtil.h"
 
 #include <vector>
 
@@ -164,7 +165,7 @@ namespace JsonUtil
 	static void DeserializeVectorPointers(std::vector<T*> &v, void fn(T &, const Json::Value &), const Json::Value &root)
 	{
 		for(unsigned i=0; i<v.size(); i++)
-			SAFE_DELETE(v[i]);
+			RageUtil::SafeDelete(v[i]);
 		v.resize(root.size());
 		for(unsigned i=0; i<v.size(); i++)
 		{
@@ -177,7 +178,7 @@ namespace JsonUtil
 	static void DeserializeVectorPointers(std::vector<T*> &v, void fn(T *, const Json::Value &), const Json::Value &root)
 	{
 		for(unsigned i=0; i<v.size(); i++)
-			SAFE_DELETE(v[i]);
+			RageUtil::SafeDelete(v[i]);
 		v.resize(root.size());
 		for(unsigned i=0; i<v.size(); i++)
 		{
@@ -191,7 +192,7 @@ namespace JsonUtil
 	static void DeserializeVectorPointersParam(std::vector<T*> &v, void fn(T &, const Json::Value &), const Json::Value &root, const P param)
 	{
 		for(unsigned i=0; i<v.size(); i++)
-			SAFE_DELETE(v[i]);
+			RageUtil::SafeDelete(v[i]);
 		v.resize(root.size());
 		for(unsigned i=0; i<v.size(); i++)
 		{

--- a/src/LifeMeterBar.cpp
+++ b/src/LifeMeterBar.cpp
@@ -75,7 +75,7 @@ LifeMeterBar::LifeMeterBar()
 
 LifeMeterBar::~LifeMeterBar()
 {
-	SAFE_DELETE( m_pStream );
+	RageUtil::SafeDelete( m_pStream );
 }
 
 void LifeMeterBar::Load( const PlayerState *pPlayerState, PlayerStageStats *pPlayerStageStats )

--- a/src/LightsManager.cpp
+++ b/src/LightsManager.cpp
@@ -126,7 +126,7 @@ LightsManager::~LightsManager()
 {
 	for (LightsDriver *iter : m_vpDrivers)
 	{
-		SAFE_DELETE( iter );
+		RageUtil::SafeDelete( iter );
 	}
 	m_vpDrivers.clear();
 }

--- a/src/LocalizedString.cpp
+++ b/src/LocalizedString.cpp
@@ -59,12 +59,12 @@ LocalizedString::~LocalizedString()
 {
 	m_Subscribers.Unsubscribe( this );
 
-	SAFE_DELETE( m_pImpl );
+	RageUtil::SafeDelete( m_pImpl );
 }
 
 void LocalizedString::CreateImpl()
 {
-	SAFE_DELETE( m_pImpl );
+	RageUtil::SafeDelete( m_pImpl );
 	m_pImpl = g_pMakeLocalizedStringImpl();
 	m_pImpl->Load(  m_sGroup, m_sName );
 }

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -278,7 +278,7 @@ LuaManager::LuaManager()
 LuaManager::~LuaManager()
 {
 	lua_close( m_pLuaMain );
-	SAFE_DELETE( pImpl );
+	RageUtil::SafeDelete( pImpl );
 }
 
 Lua *LuaManager::Get()

--- a/src/MemoryCardManager.cpp
+++ b/src/MemoryCardManager.cpp
@@ -302,7 +302,7 @@ MemoryCardManager::~MemoryCardManager()
 	LUA->UnsetGlobal( "MEMCARDMAN" );
 
 	ASSERT( g_pWorker != nullptr );
-	SAFE_DELETE(g_pWorker);
+	RageUtil::SafeDelete(g_pWorker);
 
 	FOREACH_PlayerNumber( pn )
 	{

--- a/src/ModIconRow.cpp
+++ b/src/ModIconRow.cpp
@@ -27,7 +27,7 @@ ModIconRow::~ModIconRow()
 {
 	for (ModIcon *p : m_vpModIcon)
 	{
-		SAFE_DELETE( p );
+		RageUtil::SafeDelete( p );
 	}
 	this->RemoveAllChildren();
 }

--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -21,7 +21,7 @@ ModelManager::~ModelManager()
 		RageModelGeometry* pGeom = i->second;
 		if( pGeom->m_iRefCount )
 			LOG->Trace( "MODELMAN LEAK: '%s', RefCount = %d.", i->first.c_str(), pGeom->m_iRefCount );
-		SAFE_DELETE( pGeom );
+		RageUtil::SafeDelete( pGeom );
 	}
 }
 
@@ -65,7 +65,7 @@ void ModelManager::UnloadModel( RageModelGeometry *m )
 			else
 			{
 				m_mapFileToGeometry.erase( i );	// remove map entry
-				SAFE_DELETE( m );	// free the texture
+				RageUtil::SafeDelete( m );	// free the texture
 				return;
 			}
 		}

--- a/src/MusicWheelItem.cpp
+++ b/src/MusicWheelItem.cpp
@@ -173,7 +173,7 @@ MusicWheelItem::~MusicWheelItem()
 {
 	FOREACH_ENUM( MusicWheelItemType, i )
 	{
-		SAFE_DELETE(m_pText[i]);
+		RageUtil::SafeDelete(m_pText[i]);
 	}
 	delete m_pTextSectionCount;
 }

--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -1281,7 +1281,7 @@ bool SMLoader::LoadEditFromMsd( const MsdFile &msd, const RString &sEditFilePath
 			if( pSong->IsEditAlreadyLoaded(pNewNotes) )
 			{
 				LOG->UserLog( "Edit file", sEditFilePath, "is a duplicate of another edit that was already loaded." );
-				SAFE_DELETE( pNewNotes );
+				RageUtil::SafeDelete( pNewNotes );
 				return false;
 			}
 

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -1148,7 +1148,7 @@ bool SSCLoader::LoadEditFromMsd(const MsdFile &msd,
 					{
 						LOG->UserLog("Edit file", sEditFilePath,
 							"is a duplicate of another edit that was already loaded.");
-						SAFE_DELETE(pNewNotes);
+						RageUtil::SafeDelete(pNewNotes);
 						return false;
 					}
 				}

--- a/src/OptionRow.cpp
+++ b/src/OptionRow.cpp
@@ -71,7 +71,7 @@ void OptionRow::Clear()
 		for (RString const &m : m_pHand->m_vsReloadRowMessages)
 			MESSAGEMAN->Unsubscribe( this, m );
 	}
-	SAFE_DELETE( m_pHand );
+	RageUtil::SafeDelete( m_pHand );
 
 	m_bFirstItemGoesDown = false;
 	ZERO( m_bRowHasFocus );

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -299,16 +299,16 @@ Player::Player( NoteData &nd, bool bVisibleParts ) : m_NoteData(nd)
 
 Player::~Player()
 {
-	SAFE_DELETE( m_pAttackDisplay );
-	SAFE_DELETE( m_pNoteField );
+	RageUtil::SafeDelete( m_pAttackDisplay );
+	RageUtil::SafeDelete( m_pNoteField );
 	for( unsigned i = 0; i < m_vpHoldJudgment.size(); ++i )
-		SAFE_DELETE( m_vpHoldJudgment[i] );
-	SAFE_DELETE( m_pJudgedRows );
-	SAFE_DELETE( m_pIterNeedsTapJudging );
-	SAFE_DELETE( m_pIterNeedsHoldJudging );
-	SAFE_DELETE( m_pIterUncrossedRows );
-	SAFE_DELETE( m_pIterUnjudgedRows );
-	SAFE_DELETE( m_pIterUnjudgedMineRows );
+		RageUtil::SafeDelete( m_vpHoldJudgment[i] );
+	RageUtil::SafeDelete( m_pJudgedRows );
+	RageUtil::SafeDelete( m_pIterNeedsTapJudging );
+	RageUtil::SafeDelete( m_pIterNeedsHoldJudging );
+	RageUtil::SafeDelete( m_pIterUncrossedRows );
+	RageUtil::SafeDelete( m_pIterUnjudgedRows );
+	RageUtil::SafeDelete( m_pIterUnjudgedMineRows );
 
 }
 
@@ -788,19 +788,19 @@ void Player::Load()
 	if( m_pPlayerStageStats )
 		SendComboMessages( m_pPlayerStageStats->m_iCurCombo, m_pPlayerStageStats->m_iCurMissCombo );
 
-	SAFE_DELETE( m_pIterNeedsTapJudging );
+	RageUtil::SafeDelete( m_pIterNeedsTapJudging );
 	m_pIterNeedsTapJudging = new NoteData::all_tracks_iterator( m_NoteData.GetTapNoteRangeAllTracks(iNoteRow, MAX_NOTE_ROW) );
 
-	SAFE_DELETE( m_pIterNeedsHoldJudging );
+	RageUtil::SafeDelete( m_pIterNeedsHoldJudging );
 	m_pIterNeedsHoldJudging = new NoteData::all_tracks_iterator( m_NoteData.GetTapNoteRangeAllTracks(iNoteRow, MAX_NOTE_ROW ) );
 
-	SAFE_DELETE( m_pIterUncrossedRows );
+	RageUtil::SafeDelete( m_pIterUncrossedRows );
 	m_pIterUncrossedRows = new NoteData::all_tracks_iterator( m_NoteData.GetTapNoteRangeAllTracks(iNoteRow, MAX_NOTE_ROW ) );
 
-	SAFE_DELETE( m_pIterUnjudgedRows );
+	RageUtil::SafeDelete( m_pIterUnjudgedRows );
 	m_pIterUnjudgedRows = new NoteData::all_tracks_iterator( m_NoteData.GetTapNoteRangeAllTracks(iNoteRow, MAX_NOTE_ROW ) );
 
-	SAFE_DELETE( m_pIterUnjudgedMineRows );
+	RageUtil::SafeDelete( m_pIterUnjudgedMineRows );
 	m_pIterUnjudgedMineRows = new NoteData::all_tracks_iterator( m_NoteData.GetTapNoteRangeAllTracks(iNoteRow, MAX_NOTE_ROW ) );
 }
 

--- a/src/Preference.h
+++ b/src/Preference.h
@@ -168,7 +168,7 @@ public:
 	~Preference1D()
 	{
 		for( std::size_t i=0; i<m_v.size(); ++i )
-			SAFE_DELETE( m_v[i] );
+			RageUtil::SafeDelete( m_v[i] );
 	}
 	const Preference<T>& operator[]( std::size_t i ) const
 	{

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -97,9 +97,9 @@ ProfileManager::~ProfileManager()
 	// Unregister with Lua.
 	LUA->UnsetGlobal( "PROFILEMAN" );
 
-	SAFE_DELETE( m_pMachineProfile );
+	RageUtil::SafeDelete( m_pMachineProfile );
 	FOREACH_PlayerNumber(pn)
-		SAFE_DELETE( m_pMemoryCardProfile[pn] );
+		RageUtil::SafeDelete( m_pMemoryCardProfile[pn] );
 }
 
 void ProfileManager::Init()

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -799,7 +799,7 @@ bool RageDisplay::SaveScreenshot( RString sPath, GraphicsFileFormat format )
 	if( !out.Open( sPath, RageFile::WRITE ) )
 	{
 		LOG->Trace("Couldn't write %s: %s", sPath.c_str(), out.GetError().c_str() );
-		SAFE_DELETE( surface );
+		RageUtil::SafeDelete( surface );
 		return false;
 	}
 
@@ -824,7 +824,7 @@ bool RageDisplay::SaveScreenshot( RString sPath, GraphicsFileFormat format )
 	}
 //	LOG->Trace( "Saving Screenshot file took %f seconds.", timer.GetDeltaTime() );
 
-	SAFE_DELETE( surface );
+	RageUtil::SafeDelete( surface );
 
 	if( !bSuccess )
 	{

--- a/src/RageFile.cpp
+++ b/src/RageFile.cpp
@@ -349,7 +349,7 @@ public:
 	}
 	static int destroy( T* p, lua_State *L )
 	{
-		SAFE_DELETE(p);
+		RageUtil::SafeDelete(p);
 		return 1;
 	}
 

--- a/src/RageFileDriverDeflate.cpp
+++ b/src/RageFileDriverDeflate.cpp
@@ -543,7 +543,7 @@ bool GunzipString( const RString &sIn, RString &sOut, RString &sError )
 	/* Check the CRC. */
 	unsigned iRet;
 	ASSERT( pFile->GetCRC32( &iRet ) );
-	SAFE_DELETE( pFile );
+	RageUtil::SafeDelete( pFile );
 
 	if( iRet != iCRC32 )
 	{

--- a/src/RageFileDriverTimeout.cpp
+++ b/src/RageFileDriverTimeout.cpp
@@ -292,10 +292,10 @@ void ThreadedFileWorker::HandleRequest( int iRequest )
 void ThreadedFileWorker::RequestTimedOut()
 {
 	/* The event timed out.  Clean up any residue from the last action. */
-	SAFE_DELETE( m_pRequestFile );
-	SAFE_DELETE( m_pResultFile );
-	SAFE_DELETE_ARRAY( m_pRequestBuffer );
-	SAFE_DELETE_ARRAY( m_pResultBuffer );
+	RageUtil::SafeDelete( m_pRequestFile );
+	RageUtil::SafeDelete( m_pResultFile );
+	RageUtil::SafeDeleteArray( m_pRequestBuffer );
+	RageUtil::SafeDeleteArray( m_pResultBuffer );
 }
 
 RageFileBasic *ThreadedFileWorker::Open( const RString &sPath, int iMode, int &iErr )

--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -114,10 +114,10 @@ RageLog::~RageLog()
 	g_fileUserLog->Close();
 	g_fileTimeLog->Close();
 
-	SAFE_DELETE( g_Mutex );
-	SAFE_DELETE( g_fileLog );
-	SAFE_DELETE( g_fileInfo );
-	SAFE_DELETE( g_fileUserLog );
+	RageUtil::SafeDelete( g_Mutex );
+	RageUtil::SafeDelete( g_fileLog );
+	RageUtil::SafeDelete( g_fileInfo );
+	RageUtil::SafeDelete( g_fileUserLog );
 }
 
 void RageLog::SetLogToDisk( bool b )

--- a/src/RageMath.cpp
+++ b/src/RageMath.cpp
@@ -795,7 +795,7 @@ struct LunaRageBezier2D : Luna<RageBezier2D>
 	}
 	static int destroy(T* p, lua_State* L)
 	{
-		SAFE_DELETE(p);
+		RageUtil::SafeDelete(p);
 		return 0;
 	}
 	LunaRageBezier2D()

--- a/src/RageSoundManager.cpp
+++ b/src/RageSoundManager.cpp
@@ -72,7 +72,7 @@ void RageSoundManager::low_sample_count_workaround()
  */
 void RageSoundManager::Shutdown()
 {
-	SAFE_DELETE( m_pDriver );
+	RageUtil::SafeDelete( m_pDriver );
 }
 
 void RageSoundManager::StartMixing( RageSoundBase *pSound )

--- a/src/RageTextureManager.cpp
+++ b/src/RageTextureManager.cpp
@@ -50,7 +50,7 @@ RageTextureManager::~RageTextureManager()
 		RageTexture* pTexture = i.second;
 		if( pTexture->m_iRefCount )
 			LOG->Trace( "TEXTUREMAN LEAK: '%s', RefCount = %d.", i.first.filename.c_str(), pTexture->m_iRefCount );
-		SAFE_DELETE( pTexture );
+		RageUtil::SafeDelete( pTexture );
 	}
 	m_textures_to_update.clear();
 	m_texture_ids_by_pointer.clear();
@@ -244,7 +244,7 @@ void RageTextureManager::DeleteTexture( RageTexture *t )
 		if(tex_entry != m_mapPathToTexture.end())
 		{
 			m_mapPathToTexture.erase(tex_entry);
-			SAFE_DELETE(t);
+			RageUtil::SafeDelete(t);
 		}
 		std::map<RageTextureID, RageTexture*>::iterator tex_update_entry=
 			m_textures_to_update.find(id_entry->second);

--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -80,7 +80,7 @@ struct ThreadSlot
 
 	void Release()
 	{
-		SAFE_DELETE( m_pImpl );
+		RageUtil::SafeDelete( m_pImpl );
 		Init();
 	}
 

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -16,10 +16,24 @@
 
 class RageFileDriver;
 
-/** @brief Safely delete pointers. */
-#define SAFE_DELETE(p)       do { delete (p);     (p)=nullptr; } while( false )
-/** @brief Safely delete array pointers. */
-#define SAFE_DELETE_ARRAY(p) do { delete[] (p);   (p)=nullptr; } while( false )
+class RageUtil {
+public:
+	// Safely delete pointers.
+	template <typename T>
+	inline static void SafeDelete(T*& p) noexcept
+	{
+		delete p;
+		p = nullptr;
+	}
+
+	// Safely delete array pointers.
+	template <typename T>
+	inline static void SafeDeleteArray(T*& p) noexcept
+	{
+		delete[] p;
+		p = nullptr;
+	}
+};
 
 /** @brief Zero out the memory. */
 #define ZERO(x)	memset(&(x), 0, sizeof(x))

--- a/src/ScreenDebugOverlay.cpp
+++ b/src/ScreenDebugOverlay.cpp
@@ -104,16 +104,16 @@ ScreenDebugOverlay::~ScreenDebugOverlay()
 
 	for (BitmapText *p : m_vptextPages)
 	{
-		SAFE_DELETE(p);
+		RageUtil::SafeDelete(p);
 	}
 	for (BitmapText *p : m_vptextButton)
 	{
-		SAFE_DELETE(p);
+		RageUtil::SafeDelete(p);
 	}
 	m_vptextButton.clear();
 	for (BitmapText *p : m_vptextFunction)
 	{
-		SAFE_DELETE(p);
+		RageUtil::SafeDelete(p);
 	}
 	m_vptextFunction.clear();
 }

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -205,18 +205,18 @@ void PlayerInfo::LoadDummyP1( int iDummyIndex, int iAddToDifficulty )
 
 PlayerInfo::~PlayerInfo()
 {
-	SAFE_DELETE( m_pLifeMeter );
-	SAFE_DELETE( m_ptextCourseSongNumber );
-	SAFE_DELETE( m_ptextStepsDescription );
-	SAFE_DELETE( m_pPrimaryScoreDisplay );
-	SAFE_DELETE( m_pSecondaryScoreDisplay );
-	SAFE_DELETE( m_pPrimaryScoreKeeper );
-	SAFE_DELETE( m_pSecondaryScoreKeeper );
-	SAFE_DELETE( m_ptextPlayerOptions );
-	SAFE_DELETE( m_pActiveAttackList );
-	SAFE_DELETE( m_pPlayer );
-	SAFE_DELETE( m_pInventory );
-	SAFE_DELETE( m_pStepsDisplay );
+	RageUtil::SafeDelete( m_pLifeMeter );
+	RageUtil::SafeDelete( m_ptextCourseSongNumber );
+	RageUtil::SafeDelete( m_ptextStepsDescription );
+	RageUtil::SafeDelete( m_pPrimaryScoreDisplay );
+	RageUtil::SafeDelete( m_pSecondaryScoreDisplay );
+	RageUtil::SafeDelete( m_pPrimaryScoreKeeper );
+	RageUtil::SafeDelete( m_pSecondaryScoreKeeper );
+	RageUtil::SafeDelete( m_ptextPlayerOptions );
+	RageUtil::SafeDelete( m_pActiveAttackList );
+	RageUtil::SafeDelete( m_pPlayer );
+	RageUtil::SafeDelete( m_pInventory );
+	RageUtil::SafeDelete( m_pStepsDisplay );
 }
 
 void PlayerInfo::ShowOniGameOver()
@@ -1016,13 +1016,13 @@ ScreenGameplay::~ScreenGameplay()
 
 	LOG->Trace( "ScreenGameplay::~ScreenGameplay()" );
 
-	SAFE_DELETE( m_pSongBackground );
-	SAFE_DELETE( m_pSongForeground );
+	RageUtil::SafeDelete( m_pSongBackground );
+	RageUtil::SafeDelete( m_pSongForeground );
 
 	if( !GAMESTATE->m_bDemonstrationOrJukebox )
 		MEMCARDMAN->UnPauseMountingThread();
 
-	SAFE_DELETE( m_pCombinedLifeMeter );
+	RageUtil::SafeDelete( m_pCombinedLifeMeter );
 	if( m_pSoundMusic )
 		m_pSoundMusic->StopPlaying();
 
@@ -3194,7 +3194,7 @@ void ScreenGameplay::SaveReplay()
 			RString sFileName = ssprintf( "replay%05d.xml", iIndex );
 
 			XmlFileUtil::SaveToFile( p, "Save/Replays/"+sFileName );
-			SAFE_DELETE( p );
+			RageUtil::SafeDelete( p );
 			return;
 		}
 	}

--- a/src/ScreenManager.cpp
+++ b/src/ScreenManager.cpp
@@ -220,7 +220,7 @@ namespace ScreenManagerUtil
 		BeforeDeleteScreen();
 		for (Actor *a : apActorsToDelete)
 		{
-			SAFE_DELETE( a );
+			RageUtil::SafeDelete( a );
 		}
 		AfterDeleteScreen();
 	}
@@ -265,17 +265,17 @@ ScreenManager::~ScreenManager()
 	LOG->Trace("ScreenManager::~ScreenManager()");
 	LOG->UnmapLog("ScreenManager::TopScreen");
 
-	SAFE_DELETE(g_pSharedBGA);
+	RageUtil::SafeDelete(g_pSharedBGA);
 	for (LoadedScreen& screen : g_ScreenStack)
 	{
 		if (screen.m_bDeleteWhenDone)
-			SAFE_DELETE(screen.m_pScreen);
+			RageUtil::SafeDelete(screen.m_pScreen);
 	}
 	g_ScreenStack.clear();
 	DeletePreparedScreens();
 	for (Screen* overlayScreen : g_OverlayScreens)
 	{
-		SAFE_DELETE(overlayScreen);
+		RageUtil::SafeDelete(overlayScreen);
 	}
 	g_OverlayScreens.clear();
 
@@ -301,7 +301,7 @@ void ScreenManager::ThemeChanged()
 	ReloadOverlayScreens();
 
 	// force recreate of new BGA
-	SAFE_DELETE( g_pSharedBGA );
+	RageUtil::SafeDelete( g_pSharedBGA );
 	g_pSharedBGA = new Actor;
 }
 
@@ -309,7 +309,7 @@ void ScreenManager::ReloadOverlayScreens()
 {
 	// unload overlay screens
 	for (Screen* screen : g_OverlayScreens)
-		SAFE_DELETE(screen);
+		RageUtil::SafeDelete(screen);
 	g_OverlayScreens.clear();
 
 	// reload overlay screens
@@ -412,7 +412,7 @@ ScreenMessage ScreenManager::PopTopScreenInternal( bool bSendLoseFocus )
 		if( ls.m_bDeleteWhenDone )
 		{
 			BeforeDeleteScreen();
-			SAFE_DELETE( ls.m_pScreen );
+			RageUtil::SafeDelete( ls.m_pScreen );
 			AfterDeleteScreen();
 		}
 	}
@@ -778,7 +778,7 @@ void ScreenManager::LoadDelayedScreen()
 		BeforeDeleteScreen();
 		for (Actor *a : apActorsToDelete)
 		{
-			SAFE_DELETE( a );
+			RageUtil::SafeDelete( a );
 		}
 		AfterDeleteScreen();
 	}

--- a/src/ScreenMapControllers.cpp
+++ b/src/ScreenMapControllers.cpp
@@ -37,7 +37,7 @@ ScreenMapControllers::~ScreenMapControllers()
 {
 	for(std::size_t i= 0; i < m_Line.size(); ++i)
 	{
-		SAFE_DELETE(m_Line[i]);
+		RageUtil::SafeDelete(m_Line[i]);
 	}
 }
 

--- a/src/ScreenOptions.cpp
+++ b/src/ScreenOptions.cpp
@@ -209,7 +209,7 @@ void ScreenOptions::InitMenu( const std::vector<OptionRowHandler*> &vHands )
 	for( unsigned i=0; i<m_pRows.size(); i++ )
 	{
 		m_frameContainer.RemoveChild( m_pRows[i] );
-		SAFE_DELETE( m_pRows[i] );
+		RageUtil::SafeDelete( m_pRows[i] );
 	}
 	m_pRows.clear();
 
@@ -358,7 +358,7 @@ ScreenOptions::~ScreenOptions()
 {
 	LOG->Trace( "ScreenOptions::~ScreenOptions()" );
 	for( unsigned i=0; i<m_pRows.size(); i++ )
-		SAFE_DELETE( m_pRows[i] );
+		RageUtil::SafeDelete( m_pRows[i] );
 }
 
 RString ScreenOptions::GetExplanationText( int iRow ) const

--- a/src/ScreenTextEntry.cpp
+++ b/src/ScreenTextEntry.cpp
@@ -671,7 +671,7 @@ ScreenTextEntryVisual::~ScreenTextEntryVisual()
 {
 	FOREACH_KeyboardRow( r )
 		for( int x=0; x<KEYS_PER_ROW; ++x )
-			SAFE_DELETE( m_ptextKeys[r][x] );
+			RageUtil::SafeDelete( m_ptextKeys[r][x] );
 }
 
 void ScreenTextEntryVisual::BeginScreen()

--- a/src/ScreenUnlockStatus.cpp
+++ b/src/ScreenUnlockStatus.cpp
@@ -316,19 +316,19 @@ ScreenUnlockStatus::~ScreenUnlockStatus()
 	while (Unlocks.size() > 0)
 	{
 		Sprite* entry = Unlocks[Unlocks.size()-1];
-		SAFE_DELETE(entry);
+		RageUtil::SafeDelete(entry);
 		Unlocks.pop_back();
 	}
 	while (item.size() > 0)
 	{
 		BitmapText* entry = item[item.size()-1];
-		SAFE_DELETE(entry);
+		RageUtil::SafeDelete(entry);
 		item.pop_back();
 	}
 	while (ItemIcons.size() > 0)
 	{
 		Sprite* entry = ItemIcons[ItemIcons.size()-1];
-		SAFE_DELETE(entry);
+		RageUtil::SafeDelete(entry);
 		ItemIcons.pop_back();
 	}
 }

--- a/src/ScreenWithMenuElements.cpp
+++ b/src/ScreenWithMenuElements.cpp
@@ -161,11 +161,11 @@ void ScreenWithMenuElements::HandleScreenMessage( const ScreenMessage SM )
 
 ScreenWithMenuElements::~ScreenWithMenuElements()
 {
-	SAFE_DELETE( m_MenuTimer );
+	RageUtil::SafeDelete( m_MenuTimer );
 	FOREACH_PlayerNumber( p )
 	{
 		if( m_MemoryCardDisplay[p] != nullptr )
-			SAFE_DELETE( m_MemoryCardDisplay[p] );
+			RageUtil::SafeDelete( m_MemoryCardDisplay[p] );
 	}
 	for (Actor *actor : m_vDecorations)
 		delete actor;

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -99,12 +99,12 @@ Song::~Song()
 {
 	for (Steps *s : m_vpSteps)
 	{
-		SAFE_DELETE( s );
+		RageUtil::SafeDelete( s );
 	}
 	m_vpSteps.clear();
 	for (Steps *s : m_UnknownStyleSteps)
 	{
-		SAFE_DELETE(s);
+		RageUtil::SafeDelete(s);
 	}
 	m_UnknownStyleSteps.clear();
 
@@ -170,14 +170,14 @@ void Song::Reset()
 {
 	for (Steps *s : m_vpSteps)
 	{
-		SAFE_DELETE( s );
+		RageUtil::SafeDelete( s );
 	}
 	m_vpSteps.clear();
 	FOREACH_ENUM( StepsType, st )
 		m_vpStepsByType[st].clear();
 	for (Steps *s : m_UnknownStyleSteps)
 	{
-		SAFE_DELETE(s);
+		RageUtil::SafeDelete(s);
 	}
 	m_UnknownStyleSteps.clear();
 

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -552,14 +552,14 @@ void SongManager::FreeSongs()
 
 	for (Song *song : m_pSongs)
 	{
-		SAFE_DELETE( song );
+		RageUtil::SafeDelete( song );
 	}
 	m_pSongs.clear();
 	m_SongsByDir.clear();
 
 	// also free the songs that have been deleted from disk
 	for ( unsigned i=0; i<m_pDeletedSongs.size(); ++i )
-		SAFE_DELETE( m_pDeletedSongs[i] );
+		RageUtil::SafeDelete( m_pDeletedSongs[i] );
 	m_pDeletedSongs.clear();
 
 	m_mapSongGroupIndex.clear();

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -298,43 +298,43 @@ void ShutdownGame()
 		LIGHTSMAN->TurnOffAllLights();
 	}
 
-	SAFE_DELETE( SCREENMAN );
-	SAFE_DELETE( STATSMAN );
-	SAFE_DELETE( MESSAGEMAN );
-	SAFE_DELETE( NETWORK );
+	RageUtil::SafeDelete( SCREENMAN );
+	RageUtil::SafeDelete( STATSMAN );
+	RageUtil::SafeDelete( MESSAGEMAN );
+	RageUtil::SafeDelete( NETWORK );
 	/* Delete INPUTMAN before the other INPUTFILTER handlers, or an input
 	 * driver may try to send a message to INPUTFILTER after we delete it. */
-	SAFE_DELETE( INPUTMAN );
-	SAFE_DELETE( INPUTQUEUE );
-	SAFE_DELETE( INPUTMAPPER );
-	SAFE_DELETE( INPUTFILTER );
-	SAFE_DELETE( MODELMAN );
-	SAFE_DELETE( PROFILEMAN ); // PROFILEMAN needs the songs still loaded
-	SAFE_DELETE( CHARMAN );
-	SAFE_DELETE( UNLOCKMAN );
-	SAFE_DELETE( CRYPTMAN );
-	SAFE_DELETE( MEMCARDMAN );
-	SAFE_DELETE( SONGMAN );
-	SAFE_DELETE( IMAGECACHE );
-	SAFE_DELETE( SONGINDEX );
-	SAFE_DELETE( SOUND ); // uses GAMESTATE, PREFSMAN
-	SAFE_DELETE( PREFSMAN );
-	SAFE_DELETE( GAMESTATE );
-	SAFE_DELETE( GAMEMAN );
-	SAFE_DELETE( NOTESKIN );
-	SAFE_DELETE( THEME );
-	SAFE_DELETE( ANNOUNCER );
-	SAFE_DELETE( BOOKKEEPER );
-	SAFE_DELETE( LIGHTSMAN );
-	SAFE_DELETE( SOUNDMAN );
-	SAFE_DELETE( FONT );
-	SAFE_DELETE( TEXTUREMAN );
-	SAFE_DELETE( DISPLAY );
+	RageUtil::SafeDelete( INPUTMAN );
+	RageUtil::SafeDelete( INPUTQUEUE );
+	RageUtil::SafeDelete( INPUTMAPPER );
+	RageUtil::SafeDelete( INPUTFILTER );
+	RageUtil::SafeDelete( MODELMAN );
+	RageUtil::SafeDelete( PROFILEMAN ); // PROFILEMAN needs the songs still loaded
+	RageUtil::SafeDelete( CHARMAN );
+	RageUtil::SafeDelete( UNLOCKMAN );
+	RageUtil::SafeDelete( CRYPTMAN );
+	RageUtil::SafeDelete( MEMCARDMAN );
+	RageUtil::SafeDelete( SONGMAN );
+	RageUtil::SafeDelete( IMAGECACHE );
+	RageUtil::SafeDelete( SONGINDEX );
+	RageUtil::SafeDelete( SOUND ); // uses GAMESTATE, PREFSMAN
+	RageUtil::SafeDelete( PREFSMAN );
+	RageUtil::SafeDelete( GAMESTATE );
+	RageUtil::SafeDelete( GAMEMAN );
+	RageUtil::SafeDelete( NOTESKIN );
+	RageUtil::SafeDelete( THEME );
+	RageUtil::SafeDelete( ANNOUNCER );
+	RageUtil::SafeDelete( BOOKKEEPER );
+	RageUtil::SafeDelete( LIGHTSMAN );
+	RageUtil::SafeDelete( SOUNDMAN );
+	RageUtil::SafeDelete( FONT );
+	RageUtil::SafeDelete( TEXTUREMAN );
+	RageUtil::SafeDelete( DISPLAY );
 	Dialog::Shutdown();
-	SAFE_DELETE( LOG );
-	SAFE_DELETE( FILEMAN );
-	SAFE_DELETE( LUA );
-	SAFE_DELETE( HOOKS );
+	RageUtil::SafeDelete( LOG );
+	RageUtil::SafeDelete( FILEMAN );
+	RageUtil::SafeDelete( LUA );
+	RageUtil::SafeDelete( HOOKS );
 }
 
 static void HandleException( const RString &sError )
@@ -672,7 +672,7 @@ RageDisplay *CreateDisplay()
 		if( !sError.empty() )
 		{
 			error += ssprintf(ERROR_INITIALIZING.GetValue(), sRenderer.c_str())+"\n" + sError;
-			SAFE_DELETE( pRet );
+			RageUtil::SafeDelete( pRet );
 			error += "\n\n\n";
 			continue;
 		}
@@ -1013,7 +1013,7 @@ int sm_main(int argc, char* argv[])
 	// Initialize which courses are ranking courses here.
 	SONGMAN->UpdateRankingCourses();
 
-	SAFE_DELETE( pLoadingWindow ); // destroy this before init'ing Display
+	RageUtil::SafeDelete( pLoadingWindow ); // destroy this before init'ing Display
 
 	/* If the user has tried to quit during the loading, do it before creating
 	* the main window. This prevents going to full screen just to quit. */

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -177,7 +177,7 @@ ThemeManager::ThemeManager()
 ThemeManager::~ThemeManager()
 {
 	g_vThemes.clear();
-	SAFE_DELETE( g_pLoadedThemeData );
+	RageUtil::SafeDelete( g_pLoadedThemeData );
 
 	// Unregister with Lua.
 	LUA->UnsetGlobal( "THEME" );

--- a/src/TimingData.cpp
+++ b/src/TimingData.cpp
@@ -47,7 +47,7 @@ void TimingData::Clear()
 		std::vector<TimingSegment*> &vSegs = m_avpTimingSegments[tst];
 		for( unsigned i = 0; i < vSegs.size(); ++i )
 		{
-			SAFE_DELETE( vSegs[i] );
+			RageUtil::SafeDelete( vSegs[i] );
 		}
 
 		vSegs.clear();
@@ -589,7 +589,7 @@ static void EraseSegment( std::vector<TimingSegment*> &vSegs, int index, TimingS
 #endif
 
 	vSegs.erase( vSegs.begin() + index );
-	SAFE_DELETE( cur );
+	RageUtil::SafeDelete( cur );
 }
 
 // NOTE: the pointer we're passed is a reference to a temporary,
@@ -730,7 +730,7 @@ void TimingData::AddSegment( const TimingSegment *seg )
 	if( bOnSameRow )
 	{
 		// delete the existing pointer and replace it
-		SAFE_DELETE( cur );
+		RageUtil::SafeDelete( cur );
 		vSegs[index] = cpy;
 	}
 	else

--- a/src/WheelBase.cpp
+++ b/src/WheelBase.cpp
@@ -39,7 +39,7 @@ WheelBase::~WheelBase()
 {
 	for (WheelItemBase *i : m_WheelBaseItems)
 	{
-		SAFE_DELETE( i );
+		RageUtil::SafeDelete( i );
 	}
 	m_WheelBaseItems.clear();
 	m_LastSelection = nullptr;
@@ -77,7 +77,7 @@ void WheelBase::Load( RString sType )
 		DEBUG_ASSERT( pItem );
 		m_WheelBaseItems.push_back( pItem );
 	}
-	SAFE_DELETE( pTempl );
+	RageUtil::SafeDelete( pTempl );
 
 	// draw outside->inside
 	for( int i=0; i<NUM_WHEEL_ITEMS/2; i++ )

--- a/src/arch/Dialog/Dialog.cpp
+++ b/src/arch/Dialog/Dialog.cpp
@@ -50,7 +50,7 @@ DialogDriver *MakeDialogDriver()
 		{
 			if( LOG )
 				LOG->Info( "Couldn't load driver %s: %s", asDriversToTry[i].c_str(), sError.c_str() );
-			SAFE_DELETE( pRet );
+			RageUtil::SafeDelete( pRet );
 		}
 	}
 

--- a/src/arch/Dialog/DialogDriver.cpp
+++ b/src/arch/Dialog/DialogDriver.cpp
@@ -40,7 +40,7 @@ DialogDriver *DialogDriver::Create()
 			return pRet;
 		if( LOG )
 			LOG->Info( "Couldn't load driver %s: %s", Driver.c_str(), sError.c_str() );
-		SAFE_DELETE( pRet );
+		RageUtil::SafeDelete( pRet );
 	}
 	return nullptr;
 }

--- a/src/arch/InputHandler/InputHandler_Win32_Para.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_Para.cpp
@@ -39,7 +39,7 @@ InputHandler_Win32_Para::InputHandler_Win32_Para()
 	{
 		LOG->Info("Para controller initialized");
 	}
-	SAFE_DELETE( dev );
+	RageUtil::SafeDelete( dev );
 }
 
 void InputHandler_Win32_Para::GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut )

--- a/src/arch/Lights/LightsDriver_SextetStream.cpp
+++ b/src/arch/Lights/LightsDriver_SextetStream.cpp
@@ -35,7 +35,7 @@ namespace
 			{
 				out->Flush();
 				out->Close();
-				SAFE_DELETE(out);
+				RageUtil::SafeDelete(out);
 			}
 		}
 
@@ -102,7 +102,7 @@ inline RageFile * openOutputStream(const RString& filename)
 	if(!file->Open(filename, RageFile::WRITE|RageFile::STREAMED))
 	{
 		LOG->Warn("Error opening file '%s' for output: %s", filename.c_str(), file->GetError().c_str());
-		SAFE_DELETE(file);
+		RageUtil::SafeDelete(file);
 		file = nullptr;
 	}
 

--- a/src/arch/LoadingWindow/LoadingWindow.cpp
+++ b/src/arch/LoadingWindow/LoadingWindow.cpp
@@ -46,7 +46,7 @@ LoadingWindow *LoadingWindow::Create()
 		if( sError != "" )
 		{
 			LOG->Info( "Couldn't load driver %s: %s", DriversToTry[i].c_str(), sError.c_str() );
-			SAFE_DELETE( ret );
+			RageUtil::SafeDelete( ret );
 		}
 	}
 

--- a/src/arch/MovieTexture/MovieTexture.cpp
+++ b/src/arch/MovieTexture/MovieTexture.cpp
@@ -124,7 +124,7 @@ RageMovieTexture *RageMovieTexture::Create( RageTextureID ID )
 		if( ret == nullptr )
 		{
 			LOG->Trace( "Couldn't load driver %s: %s", driverString, sError.c_str() );
-			SAFE_DELETE( ret );
+			RageUtil::SafeDelete( ret );
 			continue;
 		}
 		LOG->Trace( "Created movie texture \"%s\" with driver \"%s\"",

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -649,7 +649,7 @@ RageMovieTexture* RageMovieTextureDriver_FFMpeg::Create(RageTextureID ID, RStrin
 	MovieTexture_FFMpeg* pRet = new MovieTexture_FFMpeg(ID);
 	sError = pRet->Init();
 	if (!sError.empty())
-		SAFE_DELETE(pRet);
+		RageUtil::SafeDelete(pRet);
 	return pRet;
 }
 

--- a/src/arch/MovieTexture/MovieTexture_Generic.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Generic.cpp
@@ -258,7 +258,7 @@ void MovieTexture_Generic::CreateTexture()
 
 	if( fmt != PixelFormatYCbCr_Invalid )
 	{
-		SAFE_DELETE( m_pTextureIntermediate );
+		RageUtil::SafeDelete( m_pTextureIntermediate );
 		m_pSprite->UnloadTexture();
 
 		/* Create the render target.  This will receive the final, converted texture. */

--- a/src/arch/Sound/RageSoundDriver.cpp
+++ b/src/arch/Sound/RageSoundDriver.cpp
@@ -88,7 +88,7 @@ RageSoundDriver *RageSoundDriver::Create( const RString& drivers )
 			return pRet;
 		}
 		LOG->Info( "Couldn't load driver %s: %s", driverString, sError.c_str() );
-		SAFE_DELETE( pRet );
+		RageUtil::SafeDelete( pRet );
 	}
 	return nullptr;
 }

--- a/src/archutils/Win32/CrashHandlerChild.cpp
+++ b/src/archutils/Win32/CrashHandlerChild.cpp
@@ -733,7 +733,7 @@ INT_PTR CrashDialog::HandleMessage( UINT msg, WPARAM wParam, LPARAM lParam )
 				KillTimer( hDlg, 0 );
 
 				SetDialogInitial();
-				SAFE_DELETE( m_pPost );
+				RageUtil::SafeDelete( m_pPost );
 				return TRUE;
 			}
 
@@ -817,7 +817,7 @@ INT_PTR CrashDialog::HandleMessage( UINT msg, WPARAM wParam, LPARAM lParam )
 				if( sError.empty() && sResult.empty() )
 					sError = "No data received";
 
-				SAFE_DELETE( m_pPost );
+				RageUtil::SafeDelete( m_pPost );
 
 				XNode xml;
 				if( sError.empty() )

--- a/src/smpackage/SMPackageInstallDlg.cpp
+++ b/src/smpackage/SMPackageInstallDlg.cpp
@@ -366,8 +366,8 @@ void CSMPackageInstallDlg::OnOK()
 					goto show_error;
 				}
 
-				SAFE_DELETE( pFileFrom );
-				SAFE_DELETE( pFileTo );
+				RageUtil::SafeDelete( pFileFrom );
+				RageUtil::SafeDelete( pFileTo );
 			}
 
 			break;

--- a/src/smpackage/smpackage.cpp
+++ b/src/smpackage/smpackage.cpp
@@ -157,9 +157,9 @@ BOOL CSmpackageApp::InitInstance()
 		int nResponse = dlg.DoModal();
 	}
 
-	SAFE_DELETE( THEME );
-	SAFE_DELETE( LUA );
-	SAFE_DELETE( FILEMAN );
+	RageUtil::SafeDelete( THEME );
+	RageUtil::SafeDelete( LUA );
+	RageUtil::SafeDelete( FILEMAN );
 
 
 	// Since the dialog has been closed, return FALSE so that we exit the


### PR DESCRIPTION
Create `RageUtil` class.
`SAFE_DELETE` -> `RageUtil::SafeDelete`
`SAFE_DELETE_ARRAY` -> `RageUtil::SafeDeleteArray`


Note: I will make a PR after this to handle the `ARRAYLEN`, `ZERO` and `ONE` macros, but I won't be changing `SCALE` as the game depends on its possibly "wrong" behavior.