### PR TITLE
Fix SongPosition variable initialization

### DIFF
--- a/src/SongPosition.cpp
+++ b/src/SongPosition.cpp
@@ -37,25 +37,6 @@ void SongPosition::UpdateSongPosition( float fPositionSeconds, const TimingData 
 	m_fSongBeatVisible= beat_info.beat;
 }
 
-void SongPosition::Reset()
-{
-
-	m_fMusicSecondsVisible = 0;
-	m_fSongBeatVisible = 0;
-
-	m_fMusicSeconds = 0; // MUSIC_SECONDS_INVALID;
-	// todo: move me to FOREACH_EnabledPlayer( p ) after [NUM_PLAYERS]ing
-	m_fSongBeat = 0;
-	m_fSongBeatNoOffset = 0;
-	m_fCurBPS = 10;
-	//m_bStop = false;
-	m_bFreeze = false;
-	m_bDelay = false;
-	m_iWarpBeginRow = -1; // Set to -1 because some song may want to warp to row 0. -aj
-	m_fWarpDestination = -1; // Set when a warp is encountered. also see above. -aj
-
-}
-
 //lua start
 #include "LuaBinding.h"
 class LunaSongPosition: public Luna<SongPosition>

--- a/src/SongPosition.h
+++ b/src/SongPosition.h
@@ -11,41 +11,50 @@ struct lua_State;
 class SongPosition
 {
 public:
-	// Arcade - the current stage (one song).
-	// Oni/Endless - a single song in a course.
-	// Let a lot of classes access this info here so they don't have to keep their own copies.
-	float m_fMusicSeconds;		// time into the current song, not scaled by music rate
+	SongPosition() { SongPosition::Reset(); }
+
+	// Represents the time into the current song, not scaled by the music rate.
+	float m_fMusicSeconds;
+	// Represents the current beat of the song.
 	float m_fSongBeat;
+	// Same as above, but without any offset.
 	float m_fSongBeatNoOffset;
+	// Represents the current beats per second (BPS) of the song.
 	float m_fCurBPS;
-	float m_fLightSongBeat;		// g_fLightsFalloffSeconds ahead
-	//bool m_bStop;			// in the middle of a stop (freeze or delay)
-	bool m_bFreeze;			// A flag to determine if we're in the middle of a freeze/stop.
-	bool m_bDelay;			// A flag to determine if we're in the middle of a delay (Pump style stop).
-	int m_iWarpBeginRow;		// The row used to start a warp.
-	float m_fWarpDestination;	// The beat to warp to afterwards.
-	RageTimer m_LastBeatUpdate;	// time of last m_fSongBeat, etc. update
+	// The sum of the song beat (for lighting effects) and g_fLightsFalloffSeconds.
+	float m_fLightSongBeat;
+	// A flag to determine if the song is in the middle of a freeze or stop.
+	bool m_bFreeze;
+	// A flag to determine if the song is in the middle of a delay (Pump style stop).
+	bool m_bDelay;
+	// The row used to start a warp.
+	int m_iWarpBeginRow;
+	// The beat to warp to after a warp begins.
+	float m_fWarpDestination;
+	// The time of the last update to m_fSongBeat and related variables.
+	RageTimer m_LastBeatUpdate;
+	// Represents the visible time into the current song.
 	float m_fMusicSecondsVisible;
+	// Represents the visible beat of the song.
 	float m_fSongBeatVisible;
+	//// A flag to determine if the song is in the middle of a stop (freeze or delay).
+	//// bool m_bStop;
 
-	SongPosition()
-		: m_fMusicSeconds(0.0f),
-		  m_fSongBeat(0.0f),
-		  m_fSongBeatNoOffset(0.0f),
-		  m_fCurBPS(0.0f),
-		  m_fLightSongBeat(0.0f),
-		  //m_bStop(false),
-		  m_bFreeze(false),
-		  m_bDelay(false),
-		  m_iWarpBeginRow(0),
-		  m_fWarpDestination(0.0f),
-		  m_LastBeatUpdate(RageZeroTimer),
-		  m_fMusicSecondsVisible(0.0f),
-		  m_fSongBeatVisible(0.0f)
+	void Reset()
 	{
+		m_fMusicSeconds = 0; // MUSIC_SECONDS_INVALID;
+		m_fSongBeat = 0;
+		m_fSongBeatNoOffset = 0;
+		m_fCurBPS = 10;
+		m_fLightSongBeat = 0; // Assuming initial value
+		m_bFreeze = false;
+		m_bDelay = false;
+		//m_bStop = false;
+		m_iWarpBeginRow = -1; // Set to -1 because some song may want to warp to row 0. -aj
+		m_fWarpDestination = -1; // Set when a warp is encountered. also see above. -aj
+		m_fMusicSecondsVisible = 0;
+		m_fSongBeatVisible = 0;
 	}
-
-	void Reset();
 	
 	void UpdateSongPosition(
 		float fPositionSeconds,


### PR DESCRIPTION
~~This mostly reverts commit 74927934635513eac3ffea77465b395f6145df5c.~~

~~Soon I will open a new PR after I make this a singleton instance and test it, following discovery that this was intended to be a single instance shared across the game.~~

 Move SongPosition::Reset into the header file, and call it in the constructor.