### PR TITLE
Revert "Run as "High Priority" on Windows" (from revised patch list)

### DIFF
--- a/src/arch/ArchHooks/ArchHooks_Win32.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32.cpp
@@ -150,13 +150,20 @@ void ArchHooks_Win32::SetTime( tm newtime )
 
 void ArchHooks_Win32::BoostPriority()
 {
-	// Be sure to boost the app, not the thread, to make sure the sound thread stays higher priority than the main thread.
-	SetPriorityClass( GetCurrentProcess(), HIGH_PRIORITY_CLASS );
+	// We just want a slight boost, so we don't skip needlessly if something happens
+	// in the background. We don't really want to be high-priority—above normal should be enough.
+	//
+	// Be sure to boost the app, not the thread, to make sure the
+	// sound thread stays higher priority than the main thread.
+	//
+	// Also note that high priority won't prevent the game from being interrupted by Windows
+	// notifications - that needs to be handled within ArchUtils.
+	SetPriorityClass( GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS );
 }
 
 void ArchHooks_Win32::UnBoostPriority()
 {
-	SetPriorityClass( GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS );
+	SetPriorityClass( GetCurrentProcess(), NORMAL_PRIORITY_CLASS );
 }
 
 void ArchHooks_Win32::SetupConcurrentRenderingThread()


### PR DESCRIPTION
Revert "Run as "High Priority" on Windows" - this wasn't preventing OBS from stealing the rendering thread as we suspected. Actually it may be a regression since the main thread is supposed to stay at a lower priority than the sound thread.

This reverts commit 3f8a7f5fd389cd3e8f923229bf46df278cdbf5cf.