### PR TITLE
Fix routine chart loading/playback in EditMode.

### DIFF
--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -1508,7 +1508,6 @@ void ScreenEdit::Init()
 	this->AddChild( &m_NoteFieldRecord );
 
 	m_EditState = EditState_Invalid;
-	TransitionEditState( STATE_EDITING );
 
 	m_bRemoveNoteButtonDown = false;
 
@@ -1528,6 +1527,7 @@ void ScreenEdit::Init()
 
 	player_manager_.AddPlayers(m_NoteDataEdit);
 	player_manager_.AddPlayersToActorFrame(*this);
+	TransitionEditState(STATE_EDITING);
 
 	this->AddChild( &m_Foreground );
 


### PR DESCRIPTION
A few small bugs,

1. Routine charts are only using the P1 notefield, so P2 needs to be hidden for these.
2. Since it's the P1 notefield, P2 inputs need to be redirected to the P1 notefield
3. `TransitionEditState` is called too early, before the `player_manager_` is initialized. This causes a crash when editing routine charts.