### PR TITLE
Revert to the old RadianToDegree method (from revised patch list)

### DIFF
--- a/src/ModelTypes.cpp
+++ b/src/ModelTypes.cpp
@@ -31,19 +31,8 @@ AnimatedTexture::~AnimatedTexture()
 
 RageVector3 RadianToDegree(RageVector3 radian)
 {
-	// This is more accurate than the original SM5 implementation,
-	// but that raises a double-to-float mismatch warning, so this
-	// prevents that issue from occurring.
-	//
-	// A way to implement the original code exactly would be:
-	//
-	// RageVector3 radian = { radian.x * (180.0f / PI) };
-
-	return RageVector3(
-		static_cast<float>(radian.x * (180.0f / PI)),
-		static_cast<float>(radian.y * (180.0f / PI)),
-		static_cast<float>(radian.z * (180.0f / PI))
-	);
+	constexpr float RAD_TO_DEG = 180.0f / PI;
+	return radian * RAD_TO_DEG;
 }
 
 void AnimatedTexture::LoadBlank()


### PR DESCRIPTION
Doesn't seem to be getting called, but prefer to maintain the original behavior to ensure behavior isn't changed.

The `constexpr` is evaluated at compile time as it does not need to be calculated on demand.