### PR TITLE
Remove std prefix from uint types

### DIFF
--- a/src/ActorFrame.cpp
+++ b/src/ActorFrame.cpp
@@ -148,7 +148,7 @@ void ActorFrame::AddChild( Actor *pActor )
 #endif
 
 	ASSERT( pActor != nullptr );
-	ASSERT( reinterpret_cast<std::uintptr_t>(pActor) != static_cast<std::uintptr_t>(0xC0000005) );
+	ASSERT( reinterpret_cast<uintptr_t>(pActor) != static_cast<uintptr_t>(0xC0000005) );
 	m_SubActors.push_back( pActor );
 
 	pActor->SetParent( this );

--- a/src/ActorFrameTexture.cpp
+++ b/src/ActorFrameTexture.cpp
@@ -16,7 +16,7 @@ ActorFrameTexture::ActorFrameTexture()
 	m_bAlphaBuffer = false;
 	m_bFloat = false;
 	m_bPreserveTexture = false;
-	static std::uint64_t i = 0;
+	static uint64_t i = 0;
 	++i;
 	m_sTextureName = ssprintf( ConvertI64FormatString("ActorFrameTexture %lli"), i );
 

--- a/src/ActorMultiVertex.cpp
+++ b/src/ActorMultiVertex.cpp
@@ -248,16 +248,16 @@ void ActorMultiVertex::DrawPrimitives()
 
 		for( size_t i=0; i < TS.vertices.size(); i++ )
 		{
-			// RageVColor uses a std::uint8_t for each channel.  0-255.
+			// RageVColor uses a uint8_t for each channel.  0-255.
 			// RageColor uses a float. 0-1.
 			// So each channel of the RageVColor needs to be converted to a float,
 			// multiplied by the channel from the RageColor, then the result
-			// converted to std::uint8_t.  If implicit conversion is allowed to happen,
-			// sometimes the compiler decides to turn the RageColor into a std::uint8_t,
+			// converted to uint8_t.  If implicit conversion is allowed to happen,
+			// sometimes the compiler decides to turn the RageColor into a uint8_t,
 			// which makes any value other than 1 into 0.  Thus, the explicit
 			// conversions.  -Kyz
 #define MULT_COLOR_ELEMENTS(color_a, color_b) \
-	color_a= static_cast<std::uint8_t>(static_cast<float>(color_a) * color_b);
+	color_a= static_cast<uint8_t>(static_cast<float>(color_a) * color_b);
 			// RageVColor * RageColor
 			MULT_COLOR_ELEMENTS(TS.vertices[i].c.b, m_pTempState->diffuse[0].b);
 			MULT_COLOR_ELEMENTS(TS.vertices[i].c.r, m_pTempState->diffuse[0].r);

--- a/src/CryptManager.cpp
+++ b/src/CryptManager.cpp
@@ -66,9 +66,9 @@ bool CryptManager::VerifyFileWithFile( RString sPath, RString sSignatureFile )
 
 void CryptManager::GetRandomBytes( void *pData, int iBytes )
 {
-	std::uint8_t *pBuf = (std::uint8_t *) pData;
+	uint8_t *pBuf = (uint8_t *) pData;
 	while( iBytes-- )
-		*pBuf++ = (std::uint8_t) RandomInt( 256 );
+		*pBuf++ = (uint8_t) RandomInt( 256 );
 }
 
 #else
@@ -467,7 +467,7 @@ RString CryptManager::GetPublicKeyFileName()
 /* Generate a version 4 random UUID. */
 RString CryptManager::GenerateRandomUUID()
 {
-	std::uint32_t buf[4];
+	uint32_t buf[4];
 	CryptManager::GetRandomBytes( buf, sizeof(buf) );
 
 	buf[1] &= 0xFFFF0FFF;

--- a/src/ImageCache.cpp
+++ b/src/ImageCache.cpp
@@ -189,8 +189,8 @@ void ImageCache::ReadFromDisk()
 
 struct ImageTexture: public RageTexture
 {
-	std::uintptr_t m_uTexHandle;
-	std::uintptr_t GetTexHandle() const { return m_uTexHandle; };	// accessed by RageDisplay
+	uintptr_t m_uTexHandle;
+	uintptr_t GetTexHandle() const { return m_uTexHandle; };	// accessed by RageDisplay
 	/* This is a reference to a pointer in g_ImagePathToImage. */
 	RageSurface *&m_pImage;
 	int m_iWidth, m_iHeight;

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -422,8 +422,8 @@ LuaThreadVariable::LuaThreadVariable( lua_State *L )
 
 RString LuaThreadVariable::GetCurrentThreadIDString()
 {
-	std::uint64_t iID = RageThread::GetCurrentThreadID();
-	return ssprintf( "%08x%08x", std::uint32_t(iID >> 32), std::uint32_t(iID) );
+	uint64_t iID = RageThread::GetCurrentThreadID();
+	return ssprintf( "%08x%08x", uint32_t(iID >> 32), uint32_t(iID) );
 }
 
 bool LuaThreadVariable::PushThreadTable( lua_State *L, bool bCreate )

--- a/src/ModelTypes.h
+++ b/src/ModelTypes.h
@@ -10,7 +10,7 @@
 
 struct msTriangle
 {
-    std::uint16_t nVertexIndices[3];
+    uint16_t nVertexIndices[3];
 };
 
 

--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -870,7 +870,7 @@ void NoteField::DrawPrimitives()
 
 		// Create an oscillating / pulsing glow effect.
 		// Converts a counter to radians and uses the cosine for a cyclic appearance.
-		static std::uint_fast16_t iGlowCounter;
+		static uint_fast16_t iGlowCounter;
 		static constexpr float fCyclical = 2.0f * 3.14159265f / 360.0f;
 		iGlowCounter = (iGlowCounter + 1) % 360;
 		float phase = iGlowCounter * fCyclical;

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -1258,7 +1258,7 @@ ProfileLoadResult Profile::LoadStatsFromDir(RString dir, bool require_signature)
 	if(compressed)
 	{
 		RString sError;
-		std::uint32_t iCRC32;
+		uint32_t iCRC32;
 		RageFileObjInflate *pInflate = GunzipFile(pFile.release(), sError, &iCRC32);
 		if(pInflate == nullptr)
 		{

--- a/src/RageBitmapTexture.h
+++ b/src/RageBitmapTexture.h
@@ -15,12 +15,12 @@ public:
 	/* only called by RageTextureManager::InvalidateTextures */
 	virtual void Invalidate() { m_uTexHandle = 0; /* don't Destroy() */}
 	virtual void Reload();
-	virtual std::uintptr_t GetTexHandle() const { return m_uTexHandle; };	// accessed by RageDisplay
+	virtual uintptr_t GetTexHandle() const { return m_uTexHandle; };	// accessed by RageDisplay
 
 private:
 	void Create();	// called by constructor and Reload
 	void Destroy();
-	std::uintptr_t m_uTexHandle;	// treat as unsigned in OpenGL, IDirect3DTexture9* for D3D
+	uintptr_t m_uTexHandle;	// treat as unsigned in OpenGL, IDirect3DTexture9* for D3D
 };
 
 #endif

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -656,7 +656,7 @@ RageSurface *RageDisplay::CreateSurfaceFromPixfmt( RagePixelFormat pixfmt,
 	RageSurface *surf = CreateSurfaceFrom(
 		width, height, tpf->bpp,
 		tpf->masks[0], tpf->masks[1], tpf->masks[2], tpf->masks[3],
-		(std::uint8_t *) pixels, pitch );
+		(uint8_t *) pixels, pitch );
 
 	return surf;
 }

--- a/src/RageDisplay.h
+++ b/src/RageDisplay.h
@@ -203,7 +203,7 @@ struct RageTextureLock
 
 	/* Given a surface with a format and no pixel data, lock the texture into the
 	 * surface. The data is write-only. */
-	virtual void Lock( std::uintptr_t iTexHandle, RageSurface *pSurface ) = 0;
+	virtual void Lock( uintptr_t iTexHandle, RageSurface *pSurface ) = 0;
 
 	/* Unlock and update the texture. If bChanged is false, the texture update
 	 * may be omitted. */
@@ -259,23 +259,23 @@ public:
 
 	/* return 0 if failed or internal texture resource handle
 	 * (unsigned in OpenGL, texture pointer in D3D) */
-	virtual std::uintptr_t CreateTexture(
+	virtual uintptr_t CreateTexture(
 		RagePixelFormat pixfmt,		// format of img and of texture in video mem
 		RageSurface* img,		// must be in pixfmt
 		bool bGenerateMipMaps
 		) = 0;
 	virtual void UpdateTexture(
-		std::uintptr_t iTexHandle,
+		uintptr_t iTexHandle,
 		RageSurface* img,
 		int xoffset, int yoffset, int width, int height
 		) = 0;
-	virtual void DeleteTexture( std::uintptr_t iTexHandle ) = 0;
+	virtual void DeleteTexture( uintptr_t iTexHandle ) = 0;
 	/* Return an object to lock pixels for streaming. If not supported, returns nullptr.
 	 * Delete the object normally. */
 	virtual RageTextureLock *CreateTextureLock() { return nullptr; }
 	virtual void ClearAllTextures() = 0;
 	virtual int GetNumTextureUnits() = 0;
-	virtual void SetTexture( TextureUnit, std::uintptr_t /* iTexture */ ) = 0;
+	virtual void SetTexture( TextureUnit, uintptr_t /* iTexture */ ) = 0;
 	virtual void SetTextureMode( TextureUnit, TextureMode ) = 0;
 	virtual void SetTextureWrapping( TextureUnit, bool ) = 0;
 	virtual int GetMaxTextureSize() const = 0;
@@ -291,9 +291,9 @@ public:
 	 * DeleteTexture. (UpdateTexture is not permitted.) Returns 0 if render-to-
 	 * texture is unsupported.
 	 */
-	virtual std::uintptr_t CreateRenderTarget( const RenderTargetParam &, int & /* iTextureWidthOut */, int & /* iTextureHeightOut */ ) { return 0; }
+	virtual uintptr_t CreateRenderTarget( const RenderTargetParam &, int & /* iTextureWidthOut */, int & /* iTextureHeightOut */ ) { return 0; }
 
-	virtual std::uintptr_t GetRenderTarget()	{ return 0; }
+	virtual uintptr_t GetRenderTarget()	{ return 0; }
 
 	/* Set the render target, or 0 to resume rendering to the framebuffer. An active render
 	 * target may not be used as a texture. If bPreserveTexture is true, the contents
@@ -301,7 +301,7 @@ public:
 	 * bPreserveTexture is true the first time a render target is used, behave as if
 	 * bPreserveTexture was false.
 	 */
-	virtual void SetRenderTarget( std::uintptr_t /* iHandle */, bool /* bPreserveTexture */ = true ) { }
+	virtual void SetRenderTarget( uintptr_t /* iHandle */, bool /* bPreserveTexture */ = true ) { }
 
 	virtual bool IsZTestEnabled() const = 0;
 	virtual bool IsZWriteEnabled() const = 0;
@@ -362,9 +362,9 @@ public:
 	};
 	bool SaveScreenshot( RString sPath, GraphicsFileFormat format );
 
-	virtual RString GetTextureDiagnostics( std::uintptr_t /* id */ ) const { return RString(); }
+	virtual RString GetTextureDiagnostics( uintptr_t /* id */ ) const { return RString(); }
 	virtual RageSurface* CreateScreenshot() = 0;	// allocates a surface.  Caller must delete it.
-	virtual RageSurface *GetTexture( std::uintptr_t /* iTexture */ ) { return nullptr; } // allocates a surface.  Caller must delete it.
+	virtual RageSurface *GetTexture( uintptr_t /* iTexture */ ) { return nullptr; } // allocates a surface.  Caller must delete it.
 
 protected:
 	virtual void DrawQuadsInternal( const RageSpriteVertex v[], int iNumVerts ) = 0;

--- a/src/RageDisplay_D3D.cpp
+++ b/src/RageDisplay_D3D.cpp
@@ -48,13 +48,13 @@ const D3DFORMAT g_DefaultAdapterFormat = D3DFMT_X8R8G8B8;
 /* Direct3D doesn't associate a palette with textures. Instead, we load a
  * palette into a slot. We need to keep track of which texture's palette is
  * stored in what slot. */
-std::map<std::uintptr_t, size_t>		g_TexResourceToPaletteIndex;
+std::map<uintptr_t, size_t>		g_TexResourceToPaletteIndex;
 std::list<size_t>			g_PaletteIndex;
 struct TexturePalette { PALETTEENTRY p[256]; };
-std::map<std::uintptr_t, TexturePalette>	g_TexResourceToTexturePalette;
+std::map<uintptr_t, TexturePalette>	g_TexResourceToTexturePalette;
 
 // Load the palette, if any, for the given texture into a palette slot, and make it current.
-static void SetPalette( std::uintptr_t TexResource )
+static void SetPalette( uintptr_t TexResource )
 {
 	// If the texture isn't paletted, we have nothing to do.
 	if( g_TexResourceToTexturePalette.find(TexResource) == g_TexResourceToTexturePalette.end() )
@@ -67,7 +67,7 @@ static void SetPalette( std::uintptr_t TexResource )
 		UINT iPalIndex = static_cast<UINT>(g_PaletteIndex.front());
 
 		// If any other texture is currently using this slot, mark that palette unloaded.
-		for( std::map<std::uintptr_t, size_t>::iterator i = g_TexResourceToPaletteIndex.begin(); i != g_TexResourceToPaletteIndex.end(); ++i )
+		for( std::map<uintptr_t, size_t>::iterator i = g_TexResourceToPaletteIndex.begin(); i != g_TexResourceToPaletteIndex.end(); ++i )
 		{
 			if( i->second != iPalIndex )
 				continue;
@@ -798,7 +798,7 @@ public:
 
 			for( size_t j=0; j<Triangles.size(); j++ )
 				for( size_t k=0; k<3; k++ )
-					m_vTriangles[meshInfo.iTriangleStart+j].nVertexIndices[k] = (std::uint16_t) meshInfo.iVertexStart + Triangles[j].nVertexIndices[k];
+					m_vTriangles[meshInfo.iTriangleStart+j].nVertexIndices[k] = (uint16_t) meshInfo.iVertexStart + Triangles[j].nVertexIndices[k];
 		}
 	}
 	void Draw( int iMeshIndex ) const
@@ -854,11 +854,11 @@ void RageDisplay_D3D::DrawQuadsInternal( const RageSpriteVertex v[], int iNumVer
 	int iNumIndices = iNumTriangles*3;
 
 	// make a temporary index buffer
-	static std::vector<std::uint16_t> vIndices;
+	static std::vector<uint16_t> vIndices;
 	size_t uOldSize = vIndices.size();
 	size_t uNewSize = std::max(uOldSize, static_cast<size_t>(iNumIndices));
 	vIndices.resize( uNewSize );
-	for( std::uint16_t i=(std::uint16_t)uOldSize/6; i<(std::uint16_t)iNumQuads; i++ )
+	for( uint16_t i=(uint16_t)uOldSize/6; i<(uint16_t)iNumQuads; i++ )
 	{
 		vIndices[i*6+0] = i*4+0;
 		vIndices[i*6+1] = i*4+1;
@@ -890,11 +890,11 @@ void RageDisplay_D3D::DrawQuadStripInternal( const RageSpriteVertex v[], int iNu
 	int iNumIndices = iNumTriangles*3;
 
 	// make a temporary index buffer
-	static std::vector<std::uint16_t> vIndices;
+	static std::vector<uint16_t> vIndices;
 	size_t uOldSize = vIndices.size();
 	size_t uNewSize = std::max(uOldSize, static_cast<size_t>(iNumIndices));
 	vIndices.resize( uNewSize );
-	for( std::uint16_t i=(std::uint16_t)uOldSize/6; i<(std::uint16_t)iNumQuads; i++ )
+	for( uint16_t i=(uint16_t)uOldSize/6; i<(uint16_t)iNumQuads; i++ )
 	{
 		vIndices[i*6+0] = i*2+0;
 		vIndices[i*6+1] = i*2+1;
@@ -925,11 +925,11 @@ void RageDisplay_D3D::DrawSymmetricQuadStripInternal( const RageSpriteVertex v[]
 	int iNumIndices = iNumTriangles*3;
 
 	// make a temporary index buffer
-	static std::vector<std::uint16_t> vIndices;
+	static std::vector<uint16_t> vIndices;
 	size_t uOldSize = vIndices.size();
 	size_t uNewSize = std::max(uOldSize, static_cast<size_t>(iNumIndices));
 	vIndices.resize( uNewSize );
-	for( std::uint16_t i=(std::uint16_t)uOldSize/12; i<(std::uint16_t)iNumPieces; i++ )
+	for( uint16_t i=(uint16_t)uOldSize/12; i<(uint16_t)iNumPieces; i++ )
 	{
 		// { 1, 3, 0 } { 1, 4, 3 } { 1, 5, 4 } { 1, 2, 5 }
 		vIndices[i*12+0] = i*3+1;
@@ -1052,7 +1052,7 @@ int RageDisplay_D3D::GetNumTextureUnits()
 	return g_DeviceCaps.MaxSimultaneousTextures;
 }
 
-void RageDisplay_D3D::SetTexture( TextureUnit tu, std::uintptr_t iTexture )
+void RageDisplay_D3D::SetTexture( TextureUnit tu, uintptr_t iTexture )
 {
 //	g_DeviceCaps.MaxSimultaneousTextures = 1;
 	if( tu >= (int) g_DeviceCaps.MaxSimultaneousTextures )	// not supported
@@ -1360,7 +1360,7 @@ void RageDisplay_D3D::SetCullMode( CullMode mode )
 	}
 }
 
-void RageDisplay_D3D::DeleteTexture( std::uintptr_t iTexHandle )
+void RageDisplay_D3D::DeleteTexture( uintptr_t iTexHandle )
 {
 	if( iTexHandle == 0 )
 		return;
@@ -1376,7 +1376,7 @@ void RageDisplay_D3D::DeleteTexture( std::uintptr_t iTexHandle )
 }
 
 
-std::uintptr_t RageDisplay_D3D::CreateTexture(
+uintptr_t RageDisplay_D3D::CreateTexture(
 	RagePixelFormat pixfmt,
 	RageSurface* img,
 	bool bGenerateMipMaps )
@@ -1389,7 +1389,7 @@ std::uintptr_t RageDisplay_D3D::CreateTexture(
 		RageException::Throw( "CreateTexture(%i,%i,%s) failed: %s",
 		img->w, img->h, RagePixelFormatToString(pixfmt).c_str(), GetErrorString(hr).c_str() );
 
-	std::uintptr_t uTexHandle = reinterpret_cast<std::uintptr_t>(pTex);
+	uintptr_t uTexHandle = reinterpret_cast<uintptr_t>(pTex);
 
 	if( pixfmt == RagePixelFormat_PAL )
 	{
@@ -1415,7 +1415,7 @@ std::uintptr_t RageDisplay_D3D::CreateTexture(
 }
 
 void RageDisplay_D3D::UpdateTexture(
-	std::uintptr_t uTexHandle,
+	uintptr_t uTexHandle,
 	RageSurface* img,
 	int xoffset, int yoffset, int width, int height )
 {

--- a/src/RageDisplay_D3D.h
+++ b/src/RageDisplay_D3D.h
@@ -26,19 +26,19 @@ public:
 	bool SupportsTextureFormat( RagePixelFormat pixfmt, bool realtime=false );
 	bool SupportsThreadedRendering();
 	bool SupportsPerVertexMatrixScale() { return false; }
-	std::uintptr_t CreateTexture(
+	uintptr_t CreateTexture(
 		RagePixelFormat pixfmt,
 		RageSurface* img,
 		bool bGenerateMipMaps );
 	void UpdateTexture(
-		std::uintptr_t iTexHandle,
+		uintptr_t iTexHandle,
 		RageSurface* img,
 		int xoffset, int yoffset, int width, int height
 		);
-	void DeleteTexture( std::uintptr_t iTexHandle );
+	void DeleteTexture( uintptr_t iTexHandle );
 	void ClearAllTextures();
 	int GetNumTextureUnits();
-	void SetTexture( TextureUnit tu, std::uintptr_t iTexture );
+	void SetTexture( TextureUnit tu, uintptr_t iTexture );
 	void SetTextureMode( TextureUnit tu, TextureMode tm );
 	void SetTextureWrapping( TextureUnit tu, bool b );
 	int GetMaxTextureSize() const;

--- a/src/RageDisplay_GLES2.cpp
+++ b/src/RageDisplay_GLES2.cpp
@@ -564,7 +564,7 @@ RageDisplay_GLES2::SupportsPerVertexMatrixScale()
 	return true;
 }
 
-std::uintptr_t
+uintptr_t
 RageDisplay_GLES2::CreateTexture(
 	RagePixelFormat pixfmt,
 	RageSurface* img,
@@ -577,7 +577,7 @@ RageDisplay_GLES2::CreateTexture(
 
 void
 RageDisplay_GLES2::UpdateTexture(
-	std::uintptr_t iTexHandle,
+	uintptr_t iTexHandle,
 	RageSurface* img,
 	int xoffset, int yoffset, int width, int height
 	)
@@ -586,7 +586,7 @@ RageDisplay_GLES2::UpdateTexture(
 }
 
 void
-RageDisplay_GLES2::DeleteTexture( std::uintptr_t iTexHandle )
+RageDisplay_GLES2::DeleteTexture( uintptr_t iTexHandle )
 {
 	// TODO
 }
@@ -618,7 +618,7 @@ SetTextureUnit( TextureUnit tu )
 }
 
 void
-RageDisplay_GLES2::SetTexture( TextureUnit tu, std::uintptr_t iTexture )
+RageDisplay_GLES2::SetTexture( TextureUnit tu, uintptr_t iTexture )
 {
 	if (!SetTextureUnit( tu ))
 		return;

--- a/src/RageDisplay_GLES2.h
+++ b/src/RageDisplay_GLES2.h
@@ -20,18 +20,18 @@ public:
 	void SetBlendMode( BlendMode mode );
 	bool SupportsTextureFormat( RagePixelFormat pixfmt, bool realtime=false );
 	bool SupportsPerVertexMatrixScale();
-	std::uintptr_t CreateTexture(
+	uintptr_t CreateTexture(
 		RagePixelFormat pixfmt,
 		RageSurface* img,
 		bool bGenerateMipMaps );
 	void UpdateTexture(
-		std::uintptr_t iTexHandle,
+		uintptr_t iTexHandle,
 		RageSurface* img,
 		int xoffset, int yoffset, int width, int height );
-	void DeleteTexture( std::uintptr_t iTexHandle );
+	void DeleteTexture( uintptr_t iTexHandle );
 	void ClearAllTextures();
 	int GetNumTextureUnits();
-	void SetTexture( TextureUnit tu, std::uintptr_t iTexture );
+	void SetTexture( TextureUnit tu, uintptr_t iTexture );
 	void SetTextureMode( TextureUnit tu, TextureMode tm );
 	void SetTextureWrapping( TextureUnit tu, bool b );
 	int GetMaxTextureSize() const;

--- a/src/RageDisplay_Null.h
+++ b/src/RageDisplay_Null.h
@@ -21,19 +21,19 @@ public:
 	void SetBlendMode( BlendMode ) { }
 	bool SupportsTextureFormat( RagePixelFormat, bool /* realtime */ =false ) { return true; }
 	bool SupportsPerVertexMatrixScale() { return false; }
-	std::uintptr_t CreateTexture(
+	uintptr_t CreateTexture(
 		RagePixelFormat,
 		RageSurface* /* img */,
 		bool /* bGenerateMipMaps */ ) { return 1; }
 	void UpdateTexture(
-		std::uintptr_t /* iTexHandle */,
+		uintptr_t /* iTexHandle */,
 		RageSurface* /* img */,
 		int /* xoffset */, int /* yoffset */, int /* width */, int /* height */
 		) { }
-	void DeleteTexture( std::uintptr_t /* iTexHandle */ ) { }
+	void DeleteTexture( uintptr_t /* iTexHandle */ ) { }
 	void ClearAllTextures() { }
 	int GetNumTextureUnits() { return 1; }
-	void SetTexture( TextureUnit, std::uintptr_t /* iTexture */ ) { }
+	void SetTexture( TextureUnit, uintptr_t /* iTexture */ ) { }
 	void SetTextureMode( TextureUnit, TextureMode ) { }
 	void SetTextureWrapping( TextureUnit, bool ) { }
 	int GetMaxTextureSize() const { return 2048; }

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -66,7 +66,7 @@ static const GLenum RageSpriteVertexFormat = GL_T2F_C4F_N3F_V3F;
 /* If we support texture matrix scaling, a handle to the vertex program: */
 static GLhandleARB g_bTextureMatrixShader = 0;
 
-static std::map<std::uintptr_t, RenderTarget *> g_mapRenderTargets;
+static std::map<uintptr_t, RenderTarget *> g_mapRenderTargets;
 static RenderTarget *g_pCurrentRenderTarget = nullptr;
 
 static LowLevelWindow *g_pWind;
@@ -800,7 +800,7 @@ RString RageDisplay_Legacy::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 
 		/* Delete all render targets.  They may have associated resources other than
 		 * the texture itself. */
-		for (std::pair<std::uintptr_t const, RenderTarget *> &rt : g_mapRenderTargets)
+		for (std::pair<uintptr_t const, RenderTarget *> &rt : g_mapRenderTargets)
 			delete rt.second;
 		g_mapRenderTargets.clear();
 
@@ -927,7 +927,7 @@ RageSurface* RageDisplay_Legacy::CreateScreenshot()
 	return image;
 }
 
-RageSurface *RageDisplay_Legacy::GetTexture( std::uintptr_t iTexture )
+RageSurface *RageDisplay_Legacy::GetTexture( uintptr_t iTexture )
 {
 	if (iTexture == 0)
 		return nullptr; // XXX
@@ -1071,7 +1071,7 @@ public:
 				for( unsigned k=0; k<3; k++ )
 				{
 					int iVertexIndexInVBO = meshInfo.iVertexStart + Triangles[j].nVertexIndices[k];
-					m_vTriangles[meshInfo.iTriangleStart+j].nVertexIndices[k] = (std::uint16_t) iVertexIndexInVBO;
+					m_vTriangles[meshInfo.iTriangleStart+j].nVertexIndices[k] = (uint16_t) iVertexIndexInVBO;
 				}
 		}
 	}
@@ -1513,11 +1513,11 @@ void RageDisplay_Legacy::DrawSymmetricQuadStripInternal( const RageSpriteVertex 
 	int iNumIndices = iNumTriangles*3;
 
 	// make a temporary index buffer
-	static std::vector<std::uint16_t> vIndices;
+	static std::vector<uint16_t> vIndices;
 	unsigned uOldSize = vIndices.size();
 	unsigned uNewSize = std::max(uOldSize,(unsigned)iNumIndices);
 	vIndices.resize( uNewSize );
-	for( std::uint16_t i=(std::uint16_t)uOldSize/12; i<(std::uint16_t)iNumPieces; i++ )
+	for( uint16_t i=(uint16_t)uOldSize/12; i<(uint16_t)iNumPieces; i++ )
 	{
 		// { 1, 3, 0 } { 1, 4, 3 } { 1, 5, 4 } { 1, 2, 5 }
 		vIndices[i*12+0] = i*3+1;
@@ -1687,7 +1687,7 @@ int RageDisplay_Legacy::GetNumTextureUnits()
 		return g_iMaxTextureUnits;
 }
 
-void RageDisplay_Legacy::SetTexture( TextureUnit tu, std::uintptr_t iTexture )
+void RageDisplay_Legacy::SetTexture( TextureUnit tu, uintptr_t iTexture )
 {
 	if (!SetTextureUnit( tu ))
 		return;
@@ -2114,7 +2114,7 @@ void RageDisplay_Legacy::EndConcurrentRendering()
 	g_pWind->EndConcurrentRendering();
 }
 
-void RageDisplay_Legacy::DeleteTexture( std::uintptr_t iTexture )
+void RageDisplay_Legacy::DeleteTexture( uintptr_t iTexture )
 {
 	if (iTexture == 0)
 		return;
@@ -2199,7 +2199,7 @@ void SetPixelMapForSurface( int glImageFormat, int glTexFormat, const RageSurfac
 	DebugAssertNoGLError();
 }
 
-std::uintptr_t RageDisplay_Legacy::CreateTexture(
+uintptr_t RageDisplay_Legacy::CreateTexture(
 	RagePixelFormat pixfmt,
 	RageSurface* pImg,
 	bool bGenerateMipMaps )
@@ -2244,7 +2244,7 @@ std::uintptr_t RageDisplay_Legacy::CreateTexture(
 	SetTextureUnit( TextureUnit_1 );
 
 	// allocate OpenGL texture resource
-	std::uintptr_t iTexHandle;
+	uintptr_t iTexHandle;
 	glGenTextures( 1, reinterpret_cast<GLuint*>(&iTexHandle) );
 	ASSERT( iTexHandle != 0 );
 
@@ -2352,7 +2352,7 @@ public:
 		m_iTexHandle = 0;
 	}
 
-	void Lock( std::uintptr_t iTexHandle, RageSurface *pSurface )
+	void Lock( uintptr_t iTexHandle, RageSurface *pSurface )
 	{
 		ASSERT( m_iTexHandle == 0 );
 		ASSERT( pSurface->pixels == nullptr );
@@ -2366,7 +2366,7 @@ public:
 		glBufferDataARB( GL_PIXEL_UNPACK_BUFFER_ARB, iSize, nullptr, GL_STREAM_DRAW );
 
 		void *pSurfaceMemory = glMapBufferARB( GL_PIXEL_UNPACK_BUFFER_ARB, GL_WRITE_ONLY );
-		pSurface->pixels = (std::uint8_t *) pSurfaceMemory;
+		pSurface->pixels = (uint8_t *) pSurfaceMemory;
 		pSurface->pixels_owned = false;
 	}
 
@@ -2374,7 +2374,7 @@ public:
 	{
 		glUnmapBufferARB( GL_PIXEL_UNPACK_BUFFER_ARB );
 
-		pSurface->pixels = (std::uint8_t *) BUFFER_OFFSET(0);
+		pSurface->pixels = (uint8_t *) BUFFER_OFFSET(0);
 
 		if (bChanged)
 			DISPLAY->UpdateTexture( m_iTexHandle, pSurface, 0, 0, pSurface->w, pSurface->h );
@@ -2398,7 +2398,7 @@ private:
 
 	GLuint m_iBuffer;
 
-	std::uintptr_t m_iTexHandle;
+	uintptr_t m_iTexHandle;
 };
 
 RageTextureLock *RageDisplay_Legacy::CreateTextureLock()
@@ -2410,7 +2410,7 @@ RageTextureLock *RageDisplay_Legacy::CreateTextureLock()
 }
 
 void RageDisplay_Legacy::UpdateTexture(
-	std::uintptr_t iTexHandle,
+	uintptr_t iTexHandle,
 	RageSurface* pImg,
 	int iXOffset, int iYOffset, int iWidth, int iHeight )
 {
@@ -2452,16 +2452,16 @@ public:
 	RenderTarget_FramebufferObject();
 	~RenderTarget_FramebufferObject();
 	void Create( const RenderTargetParam &param, int &iTextureWidthOut, int &iTextureHeightOut );
-	std::uintptr_t GetTexture() const { return m_iTexHandle; }
+	uintptr_t GetTexture() const { return m_iTexHandle; }
 	void StartRenderingTo();
 	void FinishRenderingTo();
 
 	virtual bool InvertY() const { return true; }
 
 private:
-	std::uintptr_t m_iFrameBufferHandle;
-	std::uintptr_t m_iTexHandle;
-	std::uintptr_t m_iDepthBufferHandle;
+	uintptr_t m_iFrameBufferHandle;
+	uintptr_t m_iTexHandle;
+	uintptr_t m_iDepthBufferHandle;
 };
 
 RenderTarget_FramebufferObject::RenderTarget_FramebufferObject()
@@ -2584,7 +2584,7 @@ bool RageDisplay_Legacy::SupportsFullscreenBorderlessWindow() const
  * particularly GeForce 2, but is simpler and faster when available.
  */
 
-std::uintptr_t RageDisplay_Legacy::CreateRenderTarget( const RenderTargetParam &param, int &iTextureWidthOut, int &iTextureHeightOut )
+uintptr_t RageDisplay_Legacy::CreateRenderTarget( const RenderTargetParam &param, int &iTextureWidthOut, int &iTextureHeightOut )
 {
 	RenderTarget *pTarget;
 	if (GLEW_EXT_framebuffer_object)
@@ -2594,22 +2594,22 @@ std::uintptr_t RageDisplay_Legacy::CreateRenderTarget( const RenderTargetParam &
 
 	pTarget->Create( param, iTextureWidthOut, iTextureHeightOut );
 
-	std::uintptr_t iTexture = pTarget->GetTexture();
+	uintptr_t iTexture = pTarget->GetTexture();
 
 	ASSERT( g_mapRenderTargets.find(iTexture) == g_mapRenderTargets.end() );
 	g_mapRenderTargets[iTexture] = pTarget;
 	return iTexture;
 }
 
-std::uintptr_t RageDisplay_Legacy::GetRenderTarget()
+uintptr_t RageDisplay_Legacy::GetRenderTarget()
 {
-	for( std::map<std::uintptr_t, RenderTarget*>::const_iterator it = g_mapRenderTargets.begin(); it != g_mapRenderTargets.end(); ++it )
+	for( std::map<uintptr_t, RenderTarget*>::const_iterator it = g_mapRenderTargets.begin(); it != g_mapRenderTargets.end(); ++it )
 	if( it->second == g_pCurrentRenderTarget )
 		return it->first;
 	return 0;
 }
 
-void RageDisplay_Legacy::SetRenderTarget( std::uintptr_t iTexture, bool bPreserveTexture )
+void RageDisplay_Legacy::SetRenderTarget( uintptr_t iTexture, bool bPreserveTexture )
 {
 	if (iTexture == 0)
 	{
@@ -2688,7 +2688,7 @@ void RageDisplay_Legacy::SetLineWidth(float fWidth)
 	glLineWidth(fWidth);
 }
 
-RString RageDisplay_Legacy::GetTextureDiagnostics(std::uintptr_t iTexture) const
+RString RageDisplay_Legacy::GetTextureDiagnostics(uintptr_t iTexture) const
 {
 	/*
 		s << (bGenerateMipMaps? "gluBuild2DMipmaps":"glTexImage2D");

--- a/src/RageDisplay_OGL.h
+++ b/src/RageDisplay_OGL.h
@@ -55,23 +55,23 @@ public:
 	void SetBlendMode( BlendMode mode );
 	bool SupportsTextureFormat( RagePixelFormat pixfmt, bool realtime=false );
 	bool SupportsPerVertexMatrixScale();
-	std::uintptr_t CreateTexture(
+	uintptr_t CreateTexture(
 		RagePixelFormat pixfmt,
 		RageSurface* img,
 		bool bGenerateMipMaps );
 	void UpdateTexture(
-		std::uintptr_t iTexHandle,
+		uintptr_t iTexHandle,
 		RageSurface* img,
 		int xoffset, int yoffset, int width, int height
 		);
-	void DeleteTexture( std::uintptr_t iTexHandle );
+	void DeleteTexture( uintptr_t iTexHandle );
 	bool UseOffscreenRenderTarget();
-	RageSurface *GetTexture( std::uintptr_t iTexture );
+	RageSurface *GetTexture( uintptr_t iTexture );
 	RageTextureLock *CreateTextureLock();
 
 	void ClearAllTextures();
 	int GetNumTextureUnits();
-	void SetTexture( TextureUnit tu, std::uintptr_t iTexture );
+	void SetTexture( TextureUnit tu, uintptr_t iTexture );
 	void SetTextureMode( TextureUnit tu, TextureMode tm );
 	void SetTextureWrapping( TextureUnit tu, bool b );
 	int GetMaxTextureSize() const;
@@ -80,9 +80,9 @@ public:
 	bool IsEffectModeSupported( EffectMode effect );
 	bool SupportsRenderToTexture() const;
 	bool SupportsFullscreenBorderlessWindow() const;
-	std::uintptr_t CreateRenderTarget( const RenderTargetParam &param, int &iTextureWidthOut, int &iTextureHeightOut );
-	std::uintptr_t GetRenderTarget();
-	void SetRenderTarget( std::uintptr_t iHandle, bool bPreserveTexture );
+	uintptr_t CreateRenderTarget( const RenderTargetParam &param, int &iTextureWidthOut, int &iTextureHeightOut );
+	uintptr_t GetRenderTarget();
+	void SetRenderTarget( uintptr_t iHandle, bool bPreserveTexture );
 	bool IsZWriteEnabled() const;
 	bool IsZTestEnabled() const;
 	void SetZWrite( bool b );
@@ -117,7 +117,7 @@ public:
 	virtual void SetPolygonMode( PolygonMode pm );
 	virtual void SetLineWidth( float fWidth );
 
-	RString GetTextureDiagnostics( std::uintptr_t id ) const;
+	RString GetTextureDiagnostics( uintptr_t id ) const;
 
 protected:
 	void DrawQuadsInternal( const RageSpriteVertex v[], int iNumVerts );

--- a/src/RageDisplay_OGL_Helpers.h
+++ b/src/RageDisplay_OGL_Helpers.h
@@ -31,7 +31,7 @@ public:
 	virtual ~RenderTarget() { }
 	virtual void Create( const RenderTargetParam &param, int &iTextureWidthOut, int &iTextureHeightOut ) = 0;
 
-	virtual std::uintptr_t GetTexture() const = 0;
+	virtual uintptr_t GetTexture() const = 0;
 
 	/* Render to this RenderTarget. */
 	virtual void StartRenderingTo() = 0;

--- a/src/RageException.cpp
+++ b/src/RageException.cpp
@@ -16,7 +16,7 @@ using CrashHandler::IsDebuggerPresent;
 using CrashHandler::DebugBreak;
 #endif
 
-static std::uint64_t g_HandlerThreadID = RageThread::GetInvalidThreadID();
+static uint64_t g_HandlerThreadID = RageThread::GetInvalidThreadID();
 static void (*g_CleanupHandler)( const RString &sError ) = nullptr;
 void RageException::SetCleanupHandler( void (*pHandler)(const RString &sError) )
 {

--- a/src/RageFile.cpp
+++ b/src/RageFile.cpp
@@ -111,7 +111,7 @@ void RageFile::EnableCRC32( bool on )
 	m_File->EnableCRC32( on );
 }
 
-bool RageFile::GetCRC32( std::uint32_t *iRet )
+bool RageFile::GetCRC32( uint32_t *iRet )
 {
 	ASSERT_OPEN;
 	return m_File->GetCRC32( iRet );
@@ -267,20 +267,20 @@ void FileReading::Seek( RageFileBasic &f, int iOffset, RString &sError )
 		sError = "Unexpected end of file";
 }
 
-std::uint8_t FileReading::read_8( RageFileBasic &f, RString &sError )
+uint8_t FileReading::read_8( RageFileBasic &f, RString &sError )
 {
-	std::uint8_t val;
-	ReadBytes( f, &val, sizeof(std::uint8_t), sError );
+	uint8_t val;
+	ReadBytes( f, &val, sizeof(uint8_t), sError );
 	if( sError.size() == 0 )
 		return val;
 	else
 		return 0;
 }
 
-std::uint16_t FileReading::read_u16_le( RageFileBasic &f, RString &sError )
+uint16_t FileReading::read_u16_le( RageFileBasic &f, RString &sError )
 {
-	std::uint16_t val;
-	ReadBytes( f, &val, sizeof(std::uint16_t), sError );
+	uint16_t val;
+	ReadBytes( f, &val, sizeof(uint16_t), sError );
 	if( sError.size() == 0 )
 		return Swap16LE( val );
 	else
@@ -297,10 +297,10 @@ std::int16_t FileReading::read_16_le( RageFileBasic &f, RString &sError )
 		return 0;
 }
 
-std::uint32_t FileReading::read_u32_le( RageFileBasic &f, RString &sError )
+uint32_t FileReading::read_u32_le( RageFileBasic &f, RString &sError )
 {
-	std::uint32_t val;
-	ReadBytes( f, &val, sizeof(std::uint32_t), sError );
+	uint32_t val;
+	ReadBytes( f, &val, sizeof(uint32_t), sError );
 	if( sError.size() == 0 )
 		return Swap32LE( val );
 	else

--- a/src/RageFile.h
+++ b/src/RageFile.h
@@ -78,7 +78,7 @@ public:
 	int PutLine( const RString &str );
 
 	void EnableCRC32( bool on=true );
-	bool GetCRC32( std::uint32_t *iRet );
+	bool GetCRC32( uint32_t *iRet );
 
 	// Lua
 	virtual void PushSelf( lua_State *L );
@@ -103,11 +103,11 @@ namespace FileReading
 	void SkipBytes( RageFileBasic &f, int size, RString &sError );
 	void Seek( RageFileBasic &f, int iOffset, RString &sError );
 	RString ReadString( RageFileBasic &f, int size, RString &sError );
-	std::uint8_t read_8( RageFileBasic &f, RString &sError );
+	uint8_t read_8( RageFileBasic &f, RString &sError );
 	std::int16_t read_16_le( RageFileBasic &f, RString &sError );
-	std::uint16_t read_u16_le( RageFileBasic &f, RString &sError );
+	uint16_t read_u16_le( RageFileBasic &f, RString &sError );
 	std::int32_t read_32_le( RageFileBasic &f, RString &sError );
-	std::uint32_t read_u32_le( RageFileBasic &f, RString &sError );
+	uint32_t read_u32_le( RageFileBasic &f, RString &sError );
 };
 
 #endif

--- a/src/RageFileBasic.cpp
+++ b/src/RageFileBasic.cpp
@@ -314,7 +314,7 @@ void RageFileObj::EnableCRC32( bool bOn )
 	m_iCRC32 = 0;
 }
 
-bool RageFileObj::GetCRC32( std::uint32_t *iRet )
+bool RageFileObj::GetCRC32( uint32_t *iRet )
 {
 	if( !m_bCRC32Enabled )
 		return false;

--- a/src/RageFileBasic.h
+++ b/src/RageFileBasic.h
@@ -55,7 +55,7 @@ public:
 	virtual int PutLine( const RString &str ) = 0;
 
 	virtual void EnableCRC32( bool on=true ) = 0;
-	virtual bool GetCRC32( std::uint32_t *iRet ) = 0;
+	virtual bool GetCRC32( uint32_t *iRet ) = 0;
 
 	virtual int GetFileSize() const = 0;
 
@@ -95,7 +95,7 @@ public:
 	int PutLine( const RString &str );
 
 	void EnableCRC32( bool on=true );
-	bool GetCRC32( std::uint32_t *iRet );
+	bool GetCRC32( uint32_t *iRet );
 
 	virtual int GetFileSize() const = 0;
 	virtual int GetFD() { return -1; }
@@ -156,7 +156,7 @@ private:
 	 * This is only meaningful if EnableCRC32() is called at the very start of the
 	 * file, and no seeking is performed. */
 	bool m_bCRC32Enabled;
-	std::uint32_t m_iCRC32;
+	uint32_t m_iCRC32;
 
 	// Swallow up warnings. If they must be used, define them.
 	RageFileObj& operator=(const RageFileObj& rhs);

--- a/src/RageFileDriverDeflate.cpp
+++ b/src/RageFileDriverDeflate.cpp
@@ -314,7 +314,7 @@ int RageFileObjDeflate::FlushInternal()
  * Parse a .gz file, check the header CRC16 if present, and return the data
  * CRC32 and a decompressor.  pFile will be deleted.
  */
-RageFileObjInflate *GunzipFile( RageFileBasic *pFile_, RString &sError, std::uint32_t *iCRC32 )
+RageFileObjInflate *GunzipFile( RageFileBasic *pFile_, RString &sError, uint32_t *iCRC32 )
 {
 	std::unique_ptr<RageFileBasic> pFile(pFile_);
 
@@ -336,8 +336,8 @@ RageFileObjInflate *GunzipFile( RageFileBasic *pFile_, RString &sError, std::uin
 		}
 	}
 
-	std::uint8_t iCompressionMethod = FileReading::read_8( *pFile, sError );
-	std::uint8_t iFlags = FileReading::read_8( *pFile, sError );
+	uint8_t iCompressionMethod = FileReading::read_8( *pFile, sError );
+	uint8_t iFlags = FileReading::read_8( *pFile, sError );
 	FileReading::read_32_le( *pFile, sError ); /* time */
 	FileReading::read_8( *pFile, sError ); /* xfl */
 	FileReading::read_8( *pFile, sError ); /* os */
@@ -381,12 +381,12 @@ RageFileObjInflate *GunzipFile( RageFileBasic *pFile_, RString &sError, std::uin
 	{
 		/* Get the CRC of the data read so far.  Be sure to do this before
 		 * reading iExpectedCRC16. */
-		std::uint32_t iActualCRC32;
+		uint32_t iActualCRC32;
 		bool bOK = pFile->GetCRC32( &iActualCRC32 );
 		ASSERT( bOK );
 
-		std::uint16_t iExpectedCRC16 = FileReading::read_u16_le( *pFile, sError );
-		std::uint16_t iActualCRC16 = std::int16_t( iActualCRC32 & 0xFFFF );
+		uint16_t iExpectedCRC16 = FileReading::read_u16_le( *pFile, sError );
+		uint16_t iActualCRC16 = std::int16_t( iActualCRC32 & 0xFFFF );
 		if( sError != "" )
 			return nullptr;
 
@@ -411,8 +411,8 @@ RageFileObjInflate *GunzipFile( RageFileBasic *pFile_, RString &sError, std::uin
 
 	FileReading::Seek( *pFile, iFooterPos, sError );
 
-	std::uint32_t iExpectedCRC32 = FileReading::read_u32_le( *pFile, sError );
-	std::uint32_t iUncompressedSize = FileReading::read_u32_le( *pFile, sError );
+	uint32_t iExpectedCRC32 = FileReading::read_u32_le( *pFile, sError );
+	uint32_t iUncompressedSize = FileReading::read_u32_le( *pFile, sError );
 	if( iCRC32 != nullptr )
 		*iCRC32 = iExpectedCRC32;
 
@@ -487,12 +487,12 @@ int RageFileObjGzip::Finish()
 		return -1;
 
 	/* Read the CRC of the data that's been written. */
-	std::uint32_t iCRC;
+	uint32_t iCRC;
 	bool bOK = this->GetCRC32( &iCRC );
 	ASSERT( bOK );
 
 	/* Figure out the size of the data. */
-	std::uint32_t iSize = Tell() - m_iDataStartOffset;
+	uint32_t iSize = Tell() - m_iDataStartOffset;
 
 	/* Write the CRC and size directly to the file, so they don't get compressed. */
 	iCRC = Swap32LE( iCRC );
@@ -533,7 +533,7 @@ bool GunzipString( const RString &sIn, RString &sOut, RString &sError )
 	RageFileObjMem *mem = new RageFileObjMem;
 	mem->PutString( sIn );
 
-	std::uint32_t iCRC32;
+	uint32_t iCRC32;
 	RageFileBasic *pFile = GunzipFile( mem, sError, &iCRC32 );
 	if( pFile == nullptr )
 		return false;

--- a/src/RageFileDriverDeflate.h
+++ b/src/RageFileDriverDeflate.h
@@ -70,7 +70,7 @@ private:
 	int m_iDataStartOffset;
 };
 
-RageFileObjInflate *GunzipFile( RageFileBasic *pFile, RString &sError, std::uint32_t *iCRC32 );
+RageFileObjInflate *GunzipFile( RageFileBasic *pFile, RString &sError, uint32_t *iCRC32 );
 
 /* Quick helpers: */
 void GzipString( const RString &sIn, RString &sOut );

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -120,7 +120,7 @@ size_t zipRead(void *pOpaque, mz_uint64 file_ofs, void *pBuf, size_t n)
 	RageFile *f = static_cast<RageFile*>(pOpaque);
 
 	const int pos = f->Seek(file_ofs);
-	if (pos >= 0 && static_cast<std::uint64_t>(pos) != file_ofs)
+	if (pos >= 0 && static_cast<uint64_t>(pos) != file_ofs)
 	{
 		return 0;
 	}

--- a/src/RageModelGeometry.cpp
+++ b/src/RageModelGeometry.cpp
@@ -72,8 +72,8 @@ void RageModelGeometry::MergeMeshes( int iFromIndex, int iToIndex )
 	{
 		for( int j=0; j<3; j++ )
 		{
-			std::uint16_t &iIndex = meshTo.Triangles[i].nVertexIndices[j];
-			iIndex = std::uint16_t(iIndex + iShiftTriangleVertexIndicesBy);
+			uint16_t &iIndex = meshTo.Triangles[i].nVertexIndices[j];
+			iIndex = uint16_t(iIndex + iShiftTriangleVertexIndicesBy);
 		}
 	}
 }
@@ -150,7 +150,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 
 				mesh.sName = szName;
 				// mesh.nFlags = nFlags;
-				mesh.nMaterialIndex = (std::uint8_t) nIndex;
+				mesh.nMaterialIndex = (uint8_t) nIndex;
 
 				mesh.m_iBoneIndex = -1;
 
@@ -193,7 +193,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 						v.t[0] = v.p[0] / v.t[0];
 						v.t[1] = v.p[1] / v.t[1];
 					}
-					v.bone = (std::uint8_t) nIndex;
+					v.bone = (uint8_t) nIndex;
 					RageVec3AddToBounds( v.p, m_vMins, m_vMaxs );
 				}
 
@@ -240,8 +240,8 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 					if( f.GetLine( sLine ) <= 0 )
 						THROW;
 
-					std::uint16_t nIndices[3];
-					std::uint16_t nNormalIndices[3];
+					uint16_t nIndices[3];
+					uint16_t nNormalIndices[3];
 					if( sscanf (sLine, "%d %hu %hu %hu %hu %hu %hu %d",
 								&nFlags,
 								&nIndices[0], &nIndices[1], &nIndices[2],

--- a/src/RageSoundMixBuffer.cpp
+++ b/src/RageSoundMixBuffer.cpp
@@ -34,7 +34,7 @@ void RageSoundMixBuffer::SetWriteOffset( int iOffset )
 
 void RageSoundMixBuffer::Extend(unsigned iSamples)
 {
-	const std::uint64_t realsize = static_cast<std::uint64_t>(iSamples) + static_cast<std::uint64_t>(m_iOffset);
+	const uint64_t realsize = static_cast<uint64_t>(iSamples) + static_cast<uint64_t>(m_iOffset);
 	if( m_iBufSize < realsize )
 	{
 		m_pMixbuf = static_cast<float*>(std::realloc(m_pMixbuf, sizeof(float) * realsize));

--- a/src/RageSoundMixBuffer.h
+++ b/src/RageSoundMixBuffer.h
@@ -29,8 +29,8 @@ public:
 
 private:
 	float *m_pMixbuf;
-	std::uint64_t m_iBufSize; // actual allocated samples
-	std::uint64_t m_iBufUsed; // used samples
+	uint64_t m_iBufSize; // actual allocated samples
+	uint64_t m_iBufUsed; // used samples
 	int m_iOffset;
 };
 

--- a/src/RageSoundReader_MP3.cpp
+++ b/src/RageSoundReader_MP3.cpp
@@ -189,7 +189,7 @@ struct madlib_t
 		bitrate = 0;
 	}
 
-	std::uint8_t inbuf[16384];
+	uint8_t inbuf[16384];
 	float outbuf[8192];
 	int outpos;
 	unsigned outleft;

--- a/src/RageSoundReader_WAV.cpp
+++ b/src/RageSoundReader_WAV.cpp
@@ -26,7 +26,7 @@ namespace
 	void Convert8bitToFloat( void *pBuf, int iSamples )
 	{
 		/* Convert in reverse, so we can do it in-place. */
-		const std::uint8_t *pIn = (std::uint8_t *) pBuf;
+		const uint8_t *pIn = (uint8_t *) pBuf;
 		float *pOut = (float *) pBuf;
 		for( int i = iSamples-1; i >= 0; --i )
 		{
@@ -309,7 +309,7 @@ public:
 			pBuffer[m_iBufferAvail++] = (std::int16_t)iSamp1[i] / 32768.0f;
 
 		std::int8_t iBufSize = 0;
-		std::uint8_t iBuf = 0;
+		uint8_t iBuf = 0;
 
 		bool bDone = false;
 		for( int i = 2; !bDone && i < m_iFramesPerBlock; ++i )
@@ -331,7 +331,7 @@ public:
 
 				/* Store the nibble in signed char, so we get an arithmetic shift. */
 				std::int8_t iErrorDelta = (std::int8_t)(iBuf) >> 4;
-				std::uint8_t iErrorDeltaUnsigned = iBuf >> 4;
+				uint8_t iErrorDeltaUnsigned = iBuf >> 4;
 				iBuf <<= 4;
 				--iBufSize;
 

--- a/src/RageSurface.cpp
+++ b/src/RageSurface.cpp
@@ -61,7 +61,7 @@ RageSurfaceFormat::RageSurfaceFormat( const RageSurfaceFormat &cpy ):
 	}
 }
 
-void RageSurfaceFormat::GetRGB( std::uint32_t val, std::uint8_t *r, std::uint8_t *g, std::uint8_t *b ) const
+void RageSurfaceFormat::GetRGB( uint32_t val, uint8_t *r, uint8_t *g, uint8_t *b ) const
 {
 	if( BytesPerPixel == 1 )
 	{
@@ -76,7 +76,7 @@ void RageSurfaceFormat::GetRGB( std::uint32_t val, std::uint8_t *r, std::uint8_t
 	}
 }
 
-bool RageSurfaceFormat::MapRGBA( std::uint8_t r, std::uint8_t g, std::uint8_t b, std::uint8_t a, std::uint32_t &val ) const
+bool RageSurfaceFormat::MapRGBA( uint8_t r, uint8_t g, uint8_t b, uint8_t a, uint32_t &val ) const
 {
 	if( BytesPerPixel == 1 )
 	{
@@ -84,7 +84,7 @@ bool RageSurfaceFormat::MapRGBA( std::uint8_t r, std::uint8_t g, std::uint8_t b,
 		std::int32_t n = palette->FindColor( c );
 		if( n == -1 )
 			return false;
-		val = (std::uint32_t) n;
+		val = (uint32_t) n;
 	} else {
 		val  =
 			(r >> Loss[0] << Shift[0]) |
@@ -137,7 +137,7 @@ RageSurface::RageSurface( const RageSurface &cpy )
 	pixels_owned = true;
 	if( cpy.pixels )
 	{
-		pixels = new std::uint8_t[ pitch*h ];
+		pixels = new uint8_t[ pitch*h ];
 		memcpy( pixels, cpy.pixels, pitch*h );
 	}
 	else
@@ -150,7 +150,7 @@ RageSurface::~RageSurface()
 		delete [] pixels;
 }
 
-static int GetShiftFromMask( std::uint32_t mask )
+static int GetShiftFromMask( uint32_t mask )
 {
 	if( !mask )
 		return 0;
@@ -164,7 +164,7 @@ static int GetShiftFromMask( std::uint32_t mask )
 	return iShift;
 }
 
-static int GetBitsFromMask( std::uint32_t mask )
+static int GetBitsFromMask( uint32_t mask )
 {
 	if( !mask )
 		return 0;
@@ -182,7 +182,7 @@ static int GetBitsFromMask( std::uint32_t mask )
 
 
 void SetupFormat( RageSurfaceFormat &fmt,
-						 int width, int height, int BitsPerPixel, std::uint32_t Rmask, std::uint32_t Gmask, std::uint32_t Bmask, std::uint32_t Amask )
+						 int width, int height, int BitsPerPixel, uint32_t Rmask, uint32_t Gmask, uint32_t Bmask, uint32_t Amask )
 {
 	fmt.BitsPerPixel = BitsPerPixel;
 	fmt.BytesPerPixel = BitsPerPixel/8;
@@ -209,14 +209,14 @@ void SetupFormat( RageSurfaceFormat &fmt,
 		fmt.Shift[2] = GetShiftFromMask( Bmask );
 		fmt.Shift[3] = GetShiftFromMask( Amask );
 
-		fmt.Loss[0] = (std::uint8_t) (8-GetBitsFromMask( Rmask ));
-		fmt.Loss[1] = (std::uint8_t) (8-GetBitsFromMask( Gmask ));
-		fmt.Loss[2] = (std::uint8_t) (8-GetBitsFromMask( Bmask ));
-		fmt.Loss[3] = (std::uint8_t) (8-GetBitsFromMask( Amask ));
+		fmt.Loss[0] = (uint8_t) (8-GetBitsFromMask( Rmask ));
+		fmt.Loss[1] = (uint8_t) (8-GetBitsFromMask( Gmask ));
+		fmt.Loss[2] = (uint8_t) (8-GetBitsFromMask( Bmask ));
+		fmt.Loss[3] = (uint8_t) (8-GetBitsFromMask( Amask ));
 	}
 }
 
-RageSurface *CreateSurface( int width, int height, int BitsPerPixel, std::uint32_t Rmask, std::uint32_t Gmask, std::uint32_t Bmask, std::uint32_t Amask )
+RageSurface *CreateSurface( int width, int height, int BitsPerPixel, uint32_t Rmask, uint32_t Gmask, uint32_t Bmask, uint32_t Amask )
 {
 	RageSurface *pImg = new RageSurface;
 
@@ -226,7 +226,7 @@ RageSurface *CreateSurface( int width, int height, int BitsPerPixel, std::uint32
 	pImg->h = height;
 	pImg->flags = 0;
 	pImg->pitch = width*BitsPerPixel/8;
-	pImg->pixels = new std::uint8_t[ pImg->pitch*height ];
+	pImg->pixels = new uint8_t[ pImg->pitch*height ];
 
 	/*
 	if( BitsPerPixel == 8 )
@@ -238,7 +238,7 @@ RageSurface *CreateSurface( int width, int height, int BitsPerPixel, std::uint32
 	return pImg;
 }
 
-RageSurface *CreateSurfaceFrom( int width, int height, int BitsPerPixel, std::uint32_t Rmask, std::uint32_t Gmask, std::uint32_t Bmask, std::uint32_t Amask, std::uint8_t *pPixels, std::uint32_t pitch )
+RageSurface *CreateSurfaceFrom( int width, int height, int BitsPerPixel, uint32_t Rmask, uint32_t Gmask, uint32_t Bmask, uint32_t Amask, uint8_t *pPixels, uint32_t pitch )
 {
 	RageSurface *pImg = new RageSurface;
 

--- a/src/RageSurface.h
+++ b/src/RageSurface.h
@@ -10,9 +10,9 @@
 /* XXX remove? */
 struct RageSurfaceColor
 {
-	std::uint8_t r, g, b, a;
+	uint8_t r, g, b, a;
 	RageSurfaceColor(): r(0), g(0), b(0), a(0) { }
-	RageSurfaceColor( std::uint8_t r_, std::uint8_t g_, std::uint8_t b_, std::uint8_t a_ ):
+	RageSurfaceColor( uint8_t r_, uint8_t g_, uint8_t b_, uint8_t a_ ):
 		r(r_), g(g_), b(b_), a(a_) { }
 };
 
@@ -48,22 +48,22 @@ struct RageSurfaceFormat
 
 	std::int32_t BytesPerPixel;
 	std::int32_t BitsPerPixel;
-	std::array<std::uint32_t, 4> Mask;
-	std::array<std::uint32_t, 4> Shift;
-	std::array<std::uint32_t, 4> Loss;
-	std::uint32_t &Rmask, &Gmask, &Bmask, &Amask; /* deprecated */
-	std::uint32_t &Rshift, &Gshift, &Bshift, &Ashift; /* deprecated */
+	std::array<uint32_t, 4> Mask;
+	std::array<uint32_t, 4> Shift;
+	std::array<uint32_t, 4> Loss;
+	uint32_t &Rmask, &Gmask, &Bmask, &Amask; /* deprecated */
+	uint32_t &Rshift, &Gshift, &Bshift, &Ashift; /* deprecated */
 	std::unique_ptr<RageSurfacePalette> palette;
 
-	void GetRGB( std::uint32_t val, std::uint8_t *r, std::uint8_t *g, std::uint8_t *b ) const;
+	void GetRGB( uint32_t val, uint8_t *r, uint8_t *g, uint8_t *b ) const;
 
 	/* Return the decoded value for the given color; the result can be compared to
 	 * decodepixel() results.  If the image is paletted and the color isn't found,
 	 * val is undefined and false is returned. */
-	bool MapRGBA( std::uint8_t r, std::uint8_t g, std::uint8_t b, std::uint8_t a, std::uint32_t &val ) const;
+	bool MapRGBA( uint8_t r, uint8_t g, uint8_t b, uint8_t a, uint32_t &val ) const;
 
 	/* MapRGBA, but also do a nearest-match on palette colors. */
-	std::uint32_t MapNearestRGBA( std::uint8_t r, std::uint8_t g, std::uint8_t b, std::uint8_t a ) const;
+	uint32_t MapNearestRGBA( uint8_t r, uint8_t g, uint8_t b, uint8_t a ) const;
 
 	bool operator== ( const RageSurfaceFormat &rhs ) const;
 
@@ -77,7 +77,7 @@ struct RageSurface
 	RageSurfaceFormat *format; /* compatibility only */
 	RageSurfaceFormat fmt;
 
-	std::uint8_t *pixels;
+	uint8_t *pixels;
 	bool pixels_owned;
 	std::int32_t w, h, pitch;
 	std::int32_t flags;
@@ -87,8 +87,8 @@ struct RageSurface
 	~RageSurface();
 };
 
-RageSurface *CreateSurface( int width, int height, int bpp, std::uint32_t Rmask, std::uint32_t Gmask, std::uint32_t Bmask, std::uint32_t Amask );
-RageSurface *CreateSurfaceFrom( int width, int height, int bpp, std::uint32_t Rmask, std::uint32_t Gmask, std::uint32_t Bmask, std::uint32_t Amask, std::uint8_t *pPixels, std::uint32_t pitch );
+RageSurface *CreateSurface( int width, int height, int bpp, uint32_t Rmask, uint32_t Gmask, uint32_t Bmask, uint32_t Amask );
+RageSurface *CreateSurfaceFrom( int width, int height, int bpp, uint32_t Rmask, uint32_t Gmask, uint32_t Bmask, uint32_t Amask, uint8_t *pPixels, uint32_t pitch );
 
 #endif
 

--- a/src/RageSurfaceUtils.cpp
+++ b/src/RageSurfaceUtils.cpp
@@ -9,47 +9,47 @@
 #include <cstddef>
 #include <cstdint>
 
-std::uint32_t RageSurfaceUtils::decodepixel( const std::uint8_t *p, int bpp )
+uint32_t RageSurfaceUtils::decodepixel( const uint8_t *p, int bpp )
 {
 	switch(bpp)
 	{
 	case 1: return *p;
-	case 2: return *(std::uint16_t *)p;
+	case 2: return *(uint16_t *)p;
 	case 3:
 		if constexpr ( Endian::big )
 			return p[0] << 16 | p[1] << 8 | p[2];
 		else
 			return p[0] | p[1] << 8 | p[2] << 16;
 
-	case 4: return *(std::uint32_t *)p;
+	case 4: return *(uint32_t *)p;
 	default: return 0;	// shouldn't happen, but avoids warnings
 	}
 }
 
-void RageSurfaceUtils::encodepixel( std::uint8_t *p, int bpp, std::uint32_t pixel )
+void RageSurfaceUtils::encodepixel( uint8_t *p, int bpp, uint32_t pixel )
 {
 	switch(bpp)
 	{
-	case 1: *p = std::uint8_t(pixel); break;
-	case 2: *(std::uint16_t *)p = std::uint16_t(pixel); break;
+	case 1: *p = uint8_t(pixel); break;
+	case 2: *(uint16_t *)p = uint16_t(pixel); break;
 	case 3:
 		if constexpr ( Endian::big )
 		{
-			p[0] = std::uint8_t((pixel >> 16) & 0xff);
-			p[1] = std::uint8_t((pixel >> 8) & 0xff);
-			p[2] = std::uint8_t(pixel & 0xff);
+			p[0] = uint8_t((pixel >> 16) & 0xff);
+			p[1] = uint8_t((pixel >> 8) & 0xff);
+			p[2] = uint8_t(pixel & 0xff);
 		} else {
-			p[0] = std::uint8_t(pixel & 0xff);
-			p[1] = std::uint8_t((pixel >> 8) & 0xff);
-			p[2] = std::uint8_t((pixel >> 16) & 0xff);
+			p[0] = uint8_t(pixel & 0xff);
+			p[1] = uint8_t((pixel >> 8) & 0xff);
+			p[2] = uint8_t((pixel >> 16) & 0xff);
 		}
 		break;
-	case 4: *(std::uint32_t *)p = pixel; break;
+	case 4: *(uint32_t *)p = pixel; break;
 	}
 }
 
 // Get and set colors without scaling to 0..255.
-void RageSurfaceUtils::GetRawRGBAV( std::uint32_t pixel, const RageSurfaceFormat &fmt, std::uint8_t *v )
+void RageSurfaceUtils::GetRawRGBAV( uint32_t pixel, const RageSurfaceFormat &fmt, uint8_t *v )
 {
 	if( fmt.BytesPerPixel == 1 )
 	{
@@ -58,20 +58,20 @@ void RageSurfaceUtils::GetRawRGBAV( std::uint32_t pixel, const RageSurfaceFormat
 		v[2] = fmt.palette->colors[pixel].b;
 		v[3] = fmt.palette->colors[pixel].a;
 	} else {
-		v[0] = std::uint8_t((pixel & fmt.Rmask) >> fmt.Rshift);
-		v[1] = std::uint8_t((pixel & fmt.Gmask) >> fmt.Gshift);
-		v[2] = std::uint8_t((pixel & fmt.Bmask) >> fmt.Bshift);
-		v[3] = std::uint8_t((pixel & fmt.Amask) >> fmt.Ashift);
+		v[0] = uint8_t((pixel & fmt.Rmask) >> fmt.Rshift);
+		v[1] = uint8_t((pixel & fmt.Gmask) >> fmt.Gshift);
+		v[2] = uint8_t((pixel & fmt.Bmask) >> fmt.Bshift);
+		v[3] = uint8_t((pixel & fmt.Amask) >> fmt.Ashift);
 	}
 }
 
-void RageSurfaceUtils::GetRawRGBAV( const std::uint8_t *p, const RageSurfaceFormat &fmt, std::uint8_t *v )
+void RageSurfaceUtils::GetRawRGBAV( const uint8_t *p, const RageSurfaceFormat &fmt, uint8_t *v )
 {
-	std::uint32_t pixel = decodepixel( p, fmt.BytesPerPixel );
+	uint32_t pixel = decodepixel( p, fmt.BytesPerPixel );
 	GetRawRGBAV( pixel, fmt, v );
 }
 
-void RageSurfaceUtils::GetRGBAV( std::uint32_t pixel, const RageSurface *src, std::uint8_t *v )
+void RageSurfaceUtils::GetRGBAV( uint32_t pixel, const RageSurface *src, uint8_t *v )
 {
 	GetRawRGBAV(pixel, src->fmt, v);
 	const RageSurfaceFormat *fmt = src->format;
@@ -83,9 +83,9 @@ void RageSurfaceUtils::GetRGBAV( std::uint32_t pixel, const RageSurface *src, st
 		v[3] = 255;
 }
 
-void RageSurfaceUtils::GetRGBAV( const std::uint8_t *p, const RageSurface *src, std::uint8_t *v )
+void RageSurfaceUtils::GetRGBAV( const uint8_t *p, const RageSurface *src, uint8_t *v )
 {
-	std::uint32_t pixel = decodepixel(p, src->format->BytesPerPixel);
+	uint32_t pixel = decodepixel(p, src->format->BytesPerPixel);
 	if( src->format->BytesPerPixel == 1 ) // paletted
 	{
 		memcpy( v, &src->format->palette->colors[pixel], sizeof(RageSurfaceColor));
@@ -96,7 +96,7 @@ void RageSurfaceUtils::GetRGBAV( const std::uint8_t *p, const RageSurface *src, 
 
 
 // Inverse of GetRawRGBAV.
-std::uint32_t RageSurfaceUtils::SetRawRGBAV( const RageSurfaceFormat *fmt, const std::uint8_t *v )
+uint32_t RageSurfaceUtils::SetRawRGBAV( const RageSurfaceFormat *fmt, const uint8_t *v )
 {
 	return 	v[0] << fmt->Rshift |
 			v[1] << fmt->Gshift |
@@ -104,14 +104,14 @@ std::uint32_t RageSurfaceUtils::SetRawRGBAV( const RageSurfaceFormat *fmt, const
 			v[3] << fmt->Ashift;
 }
 
-void RageSurfaceUtils::SetRawRGBAV( std::uint8_t *p, const RageSurface *src, const std::uint8_t *v )
+void RageSurfaceUtils::SetRawRGBAV( uint8_t *p, const RageSurface *src, const uint8_t *v )
 {
-	std::uint32_t pixel = SetRawRGBAV(src->format, v);
+	uint32_t pixel = SetRawRGBAV(src->format, v);
 	encodepixel(p, src->format->BytesPerPixel, pixel);
 }
 
 // Inverse of GetRGBAV.
-std::uint32_t RageSurfaceUtils::SetRGBAV( const RageSurfaceFormat *fmt, const std::uint8_t *v )
+uint32_t RageSurfaceUtils::SetRGBAV( const RageSurfaceFormat *fmt, const uint8_t *v )
 {
 	return 	(v[0] >> fmt->Loss[0]) << fmt->Shift[0] |
 			(v[1] >> fmt->Loss[1]) << fmt->Shift[1] |
@@ -119,14 +119,14 @@ std::uint32_t RageSurfaceUtils::SetRGBAV( const RageSurfaceFormat *fmt, const st
 			(v[3] >> fmt->Loss[3]) << fmt->Shift[3];
 }
 
-void RageSurfaceUtils::SetRGBAV( std::uint8_t *p, const RageSurface *src, const std::uint8_t *v )
+void RageSurfaceUtils::SetRGBAV( uint8_t *p, const RageSurface *src, const uint8_t *v )
 {
-	std::uint32_t pixel = SetRGBAV(src->format, v);
+	uint32_t pixel = SetRGBAV(src->format, v);
 	encodepixel(p, src->format->BytesPerPixel, pixel);
 }
 
 
-void RageSurfaceUtils::GetBitsPerChannel( const RageSurfaceFormat *fmt, std::uint32_t bits[4] )
+void RageSurfaceUtils::GetBitsPerChannel( const RageSurfaceFormat *fmt, uint32_t bits[4] )
 {
 	// The actual bits stored in each color is 8-loss.
 	for( int c = 0; c < 4; ++c )
@@ -147,7 +147,7 @@ void RageSurfaceUtils::CopySurface( const RageSurface *src, RageSurface *dest )
 
 bool RageSurfaceUtils::ConvertSurface( const RageSurface *src, RageSurface *&dst,
 		int width, int height, int bpp,
-		std::uint32_t R, std::uint32_t G, std::uint32_t B, std::uint32_t A )
+		uint32_t R, uint32_t G, uint32_t B, uint32_t A )
 {
 	dst = CreateSurface( width, height, bpp, R, G, B, A );
 
@@ -165,7 +165,7 @@ bool RageSurfaceUtils::ConvertSurface( const RageSurface *src, RageSurface *&dst
 
 void RageSurfaceUtils::ConvertSurface(RageSurface *&image,
 		int width, int height, int bpp,
-		std::uint32_t R, std::uint32_t G, std::uint32_t B, std::uint32_t A)
+		uint32_t R, uint32_t G, uint32_t B, uint32_t A)
 {
 	RageSurface *ret_image;
 	if( !ConvertSurface( image, ret_image, width, height, bpp, R, G, B, A ) )
@@ -177,7 +177,7 @@ void RageSurfaceUtils::ConvertSurface(RageSurface *&image,
 
 
 // Local helper for FixHiddenAlpha.
-static void FindAlphaRGB(const RageSurface *img, std::uint8_t &r, std::uint8_t &g, std::uint8_t &b, bool reverse)
+static void FindAlphaRGB(const RageSurface *img, uint8_t &r, uint8_t &g, uint8_t &b, bool reverse)
 {
 	r = g = b = 0;
 
@@ -189,13 +189,13 @@ static void FindAlphaRGB(const RageSurface *img, std::uint8_t &r, std::uint8_t &
 	for(int y = reverse? img->h-1:0;
 		reverse? (y >=0):(y < img->h); reverse? (--y):(++y))
 	{
-		std::uint8_t *row = (std::uint8_t *)img->pixels + img->pitch*y;
+		uint8_t *row = (uint8_t *)img->pixels + img->pitch*y;
 		if(reverse)
 			row += img->format->BytesPerPixel * (img->w-1);
 
 		for(int x = 0; x < img->w; ++x)
 		{
-			std::uint32_t val = RageSurfaceUtils::decodepixel(row, img->format->BytesPerPixel);
+			uint32_t val = RageSurfaceUtils::decodepixel(row, img->format->BytesPerPixel);
 			if( img->format->BitsPerPixel == 8 )
 			{
 				if( img->format->palette->colors[val].a )
@@ -230,7 +230,7 @@ static void FindAlphaRGB(const RageSurface *img, std::uint8_t &r, std::uint8_t &
 
 /* Local helper for FixHiddenAlpha. Set the underlying RGB values of all pixels
  * in img that are completely transparent. */
-static void SetAlphaRGB(const RageSurface *pImg, std::uint8_t r, std::uint8_t g, std::uint8_t b)
+static void SetAlphaRGB(const RageSurface *pImg, uint8_t r, uint8_t g, uint8_t b)
 {
 	// If it's a paletted surface, all we have to do is change the palette.
 	if( pImg->format->BitsPerPixel == 8 )
@@ -250,15 +250,15 @@ static void SetAlphaRGB(const RageSurface *pImg, std::uint8_t r, std::uint8_t g,
 	if( pImg->format->BitsPerPixel > 8 && !pImg->format->Amask )
 		return;
 
-	std::uint32_t trans;
+	uint32_t trans;
 	pImg->format->MapRGBA( r, g, b, 0, trans );
 	for( int y = 0; y < pImg->h; ++y )
 	{
-		std::uint8_t *row = pImg->pixels + pImg->pitch*y;
+		uint8_t *row = pImg->pixels + pImg->pitch*y;
 
 		for( int x = 0; x < pImg->w; ++x )
 		{
-			std::uint32_t val = RageSurfaceUtils::decodepixel( row, pImg->format->BytesPerPixel );
+			uint32_t val = RageSurfaceUtils::decodepixel( row, pImg->format->BytesPerPixel );
 			if( val != trans && !(val&pImg->format->Amask) )
 			{
 				RageSurfaceUtils::encodepixel( row, pImg->format->BytesPerPixel, trans );
@@ -290,10 +290,10 @@ void RageSurfaceUtils::FixHiddenAlpha( RageSurface *pImg )
 	if( pImg->format->BitsPerPixel != 8 && pImg->format->Amask == 0 )
 		return;
 
-	std::uint8_t r, g, b;
+	uint8_t r, g, b;
 	FindAlphaRGB( pImg, r, g, b, false );
 
-	std::uint8_t cr, cg, cb; // compare
+	uint8_t cr, cg, cb; // compare
 	FindAlphaRGB( pImg, cr, cg, cb, true );
 
 	if( cr != r || cg != g || cb != b )
@@ -311,7 +311,7 @@ int RageSurfaceUtils::FindSurfaceTraits( const RageSurface *img )
 	const int NEEDS_NO_ALPHA=0, NEEDS_BOOL_ALPHA=1, NEEDS_FULL_ALPHA=2;
 	int alpha_type = NEEDS_NO_ALPHA;
 
-	std::uint32_t max_alpha;
+	uint32_t max_alpha;
 	if( img->format->BitsPerPixel == 8 )
 	{
 		// Short circuit if we already know we have no transparency.
@@ -338,13 +338,13 @@ int RageSurfaceUtils::FindSurfaceTraits( const RageSurface *img )
 
 	for(int y = 0; y < img->h; ++y)
 	{
-		std::uint8_t *row = (std::uint8_t *)img->pixels + img->pitch*y;
+		uint8_t *row = (uint8_t *)img->pixels + img->pitch*y;
 
 		for(int x = 0; x < img->w; ++x)
 		{
-			std::uint32_t val = decodepixel(row, img->format->BytesPerPixel);
+			uint32_t val = decodepixel(row, img->format->BytesPerPixel);
 
-			std::uint32_t alpha;
+			uint32_t alpha;
 			if( img->format->BitsPerPixel == 8 )
 				alpha = img->format->palette->colors[val].a;
 			else
@@ -374,10 +374,10 @@ int RageSurfaceUtils::FindSurfaceTraits( const RageSurface *img )
 
 
 // Local helper for BlitTransform.
-static inline void GetRawRGBAV_XY( const RageSurface *src, std::uint8_t *v, int x, int y )
+static inline void GetRawRGBAV_XY( const RageSurface *src, uint8_t *v, int x, int y )
 {
-	const std::uint8_t *srcp = (const std::uint8_t *) src->pixels + (y * src->pitch);
-	const std::uint8_t *srcpx = srcp + (x * src->fmt.BytesPerPixel);
+	const uint8_t *srcp = (const uint8_t *) src->pixels + (y * src->pitch);
+	const uint8_t *srcpx = srcp + (x * src->fmt.BytesPerPixel);
 
 	RageSurfaceUtils::GetRawRGBAV( srcpx, src->fmt, v );
 }
@@ -405,8 +405,8 @@ void RageSurfaceUtils::BlitTransform( const RageSurface *src, RageSurface *dst,
 
 	for( int y = 0; y < dst->h; ++y )
 	{
-		std::uint8_t *dstp = (std::uint8_t *) dst->pixels + (y * dst->pitch); /* line */
-		std::uint8_t *dstpx = dstp; // pixel
+		uint8_t *dstp = (uint8_t *) dst->pixels + (y * dst->pitch); /* line */
+		uint8_t *dstpx = dstp; // pixel
 
 		const float start_y = scale(float(y), 0, float(dst->h), Coords[TL_Y], Coords[BL_Y]);
 		const float end_y = scale(float(y), 0, float(dst->h), Coords[TR_Y], Coords[BR_Y]);
@@ -437,7 +437,7 @@ void RageSurfaceUtils::BlitTransform( const RageSurface *src, RageSurface *dst,
 			src_y[1] = std::clamp(src_y[1], 0, src->h);
 
 			// Decode our four pixels.
-			std::uint8_t v[4][4];
+			uint8_t v[4][4];
 			GetRawRGBAV_XY(src, v[0], src_x[0], src_y[0]);
 			GetRawRGBAV_XY(src, v[1], src_x[0], src_y[1]);
 			GetRawRGBAV_XY(src, v[2], src_x[1], src_y[0]);
@@ -448,7 +448,7 @@ void RageSurfaceUtils::BlitTransform( const RageSurface *src, RageSurface *dst,
 			float weight_y = src_yp - (src_y[0] + 0.5f);
 
 			// Filter:
-			std::uint8_t out[4] = { 0,0,0,0 };
+			uint8_t out[4] = { 0,0,0,0 };
 			for(int i = 0; i < 4; ++i)
 			{
 				float sum = 0;
@@ -456,12 +456,12 @@ void RageSurfaceUtils::BlitTransform( const RageSurface *src, RageSurface *dst,
 				sum += v[1][i] * (1-weight_x) * (weight_y);
 				sum += v[2][i] * (weight_x)   * (1-weight_y);
 				sum += v[3][i] * (weight_x)   * (weight_y);
-				out[i] = (std::uint8_t) std::clamp( std::lrint(sum), 0L, 255L );
+				out[i] = (uint8_t) std::clamp( std::lrint(sum), 0L, 255L );
 			}
 
 			// If the source has no alpha, set the destination to opaque.
 			if( src->format->Amask == 0 )
-				out[3] = std::uint8_t( dst->format->Amask >> dst->format->Ashift );
+				out[3] = uint8_t( dst->format->Amask >> dst->format->Ashift );
 
 			SetRawRGBAV(dstpx, dst, out);
 
@@ -487,8 +487,8 @@ static bool blit_same_type( const RageSurface *src_surf, const RageSurface *dst_
 		src_surf->format->Amask != dst_surf->format->Amask )
 		return false;
 
-	const std::uint8_t *src = src_surf->pixels;
-	std::uint8_t *dst = dst_surf->pixels;
+	const uint8_t *src = src_surf->pixels;
+	uint8_t *dst = dst_surf->pixels;
 
 	// If possible, memcpy the whole thing.
 	if( src_surf->w == width && dst_surf->w == width && src_surf->pitch == dst_surf->pitch )
@@ -515,23 +515,23 @@ static bool blit_rgba_to_rgba( const RageSurface *src_surf, const RageSurface *d
 	if( src_surf->format->BytesPerPixel == 1 || dst_surf->format->BytesPerPixel == 1 )
 		return false;
 
-	const std::uint8_t *src = src_surf->pixels;
-	std::uint8_t *dst = dst_surf->pixels;
+	const uint8_t *src = src_surf->pixels;
+	uint8_t *dst = dst_surf->pixels;
 
 	// Bytes to skip at the end of a line.
 	const int srcskip = src_surf->pitch - width*src_surf->format->BytesPerPixel;
 	const int dstskip = dst_surf->pitch - width*dst_surf->format->BytesPerPixel;
 
-	const std::array<std::uint32_t, 4> &src_shifts = src_surf->format->Shift;
-	const std::array<std::uint32_t, 4> &dst_shifts = dst_surf->format->Shift;
-	const std::array<std::uint32_t, 4> &src_masks = src_surf->format->Mask;
-	const std::array<std::uint32_t, 4> &dst_masks = dst_surf->format->Mask;
+	const std::array<uint32_t, 4> &src_shifts = src_surf->format->Shift;
+	const std::array<uint32_t, 4> &dst_shifts = dst_surf->format->Shift;
+	const std::array<uint32_t, 4> &src_masks = src_surf->format->Mask;
+	const std::array<uint32_t, 4> &dst_masks = dst_surf->format->Mask;
 
-	std::uint8_t lookup[4][256];
+	uint8_t lookup[4][256];
 	for( int c = 0; c < 4; ++c )
 	{
-		const std::uint32_t max_src_val = src_masks[c] >> src_shifts[c];
-		const std::uint32_t max_dst_val = dst_masks[c] >> dst_shifts[c];
+		const uint32_t max_src_val = src_masks[c] >> src_shifts[c];
+		const uint32_t max_dst_val = dst_masks[c] >> dst_shifts[c];
 		ASSERT( max_src_val <= 0xFF );
 		ASSERT( max_dst_val <= 0xFF );
 
@@ -540,7 +540,7 @@ static bool blit_rgba_to_rgba( const RageSurface *src_surf, const RageSurface *d
 			/* The source is missing a channel. Alpha defaults to opaque, other
 			 * channels default to 0. */
 			if( c == 3 )
-				lookup[c][0] = (std::uint8_t) max_dst_val;
+				lookup[c][0] = (uint8_t) max_dst_val;
 			else
 				lookup[c][0] = 0;
 		} else {
@@ -571,11 +571,11 @@ static bool blit_rgba_to_rgba( const RageSurface *src_surf, const RageSurface *d
 			 * Having separate formulas for increasing and decreasing resolution seems
 			 * strange; what's wrong here? */
 			if( max_src_val > max_dst_val )
-				for( std::uint32_t i = 0; i <= max_src_val; ++i )
-					lookup[c][i] = (std::uint8_t) SCALE( i, 0, max_src_val+1, 0, max_dst_val+1 );
+				for( uint32_t i = 0; i <= max_src_val; ++i )
+					lookup[c][i] = (uint8_t) SCALE( i, 0, max_src_val+1, 0, max_dst_val+1 );
 			else
-				for( std::uint32_t i = 0; i <= max_src_val; ++i )
-					lookup[c][i] = (std::uint8_t) SCALE( i, 0, max_src_val, 0, max_dst_val );
+				for( uint32_t i = 0; i <= max_src_val; ++i )
+					lookup[c][i] = (uint8_t) SCALE( i, 0, max_src_val, 0, max_dst_val );
 		}
 	}
 
@@ -613,8 +613,8 @@ static bool blit_generic( const RageSurface *src_surf, const RageSurface *dst_su
 	if( src_surf->format->BytesPerPixel != 1 || dst_surf->format->BytesPerPixel == 1 )
 		return false;
 
-	const std::uint8_t *src = src_surf->pixels;
-	std::uint8_t *dst = dst_surf->pixels;
+	const uint8_t *src = src_surf->pixels;
+	uint8_t *dst = dst_surf->pixels;
 
 	// Bytes to skip at the end of a line.
 	const int srcskip = src_surf->pitch - width*src_surf->format->BytesPerPixel;
@@ -627,7 +627,7 @@ static bool blit_generic( const RageSurface *src_surf, const RageSurface *dst_su
 		{
 			unsigned int pixel = RageSurfaceUtils::decodepixel( src, src_surf->format->BytesPerPixel );
 
-			std::uint8_t colors[4];
+			uint8_t colors[4];
 				// Convert pixel to the destination RGBA.
 				colors[0] = src_surf->format->palette->colors[pixel].r;
 				colors[1] = src_surf->format->palette->colors[pixel].g;
@@ -713,11 +713,11 @@ void RageSurfaceUtils::CorrectBorderPixels( RageSurface *img, int width, int hei
 	{
 		// Duplicate the last column.
 		int offset = img->format->BytesPerPixel * (width-1);
-		std::uint8_t *p = (std::uint8_t *) img->pixels + offset;
+		uint8_t *p = (uint8_t *) img->pixels + offset;
 
 		for( int y = 0; y < height; ++y )
 		{
-			std::uint32_t pixel = decodepixel( p, img->format->BytesPerPixel );
+			uint32_t pixel = decodepixel( p, img->format->BytesPerPixel );
 			encodepixel( p+img->format->BytesPerPixel, img->format->BytesPerPixel, pixel );
 
 			p += img->pitch;
@@ -727,7 +727,7 @@ void RageSurfaceUtils::CorrectBorderPixels( RageSurface *img, int width, int hei
 	if( height < img->h )
 	{
 		// Duplicate the last row.
-		std::uint8_t *srcp = img->pixels;
+		uint8_t *srcp = img->pixels;
 		srcp += img->pitch * (height-1);
 		memcpy( srcp + img->pitch, srcp, img->pitch );
 	}
@@ -865,10 +865,10 @@ RageSurface *RageSurfaceUtils::PalettizeToGrayscale( const RageSurface *src_surf
 		const unsigned int A = (index & Amask) >> Ashift;
 
 		// if only one intensity value, always fullbright
-		const std::uint8_t ScaledI = Ivalues == 1 ? 255 : std::clamp( std::lrint(I * (255.0f / (Ivalues-1))), 0L, 255L );
+		const uint8_t ScaledI = Ivalues == 1 ? 255 : std::clamp( std::lrint(I * (255.0f / (Ivalues-1))), 0L, 255L );
 
 		// if only one alpha value, always opaque
-		const std::uint8_t ScaledA = Avalues == 1 ? 255 : std::clamp( std::lrint(A * (255.0f / (Avalues-1))), 0L, 255L );
+		const uint8_t ScaledA = Avalues == 1 ? 255 : std::clamp( std::lrint(A * (255.0f / (Avalues-1))), 0L, 255L );
 
 		RageSurfaceColor c;
 		c.r = ScaledI;
@@ -879,8 +879,8 @@ RageSurface *RageSurfaceUtils::PalettizeToGrayscale( const RageSurface *src_surf
 		dst_surf->fmt.palette->colors[index] = c;
 	}
 
-	const std::uint8_t *src = src_surf->pixels;
-	std::uint8_t *dst = dst_surf->pixels;
+	const uint8_t *src = src_surf->pixels;
+	uint8_t *dst = dst_surf->pixels;
 
 	int height = src_surf->h;
 	int width = src_surf->w;
@@ -896,7 +896,7 @@ RageSurface *RageSurfaceUtils::PalettizeToGrayscale( const RageSurface *src_surf
 		{
 			unsigned int pixel = decodepixel( src, src_surf->format->BytesPerPixel );
 
-			std::uint8_t colors[4];
+			uint8_t colors[4];
 			GetRGBAV(pixel, src_surf, colors);
 
 			int Ival = 0;
@@ -909,7 +909,7 @@ RageSurface *RageSurfaceUtils::PalettizeToGrayscale( const RageSurface *src_surf
 					(colors[3] >> Aloss) << Ashift;
 
 			// Store it.
-			*dst = std::uint8_t(pixel);
+			*dst = uint8_t(pixel);
 
 			src += src_surf->format->BytesPerPixel;
 			dst += dst_surf->format->BytesPerPixel;
@@ -939,14 +939,14 @@ RageSurface *RageSurfaceUtils::MakeDummySurface( int height, int width )
  * Search the edge for it; if we find it, use that as the color key. */
 static bool ImageUsesOffHotPink( const RageSurface *img )
 {
-	std::uint32_t OffHotPink;
+	uint32_t OffHotPink;
 	if( !img->format->MapRGBA( 0xF8, 0, 0xF8, 0xFF, OffHotPink ) )
 		return false;
 
-	const std::uint8_t *p = img->pixels;
+	const uint8_t *p = img->pixels;
 	for( int x = 0; x < img->w; ++x )
 	{
-		std::uint32_t val = RageSurfaceUtils::decodepixel( p, img->format->BytesPerPixel );
+		uint32_t val = RageSurfaceUtils::decodepixel( p, img->format->BytesPerPixel );
 		if( val == OffHotPink )
 			return true;
 		p += img->format->BytesPerPixel;
@@ -956,7 +956,7 @@ static bool ImageUsesOffHotPink( const RageSurface *img )
 	p += img->pitch * (img->h-1);
 	for( int i=0; i < img->w; i++ )
 	{
-		std::uint32_t val = RageSurfaceUtils::decodepixel( p, img->format->BytesPerPixel );
+		uint32_t val = RageSurfaceUtils::decodepixel( p, img->format->BytesPerPixel );
 		if( val == OffHotPink )
 			return true;
 		p += img->format->BytesPerPixel;
@@ -970,7 +970,7 @@ void RageSurfaceUtils::ApplyHotPinkColorKey( RageSurface *&img )
 {
 	if( img->format->BitsPerPixel == 8 )
 	{
-		std::uint32_t color;
+		uint32_t color;
 		if( img->format->MapRGBA( 0xF8, 0, 0xF8, 0xFF, color ) )
 			img->format->palette->colors[ color ].a = 0;
 		if( img->format->MapRGBA( 0xFF, 0, 0xFF, 0xFF, color ) )
@@ -992,7 +992,7 @@ void RageSurfaceUtils::ApplyHotPinkColorKey( RageSurface *&img )
 			{
 				img->format->Amask = 1<<i;
 				img->format->Aloss = 7;
-				img->format->Ashift = (std::uint8_t) i;
+				img->format->Ashift = (uint8_t) i;
 			}
 		}
 		*/
@@ -1002,7 +1002,7 @@ void RageSurfaceUtils::ApplyHotPinkColorKey( RageSurface *&img )
 				32, 0xFF000000, 0x00FF0000, 0x0000FF00, 0x000000FF );
 	}
 
-	std::uint32_t HotPink;
+	uint32_t HotPink;
 
 	bool bHaveColorKey;
 	if( ImageUsesOffHotPink(img) )
@@ -1014,11 +1014,11 @@ void RageSurfaceUtils::ApplyHotPinkColorKey( RageSurface *&img )
 
 	for( int y = 0; y < img->h; ++y )
 	{
-		std::uint8_t *row = img->pixels + img->pitch*y;
+		uint8_t *row = img->pixels + img->pitch*y;
 
 		for( int x = 0; x < img->w; ++x )
 		{
-			std::uint32_t val = decodepixel( row, img->format->BytesPerPixel );
+			uint32_t val = decodepixel( row, img->format->BytesPerPixel );
 			if( val == HotPink )
 				encodepixel( row, img->format->BytesPerPixel, 0 );
 

--- a/src/RageSurfaceUtils.h
+++ b/src/RageSurfaceUtils.h
@@ -13,27 +13,27 @@ struct RageSurface;
 /** @brief Utility functions for the RageSurfaces. */
 namespace RageSurfaceUtils
 {
-	std::uint32_t decodepixel( const std::uint8_t *p, int bpp );
-	void encodepixel( std::uint8_t *p, int bpp, std::uint32_t pixel );
+	uint32_t decodepixel( const uint8_t *p, int bpp );
+	void encodepixel( uint8_t *p, int bpp, uint32_t pixel );
 
-	void GetRawRGBAV( std::uint32_t pixel, const RageSurfaceFormat &fmt, std::uint8_t *v );
-	void GetRawRGBAV( const std::uint8_t *p, const RageSurfaceFormat &fmt, std::uint8_t *v );
-	void GetRGBAV( std::uint32_t pixel, const RageSurface *src, std::uint8_t *v );
-	void GetRGBAV( const std::uint8_t *p, const RageSurface *src, std::uint8_t *v );
+	void GetRawRGBAV( uint32_t pixel, const RageSurfaceFormat &fmt, uint8_t *v );
+	void GetRawRGBAV( const uint8_t *p, const RageSurfaceFormat &fmt, uint8_t *v );
+	void GetRGBAV( uint32_t pixel, const RageSurface *src, uint8_t *v );
+	void GetRGBAV( const uint8_t *p, const RageSurface *src, uint8_t *v );
 
-	std::uint32_t SetRawRGBAV( const RageSurfaceFormat *fmt, const std::uint8_t *v );
-	void SetRawRGBAV( std::uint8_t *p, const RageSurface *src, const std::uint8_t *v );
-	std::uint32_t SetRGBAV( const RageSurfaceFormat *fmt, const std::uint8_t *v );
-	void SetRGBAV( std::uint8_t *p, const RageSurface *src, const std::uint8_t *v );
+	uint32_t SetRawRGBAV( const RageSurfaceFormat *fmt, const uint8_t *v );
+	void SetRawRGBAV( uint8_t *p, const RageSurface *src, const uint8_t *v );
+	uint32_t SetRGBAV( const RageSurfaceFormat *fmt, const uint8_t *v );
+	void SetRGBAV( uint8_t *p, const RageSurface *src, const uint8_t *v );
 
 	/* Get the number of bits representing each color channel in fmt. */
-	void GetBitsPerChannel( const RageSurfaceFormat *fmt, std::uint32_t bits[4] );
+	void GetBitsPerChannel( const RageSurfaceFormat *fmt, uint32_t bits[4] );
 
 	void CopySurface( const RageSurface *src, RageSurface *dest );
 	bool ConvertSurface( const RageSurface *src, RageSurface *&dst,
-		int width, int height, int bpp, std::uint32_t R, std::uint32_t G, std::uint32_t B, std::uint32_t A );
+		int width, int height, int bpp, uint32_t R, uint32_t G, uint32_t B, uint32_t A );
 	void ConvertSurface( RageSurface *&image,
-		int width, int height, int bpp, std::uint32_t R, std::uint32_t G, std::uint32_t B, std::uint32_t A );
+		int width, int height, int bpp, uint32_t R, uint32_t G, uint32_t B, uint32_t A );
 
 	void FixHiddenAlpha( RageSurface *img );
 

--- a/src/RageSurfaceUtils_Dither.cpp
+++ b/src/RageSurfaceUtils_Dither.cpp
@@ -20,7 +20,7 @@ static const int DitherMat[DitherMatDim][DitherMatDim] =
 static int DitherMatCalc[DitherMatDim][DitherMatDim];
 
 // conv is the ratio from the input to the output.
-static std::uint8_t DitherPixel(int x, int y, int intensity,  int conv)
+static uint8_t DitherPixel(int x, int y, int intensity,  int conv)
 {
 	// The intensity matrix wraps. This assumes the matrix dims are a power of 2.
 	x &= DitherMatDim-1;
@@ -43,7 +43,7 @@ static std::uint8_t DitherPixel(int x, int y, int intensity,  int conv)
 	out_intensity += DitherMatCalc[y][x];
 
 	// Truncate, and add e to make sure a value of 14.999998 -> 15.
-	return std::uint8_t((out_intensity + 1) >> 16);
+	return uint8_t((out_intensity + 1) >> 16);
 }
 
 void RageSurfaceUtils::OrderedDither( const RageSurface *src, RageSurface *dst )
@@ -68,7 +68,7 @@ void RageSurfaceUtils::OrderedDither( const RageSurface *src, RageSurface *dst )
 	// We can't dither to paletted surfaces.
 	ASSERT( dst->format->BytesPerPixel > 1 );
 
-	std::uint32_t src_cbits[4], dst_cbits[4];
+	uint32_t src_cbits[4], dst_cbits[4];
 	RageSurfaceUtils::GetBitsPerChannel( src->format, src_cbits );
 	RageSurfaceUtils::GetBitsPerChannel( dst->format, dst_cbits );
 
@@ -86,18 +86,18 @@ void RageSurfaceUtils::OrderedDither( const RageSurface *src, RageSurface *dst )
 	}
 
 	// Max alpha value; used when there's no alpha source.
-	const std::uint8_t alpha_max = std::uint8_t((1 << dst_cbits[3]) - 1);
+	const uint8_t alpha_max = uint8_t((1 << dst_cbits[3]) - 1);
 
 	// For each row:
 	for( int row = 0; row < src->h; ++row )
 	{
-		const std::uint8_t *srcp = src->pixels + row * src->pitch;
-		std::uint8_t *dstp = dst->pixels + row * dst->pitch;
+		const uint8_t *srcp = src->pixels + row * src->pitch;
+		uint8_t *dstp = dst->pixels + row * dst->pitch;
 
 		// For each pixel:
 		for( int col = 0; col < src->w; ++col )
 		{
-			std::uint8_t colors[4];
+			uint8_t colors[4];
 			RageSurfaceUtils::GetRawRGBAV( srcp, src->fmt, colors );
 
 			// Note that we don't dither the alpha channel.
@@ -119,7 +119,7 @@ void RageSurfaceUtils::OrderedDither( const RageSurface *src, RageSurface *dst )
 				int out_intensity = colors[3] * conv[3];
 
 				// Round:
-				colors[3] = std::uint8_t((out_intensity + 32767) >> 16);
+				colors[3] = uint8_t((out_intensity + 32767) >> 16);
 			}
 
 			// Raw value -> int -> pixel
@@ -132,7 +132,7 @@ void RageSurfaceUtils::OrderedDither( const RageSurface *src, RageSurface *dst )
 }
 
 
-static std::uint8_t EDDitherPixel( int x, int y, int intensity, int conv, std::int32_t &accumError )
+static uint8_t EDDitherPixel( int x, int y, int intensity, int conv, std::int32_t &accumError )
 {
 	// Convert the number to the destination range.
 	int out_intensity = intensity * conv;
@@ -151,7 +151,7 @@ static std::uint8_t EDDitherPixel( int x, int y, int intensity, int conv, std::i
 	clamped_intensity &= 0xFF0000;
 
 	// Truncate.
-	std::uint8_t ret = std::uint8_t(clamped_intensity >> 16);
+	uint8_t ret = uint8_t(clamped_intensity >> 16);
 
 	accumError = out_intensity - clamped_intensity;
 
@@ -172,7 +172,7 @@ void RageSurfaceUtils::ErrorDiffusionDither( const RageSurface *src, RageSurface
 	// We can't dither to paletted surfaces.
 	ASSERT( dst->format->BytesPerPixel > 1 );
 
-	std::uint32_t src_cbits[4], dst_cbits[4];
+	uint32_t src_cbits[4], dst_cbits[4];
 	RageSurfaceUtils::GetBitsPerChannel( src->format, src_cbits );
 	RageSurfaceUtils::GetBitsPerChannel( dst->format, dst_cbits );
 
@@ -190,20 +190,20 @@ void RageSurfaceUtils::ErrorDiffusionDither( const RageSurface *src, RageSurface
 	}
 
 	// Max alpha value; used when there's no alpha source.
-	const std::uint8_t alpha_max = std::uint8_t((1 << dst_cbits[3]) - 1);
+	const uint8_t alpha_max = uint8_t((1 << dst_cbits[3]) - 1);
 
 	// For each row:
 	for(int row = 0; row < src->h; ++row)
 	{
 		std::int32_t accumError[4] = { 0, 0, 0, 0 }; // accum error values are reset every row
 
-		const std::uint8_t *srcp = src->pixels + row * src->pitch;
-		std::uint8_t *dstp = dst->pixels + row * dst->pitch;
+		const uint8_t *srcp = src->pixels + row * src->pitch;
+		uint8_t *dstp = dst->pixels + row * dst->pitch;
 
 		// For each pixel in row:
 		for( int col = 0; col < src->w; ++col )
 		{
-			std::uint8_t colors[4];
+			uint8_t colors[4];
 			RageSurfaceUtils::GetRawRGBAV( srcp, src->fmt, colors );
 
 			for( int c = 0; c < 3; ++c )
@@ -223,7 +223,7 @@ void RageSurfaceUtils::ErrorDiffusionDither( const RageSurface *src, RageSurface
 				int out_intensity = colors[3] * conv[3];
 
 				// Round:
-				colors[3] = std::uint8_t((out_intensity + 32767) >> 16);
+				colors[3] = uint8_t((out_intensity + 32767) >> 16);
 			}
 
 			RageSurfaceUtils::SetRawRGBAV( dstp, dst, colors );

--- a/src/RageSurfaceUtils_Palettize.cpp
+++ b/src/RageSurfaceUtils_Palettize.cpp
@@ -8,8 +8,8 @@
 
 #include <cstdint>
 
-typedef std::uint8_t pixval;
-typedef std::uint8_t apixel[4];
+typedef uint8_t pixval;
+typedef uint8_t apixel[4];
 
 #define PAM_GETR(p) ((p)[0])
 #define PAM_GETG(p) ((p)[1])
@@ -20,7 +20,7 @@ typedef std::uint8_t apixel[4];
 #define PAM_EQUAL(p,q) \
    ((p)[0] == (q)[0] && (p)[1] == (q)[1] && (p)[2] == (q)[2] && (p)[3] == (q)[3])
 #define PAM_DEPTH(p) \
-   PAM_ASSIGN( (p), (std::uint8_t) table[PAM_GETR(p)], (std::uint8_t) table[PAM_GETG(p)], (std::uint8_t) table[PAM_GETB(p)], (std::uint8_t) table[PAM_GETA(p)] )
+   PAM_ASSIGN( (p), (uint8_t) table[PAM_GETR(p)], (uint8_t) table[PAM_GETG(p)], (uint8_t) table[PAM_GETB(p)], (uint8_t) table[PAM_GETA(p)] )
 
 struct acolorhist_item
 {
@@ -92,8 +92,8 @@ static bool compare_index_3( const acolorhist_item &ch1, const acolorhist_item &
 }
 
 static acolorhist_item *pam_computeacolorhist( const RageSurface *src, int maxacolors, int* acolorsP );
-static void pam_addtoacolorhash( acolorhash_hash &acht, const std::uint8_t acolorP[4], int value );
-static int pam_lookupacolor( const acolorhash_hash &acht, const std::uint8_t acolorP[4] );
+static void pam_addtoacolorhash( acolorhash_hash &acht, const uint8_t acolorP[4], int value );
+static int pam_lookupacolor( const acolorhash_hash &acht, const uint8_t acolorP[4] );
 static void pam_freeacolorhist( acolorhist_item *achv );
 
 struct pixerror_t
@@ -134,7 +134,7 @@ void RageSurfaceUtils::Palettize( RageSurface *&pImg, int iColors, bool bDither 
 			int table[256];
 			for( int c = 0; c <= maxval; ++c )
 			{
-				table[c] = ( (std::uint8_t) c * newmaxval + maxval/2 ) / maxval;
+				table[c] = ( (uint8_t) c * newmaxval + maxval/2 ) / maxval;
 			}
 			for( int row = 0; row < pImg->h; ++row )
 			{
@@ -203,15 +203,15 @@ void RageSurfaceUtils::Palettize( RageSurface *&pImg, int iColors, bool bDither 
 			limitcol = -1;
 		}
 
-		const std::uint8_t *pIn = pImg->pixels + row*pImg->pitch;
-		std::uint8_t *pOut = pRet->pixels + row*pRet->pitch;
+		const uint8_t *pIn = pImg->pixels + row*pImg->pitch;
+		uint8_t *pOut = pRet->pixels + row*pRet->pitch;
 		pIn += col * 4;
 		pOut += col;
 
 		do
 		{
 			std::int32_t sc[4];
-			std::uint8_t pixel[4] = { pIn[0], pIn[1], pIn[2], pIn[3] };
+			uint8_t pixel[4] = { pIn[0], pIn[1], pIn[2], pIn[3] };
 			if( bDither )
 			{
 				// Use Floyd-Steinberg errors to adjust actual color.
@@ -221,7 +221,7 @@ void RageSurfaceUtils::Palettize( RageSurface *&pImg, int iColors, bool bDither 
 					sc[c] = std::clamp( sc[c], 0, (std::int32_t) maxval );
 				}
 
-				PAM_ASSIGN( pixel, (std::uint8_t)sc[0], (std::uint8_t)sc[1], (std::uint8_t)sc[2], (std::uint8_t)sc[3] );
+				PAM_ASSIGN( pixel, (uint8_t)sc[0], (uint8_t)sc[1], (uint8_t)sc[2], (uint8_t)sc[3] );
 			}
 
 			// Check hash table to see if we have already matched this color.
@@ -240,7 +240,7 @@ void RageSurfaceUtils::Palettize( RageSurface *&pImg, int iColors, bool bDither 
 				long dist = 2000000000;
 				for( int i = 0; i < newcolors; ++i )
 				{
-					const std::uint8_t *colors2 = acolormap[i].acolor;
+					const uint8_t *colors2 = acolormap[i].acolor;
 
 					int newdist = 0;
 					newdist += pSquareTable[ int(pixel[0]) - colors2[0] ];
@@ -283,7 +283,7 @@ void RageSurfaceUtils::Palettize( RageSurface *&pImg, int iColors, bool bDither 
 				}
 			}
 
-			*pOut = (std::uint8_t) ind;
+			*pOut = (uint8_t) ind;
 
 			if( !fs_direction )
 			{
@@ -480,7 +480,7 @@ static acolorhist_item *mediancut( acolorhist_item *achv, int colors, int sum, i
 		b = std::min( b, (long) maxval );
 		a = a / lSum;
 		a = std::min( a, (long) maxval );
-		PAM_ASSIGN( acolormap[bi].acolor, (std::uint8_t)r, (std::uint8_t)g, (std::uint8_t)b, (std::uint8_t)a );
+		PAM_ASSIGN( acolormap[bi].acolor, (uint8_t)r, (uint8_t)g, (uint8_t)b, (uint8_t)a );
 #endif // REP_AVERAGE_PIXELS
 	}
 
@@ -579,7 +579,7 @@ static acolorhist_item *pam_computeacolorhist( const RageSurface *src, int maxac
 	return achv;
 }
 
-static void pam_addtoacolorhash( acolorhash_hash &acht, const std::uint8_t acolorP[4], int value )
+static void pam_addtoacolorhash( acolorhash_hash &acht, const uint8_t acolorP[4], int value )
 {
 	acolorhist_list achl = (acolorhist_list) malloc( sizeof(struct acolorhist_list_item) );
 	ASSERT( achl != nullptr );
@@ -592,7 +592,7 @@ static void pam_addtoacolorhash( acolorhash_hash &acht, const std::uint8_t acolo
 }
 
 
-static int pam_lookupacolor( const acolorhash_hash &acht, const std::uint8_t acolorP[4] )
+static int pam_lookupacolor( const acolorhash_hash &acht, const uint8_t acolorP[4] )
 {
 	const int hash = pam_hashapixel( acolorP );
 	for ( acolorhist_list_item *achl = acht.hash[hash]; achl != nullptr; achl = achl->next )

--- a/src/RageSurfaceUtils_Zoom.cpp
+++ b/src/RageSurfaceUtils_Zoom.cpp
@@ -15,7 +15,7 @@
  * (Look at a grid: map coordinates to the lines, not the squares between the
  * lines.) */
 
-static void InitVectors( std::vector<int> &s0, std::vector<int> &s1, std::vector<std::uint32_t> &percent, int src, int dst )
+static void InitVectors( std::vector<int> &s0, std::vector<int> &s1, std::vector<uint32_t> &percent, int src, int dst )
 {
 	if( src >= dst )
 	{
@@ -52,7 +52,7 @@ static void InitVectors( std::vector<int> &s0, std::vector<int> &s1, std::vector
 				/* sax is somewhere between the centers of both sampled
 				 * pixels; find the percentage: */
 				const float p = (1.0f - (sax - fleft) / xdist) * 16777216.0f;
-				percent.push_back( std::uint32_t(p) );
+				percent.push_back( uint32_t(p) );
 			}
 		}
 	}
@@ -75,7 +75,7 @@ static void InitVectors( std::vector<int> &s0, std::vector<int> &s1, std::vector
 			s1.push_back( std::clamp(int(sax+1), 0, src-1) );
 
 			const float p = (1.0f - (sax - std::floor(sax))) * 16777216.0f;
-			percent.push_back( std::uint32_t(p) );
+			percent.push_back( uint32_t(p) );
 		}
 	}
 }
@@ -85,42 +85,42 @@ static void ZoomSurface( const RageSurface * src, RageSurface * dst )
 	/* For each destination coordinate, two source rows, two source columns
 	 * and the percentage of the first row and first column: */
 	std::vector<int> esx0, esx1, esy0, esy1;
-	std::vector<std::uint32_t> ex0, ey0;
+	std::vector<uint32_t> ex0, ey0;
 
 	InitVectors( esx0, esx1, ex0, src->w, dst->w );
 	InitVectors( esy0, esy1, ey0, src->h, dst->h );
 
 	// This is where all of the real work is done.
-	const std::uint8_t *sp = (std::uint8_t *) src->pixels;
+	const uint8_t *sp = (uint8_t *) src->pixels;
 	const int height = dst->h;
 	const int width = dst->w;
 	for( int y = 0; y < height; y++ )
 	{
-		std::uint8_t *dp = (std::uint8_t *) (dst->pixels + dst->pitch*y);
+		uint8_t *dp = (uint8_t *) (dst->pixels + dst->pitch*y);
 		/* current source pointer and next source pointer (first and second
 		 * rows sampled for this row): */
-		const std::uint8_t *csp = sp + esy0[y] * src->pitch;
-		const std::uint8_t *ncsp = sp + esy1[y] * src->pitch;
+		const uint8_t *csp = sp + esy0[y] * src->pitch;
+		const uint8_t *ncsp = sp + esy1[y] * src->pitch;
 
 		for( int x = 0; x < width; x++ )
 		{
 			// Grab pointers to the sampled pixels:
-			const std::uint8_t *c00 = csp + esx0[x]*4;
-			const std::uint8_t *c01 = csp + esx1[x]*4;
-			const std::uint8_t *c10 = ncsp + esx0[x]*4;
-			const std::uint8_t *c11 = ncsp + esx1[x]*4;
+			const uint8_t *c00 = csp + esx0[x]*4;
+			const uint8_t *c01 = csp + esx1[x]*4;
+			const uint8_t *c10 = ncsp + esx0[x]*4;
+			const uint8_t *c11 = ncsp + esx1[x]*4;
 
 			for( int c = 0; c < 4; ++c )
 			{
-				std::uint32_t x0 = std::uint32_t(c00[c]) * ex0[x];
-				x0 += std::uint32_t(c01[c]) * (16777216 - ex0[x]);
+				uint32_t x0 = uint32_t(c00[c]) * ex0[x];
+				x0 += uint32_t(c01[c]) * (16777216 - ex0[x]);
 				x0 >>= 24;
-				std::uint32_t x1 = std::uint32_t(c10[c]) * ex0[x];
-				x1 += std::uint32_t(c11[c]) * (16777216 - ex0[x]);
+				uint32_t x1 = uint32_t(c10[c]) * ex0[x];
+				x1 += uint32_t(c11[c]) * (16777216 - ex0[x]);
 				x1 >>= 24;
 
-				const std::uint32_t res = ((x0 * ey0[y]) + (x1 * (16777216-ey0[y])) + 8388608) >> 24;
-				dp[c] = std::uint8_t(res);
+				const uint32_t res = ((x0 * ey0[y]) + (x1 * (16777216-ey0[y])) + 8388608) >> 24;
+				dp[c] = uint8_t(res);
 			}
 
 			// Advance destination pointer.

--- a/src/RageSurface_Load_BMP.cpp
+++ b/src/RageSurface_Load_BMP.cpp
@@ -41,10 +41,10 @@ static RageSurfaceUtils::OpenResult LoadBMP( RageFile &f, RageSurface *&img, RSt
 
 	read_u32_le( f, sError ); /* file size */
 	read_u32_le( f, sError ); /* unused */
-	std::uint32_t iDataOffset = read_u32_le( f, sError );
-	std::uint32_t iHeaderSize = read_u32_le( f, sError );
+	uint32_t iDataOffset = read_u32_le( f, sError );
+	uint32_t iHeaderSize = read_u32_le( f, sError );
 
-	std::uint32_t iWidth, iHeight, iPlanes, iBPP, iCompression = COMP_BI_RGB, iColors = 0;
+	uint32_t iWidth, iHeight, iPlanes, iBPP, iCompression = COMP_BI_RGB, iColors = 0;
 	if( iHeaderSize == 12 )
 	{
 		/* OS/2 format */
@@ -157,7 +157,7 @@ static RageSurfaceUtils::OpenResult LoadBMP( RageFile &f, RageSurface *&img, RSt
 
 	for( int y = (int) iHeight-1; y >= 0; --y )
 	{
-		std::uint8_t *pRow = img->pixels + img->pitch*y;
+		uint8_t *pRow = img->pixels + img->pitch*y;
 		RString buf;
 
 		f.Read( buf, iFilePitch );

--- a/src/RageSurface_Load_XPM.cpp
+++ b/src/RageSurface_Load_XPM.cpp
@@ -60,9 +60,9 @@ RageSurface *RageSurface_Load_XPM( char * const *xpm, RString &error )
 		if( sscanf( clr, "%2x%2x%2x", &r, &g, &b ) != 3 )
 			continue;
 		RageSurfaceColor colorval;
-		colorval.r = (std::uint8_t) r;
-		colorval.g = (std::uint8_t) g;
-		colorval.b = (std::uint8_t) b;
+		colorval.r = (uint8_t) r;
+		colorval.g = (uint8_t) g;
+		colorval.b = (uint8_t) b;
 		colorval.a = 0xFF;
 
 		colors.push_back( colorval );

--- a/src/RageSurface_Save_BMP.cpp
+++ b/src/RageSurface_Save_BMP.cpp
@@ -17,16 +17,16 @@ static void WriteBytes( RageFile &f, RString &sError, const void *buf, int size 
 		sError = f.GetError();
 }
 
-static void write_le16( RageFile &f, RString &sError, std::uint16_t val )
+static void write_le16( RageFile &f, RString &sError, uint16_t val )
 {
 	val = Swap16LE( val );
-	WriteBytes( f, sError, &val, sizeof(std::uint16_t) );
+	WriteBytes( f, sError, &val, sizeof(uint16_t) );
 }
 
-static void write_le32( RageFile &f, RString &sError, std::uint32_t val )
+static void write_le32( RageFile &f, RString &sError, uint32_t val )
 {
 	val = Swap32LE( val );
-	WriteBytes( f, sError, &val, sizeof(std::uint32_t) );
+	WriteBytes( f, sError, &val, sizeof(uint32_t) );
 }
 
 bool RageSurfaceUtils::SaveBMP( RageSurface *surface, RageFile &f )
@@ -53,7 +53,7 @@ bool RageSurfaceUtils::SaveBMP( RageSurface *surface, RageFile &f )
 	write_le32( f, sError, surface->w ); // width (offset 0x14)
 	write_le32( f, sError, surface->h ); // height (offset 0x18)
 	write_le16( f, sError, 1 ); // planes (offset 0x1A)
-	write_le16( f, sError, (std::uint16_t) converted_surface->fmt.BytesPerPixel*8 ); // bpp (offset 0x1C)
+	write_le16( f, sError, (uint16_t) converted_surface->fmt.BytesPerPixel*8 ); // bpp (offset 0x1C)
 	write_le32( f, sError, 0 ); // compression (offset 0x1E)
 	write_le32( f, sError, iDataSize ); // bitmap size (offset 0x22)
 	write_le32( f, sError, 0 ); // horiz resolution (offset 0x26)
@@ -63,11 +63,11 @@ bool RageSurfaceUtils::SaveBMP( RageSurface *surface, RageFile &f )
 
 	for( int y = converted_surface->h-1; y >= 0; --y )
 	{
-		const std::uint8_t *pRow = converted_surface->pixels + converted_surface->pitch*y;
+		const uint8_t *pRow = converted_surface->pixels + converted_surface->pitch*y;
 		WriteBytes( f, sError, pRow, converted_surface->pitch );
 
 		/* Pad the row to the pitch. */
-		std::uint8_t padding[4] = { 0,0,0,0 };
+		uint8_t padding[4] = { 0,0,0,0 };
 		WriteBytes( f, sError, padding, iFilePitch-converted_surface->pitch );
 	}
 

--- a/src/RageSurface_Save_JPEG.cpp
+++ b/src/RageSurface_Save_JPEG.cpp
@@ -25,7 +25,7 @@ typedef struct
 	struct jpeg::jpeg_destination_mgr pub;
 
 	RageFile *f;
-	std::uint8_t buffer[OUTPUT_BUFFER_SIZE];
+	uint8_t buffer[OUTPUT_BUFFER_SIZE];
 } my_destination_mgr;
 
 

--- a/src/RageTexture.h
+++ b/src/RageTexture.h
@@ -19,7 +19,7 @@ public:
 	virtual void Update( float /* fDeltaTime */ ) {}
 	virtual void Reload() {}
 	virtual void Invalidate() { }	/* only called by RageTextureManager::InvalidateTextures */
-	virtual std::uintptr_t GetTexHandle() const = 0;	// accessed by RageDisplay
+	virtual uintptr_t GetTexHandle() const = 0;	// accessed by RageDisplay
 
 	// movie texture/animated texture stuff
 	virtual void SetPosition( float /* fSeconds */ ) {} // seek

--- a/src/RageTextureManager.cpp
+++ b/src/RageTextureManager.cpp
@@ -133,10 +133,10 @@ public:
 		m_iImageWidth = m_iImageHeight = 1;
 		CreateFrameRects();
 	}
-	std::uintptr_t GetTexHandle() const { return m_uTexHandle; }
+	uintptr_t GetTexHandle() const { return m_uTexHandle; }
 
 private:
-	std::uintptr_t m_uTexHandle;
+	uintptr_t m_uTexHandle;
 };
 
 // Load and unload textures from disk.

--- a/src/RageTextureRenderTarget.h
+++ b/src/RageTextureRenderTarget.h
@@ -16,7 +16,7 @@ public:
 	virtual ~RageTextureRenderTarget();
 	virtual void Invalidate() { m_iTexHandle = 0; /* don't Destroy() */ }
 	virtual void Reload();
-	virtual std::uintptr_t GetTexHandle() const { return m_iTexHandle; }
+	virtual uintptr_t GetTexHandle() const { return m_iTexHandle; }
 
 	void BeginRenderingTo( bool bPreserveTexture = true );
 	void FinishRenderingTo();
@@ -28,8 +28,8 @@ private:
 
 	void Create();
 	void Destroy();
-	std::uintptr_t m_iTexHandle;
-	std::uintptr_t m_iPreviousRenderTarget;
+	uintptr_t m_iTexHandle;
+	uintptr_t m_iPreviousRenderTarget;
 };
 
 #endif

--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -46,7 +46,7 @@ struct ThreadSlot
 	char m_szThreadFormattedOutput[1024];
 
 	bool m_bUsed;
-	std::uint64_t m_iID;
+	uint64_t m_iID;
 
 	ThreadImpl *m_pImpl;
 
@@ -184,7 +184,7 @@ static void InitThreads()
 }
 
 
-static ThreadSlot *GetThreadSlotFromID( std::uint64_t iID )
+static ThreadSlot *GetThreadSlotFromID( uint64_t iID )
 {
 	InitThreads();
 
@@ -284,7 +284,7 @@ const char *RageThread::GetCurrentThreadName()
 	return GetThreadNameByID( GetCurrentThreadID() );
 }
 
-const char *RageThread::GetThreadNameByID( std::uint64_t iID )
+const char *RageThread::GetThreadNameByID( uint64_t iID )
 {
 	ThreadSlot *slot = GetThreadSlotFromID( iID );
 	if( slot == nullptr )
@@ -293,7 +293,7 @@ const char *RageThread::GetThreadNameByID( std::uint64_t iID )
 	return slot->GetThreadName();
 }
 
-bool RageThread::EnumThreadIDs( int n, std::uint64_t &iID )
+bool RageThread::EnumThreadIDs( int n, uint64_t &iID )
 {
 	if( n >= MAX_THREADS )
 		return false;
@@ -337,7 +337,7 @@ void RageThread::Resume() {
 
 void RageThread::HaltAllThreads( bool Kill )
 {
-	const std::uint64_t ThisThreadID = GetThisThreadId();
+	const uint64_t ThisThreadID = GetThisThreadId();
 	for( int entry = 0; entry < MAX_THREADS; ++entry )
 	{
 		if( !g_ThreadSlots[entry].m_bUsed )
@@ -350,7 +350,7 @@ void RageThread::HaltAllThreads( bool Kill )
 
 void RageThread::ResumeAllThreads()
 {
-	const std::uint64_t ThisThreadID = GetThisThreadId();
+	const uint64_t ThisThreadID = GetThisThreadId();
 	for( int entry = 0; entry < MAX_THREADS; ++entry )
 	{
 		if( !g_ThreadSlots[entry].m_bUsed )
@@ -362,11 +362,11 @@ void RageThread::ResumeAllThreads()
 	}
 }
 
-std::uint64_t RageThread::GetCurrentThreadID()
+uint64_t RageThread::GetCurrentThreadID()
 {
 	return GetThisThreadId();
 }
-std::uint64_t RageThread::GetInvalidThreadID()
+uint64_t RageThread::GetInvalidThreadID()
 {
 	return GetInvalidThreadId();
 }
@@ -583,7 +583,7 @@ RageMutex::~RageMutex()
 
 void RageMutex::Lock()
 {
-	std::uint64_t iThisThreadId = GetThisThreadId();
+	uint64_t iThisThreadId = GetThisThreadId();
 	if( m_LockedBy == iThisThreadId )
 	{
 		++m_LockCnt;
@@ -607,7 +607,7 @@ void RageMutex::Lock()
 #if defined(CRASH_HANDLER)
 		/* Don't leave GetThreadSlotsLock() locked when we call ForceCrashHandlerDeadlock. */
 		GetThreadSlotsLock().Lock();
-		std::uint64_t CrashHandle = OtherSlot? OtherSlot->m_iID:0;
+		uint64_t CrashHandle = OtherSlot? OtherSlot->m_iID:0;
 		GetThreadSlotsLock().Unlock();
 
 		/* Pass the crash handle of the other thread, so it can backtrace that thread. */

--- a/src/RageThreads.h
+++ b/src/RageThreads.h
@@ -30,11 +30,11 @@ public:
 	/* If HaltAllThreads was called (with Kill==false), resume. */
 	static void ResumeAllThreads();
 
-	static std::uint64_t GetCurrentThreadID();
+	static uint64_t GetCurrentThreadID();
 
 	static const char *GetCurrentThreadName();
-	static const char *GetThreadNameByID( std::uint64_t iID );
-	static bool EnumThreadIDs( int n, std::uint64_t &iID );
+	static const char *GetThreadNameByID( uint64_t iID );
+	static bool EnumThreadIDs( int n, uint64_t &iID );
 	int Wait();
 	bool IsCreated() const { return m_pSlot != nullptr; }
 
@@ -46,7 +46,7 @@ public:
 
 	static bool GetIsShowingDialog() { return s_bIsShowingDialog; }
 	static void SetIsShowingDialog( bool b ) { s_bIsShowingDialog = b; }
-	static std::uint64_t GetInvalidThreadID();
+	static uint64_t GetInvalidThreadID();
 
 private:
 	ThreadSlot *m_pSlot;
@@ -111,7 +111,7 @@ protected:
 
 	int m_UniqueID;
 
-	std::uint64_t m_LockedBy;
+	uint64_t m_LockedBy;
 	int m_LockCnt;
 
 	void MarkLockedMutex();

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -30,16 +30,16 @@
 #include <cmath>
 #include <cstdint>
 
-const std::uint64_t ONE_SECOND_IN_MICROSECONDS_ULL = 1000000ULL;
+const uint64_t ONE_SECOND_IN_MICROSECONDS_ULL = 1000000ULL;
 const std::int64_t ONE_SECOND_IN_MICROSECONDS_LL = 1000000LL;
 const uint_fast64_t ONE_SECOND_IN_MICROSECONDS_FAST_ULL = 1000000ULL;
 const double ONE_SECOND_IN_MICROSECONDS_DBL = 1000000.0;
 
 const RageTimer RageZeroTimer(0,0);
-static const std::uint64_t g_iStartTime = ArchHooks::GetSystemTimeInMicroseconds();
+static const uint64_t g_iStartTime = ArchHooks::GetSystemTimeInMicroseconds();
 static uint_fast64_t g_iStartTimeFast64 = g_iStartTime;
 
-static std::uint64_t GetTime()
+static uint64_t GetTime()
 {
 	return ArchHooks::GetSystemTimeInMicroseconds();
 }
@@ -71,10 +71,10 @@ uint_fast64_t RageTimer::GetTimeSinceStartMicroseconds()
 
 void RageTimer::Touch()
 {
-	std::uint64_t usecs = GetTime();
+	uint64_t usecs = GetTime();
 
-	this->m_secs = std::uint64_t(usecs / ONE_SECOND_IN_MICROSECONDS_ULL);
-	this->m_us = std::uint64_t(usecs % ONE_SECOND_IN_MICROSECONDS_ULL);
+	this->m_secs = uint64_t(usecs / ONE_SECOND_IN_MICROSECONDS_ULL);
+	this->m_us = uint64_t(usecs % ONE_SECOND_IN_MICROSECONDS_ULL);
 }
 
 float RageTimer::Ago() const

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -46,7 +46,7 @@ public:
 	 * microseconds values into two integers and combining them later allows for
 	 * better precision. Use caution when changing data types, since resolution
 	 * mismatch errors are easy to cause when changing things in RageTimer. */
-	std::uint64_t m_secs, m_us;
+	uint64_t m_secs, m_us;
 
 private:
 	static RageTimer Sum( const RageTimer &lhs, float tm );

--- a/src/RageTypes.h
+++ b/src/RageTypes.h
@@ -290,7 +290,7 @@ inline unsigned char FTOC(float a)
 class RageVColor
 {
 public:
-	std::uint8_t b,g,r,a;	// specific ordering required by Direct3D
+	uint8_t b,g,r,a;	// specific ordering required by Direct3D
 
 	RageVColor(): b(0), g(0), r(0), a(0) { }
 	RageVColor(const RageColor &rc): b(0), g(0), r(0), a(0) { *this = rc; }

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -196,7 +196,7 @@ bool HexToBinary( const RString &s, unsigned char *stringOut )
 			break;
 		RString sByte = s.substr( i*2, 2 );
 
-		std::uint8_t val = 0;
+		uint8_t val = 0;
 		if( sscanf( sByte, "%hhx", &val ) != 1 )
 			return false;
 		stringOut[i] = val;

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -225,12 +225,12 @@ namespace Endian
 #define Swap16(n) __builtin_bswap16(n)
 #endif
 
-inline std::uint32_t Swap32LE( std::uint32_t n ) { return Endian::little ? n : Swap32( n ); }
-inline std::uint32_t Swap24LE( std::uint32_t n ) { return Endian::little ? n : Swap24( n ); }
-inline std::uint16_t Swap16LE( std::uint16_t n ) { return Endian::little ? n : Swap16( n ); }
-inline std::uint32_t Swap32BE( std::uint32_t n ) { return Endian::big    ? n : Swap32( n ); }
-inline std::uint32_t Swap24BE( std::uint32_t n ) { return Endian::big    ? n : Swap24( n ); }
-inline std::uint16_t Swap16BE( std::uint16_t n ) { return Endian::big    ? n : Swap16( n ); }
+inline uint32_t Swap32LE( uint32_t n ) { return Endian::little ? n : Swap32( n ); }
+inline uint32_t Swap24LE( uint32_t n ) { return Endian::little ? n : Swap24( n ); }
+inline uint16_t Swap16LE( uint16_t n ) { return Endian::little ? n : Swap16( n ); }
+inline uint32_t Swap32BE( uint32_t n ) { return Endian::big    ? n : Swap32( n ); }
+inline uint32_t Swap24BE( uint32_t n ) { return Endian::big    ? n : Swap24( n ); }
+inline uint16_t Swap16BE( uint16_t n ) { return Endian::big    ? n : Swap16( n ); }
 
 class MersenneTwister : public std::mt19937
 {

--- a/src/ScoreKeeperNormal.cpp
+++ b/src/ScoreKeeperNormal.cpp
@@ -282,7 +282,7 @@ void ScoreKeeperNormal::AddScoreInternal( TapNoteScore score )
 
 		m_iTapNotesHit++;
 
-		const std::int64_t N = std::uint64_t(m_iNumTapsAndHolds);
+		const std::int64_t N = uint64_t(m_iNumTapsAndHolds);
 		const std::int64_t sum = (N * (N + 1)) / 2;
 		const int Z = m_iMaxPossiblePoints/10;
 

--- a/src/WheelNotifyIcon.cpp
+++ b/src/WheelNotifyIcon.cpp
@@ -86,7 +86,7 @@ void WheelNotifyIcon::Update( float fDeltaTime )
 		/* We should probably end up parsing the vector and then dynamically
 		 * insert flag icons based on "priority". Easy to do, hopefully
 			- Midiman */
-        static std::uint_fast32_t updateCounter = 0;
+        static uint_fast32_t updateCounter = 0;
         updateCounter++;
         const int index = updateCounter % m_vIconsToShow.size();
         Sprite::SetState(m_vIconsToShow[index]);

--- a/src/arch/ArchHooks/ArchHooksUtil.cpp
+++ b/src/arch/ArchHooks/ArchHooksUtil.cpp
@@ -33,9 +33,9 @@ std::int64_t ArchHooks::FixupTimeIfLooped( std::int64_t usecs )
 	static std::int64_t offset_us = 0;
 
 	/* The time has wrapped if the last time was very high and the current time is very low. */
-	const std::int64_t i32BitMaxMs = std::uint64_t(1) << 32;
+	const std::int64_t i32BitMaxMs = uint64_t(1) << 32;
 	const std::int64_t i32BitMaxUs = i32BitMaxMs*1000;
-	const std::int64_t one_day = std::uint64_t(24*60*60)*1000000;
+	const std::int64_t one_day = uint64_t(24*60*60)*1000000;
 	if( last > (i32BitMaxUs-one_day) && usecs < one_day )
 		offset_us += i32BitMaxUs;
 

--- a/src/arch/ArchHooks/ArchHooks_MacOSX.mm
+++ b/src/arch/ArchHooks/ArchHooks_MacOSX.mm
@@ -161,7 +161,7 @@ void ArchHooks_MacOSX::DumpDebugInfo()
 	float fRam;
 	char ramPower;
 	{
-		std::uint64_t iRam = 0;
+		uint64_t iRam = 0;
 		GET_PARAM( "hw.memsize", iRam );
 
 		fRam = float( double(iRam) / 1073741824.0 );
@@ -176,7 +176,7 @@ void ArchHooks_MacOSX::DumpDebugInfo()
 	RString sModel("Unknown");
 	do {
 		char szModel[128];
-		std::uint64_t iFreq;
+		uint64_t iFreq;
 
 		GET_PARAM( "hw.logicalcpu_max", iMaxCPUs );
 		GET_PARAM( "hw.logicalcpu", iCPUs );

--- a/src/arch/ArchHooks/ArchHooks_Win32.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32.cpp
@@ -22,7 +22,7 @@ static HANDLE g_hInstanceMutex;
 static bool g_bIsMultipleInstance = false;
 
 void InvalidParameterHandler( const wchar_t *szExpression, const wchar_t *szFunction, const wchar_t *szFile,
-					  unsigned int iLine, std::uintptr_t pReserved )
+					  unsigned int iLine, uintptr_t pReserved )
 {
 	FAIL_M( "Invalid parameter" ); //TODO: Make this more informative
 }

--- a/src/arch/InputHandler/InputHandler_Linux_Event.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Event.cpp
@@ -72,7 +72,7 @@ struct EventDevice
 
 static std::vector<EventDevice *> g_apEventDevices;
 
-static bool BitIsSet( const std::uint8_t *pArray, std::uint32_t iBit )
+static bool BitIsSet( const uint8_t *pArray, uint32_t iBit )
 {
 	return !!(pArray[iBit/8] & (1<<(iBit%8)));
 }
@@ -128,7 +128,7 @@ bool EventDevice::Open( RString sFile, InputDevice dev )
 			DevInfo.version, m_sName.c_str() );
 	}
 
-	std::uint8_t iABSMask[ABS_MAX/8 + 1];
+	uint8_t iABSMask[ABS_MAX/8 + 1];
 	memset( iABSMask, 0, sizeof(iABSMask) );
 	if( ioctl(m_iFD, EVIOCGBIT(EV_ABS, sizeof(iABSMask)), iABSMask) < 0 )
 		LOG->Warn( "ioctl(EVIOCGBIT(EV_ABS)): %s", strerror(errno) );
@@ -145,12 +145,12 @@ bool EventDevice::Open( RString sFile, InputDevice dev )
 		}
 	}
 
-	std::uint8_t iKeyMask[KEY_MAX/8 + 1];
+	uint8_t iKeyMask[KEY_MAX/8 + 1];
 	memset( iKeyMask, 0, sizeof(iKeyMask) );
 	if( ioctl(m_iFD, EVIOCGBIT(EV_KEY, sizeof(iKeyMask)), iKeyMask) < 0 )
 		LOG->Warn( "ioctl(EVIOCGBIT(EV_KEY)): %s", strerror(errno) );
 
-	std::uint8_t iEventTypes[EV_MAX/8];
+	uint8_t iEventTypes[EV_MAX/8];
 	memset( iEventTypes, 0, sizeof(iEventTypes) );
 	if( ioctl(m_iFD, EVIOCGBIT(0, EV_MAX), iEventTypes) == -1 )
 		LOG->Warn( "ioctl(EV_MAX): %s", strerror(errno) );

--- a/src/arch/InputHandler/InputHandler_SextetStream.cpp
+++ b/src/arch/InputHandler/InputHandler_SextetStream.cpp
@@ -132,7 +132,7 @@ class InputHandler_SextetStream::Impl
 			handler->ButtonPressed(di);
 		}
 
-		std::uint8_t stateBuffer[STATE_BUFFER_SIZE];
+		uint8_t stateBuffer[STATE_BUFFER_SIZE];
 		size_t timeout_ms;
 		RageThread inputThread;
 		bool continueInputThread;
@@ -192,7 +192,7 @@ class InputHandler_SextetStream::Impl
 			return 0;
 		}
 
-		inline void GetNewState(std::uint8_t * buffer, RString& line)
+		inline void GetNewState(uint8_t * buffer, RString& line)
 		{
 			size_t lineLen = line.length();
 			size_t i, cursor;
@@ -228,10 +228,10 @@ class InputHandler_SextetStream::Impl
 			}
 		}
 
-		inline void ReactToChanges(const std::uint8_t * newStateBuffer)
+		inline void ReactToChanges(const uint8_t * newStateBuffer)
 		{
 			InputDevice id = InputDevice(FIRST_DEVICE);
-			std::uint8_t changes[STATE_BUFFER_SIZE];
+			uint8_t changes[STATE_BUFFER_SIZE];
 			RageTimer now;
 
 			// XOR to find differences
@@ -276,7 +276,7 @@ class InputHandler_SextetStream::Impl
 					if(linereader->ReadLine(line)) {
 						LOG->Trace("Got line: '%s'", line.c_str());
 						if(line.length() > 0) {
-							std::uint8_t newStateBuffer[STATE_BUFFER_SIZE];
+							uint8_t newStateBuffer[STATE_BUFFER_SIZE];
 							GetNewState(newStateBuffer, line);
 							ReactToChanges(newStateBuffer);
 						}

--- a/src/arch/InputHandler/InputHandler_Win32_ddrio.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_ddrio.cpp
@@ -13,7 +13,7 @@
 #include <process.h>
 
 typedef int (*thread_create_t)(
-	int (*proc)(void*), void* ctx, std::uint32_t stack_sz, unsigned int priority);
+	int (*proc)(void*), void* ctx, uint32_t stack_sz, unsigned int priority);
 typedef void (*thread_join_t)(int thread_id, int* result);
 typedef void (*thread_destroy_t)(int thread_id);
 
@@ -28,13 +28,13 @@ static DDRIO_IO_INIT ddrio_io_init;
 typedef int (*DDRIO_READ_PAD)();
 static DDRIO_READ_PAD ddrio_io_read_pad;
 
-typedef int (*DDRIO_SETLIGHTS_P3IO)(std::uint32_t lights);
+typedef int (*DDRIO_SETLIGHTS_P3IO)(uint32_t lights);
 static DDRIO_SETLIGHTS_P3IO ddrio_set_lights_p3io;
 
-typedef int (*DDRIO_SETLIGHTS_EXTIO)(std::uint32_t lights);
+typedef int (*DDRIO_SETLIGHTS_EXTIO)(uint32_t lights);
 static DDRIO_SETLIGHTS_EXTIO ddrio_set_lights_extio;
 
-typedef int (*DDRIO_SETLIGHTS_HDXSPANEL)(std::uint32_t lights);
+typedef int (*DDRIO_SETLIGHTS_HDXSPANEL)(uint32_t lights);
 static DDRIO_SETLIGHTS_HDXSPANEL ddrio_set_lights_hdxs_panel;
 
 typedef int (*DDRIO_FINI)();
@@ -69,13 +69,13 @@ static unsigned int crt_thread_shim(void* outer_ctx)
 
 
 int crt_thread_create(
-	int (*proc)(void*), void* ctx, std::uint32_t stack_sz, unsigned int priority)
+	int (*proc)(void*), void* ctx, uint32_t stack_sz, unsigned int priority)
 {
 
 	LOG->Trace("crt_thread_create");
 
 	struct shim_ctx sctx;
-	std::uintptr_t thread_id;
+	uintptr_t thread_id;
 
 	sctx.barrier = CreateEvent(NULL, TRUE, FALSE, NULL);
 	sctx.proc = proc;
@@ -96,7 +96,7 @@ void crt_thread_destroy(int thread_id)
 {
 	LOG->Trace("crt_thread_destroy %d", thread_id);
 
-	CloseHandle((HANDLE)(std::uintptr_t)thread_id);
+	CloseHandle((HANDLE)(uintptr_t)thread_id);
 }
 
 
@@ -104,11 +104,11 @@ void crt_thread_join(int thread_id, int* result)
 {
 	LOG->Trace("crt_thread_join %d", thread_id);
 
-	WaitForSingleObject((HANDLE)(std::uintptr_t)thread_id, INFINITE);
+	WaitForSingleObject((HANDLE)(uintptr_t)thread_id, INFINITE);
 
 	if (result)
 	{
-		GetExitCodeThread((HANDLE)(std::uintptr_t)thread_id, (DWORD*)result);
+		GetExitCodeThread((HANDLE)(uintptr_t)thread_id, (DWORD*)result);
 	}
 }
 
@@ -265,7 +265,7 @@ int InputHandler_Win32_ddrio::InputThread_Start( void *p )
 
 void InputHandler_Win32_ddrio::InputThreadMain()
 {
-	std::uint32_t prevInput = 0, newInput = 0;
+	uint32_t prevInput = 0, newInput = 0;
 	LightsState prevLS = { 0 };
 	LightsState newLS = { 0 };
 
@@ -294,7 +294,7 @@ void InputHandler_Win32_ddrio::InputThreadMain()
 	}
 }
 
-void InputHandler_Win32_ddrio::PushInputState(std::uint32_t newInput)
+void InputHandler_Win32_ddrio::PushInputState(uint32_t newInput)
 {
 	for (int i = 0; i < 32; i++)
 	{
@@ -337,9 +337,9 @@ bool InputHandler_Win32_ddrio::IsLightChange(LightsState prevLS, LightsState new
 
 void InputHandler_Win32_ddrio::PushLightState(LightsState newLS)
 {
-	std::uint32_t p3io = 0;
-	std::uint32_t hdxs = 0;
-	std::uint32_t extio = 0;
+	uint32_t p3io = 0;
+	uint32_t hdxs = 0;
+	uint32_t extio = 0;
 
 	//lighting state has already been verified to have changed in this method, so create the new one from scratch.
 

--- a/src/arch/InputHandler/InputHandler_Win32_ddrio.h
+++ b/src/arch/InputHandler/InputHandler_Win32_ddrio.h
@@ -81,7 +81,7 @@ private:
 	static int InputThread_Start( void *p );
 	void InputThreadMain();
 
-	void PushInputState(std::uint32_t newInput);
+	void PushInputState(uint32_t newInput);
 
 	bool IsLightChange(LightsState prevLS, LightsState newLS);
 	void PushLightState(LightsState newLS);

--- a/src/arch/Lights/LightsDriver_LinuxPacDrive.cpp
+++ b/src/arch/Lights/LightsDriver_LinuxPacDrive.cpp
@@ -79,7 +79,7 @@ void LightsDriver_LinuxPacDrive::Set( const LightsState *ls )
 {
 	if ( !DeviceHandle ) return;
 
-	std::uint16_t outb = 0;
+	uint16_t outb = 0;
 
 	switch (iLightingOrder) {
 	case 1:
@@ -245,13 +245,13 @@ void LightsDriver_LinuxPacDrive::OpenDevice()
 	}
 }
 
-void LightsDriver_LinuxPacDrive::WriteDevice(std::uint16_t out)
+void LightsDriver_LinuxPacDrive::WriteDevice(uint16_t out)
 {
 	if ( !DeviceHandle ) return;
 
 	// output is within the first 16 bits - accept a
 	// 16-bit arg and cast it, for simplicity's sake.
-	std::uint32_t data = (out << 16);
+	uint32_t data = (out << 16);
 	int expected = sizeof(data);
 
 	int result = usb_control_msg( DeviceHandle, USB_DIR_OUT | USB_TYPE_CLASS | USB_RECIP_INTERFACE,

--- a/src/arch/Lights/LightsDriver_LinuxPacDrive.h
+++ b/src/arch/Lights/LightsDriver_LinuxPacDrive.h
@@ -22,7 +22,7 @@ private:
 
 	void FindDevice();
 	void OpenDevice();
-	void WriteDevice(std::uint16_t out);
+	void WriteDevice(uint16_t out);
 	void CloseDevice();
 
 	struct usb_device *Device;

--- a/src/arch/Lights/LightsDriver_Linux_Leds.h
+++ b/src/arch/Lights/LightsDriver_Linux_Leds.h
@@ -10,8 +10,8 @@
 class LightsDriver_Linux_Leds : public LightsDriver
 {
 private:
-	static const std::uint8_t LINUX_LED_STATE_ON = 255;
-	static const std::uint8_t LINUX_LED_STATE_OFF = 0;
+	static const uint8_t LINUX_LED_STATE_ON = 255;
+	static const uint8_t LINUX_LED_STATE_OFF = 0;
 	static const int LINUX_LED_MAX_DIRECTORY_LENGTH = PATH_MAX;
 
 	const InputScheme *pInput;

--- a/src/arch/Lights/LightsDriver_Linux_stac.cpp
+++ b/src/arch/Lights/LightsDriver_Linux_stac.cpp
@@ -25,7 +25,7 @@
 
 REGISTER_LIGHTS_DRIVER_CLASS2(stac, Linux_stac);
 
-StacDevice::StacDevice(std::uint8_t pn)
+StacDevice::StacDevice(uint8_t pn)
 {
     memset(outputBuffer, 0x00, sizeof(outputBuffer));
 
@@ -177,11 +177,11 @@ void StacDevice::Close()
 void StacDevice::SetInBuffer(int index, bool lightState)
 {
     //the first byte is the report ID, so we offset it here to adjust.
-    std::uint8_t index_offset = index + 1;
+    uint8_t index_offset = index + 1;
 
     //each index in the array represents a single light,
     //the light will turn on for any value that isn't 0x00
-    std::uint8_t val = lightState ? 0xFF : 0x00;
+    uint8_t val = lightState ? 0xFF : 0x00;
 
     //ensure the index is valid and the light value has changed.
     if (index_offset < STAC_HIDREPORT_SIZE && outputBuffer[index_offset] != val)

--- a/src/arch/Lights/LightsDriver_Linux_stac.h
+++ b/src/arch/Lights/LightsDriver_Linux_stac.h
@@ -52,12 +52,12 @@ public:
     const char *devicePath;
     int fd = -1;
 
-    std::uint8_t playerNumber = 0;
+    uint8_t playerNumber = 0;
     bool newState = false;
 
-    std::uint8_t outputBuffer[STAC_HIDREPORT_SIZE];
+    uint8_t outputBuffer[STAC_HIDREPORT_SIZE];
 
-    StacDevice(std::uint8_t pn);
+    StacDevice(uint8_t pn);
 
     void FindDevice();
     void Connect();

--- a/src/arch/Lights/LightsDriver_SextetStream.cpp
+++ b/src/arch/Lights/LightsDriver_SextetStream.cpp
@@ -19,7 +19,7 @@ namespace
 	class SextetImpl
 	{
 	protected:
-		std::uint8_t lastOutput[FULL_SEXTET_COUNT];
+		uint8_t lastOutput[FULL_SEXTET_COUNT];
 		RageFile * out;
 
 	public:
@@ -41,7 +41,7 @@ namespace
 
 		void Set(const LightsState * ls)
 		{
-			std::uint8_t buffer[FULL_SEXTET_COUNT];
+			uint8_t buffer[FULL_SEXTET_COUNT];
 
 			packLine(buffer, ls);
 

--- a/src/arch/Lights/LightsDriver_Win32Serial.cpp
+++ b/src/arch/Lights/LightsDriver_Win32Serial.cpp
@@ -71,7 +71,7 @@ LightsDriver_Win32Serial::~LightsDriver_Win32Serial()
 void LightsDriver_Win32Serial::Set(const LightsState* ls)
 {
 	if (serialPort != INVALID_HANDLE_VALUE) {
-		std::uint8_t buffer[FULL_SEXTET_COUNT];
+		uint8_t buffer[FULL_SEXTET_COUNT];
 
 		packLine(buffer, ls);
 

--- a/src/arch/Lights/LightsDriver_Win32Serial.h
+++ b/src/arch/Lights/LightsDriver_Win32Serial.h
@@ -16,7 +16,7 @@
 class LightsDriver_Win32Serial : public LightsDriver
 {
 protected:
-	std::uint8_t lastOutput[FULL_SEXTET_COUNT];
+	uint8_t lastOutput[FULL_SEXTET_COUNT];
 public:
 	LightsDriver_Win32Serial();
 	virtual ~LightsDriver_Win32Serial();

--- a/src/arch/Lights/SextetUtils.h
+++ b/src/arch/Lights/SextetUtils.h
@@ -23,7 +23,7 @@ static const size_t FULL_SEXTET_COUNT = CABINET_SEXTET_COUNT + (NUM_GameControll
 // Encodes the low 6 bits of a byte as a printable, non-space ASCII
 // character (i.e., within the range 0x21-0x7E) such that the low 6 bits of
 // the character are the same as the input.
-inline std::uint8_t printableSextet(std::uint8_t data)
+inline uint8_t printableSextet(uint8_t data)
 {
 	// Maps the 6-bit value into the range 0x30-0x6F, wrapped in such a way
 	// that the low 6 bits of the result are the same as the data (so
@@ -38,13 +38,13 @@ inline std::uint8_t printableSextet(std::uint8_t data)
 	// the top two bits T of the input like so:
 	// 	H = ((T + 1) mod 4) + 3
 
-	return ((data + (std::uint8_t)0x10) & (std::uint8_t)0x3F) + (std::uint8_t)0x30;
+	return ((data + (uint8_t)0x10) & (uint8_t)0x3F) + (uint8_t)0x30;
 }
 
 // Packs 6 booleans into a 6-bit value
-inline std::uint8_t packPlainSextet(bool b0, bool b1, bool b2, bool b3, bool b4, bool b5)
+inline uint8_t packPlainSextet(bool b0, bool b1, bool b2, bool b3, bool b4, bool b5)
 {
-	return (std::uint8_t)(
+	return (uint8_t)(
 		(b0 ? 0x01 : 0) |
 		(b1 ? 0x02 : 0) |
 		(b2 ? 0x04 : 0) |
@@ -54,13 +54,13 @@ inline std::uint8_t packPlainSextet(bool b0, bool b1, bool b2, bool b3, bool b4,
 }
 
 // Packs 6 booleans into a printable sextet
-inline std::uint8_t packPrintableSextet(bool b0, bool b1, bool b2, bool b3, bool b4, bool b5)
+inline uint8_t packPrintableSextet(bool b0, bool b1, bool b2, bool b3, bool b4, bool b5)
 {
 	return printableSextet(packPlainSextet(b0, b1, b2, b3, b4, b5));
 }
 
 // Packs the cabinet lights into a printable sextet and adds it to a buffer
-inline size_t packCabinetLights(const LightsState* ls, std::uint8_t* buffer)
+inline size_t packCabinetLights(const LightsState* ls, uint8_t* buffer)
 {
 	buffer[0] = packPrintableSextet(
 		ls->m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT],
@@ -74,7 +74,7 @@ inline size_t packCabinetLights(const LightsState* ls, std::uint8_t* buffer)
 
 // Packs the button lights for a controller into 6 printable sextets and
 // adds them to a buffer
-inline size_t packControllerLights(const LightsState* ls, GameController gc, std::uint8_t* buffer)
+inline size_t packControllerLights(const LightsState* ls, GameController gc, uint8_t* buffer)
 {
 	// Menu buttons
 	buffer[0] = packPrintableSextet(
@@ -127,7 +127,7 @@ inline size_t packControllerLights(const LightsState* ls, GameController gc, std
 	return CONTROLLER_SEXTET_COUNT;
 }
 
-inline size_t packLine(std::uint8_t* buffer, const LightsState* ls)
+inline size_t packLine(uint8_t* buffer, const LightsState* ls)
 {
 	size_t index = 0;
 

--- a/src/arch/LoadingWindow/LoadingWindow_Gtk.cpp
+++ b/src/arch/LoadingWindow/LoadingWindow_Gtk.cpp
@@ -77,7 +77,7 @@ void LoadingWindow_Gtk::SetText( RString s )
 
 static void DeletePixels( guchar *pixels, gpointer data )
 {
-	delete[] (std::uint8_t *)pixels;
+	delete[] (uint8_t *)pixels;
 }
 
 static GdkPixbuf *MakePixbuf( const RageSurface *pSrc )

--- a/src/arch/LowLevelWindow/LowLevelWindow_MacOSX.h
+++ b/src/arch/LowLevelWindow/LowLevelWindow_MacOSX.h
@@ -9,7 +9,7 @@
 #include <objc/objc.h>
 
 typedef const struct __CFDictionary *CFDictionaryRef;
-typedef std::uint32_t CGDirectDisplayID;
+typedef uint32_t CGDirectDisplayID;
 
 class LowLevelWindow_MacOSX : public LowLevelWindow
 {

--- a/src/arch/LowLevelWindow/LowLevelWindow_MacOSX.mm
+++ b/src/arch/LowLevelWindow/LowLevelWindow_MacOSX.mm
@@ -190,7 +190,7 @@ public:
 	RenderTarget_MacOSX( id shareContext );
 	~RenderTarget_MacOSX();
 	void Create( const RenderTargetParam &param, int &iTextureWidthOut, int &iTextureHeightOut );
-	std::uintptr_t GetTexture() const { return static_cast<std::uintptr_t>(m_iTexHandle); }
+	uintptr_t GetTexture() const { return static_cast<uintptr_t>(m_iTexHandle); }
 	void StartRenderingTo();
 	void FinishRenderingTo();
 
@@ -326,11 +326,11 @@ void *LowLevelWindow_MacOSX::GetProcAddress( RString s )
 	// http://developer.apple.com/qa/qa2001/qa1188.html
 	// Both functions mentioned in there are deprecated in 10.4.
 	const RString& symbolName( '_' + s );
-	const std::uint32_t count = _dyld_image_count();
+	const uint32_t count = _dyld_image_count();
 	NSSymbol symbol = nil;
-	const std::uint32_t options = NSLOOKUPSYMBOLINIMAGE_OPTION_RETURN_ON_ERROR;
+	const uint32_t options = NSLOOKUPSYMBOLINIMAGE_OPTION_RETURN_ON_ERROR;
 
-	for( std::uint32_t i = 0; i < count && !symbol; ++i )
+	for( uint32_t i = 0; i < count && !symbol; ++i )
 		symbol = NSLookupSymbolInImage( _dyld_get_image_header(i), symbolName, options );
 	return symbol ? NSAddressOfSymbol( symbol ) : nil;
 }

--- a/src/arch/LowLevelWindow/LowLevelWindow_Win32.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_Win32.cpp
@@ -325,7 +325,7 @@ public:
 	virtual ~RenderTarget_Win32();
 
 	void Create( const RenderTargetParam &param, int &iTextureWidthOut, int &iTextureHeightOut );
-	std::uintptr_t GetTexture() const { return static_cast<std::uintptr_t>(m_texHandle); }
+	uintptr_t GetTexture() const { return static_cast<uintptr_t>(m_texHandle); }
 	void StartRenderingTo();
 	void FinishRenderingTo();
 

--- a/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
@@ -321,7 +321,7 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 			// If an output name has been specified, search for it
 			RROutput targetOut = None;
 			if (p.sDisplayId.length() > 0) {
-				for (unsigned int i = 0; i < static_cast<std::uint32_t>(scrRes->noutput) && targetOut == None; ++i) {
+				for (unsigned int i = 0; i < static_cast<uint32_t>(scrRes->noutput) && targetOut == None; ++i) {
 					XRROutputInfo *outInfo = XRRGetOutputInfo(Dpy, scrRes, scrRes->outputs[i]);
 					std::string outName = std::string(outInfo->name, static_cast<unsigned int> (outInfo->nameLen));
 					if (p.sDisplayId == outName) {
@@ -341,7 +341,7 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 					// (it is possible the connection state could be unknown), we'll at least
 					// look for an output with a CRTC driving it
 					RROutput connected = None, hasCrtc = None;
-					for (unsigned int i = 0; i < static_cast<std::uint32_t>(scrRes->noutput); ++i) {
+					for (unsigned int i = 0; i < static_cast<uint32_t>(scrRes->noutput); ++i) {
 						XRROutputInfo *outInfo = XRRGetOutputInfo(Dpy, scrRes, scrRes->outputs[i]);
 						if (outInfo->connection == RR_Connected) { // Check for CONNECTED state: Connected == 0
 							connected = scrRes->outputs[i];
@@ -368,7 +368,7 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 			RRCrtc tgtOutCrtc = tgtOutInfo->crtc;
 			if (tgtOutCrtc == None)
 			{
-				for (unsigned int i = 0; i < static_cast<std::uint32_t>(tgtOutInfo->ncrtc); ++i)
+				for (unsigned int i = 0; i < static_cast<uint32_t>(tgtOutInfo->ncrtc); ++i)
 				{
 					XRRCrtcInfo *crtcInfo = XRRGetCrtcInfo( Dpy, scrRes, tgtOutInfo->crtcs[i] );
 					if (crtcInfo->mode == None)
@@ -396,7 +396,7 @@ RString LowLevelWindow_X11::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 				const XRRModeInfo &thisMI = scrRes->modes[i];
 				const unsigned int modeWidth = bPortrait ? thisMI.height : thisMI.width;
 				const unsigned int modeHeight = bPortrait ? thisMI.width : thisMI.height;
-				if (p.width >= 0 && p.height >= 0 && modeWidth == static_cast<std::uint32_t>(p.width) && modeHeight == static_cast<std::uint32_t>(p.height)) {
+				if (p.width >= 0 && p.height >= 0 && modeWidth == static_cast<uint32_t>(p.width) && modeHeight == static_cast<uint32_t>(p.height)) {
 					float fTempRefresh = calcRandRRefresh(thisMI.dotClock, thisMI.hTotal, thisMI.vTotal);
 					float fTempDiff = std::abs(p.rate - fTempRefresh);
 					if ((p.rate != REFRESH_DEFAULT && fTempDiff < fRefreshDiff) ||
@@ -670,11 +670,11 @@ void LowLevelWindow_X11::GetDisplaySpecs(DisplaySpecs &out) const {
 	int nsizes = 0;
 	XRRScreenSize *screenSizes = XRRSizes( Dpy, screenNum, &nsizes);
 	DisplayMode screenCurMode{};
-	for (unsigned int szIdx = 0, mode_idx = 0; nsizes >= 0 && szIdx < static_cast<std::uint32_t>(nsizes); ++szIdx) {
+	for (unsigned int szIdx = 0, mode_idx = 0; nsizes >= 0 && szIdx < static_cast<uint32_t>(nsizes); ++szIdx) {
 		XRRScreenSize &size = screenSizes[szIdx];
 		int nrates = 0;
 		short *rates = XRRRates(Dpy, screenNum, szIdx, &nrates);
-		for (unsigned int rIdx = 0; nrates >=0 && rIdx < static_cast<std::uint32_t>(nrates); ++rIdx, ++mode_idx) {
+		for (unsigned int rIdx = 0; nrates >=0 && rIdx < static_cast<uint32_t>(nrates); ++rIdx, ++mode_idx) {
 			DisplayMode m = {static_cast<unsigned int> (size.width), static_cast<unsigned int> (size.height), static_cast<double> (rates[rIdx])};
 			screenModes.insert(m);
 			if (rates[rIdx] == curRate && szIdx == curSizeId) {
@@ -704,7 +704,7 @@ void LowLevelWindow_X11::GetDisplaySpecs(DisplaySpecs &out) const {
 		}
 
 		// Now, for each output, build a corresponding DisplaySpec
-		for (unsigned int outIdx = 0; outIdx < static_cast<std::uint32_t>(scrRes->noutput); ++outIdx)
+		for (unsigned int outIdx = 0; outIdx < static_cast<uint32_t>(scrRes->noutput); ++outIdx)
 		{
 			XRROutputInfo *outInfo = XRRGetOutputInfo( Dpy, scrRes, scrRes->outputs[outIdx] );
 			if (outInfo->nmode > 0)
@@ -727,7 +727,7 @@ void LowLevelWindow_X11::GetDisplaySpecs(DisplaySpecs &out) const {
 				std::set<DisplayMode> outputSupported;
 				DisplayMode outputCurMode{};
 				RectI outBounds;
-				for (unsigned int modeIdx = 0; modeIdx < static_cast<std::uint32_t>(outInfo->nmode); ++modeIdx)
+				for (unsigned int modeIdx = 0; modeIdx < static_cast<uint32_t>(outInfo->nmode); ++modeIdx)
 				{
 					DisplayMode mode = outputModes[outInfo->modes[modeIdx]];
 					unsigned int modeWidth = bPortrait ? mode.height : mode.width;
@@ -768,7 +768,7 @@ public:
 	~RenderTarget_X11();
 
 	void Create( const RenderTargetParam &param, int &iTextureWidthOut, int &iTextureHeightOut );
-	std::uintptr_t GetTexture() const { return static_cast<std::uintptr_t>(m_iTexHandle); }
+	uintptr_t GetTexture() const { return static_cast<uintptr_t>(m_iTexHandle); }
 	void StartRenderingTo();
 	void FinishRenderingTo();
 

--- a/src/arch/MemoryCard/MemoryCardDriverThreaded_MacOSX.cpp
+++ b/src/arch/MemoryCard/MemoryCardDriverThreaded_MacOSX.cpp
@@ -206,7 +206,7 @@ void MemoryCardDriverThreaded_MacOSX::GetUSBStorageDevices( std::vector<UsbStora
 
 			LOG->Trace( "Found memory card at path: %s.", fs[i].f_mntonname );
 			usbd.SetOsMountDir( fs[i].f_mntonname );
-			usbd.iVolumeSizeMB = int( (std::uint64_t(fs[i].f_blocks) * fs[i].f_bsize) >> 20 );
+			usbd.iVolumeSizeMB = int( (uint64_t(fs[i].f_blocks) * fs[i].f_bsize) >> 20 );
 
 			// Now we can get some more information from the registry tree.
 			usbd.iBus = GetIntProperty( device, CFSTR("USB Address") );

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -497,7 +497,7 @@ static RString averr_ssprintf(int err, const char* fmt, ...)
 	return s + " (" + Error + ")";
 }
 
-static int AVIORageFile_ReadPacket(void* opaque, std::uint8_t* buf, int buf_size)
+static int AVIORageFile_ReadPacket(void* opaque, uint8_t* buf, int buf_size)
 {
 	RageFile* f = (RageFile*)opaque;
 	int n = f->Read(buf, buf_size);

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -186,7 +186,7 @@ private:
 static struct AVPixelFormat_t
 {
 	int bpp;
-	std::uint32_t masks[4];
+	uint32_t masks[4];
 	avcodec::AVPixelFormat pf;
 	bool bHighColor;
 	bool bByteSwapOnLittleEndian;

--- a/src/arch/MovieTexture/MovieTexture_Generic.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Generic.cpp
@@ -142,7 +142,7 @@ public:
 
 	virtual void Invalidate() { m_uTexHandle = 0; }
 	virtual void Reload() { }
-	virtual std::uintptr_t GetTexHandle() const
+	virtual uintptr_t GetTexHandle() const
 	{
 		return m_uTexHandle;
 	}
@@ -165,7 +165,7 @@ private:
 		delete pSurface;
 	}
 
-	std::uintptr_t m_uTexHandle;
+	uintptr_t m_uTexHandle;
 	RageSurfaceFormat m_SurfaceFormat;
 	RagePixelFormat m_PixFmt;
 };
@@ -339,7 +339,7 @@ void MovieTexture_Generic::UpdateFrame()
 
 	if(m_pTextureLock != nullptr)
 	{
-		std::uintptr_t iHandle = m_pTextureIntermediate != nullptr ? m_pTextureIntermediate->GetTexHandle(): this->GetTexHandle();
+		uintptr_t iHandle = m_pTextureIntermediate != nullptr ? m_pTextureIntermediate->GetTexHandle(): this->GetTexHandle();
 		m_pTextureLock->Lock(iHandle, m_pSurface);
 	}
 
@@ -437,7 +437,7 @@ void MovieTexture_Generic::SetPosition(float fSeconds)
 	m_pDecoder->Rewind();
 }
 
-std::uintptr_t MovieTexture_Generic::GetTexHandle() const
+uintptr_t MovieTexture_Generic::GetTexHandle() const
 {
 	if( m_pRenderTarget != nullptr )
 		return m_pRenderTarget->GetTexHandle();

--- a/src/arch/MovieTexture/MovieTexture_Generic.h
+++ b/src/arch/MovieTexture/MovieTexture_Generic.h
@@ -103,7 +103,7 @@ public:
 	virtual void UpdateMovie( float fSeconds );
 	virtual void SetPlaybackRate( float fRate ) { m_fRate = fRate; }
 	void SetLooping( bool bLooping=true ) { m_bLoop = bLooping; }
-	std::uintptr_t GetTexHandle() const;
+	uintptr_t GetTexHandle() const;
 
 	static EffectMode GetEffectMode( MovieDecoderPixelFormatYCbCr fmt );
 
@@ -119,7 +119,7 @@ private:
 	// If true, halts all decoding and display.
 	bool m_failure = false;
 
-	std::uintptr_t m_uTexHandle;
+	uintptr_t m_uTexHandle;
 	RageTextureRenderTarget *m_pRenderTarget;
 	RageTexture *m_pTextureIntermediate;
 	Sprite *m_pSprite;

--- a/src/arch/MovieTexture/MovieTexture_Null.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Null.cpp
@@ -13,7 +13,7 @@ public:
 	MovieTexture_Null(RageTextureID ID);
 	virtual ~MovieTexture_Null();
 	void Invalidate() { texHandle = 0; }
-	std::uintptr_t GetTexHandle() const { return texHandle; }
+	uintptr_t GetTexHandle() const { return texHandle; }
 	void Update(float /* delta */) { }
 	void Reload() { }
 	void SetPosition(float /* seconds */) { }
@@ -23,7 +23,7 @@ public:
 private:
 	bool playing;
 	bool loop;
-	std::uintptr_t texHandle;
+	uintptr_t texHandle;
 };
 
 MovieTexture_Null::MovieTexture_Null(RageTextureID ID) : RageMovieTexture(ID)

--- a/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
@@ -519,14 +519,14 @@ std::int64_t RageSoundDriver::GetHardwareFrame( RageTimer *pTimestamp=nullptr ) 
 	 */
 	int iTries = 3;
 	std::int64_t iPositionFrames;
-	std::uint64_t iStartTime;
-	const std::uint64_t iThreshold = 2000ULL;
+	uint64_t iStartTime;
+	const uint64_t iThreshold = 2000ULL;
 
 	do
 	{
 		iStartTime = RageTimer::GetTimeSinceStartMicroseconds();
 		iPositionFrames = GetPosition();
-		std::uint64_t elapsedTime = RageTimer::GetTimeSinceStartMicroseconds() - iStartTime;
+		uint64_t elapsedTime = RageTimer::GetTimeSinceStartMicroseconds() - iStartTime;
 		if (elapsedTime <= iThreshold) break;
 	} while (--iTries);
 

--- a/src/arch/Sound/RageSoundDriver_PulseAudio.cpp
+++ b/src/arch/Sound/RageSoundDriver_PulseAudio.cpp
@@ -184,7 +184,7 @@ void RageSoundDriver_PulseAudio::m_InitStream(void)
 	*
 	* "The server tries to assure that at least tlength bytes are always
 	*  available in the per-stream server-side playback buffer. It is
-	*  recommended to set this to (std::uint32_t) -1, which will initialize
+	*  recommended to set this to (uint32_t) -1, which will initialize
 	*  this to a value that is deemed sensible by the server. However,
 	*  this value will default to something like 2s, i.e. for applications
 	*  that have specific latency requirements this value should be set to
@@ -197,10 +197,10 @@ void RageSoundDriver_PulseAudio::m_InitStream(void)
 
 	/* maxlength: Maximum length of the buffer
 	*
-	* "Setting this to (std::uint32_t) -1 will initialize this to the maximum
+	* "Setting this to (uint32_t) -1 will initialize this to the maximum
 	*  value supported by server, which is recommended."
 	*
-	* (std::uint32_t)-1 is NOT working here, setting it to tlength*2, like
+	* (uint32_t)-1 is NOT working here, setting it to tlength*2, like
 	* openal-soft-pulseaudio does.
 	*/
 	attr.maxlength = attr.tlength*2;
@@ -209,10 +209,10 @@ void RageSoundDriver_PulseAudio::m_InitStream(void)
 	*
 	* "The server does not request less than minreq bytes from the client,
 	*  instead waits until the buffer is free enough to request more bytes
-	*  at once. It is recommended to set this to (std::uint32_t) -1, which will
+	*  at once. It is recommended to set this to (uint32_t) -1, which will
 	*  initialize this to a value that is deemed sensible by the server."
 	*
-	* (std::uint32_t)-1 is NOT working here, setting it to 0, like
+	* (uint32_t)-1 is NOT working here, setting it to 0, like
 	* openal-soft-pulseaudio does.
 	*/
 	attr.minreq = 0;
@@ -221,10 +221,10 @@ void RageSoundDriver_PulseAudio::m_InitStream(void)
 	*
 	* "The server does not start with playback before at least prebuf
 	*  bytes are available in the buffer. It is recommended to set this
-	*  to (std::uint32_t) -1, which will initialize this to the same value as
+	*  to (uint32_t) -1, which will initialize this to the same value as
 	*  tlength"
 	*/
-	attr.prebuf = (std::uint32_t)-1;
+	attr.prebuf = (uint32_t)-1;
 
 	/* log the used target buffer length */
 	LOG->Trace("Pulse: using target buffer length of %i bytes", attr.tlength);

--- a/src/arch/Sound/RageSoundDriver_WDMKS.cpp
+++ b/src/arch/Sound/RageSoundDriver_WDMKS.cpp
@@ -1142,7 +1142,7 @@ void RageSoundDriver_WDMKS::Read( void *pData, int iFrames, int iLastCursorPos, 
 
 bool RageSoundDriver_WDMKS::Fill( int iPacket, RString &sError )
 {
-	std::uint64_t iCurrentFrame = GetPosition();
+	uint64_t iCurrentFrame = GetPosition();
 //	if( iCurrentFrame == m_iLastCursorPos )
 //		LOG->Trace( "underrun" );
 

--- a/src/arch/Threads/Threads.h
+++ b/src/arch/Threads/Threads.h
@@ -18,7 +18,7 @@ public:
 	 * implementation-defined, except that each thread has exactly one ID
 	 * and each ID corresponds to one thread. (This means that Win32
 	 * thread handles are not acceptable as ThreadIds.) */
-	virtual std::uint64_t GetThreadId() const = 0;
+	virtual uint64_t GetThreadId() const = 0;
 
 	virtual int Wait() = 0;
 };
@@ -71,16 +71,16 @@ public:
 };
 
 // These functions must be implemented by the thread implementation.
-ThreadImpl *MakeThread( int (*fn)(void *), void *data, std::uint64_t *piThreadID );
+ThreadImpl *MakeThread( int (*fn)(void *), void *data, uint64_t *piThreadID );
 ThreadImpl *MakeThisThread();
 MutexImpl *MakeMutex( RageMutex *pParent );
 EventImpl *MakeEvent( MutexImpl *pMutex );
 SemaImpl *MakeSemaphore( int iInitialValue );
-std::uint64_t GetThisThreadId();
+uint64_t GetThisThreadId();
 
 /* Since ThreadId is implementation-defined, we can't define a universal
  * invalid value. Return the invalid value for this implementation. */
-std::uint64_t GetInvalidThreadId();
+uint64_t GetInvalidThreadId();
 
 #endif
 

--- a/src/arch/Threads/Threads_Pthreads.cpp
+++ b/src/arch/Threads/Threads_Pthreads.cpp
@@ -38,7 +38,7 @@ void ThreadImpl_Pthreads::Resume()
 	ResumeThread( threadHandle );
 }
 
-std::uint64_t ThreadImpl_Pthreads::GetThreadId() const
+uint64_t ThreadImpl_Pthreads::GetThreadId() const
 {
 	return threadHandle;
 }
@@ -79,7 +79,7 @@ static void *StartThread( void *pData )
 	return new int(iRet);
 }
 
-ThreadImpl *MakeThread( int (*pFunc)(void *pData), void *pData, std::uint64_t *piThreadID )
+ThreadImpl *MakeThread( int (*pFunc)(void *pData), void *pData, uint64_t *piThreadID )
 {
 	ThreadImpl_Pthreads *thread = new ThreadImpl_Pthreads;
 	thread->m_pFunc = pFunc;
@@ -227,12 +227,12 @@ void MutexImpl_Pthreads::Unlock()
 	pthread_mutex_unlock( &mutex );
 }
 
-std::uint64_t GetThisThreadId()
+uint64_t GetThisThreadId()
 {
 	return GetCurrentThreadId();
 }
 
-std::uint64_t GetInvalidThreadId()
+uint64_t GetInvalidThreadId()
 {
 	return 0;
 }

--- a/src/arch/Threads/Threads_Pthreads.h
+++ b/src/arch/Threads/Threads_Pthreads.h
@@ -18,17 +18,17 @@ public:
 	 * Keep a list of child PIDs, so we can send them SIGKILL. This has
 	 * an added bonus: if this is corrupted, we'll just send signals and
 	 * they'll fail; we won't blow up (unless we're root). */
-	std::uint64_t threadHandle;
+	uint64_t threadHandle;
 
 	// These are only used during initialization.
 	int (*m_pFunc)( void *pData );
 	void *m_pData;
-	std::uint64_t *m_piThreadID;
+	uint64_t *m_piThreadID;
 	SemaImpl *m_StartFinishedSem;
 
 	void Halt( bool Kill );
 	void Resume();
-	std::uint64_t GetThreadId() const;
+	uint64_t GetThreadId() const;
 	int Wait();
 };
 

--- a/src/arch/Threads/Threads_Win32.cpp
+++ b/src/arch/Threads/Threads_Win32.cpp
@@ -17,10 +17,10 @@ static void InitThreadIdMutex()
 	g_pThreadIdMutex = new MutexImpl_Win32(nullptr);
 }
 
-static std::uint64_t g_ThreadIds[MAX_THREADS];
+static uint64_t g_ThreadIds[MAX_THREADS];
 static HANDLE g_ThreadHandles[MAX_THREADS];
 
-HANDLE Win32ThreadIdToHandle( std::uint64_t iID )
+HANDLE Win32ThreadIdToHandle( uint64_t iID )
 {
 	for( int i = 0; i < MAX_THREADS; ++i )
 	{
@@ -44,9 +44,9 @@ void ThreadImpl_Win32::Resume()
 	ResumeThread( ThreadHandle );
 }
 
-std::uint64_t ThreadImpl_Win32::GetThreadId() const
+uint64_t ThreadImpl_Win32::GetThreadId() const
 {
-	return (std::uint64_t) ThreadId;
+	return (uint64_t) ThreadId;
 }
 
 int ThreadImpl_Win32::Wait()
@@ -112,7 +112,7 @@ static DWORD WINAPI StartThread( LPVOID pData )
 	return ret;
 }
 
-static int GetOpenSlot( std::uint64_t iID )
+static int GetOpenSlot( uint64_t iID )
 {
 	InitThreadIdMutex();
 
@@ -157,14 +157,14 @@ ThreadImpl *MakeThisThread()
 	return thread;
 }
 
-ThreadImpl *MakeThread( int (*pFunc)(void *pData), void *pData, std::uint64_t *piThreadID )
+ThreadImpl *MakeThread( int (*pFunc)(void *pData), void *pData, uint64_t *piThreadID )
 {
 	ThreadImpl_Win32 *thread = new ThreadImpl_Win32;
 	thread->m_pFunc = pFunc;
 	thread->m_pData = pData;
 
 	thread->ThreadHandle = CreateThread( nullptr, 0, &StartThread, thread, CREATE_SUSPENDED, &thread->ThreadId );
-	*piThreadID = (std::uint64_t) thread->ThreadId;
+	*piThreadID = (uint64_t) thread->ThreadId;
 	ASSERT_M( thread->ThreadHandle != nullptr, ssprintf("%s", werr_ssprintf(GetLastError(), "CreateThread").c_str() ) );
 
 	int slot = GetOpenSlot( thread->ThreadId );
@@ -248,12 +248,12 @@ void MutexImpl_Win32::Unlock()
 		sm_crash( werr_ssprintf( GetLastError(), "ReleaseMutex failed" ) );
 }
 
-std::uint64_t GetThisThreadId()
+uint64_t GetThisThreadId()
 {
 	return GetCurrentThreadId();
 }
 
-std::uint64_t GetInvalidThreadId()
+uint64_t GetInvalidThreadId()
 {
 	return 0;
 }

--- a/src/arch/Threads/Threads_Win32.h
+++ b/src/arch/Threads/Threads_Win32.h
@@ -21,11 +21,11 @@ public:
 
 	void Halt( bool Kill );
 	void Resume();
-	std::uint64_t GetThreadId() const;
+	uint64_t GetThreadId() const;
 	int Wait();
 };
 
-HANDLE Win32ThreadIdToHandle( std::uint64_t iID );
+HANDLE Win32ThreadIdToHandle( uint64_t iID );
 
 class MutexImpl_Win32: public MutexImpl
 {

--- a/src/archutils/Common/PthreadHelpers.cpp
+++ b/src/archutils/Common/PthreadHelpers.cpp
@@ -127,7 +127,7 @@ static int PtraceDetach( int ThreadID )
 
 
 /* Get this thread's ID (this may be a TID or a PID). */
-static std::uint64_t GetCurrentThreadIdInternal()
+static uint64_t GetCurrentThreadIdInternal()
 {
 	/* If we're under Valgrind, neither the PID nor the TID is associated with the
 	 * thread.  Return the pthread ID.  This can't be used to kill threads, etc.,
@@ -157,14 +157,14 @@ static std::uint64_t GetCurrentThreadIdInternal()
 	return getpid();
 }
 
-std::uint64_t GetCurrentThreadId()
+uint64_t GetCurrentThreadId()
 {
 #if defined(HAVE_TLS)
 	/* This is called each time we lock a mutex, and gettid() is a little slow, so
 	 * cache the result if we support TLS. */
 	if( RageThread::GetSupportsTLS() )
 	{
-		static thread_local std::uint64_t cached_tid = 0;
+		static thread_local uint64_t cached_tid = 0;
 		static thread_local bool cached = false;
 		if( !cached )
 		{
@@ -178,7 +178,7 @@ std::uint64_t GetCurrentThreadId()
 	return GetCurrentThreadIdInternal();
 }
 
-int SuspendThread( std::uint64_t ThreadID )
+int SuspendThread( uint64_t ThreadID )
 {
 	/*
 	 * Linux: We can't simply kill(SIGSTOP) (or tkill), since that will stop all processes
@@ -189,7 +189,7 @@ int SuspendThread( std::uint64_t ThreadID )
 	// kill( ThreadID, SIGSTOP );
 }
 
-int ResumeThread( std::uint64_t ThreadID )
+int ResumeThread( uint64_t ThreadID )
 {
 	return PtraceDetach( int(ThreadID) );
 	// kill( ThreadID, SIGSTOP );
@@ -205,7 +205,7 @@ int ResumeThread( std::uint64_t ThreadID )
  * This call leaves the given thread suspended, so the returned context doesn't become invalid.
  * ResumeThread() can be used to resume a thread after this call. */
 #if defined(CRASH_HANDLER)
-bool GetThreadBacktraceContext( std::uint64_t ThreadID, BacktraceContext *ctx )
+bool GetThreadBacktraceContext( uint64_t ThreadID, BacktraceContext *ctx )
 {
 	/* Can't GetThreadBacktraceContext the current thread. */
 	ASSERT( ThreadID != GetCurrentThreadId() );
@@ -266,17 +266,17 @@ RString ThreadsVersion()
 	return "(unknown)";
 }
 
-std::uint64_t GetCurrentThreadId()
+uint64_t GetCurrentThreadId()
 {
-	return std::uint64_t( pthread_self() );
+	return uint64_t( pthread_self() );
 }
 
-int SuspendThread( std::uint64_t id )
+int SuspendThread( uint64_t id )
 {
 	return pthread_kill( pthread_t(id), SIGSTOP );
 }
 
-int ResumeThread( std::uint64_t id )
+int ResumeThread( uint64_t id )
 {
 	return pthread_kill( pthread_t(id), SIGCONT );
 }

--- a/src/archutils/Common/PthreadHelpers.h
+++ b/src/archutils/Common/PthreadHelpers.h
@@ -8,16 +8,16 @@
 RString ThreadsVersion();
 
 /* Get the current thread's ThreadID. */
-std::uint64_t GetCurrentThreadId();
+uint64_t GetCurrentThreadId();
 
 /* Return true if NPTL libraries are in use, false if linuxthreads. */
 bool UsingNPTL();
 
-int SuspendThread( std::uint64_t ThreadID );
-int ResumeThread( std::uint64_t ThreadID );
+int SuspendThread( uint64_t ThreadID );
+int ResumeThread( uint64_t ThreadID );
 
 struct BacktraceContext;
-int GetThreadContext( std::uint64_t ThreadID, BacktraceContext *ctx );
+int GetThreadContext( uint64_t ThreadID, BacktraceContext *ctx );
 
 #endif
 

--- a/src/archutils/Darwin/DarwinThreadHelpers.cpp
+++ b/src/archutils/Darwin/DarwinThreadHelpers.cpp
@@ -8,22 +8,22 @@
 #include <cmath>
 #include <cstdint>
 
-bool SuspendThread( std::uint64_t threadHandle )
+bool SuspendThread( uint64_t threadHandle )
 {
 	return !thread_suspend( thread_act_t(threadHandle) );
 }
 
-bool ResumeThread( std::uint64_t threadHandle )
+bool ResumeThread( uint64_t threadHandle )
 {
 	return !thread_resume( thread_act_t(threadHandle) );
 }
 
-std::uint64_t GetCurrentThreadId()
+uint64_t GetCurrentThreadId()
 {
 	return mach_thread_self();
 }
 
-bool GetThreadBacktraceContext( std::uint64_t iID, BacktraceContext *ctx )
+bool GetThreadBacktraceContext( uint64_t iID, BacktraceContext *ctx )
 {
 	/* Can't GetThreadBacktraceContext the current thread. */
 	ASSERT( iID != GetCurrentThreadId() );

--- a/src/archutils/Darwin/DarwinThreadHelpers.h
+++ b/src/archutils/Darwin/DarwinThreadHelpers.h
@@ -7,16 +7,16 @@
  * @brief Attempt to suspend the specified thread.
  * @param threadHandle the thread to suspend.
  * @return true if the thread is suspended, false otherwise. */
-bool SuspendThread( std::uint64_t threadHandle );
+bool SuspendThread( uint64_t threadHandle );
 /**
  * @brief Attempt to resume the specified thread.
  * @param threadHandle the thread to resume.
  * @return true if the thread is resumed, false otherwise. */
-bool ResumeThread( std::uint64_t threadHandle );
+bool ResumeThread( uint64_t threadHandle );
 /**
  * @brief Retrieve the current thread ID.
  * @return the current thread ID. */
-std::uint64_t GetCurrentThreadId();
+uint64_t GetCurrentThreadId();
 /**
  * @brief Set the precedence for the thread.
  *

--- a/src/archutils/Darwin/HIDDevice.h
+++ b/src/archutils/Darwin/HIDDevice.h
@@ -50,11 +50,11 @@ namespace __gnu_cxx
 {
 #ifndef __LP64__
 	template<>
-	struct hash<IOHIDElementCookie> : private hash<std::uintptr_t>
+	struct hash<IOHIDElementCookie> : private hash<uintptr_t>
 	{
 		size_t operator()( const IOHIDElementCookie& cookie ) const
 		{
-			return hash<unsigned long>::operator()( std::uintptr_t(cookie) );
+			return hash<unsigned long>::operator()( uintptr_t(cookie) );
 		}
 	};
 #endif

--- a/src/archutils/Darwin/JoystickDevice.cpp
+++ b/src/archutils/Darwin/JoystickDevice.cpp
@@ -146,7 +146,7 @@ bool JoystickDevice::InitDevice( int vid, int pid )
 	if( vid != 0x0507 || pid != 0x0011 )
 		return true;
 	// It's a Para controller, so try to power it on.
-	std::uint8_t powerOn = 1;
+	uint8_t powerOn = 1;
 	IOReturn ret = SetReport( kIOHIDReportTypeFeature, 0, &powerOn, 1, 10 );
 
 	if( ret )

--- a/src/archutils/Darwin/PumpDevice.cpp
+++ b/src/archutils/Darwin/PumpDevice.cpp
@@ -22,7 +22,7 @@ void PumpDevice::GetButtonPresses( std::vector<DeviceInput>& vPresses, IOHIDElem
 	bool pressed1 = !(value & 0x1);
 	bool pressed2 = !(value & 0x2);
 
-	switch( std::uintptr_t(cookie) )
+	switch( uintptr_t(cookie) )
 	{
 	case 2:
 		db2 = JOY_BUTTON_1; // bit 9

--- a/src/archutils/Unix/Backtrace.cpp
+++ b/src/archutils/Unix/Backtrace.cpp
@@ -599,7 +599,7 @@ void GetBacktrace( const void **buf, size_t size, const BacktraceContext *ctx )
 		// Make sure this is on the stack
 		if( !GetRegionInfo(self, frame, start, protection) || protection != PROT_RW )
 			break;
-		if( (start != g_StackPointer && start != stackPointer) || std::uintptr_t(frame)-std::uintptr_t(start) < sizeof(Frame) )
+		if( (start != g_StackPointer && start != stackPointer) || uintptr_t(frame)-uintptr_t(start) < sizeof(Frame) )
 			break;
 
 		/* The stack pointer is always 16 byte aligned _before_ the call. Thus a valid frame
@@ -617,7 +617,7 @@ void GetBacktrace( const void **buf, size_t size, const BacktraceContext *ctx )
 		 * Therefore, frame + 8 should be on a 16 byte boundary, the frame link should be
 		 * at a higher address, the link should be on the stack and it should be RW. The
 		 * return address should be EXE and point to a valid call (well, just after). */
-		if( (((std::uintptr_t)frame+8) & 0xF) != 0 ||// boundary
+		if( (((uintptr_t)frame+8) & 0xF) != 0 ||// boundary
 		    frame->link <= frame || // the frame link goes up
 		    !GetRegionInfo(self, frame->link, start, protection) ||
 		    (start != g_StackPointer && start != stackPointer) || // the link is on the stack
@@ -629,7 +629,7 @@ void GetBacktrace( const void **buf, size_t size, const BacktraceContext *ctx )
 			/* This is not a valid frame but we might be in code compiled with
 			 * -fomit-frame-pointer so look at each address on the stack that is
 			 * 4 bytes below a 16 byte boundary. */
-			if( (((std::uintptr_t)frame+4) & 0xF) == 0 )
+			if( (((uintptr_t)frame+4) & 0xF) == 0 )
 			{
 				void *p = *(void **)frame;
 				if( GetRegionInfo(self, p, start, protection) &&

--- a/src/archutils/Unix/Backtrace.h
+++ b/src/archutils/Unix/Backtrace.h
@@ -41,7 +41,7 @@ void GetBacktrace( const void **buf, size_t size, const BacktraceContext *ctx = 
 
 /* Set up a BacktraceContext to get a backtrace for a thread.  ThreadID may
  * not be the current thread.  True is returned on success, false on failure. */
-bool GetThreadBacktraceContext( std::uint64_t ThreadID, BacktraceContext *ctx );
+bool GetThreadBacktraceContext( uint64_t ThreadID, BacktraceContext *ctx );
 
 /* Set up a BacktraceContext to get a backtrace after receiving a signal, given
  * a ucontext_t (see sigaction(2)).  (This interface is UNIX-specific.) */

--- a/src/archutils/Unix/CrashHandler.cpp
+++ b/src/archutils/Unix/CrashHandler.cpp
@@ -25,7 +25,7 @@
 #include "CrashHandler.h"
 #include "CrashHandlerInternal.h"
 
-extern std::uint64_t GetInvalidThreadId();
+extern uint64_t GetInvalidThreadId();
 extern const char *g_pCrashHandlerArgv0;
 
 static void safe_print( int fd, ... )
@@ -315,7 +315,7 @@ static void RunCrashHandler( const CrashData *crash )
 static void BacktraceAllThreads( CrashData& crash )
 {
 	int iCnt = 1;
-	std::uint64_t iID;
+	uint64_t iID;
 
 	for( int i = 0; RageThread::EnumThreadIDs(i, iID); ++i )
 	{
@@ -348,7 +348,7 @@ void CrashHandler::ForceCrash( const char *reason )
 	RunCrashHandler( &crash );
 }
 
-void CrashHandler::ForceDeadlock( RString reason, std::uint64_t iID )
+void CrashHandler::ForceDeadlock( RString reason, uint64_t iID )
 {
 	CrashData crash;
 	memset( &crash, 0, sizeof(crash) );

--- a/src/archutils/Unix/CrashHandler.h
+++ b/src/archutils/Unix/CrashHandler.h
@@ -12,7 +12,7 @@ namespace CrashHandler
 	void InitializeCrashHandler();
 	void CrashSignalHandler( int signal, siginfo_t *si, const ucontext_t *uc );
 	void ForceCrash( const char *reason );
-	void ForceDeadlock( RString reason, std::uint64_t CrashHandle );
+	void ForceDeadlock( RString reason, uint64_t CrashHandle );
 }
 
 #endif

--- a/src/archutils/Unix/X11Helper.cpp
+++ b/src/archutils/Unix/X11Helper.cpp
@@ -208,8 +208,8 @@ bool X11Helper::SetWMFullscreenMonitors( const DisplaySpec &target )
 	{
 		auto mon = std::find_if( screens, end, [&]( XineramaScreenInfo &screen ) {
 			return screen.x_org == target.currentBounds().left && screen.y_org == target.currentBounds().top
-				   && screen.width >= 0 && static_cast<std::uint32_t>(screen.width) == target.currentMode()->width
-				   && screen.height >= 0 && static_cast<std::uint32_t>(screen.height) == target.currentMode()->height;
+				   && screen.width >= 0 && static_cast<uint32_t>(screen.width) == target.currentMode()->width
+				   && screen.height >= 0 && static_cast<uint32_t>(screen.height) == target.currentMode()->height;
 		} );
 		if (mon != end)
 		{

--- a/src/archutils/Win32/Crash.cpp
+++ b/src/archutils/Win32/Crash.cpp
@@ -584,7 +584,7 @@ static void debug_crash()
 
 /* Get a stack trace of the current thread and the specified thread.
  * If iID == GetInvalidThreadId(), then output a stack trace for every thread. */
-void CrashHandler::ForceDeadlock( RString reason, std::uint64_t iID )
+void CrashHandler::ForceDeadlock( RString reason, uint64_t iID )
 {
 	strncpy( g_CrashInfo.m_CrashReason, reason, sizeof(g_CrashInfo.m_CrashReason) );
 	g_CrashInfo.m_CrashReason[ sizeof(g_CrashInfo.m_CrashReason)-1 ] = 0;
@@ -611,7 +611,7 @@ void CrashHandler::ForceDeadlock( RString reason, std::uint64_t iID )
 			context.ContextFlags = CONTEXT_FULL;
 			if( !GetThreadContext( hThread, &context ) )
 				wsprintf( g_CrashInfo.m_CrashReason + strlen(g_CrashInfo.m_CrashReason),
-					"; GetThreadContext(%Ix) failed", reinterpret_cast<std::uintptr_t>(hThread) );
+					"; GetThreadContext(%Ix) failed", reinterpret_cast<uintptr_t>(hThread) );
 			else
 			{
 				static const void *BacktracePointers[BACKTRACE_MAX_SIZE];

--- a/src/archutils/Win32/Crash.h
+++ b/src/archutils/Win32/Crash.h
@@ -13,7 +13,7 @@ namespace CrashHandler
 	void do_backtrace( const void **buf, size_t size, HANDLE hProcess, HANDLE hThread, const CONTEXT *pContext );
 	void SymLookup( const void *ptr, char *buf );
 	void ForceCrash( const char *reason );
-	void ForceDeadlock( RString reason, std::uint64_t iID );
+	void ForceDeadlock( RString reason, uint64_t iID );
 
 	/* Inform the crash handler of a foreground window that may be fullscreen.
 	 * If set, the crash handler will attempt to hide the window or reset the

--- a/src/archutils/Win32/CrashHandlerChild.cpp
+++ b/src/archutils/Win32/CrashHandlerChild.cpp
@@ -56,10 +56,10 @@ namespace VDDebugInfo
 		int nBuildNumber;
 
 		const unsigned char *pRVAHeap;
-		std::uintptr_t nFirstRVA;
+		uintptr_t nFirstRVA;
 
 		const char *pFuncNameHeap;
-		const std::uintptr_t (*pSegments)[2];
+		const uintptr_t (*pSegments)[2];
 		int nSegments;
 		char sFilename[1024];
 		RString sError;
@@ -113,10 +113,10 @@ namespace VDDebugInfo
 		src += 2 * (sizeof(int) + sizeof(size_t));
 
 		pctx->nBuildNumber		= *pVer;
-		pctx->pRVAHeap			= reinterpret_cast<const unsigned char*>(src + sizeof(std::uintptr_t));
-		pctx->nFirstRVA			= *reinterpret_cast<const std::uintptr_t*>(src);
+		pctx->pRVAHeap			= reinterpret_cast<const unsigned char*>(src + sizeof(uintptr_t));
+		pctx->nFirstRVA			= *reinterpret_cast<const uintptr_t*>(src);
 		pctx->pFuncNameHeap		= reinterpret_cast<const char*>(src + *pRVASize);
-		pctx->pSegments			= reinterpret_cast<const std::uintptr_t(*)[2]>(src + *pRVASize + *pFNamSize);
+		pctx->pSegments			= reinterpret_cast<const uintptr_t(*)[2]>(src + *pRVASize + *pFNamSize);
 		pctx->nSegments			= *pSegCnt;
 
 		return true;
@@ -170,7 +170,7 @@ namespace VDDebugInfo
 		return false;
 	}
 
-	static bool PointerIsInAnySegment( const Context *pctx, std::uintptr_t rva )
+	static bool PointerIsInAnySegment( const Context *pctx, uintptr_t rva )
 	{
 		for( int i=0; i<pctx->nSegments; ++i )
 		{
@@ -189,7 +189,7 @@ namespace VDDebugInfo
 		return heap;
 	}
 
-	std::intptr_t VDDebugInfoLookupRVA( const Context *pctx, std::uintptr_t rva, char *buf, int buflen )
+	std::intptr_t VDDebugInfoLookupRVA( const Context *pctx, uintptr_t rva, char *buf, int buflen )
 	{
 		if( !PointerIsInAnySegment(pctx, rva) )
 			return -1;
@@ -207,7 +207,7 @@ namespace VDDebugInfo
 		while( pr < pr_limit )
 		{
 			unsigned char c;
-			std::uintptr_t diff = 0;
+			uintptr_t diff = 0;
 
 			do
 			{
@@ -290,7 +290,7 @@ namespace SymbolLookup
 		return true;
 	}
 
-	SYMBOL_INFO *GetSym( std::uintptr_t ptr, DWORD64 &disp )
+	SYMBOL_INFO *GetSym( uintptr_t ptr, DWORD64 &disp )
 	{
 		InitDbghelp();
 
@@ -370,12 +370,12 @@ namespace SymbolLookup
 		VirtualQueryEx( g_hParent, ptr, &meminfo, sizeof meminfo );
 
 		char tmp[512];
-		std::intptr_t iAddress = VDDebugInfo::VDDebugInfoLookupRVA(pctx, reinterpret_cast<std::uintptr_t>(ptr), tmp, sizeof(tmp));
+		std::intptr_t iAddress = VDDebugInfo::VDDebugInfoLookupRVA(pctx, reinterpret_cast<uintptr_t>(ptr), tmp, sizeof(tmp));
 		if( iAddress >= 0 )
 		{
-			wsprintf( buf, "%" ADDRESS_ZEROS "Ix: %s [%" ADDRESS_ZEROS "Ix+%Ix+%Ix]", reinterpret_cast<std::uintptr_t>(ptr), Demangle(tmp),
+			wsprintf( buf, "%" ADDRESS_ZEROS "Ix: %s [%" ADDRESS_ZEROS "Ix+%Ix+%Ix]", reinterpret_cast<uintptr_t>(ptr), Demangle(tmp),
 				pctx->nFirstRVA,
-				reinterpret_cast<std::uintptr_t>(ptr) - pctx->nFirstRVA - iAddress,
+				reinterpret_cast<uintptr_t>(ptr) - pctx->nFirstRVA - iAddress,
 				iAddress );
 			return;
 		}
@@ -383,21 +383,21 @@ namespace SymbolLookup
 		RString sName = CrashChildGetModuleBaseName( (HMODULE)meminfo.AllocationBase );
 
 		DWORD64 disp;
-		SYMBOL_INFO *pSymbol = GetSym( reinterpret_cast<std::uintptr_t>(ptr), disp );
+		SYMBOL_INFO *pSymbol = GetSym( reinterpret_cast<uintptr_t>(ptr), disp );
 
 		if( pSymbol )
 		{
 			wsprintf( buf, "%" ADDRESS_ZEROS "Ix: %s!%s [%" ADDRESS_ZEROS "Ix+%Ix+%Ix]",
-				reinterpret_cast<std::uintptr_t>(ptr), sName.c_str(), pSymbol->Name,
-				reinterpret_cast<std::uintptr_t>(meminfo.AllocationBase),
-				static_cast<std::uintptr_t>(pSymbol->Address) - reinterpret_cast<std::uintptr_t>(meminfo.AllocationBase),
+				reinterpret_cast<uintptr_t>(ptr), sName.c_str(), pSymbol->Name,
+				reinterpret_cast<uintptr_t>(meminfo.AllocationBase),
+				static_cast<uintptr_t>(pSymbol->Address) - reinterpret_cast<uintptr_t>(meminfo.AllocationBase),
 				static_cast<ULONG_PTR>(disp));
 			return;
 		}
 
 		wsprintf( buf, "%" ADDRESS_ZEROS "Ix: %s!%" ADDRESS_ZEROS "Ix",
-			reinterpret_cast<std::uintptr_t>(ptr), sName.c_str(),
-			reinterpret_cast<std::uintptr_t>(meminfo.AllocationBase) );
+			reinterpret_cast<uintptr_t>(ptr), sName.c_str(),
+			reinterpret_cast<uintptr_t>(meminfo.AllocationBase) );
 	}
 }
 

--- a/src/archutils/Win32/CrashHandlerNetworking.cpp
+++ b/src/archutils/Win32/CrashHandlerNetworking.cpp
@@ -397,7 +397,7 @@ void NetworkStream_Win32::Open( const RString &sHost, int iPort, ConnectionType 
 		sockaddr_in addr;
 		addr.sin_addr.s_addr = *(DWORD *)pHost->h_addr_list[0];
 		addr.sin_family = PF_INET;
-		addr.sin_port = htons( (std::uint16_t) iPort );
+		addr.sin_port = htons( (uint16_t) iPort );
 
 		m_Mutex.Lock();
 		m_Socket = socket( PF_INET, SOCK_STREAM, IPPROTO_TCP );

--- a/src/archutils/Win32/GetFileInformation.cpp
+++ b/src/archutils/Win32/GetFileInformation.cpp
@@ -89,7 +89,7 @@ RString FindSystemFile( RString sFile )
 
 /* Get the full path of the process running in iProcessID. On error, false is
  * returned and an error message is placed in sName. */
-bool GetProcessFileName( std::uint32_t iProcessID, RString &sName )
+bool GetProcessFileName( uint32_t iProcessID, RString &sName )
 {
 	/* This method works in everything except for NT4, and only uses
 	 * kernel32.lib functions. */

--- a/src/archutils/Win32/GetFileInformation.h
+++ b/src/archutils/Win32/GetFileInformation.h
@@ -7,7 +7,7 @@
 
 bool GetFileVersion( RString fsFile, RString &sOut );
 RString FindSystemFile( RString sFile );
-bool GetProcessFileName( std::uint32_t iProcessID, RString &sName );
+bool GetProcessFileName( uint32_t iProcessID, RString &sName );
 
 #endif
 

--- a/src/archutils/Win32/WindowIcon.cpp
+++ b/src/archutils/Win32/WindowIcon.cpp
@@ -47,8 +47,8 @@ HICON IconFromSurface( const RageSurface *pSrcImg )
 	pBitmap->biCompression = BI_RGB;
 	pBitmap->biSizeImage = pImg->h * pImg->pitch;
 
-	std::uint8_t *pImage = ((std::uint8_t *) pBitmap) + iSize;
-	std::uint8_t *pMask = pImage + pImg->h * pImg->pitch;
+	uint8_t *pImage = ((uint8_t *) pBitmap) + iSize;
+	uint8_t *pMask = pImage + pImg->h * pImg->pitch;
 
 	memcpy( pImage, pImg->pixels, pImg->h * pImg->pitch );
 
@@ -56,8 +56,8 @@ HICON IconFromSurface( const RageSurface *pSrcImg )
 	for( int y = 0; y < pImg->h; ++y )
 	{
 		int bit = 0x80;
-		std::uint32_t *pRow = (std::uint32_t *) (pImage + y*pImg->pitch);
-		std::uint8_t *pMaskRow = pMask + y*iMaskPitch;
+		uint32_t *pRow = (uint32_t *) (pImage + y*pImg->pitch);
+		uint8_t *pMaskRow = pMask + y*iMaskPitch;
 		for( int x = 0; x < pImg->w; ++x )
 		{
 			if( !(pRow[x] & pImg->fmt.Mask[3]) )

--- a/src/archutils/Win32/mapconv.cpp
+++ b/src/archutils/Win32/mapconv.cpp
@@ -16,7 +16,7 @@
 #define MAX_GROUPS		(64)
 
 struct RVAEnt {
-	std::uintptr_t rva;
+	uintptr_t rva;
 	char *line;
 };
 
@@ -25,10 +25,10 @@ std::vector<RVAEnt> rvabuf;
 char fnambuf[MAX_FNAMBUF];
 char *fnamptr = fnambuf;
 
-std::uintptr_t segbuf[MAX_SEGMENTS][2];
+uintptr_t segbuf[MAX_SEGMENTS][2];
 int segcnt = 0;
-std::uint16_t seggrp[MAX_SEGMENTS];
-std::uintptr_t grpstart[MAX_GROUPS];
+uint16_t seggrp[MAX_SEGMENTS];
+uintptr_t grpstart[MAX_GROUPS];
 
 char line[8192];
 long codeseg_flags = 0;
@@ -94,7 +94,7 @@ void RemoveAnonymousNamespaces( char *p )
 
 }
 
-void parsename(std::uintptr_t rva, char *func_name) {
+void parsename(uintptr_t rva, char *func_name) {
 	RemoveAnonymousNamespaces( func_name );
 
 	fnamptr = strtack(fnamptr, func_name, fnambuf+MAX_FNAMBUF);
@@ -140,9 +140,9 @@ int main(int argc, char **argv) {
 //		printf("Reading in segment list.\n");
 
 		while (readline()) {
-			std::uint16_t grp;
-			std::uint32_t start;
-			std::uint32_t len;
+			uint16_t grp;
+			uint32_t start;
+			uint32_t len;
 
 			if (sscanf(line, "%" SCNx16 ":%" SCNx32 " %" SCNx32, &grp, &start, &len) != 3)
 				break;
@@ -152,8 +152,8 @@ int main(int argc, char **argv) {
 
 				codeseg_flags |= 1 << grp;
 
-				segbuf[segcnt][0] = static_cast<std::uintptr_t>(start);
-				segbuf[segcnt][1] = static_cast<std::uintptr_t>(len);
+				segbuf[segcnt][0] = static_cast<uintptr_t>(start);
+				segbuf[segcnt][1] = static_cast<uintptr_t>(len);
 				seggrp[segcnt] = grp;
 				++segcnt;
 			}
@@ -169,9 +169,9 @@ int main(int argc, char **argv) {
 //		printf("Found public symbol list.\n");
 
 		while (readline()) {
-			std::uint16_t grp;
-			std::uint32_t start;
-			std::uintptr_t rva;
+			uint16_t grp;
+			uint32_t start;
+			uintptr_t rva;
 			char symname[2048];
 
 			if (sscanf(line, "%" SCNx16 ":%" SCNx32 " %s %" SCNxPTR, &grp, &start, symname, &rva) != 4)
@@ -199,9 +199,9 @@ int main(int argc, char **argv) {
 			readline();
 
 			while (readline()) {
-				std::uint16_t grp;
-				std::uint32_t start;
-				std::uintptr_t rva;
+				uint16_t grp;
+				uint32_t start;
+				uintptr_t rva;
 				char symname[4096];
 
 				if (sscanf(line, "%" SCNx16 ":%" SCNx32 " %s %" SCNxPTR, &grp, &start, symname, &rva) != 4)
@@ -225,15 +225,15 @@ int main(int argc, char **argv) {
 //		printf("Processing RVA entries...\n");
 
 		for (size_t i = 0; i < rvabuf.size(); ++i) {
-			std::uint16_t grp;
-			std::uint32_t start;
-			std::uintptr_t rva;
+			uint16_t grp;
+			uint32_t start;
+			uintptr_t rva;
 			char symname[4096];
 
 			if (sscanf(rvabuf[i].line, "%" SCNx16 ":%" SCNx32 " %s %" SCNxPTR, &grp, &start, symname, &rva) != 4)
 				break;
 
-			grpstart[grp] = rva - static_cast<std::uintptr_t>(start);
+			grpstart[grp] = rva - static_cast<uintptr_t>(start);
 
 			parsename(rva, symname);
 		}
@@ -253,8 +253,8 @@ int main(int argc, char **argv) {
 */
 		std::vector<RVAEnt>::iterator itRVA = rvabuf.begin(), itRVAEnd = rvabuf.end();
 		std::vector<char> rvaout;
-		std::uintptr_t firstrva = (*itRVA++).rva;
-		std::uintptr_t lastrva = firstrva;
+		uintptr_t firstrva = (*itRVA++).rva;
+		uintptr_t lastrva = firstrva;
 
 		for(; itRVA != itRVAEnd; ++itRVA) {
 			std::ptrdiff_t rvadiff = (*itRVA).rva - lastrva;
@@ -303,7 +303,7 @@ int main(int argc, char **argv) {
 		fwrite(&firstrva, sizeof firstrva, 1, fo);
 		fwrite(&rvaout[0], rvaout.size(), 1, fo);
 		fwrite(fnambuf, fnamptr - fnambuf, 1, fo);
-		fwrite(segbuf, segcnt * 2 * sizeof(std::uintptr_t), 1, fo);
+		fwrite(segbuf, segcnt * 2 * sizeof(uintptr_t), 1, fo);
 
 		// really all done
 

--- a/src/tests/test_threads.cpp
+++ b/src/tests/test_threads.cpp
@@ -11,7 +11,7 @@
 #include "archutils/Common/PthreadHelpers.h"
 
 /* These are volatile, so writes to them aren't optimized. */
-volatile std::uint64_t g_ThreadId = (std::uint64_t) -1;
+volatile uint64_t g_ThreadId = (uint64_t) -1;
 volatile int g_Counter = 0;
 volatile bool g_Finish = false;
 
@@ -31,7 +31,7 @@ int TestSuspendThread( void *p )
 	return 0;
 }
 
-void test_suspend_threadid( std::uint64_t ThreadId )
+void test_suspend_threadid( uint64_t ThreadId )
 {
 	/* Wait for g_Counter to increment a bit. */
 	usleep( 100000 );
@@ -74,13 +74,13 @@ void test_suspend_threadid( std::uint64_t ThreadId )
 void test_suspend_secondary_thread()
 {
 	ASSERT( !g_Finish );
-	ASSERT( g_ThreadId == (std::uint64_t) -1 );
+	ASSERT( g_ThreadId == (uint64_t) -1 );
 
 	RageThread testing;
 	testing.SetName( "TestSuspend" );
 	testing.Create( TestSuspendThread, NULL );
 
-	while( g_ThreadId == (std::uint64_t) -1 )
+	while( g_ThreadId == (uint64_t) -1 )
 		;
 
 	test_suspend_threadid( g_ThreadId );
@@ -88,7 +88,7 @@ void test_suspend_secondary_thread()
 	g_Finish = true;
 	testing.Wait();
 	g_Finish = false;
-	g_ThreadId = (std::uint64_t) -1;
+	g_ThreadId = (uint64_t) -1;
 }
 
 int TestSuspendMainThread( void *p )
@@ -97,7 +97,7 @@ int TestSuspendMainThread( void *p )
 
 	printf("Test thread started\n");
 
-	ASSERT( g_ThreadId != (std::uint64_t) -1 );
+	ASSERT( g_ThreadId != (uint64_t) -1 );
 	test_suspend_threadid( g_ThreadId );
 	g_Finish = true;
 
@@ -108,7 +108,7 @@ int TestSuspendMainThread( void *p )
 void test_suspend_main_thread()
 {
 	ASSERT( !g_Finish );
-	ASSERT( g_ThreadId == (std::uint64_t) -1 );
+	ASSERT( g_ThreadId == (uint64_t) -1 );
 
 	g_ThreadId = GetCurrentThreadId();
 
@@ -120,7 +120,7 @@ void test_suspend_main_thread()
 
 	testing.Wait();
 	g_Finish = false;
-	g_ThreadId = (std::uint64_t) -1;
+	g_ThreadId = (uint64_t) -1;
 }
 
 /* Run a second function, so we have two symbols to search for. */
@@ -178,7 +178,7 @@ void test_backtracing_secondary_thread()
 	testing.SetName( "TestBacktrace" );
 	testing.Create( TestBacktraceThread, NULL );
 
-	while( g_ThreadId == (std::uint64_t) -1 )
+	while( g_ThreadId == (uint64_t) -1 )
 		;
 
 	if( !test_thread_backtrace( g_ThreadId, (void *) TestBacktraceThread, (void *) TestBacktraceThreadLoop ) )
@@ -190,14 +190,14 @@ void test_backtracing_secondary_thread()
 	g_Finish = true;
 	testing.Wait();
 	g_Finish = false;
-	g_ThreadId = (std::uint64_t) -1;
+	g_ThreadId = (uint64_t) -1;
 }
 
 int TestBacktraceMainThread( void *p )
 {
 	printf("Test thread started\n");
 
-	while( g_ThreadId == (std::uint64_t) -1 )
+	while( g_ThreadId == (uint64_t) -1 )
 		;
 
 	if( !test_thread_backtrace( g_ThreadId, (void *) TestBacktraceThread, (void *) TestBacktraceThreadLoop ) )
@@ -214,7 +214,7 @@ int TestBacktraceMainThread( void *p )
 void test_backtracing_main_thread()
 {
 	ASSERT( !g_Finish );
-	ASSERT( g_ThreadId == (std::uint64_t) -1 );
+	ASSERT( g_ThreadId == (uint64_t) -1 );
 
 	RageThread testing;
 	testing.SetName( "TestBacktrace" );
@@ -224,7 +224,7 @@ void test_backtracing_main_thread()
 
 	testing.Wait();
 	g_Finish = false;
-	g_ThreadId = (std::uint64_t) -1;
+	g_ThreadId = (uint64_t) -1;
 }
 
 static RageMutex g_Mutex("test");
@@ -248,13 +248,13 @@ int TestLocksThread( void *p )
 void test_locks()
 {
 	ASSERT( !g_Finish );
-	ASSERT( g_ThreadId == (std::uint64_t) -1 );
+	ASSERT( g_ThreadId == (uint64_t) -1 );
 
 	RageThread testing;
 	testing.SetName( "TestLocks" );
 	testing.Create( TestLocksThread, NULL );
 
-	while( g_ThreadId == (std::uint64_t) -1 )
+	while( g_ThreadId == (uint64_t) -1 )
 		;
 
 	/* Stop the thread. */
@@ -277,7 +277,7 @@ void test_locks()
 	g_Finish = true;
 	testing.Wait();
 	g_Finish = false;
-	g_ThreadId = (std::uint64_t) -1;
+	g_ThreadId = (uint64_t) -1;
 }
 
 void go()


### PR DESCRIPTION
`std::uint*`  ->  `uint*`

Follows up on the PR to remove the std prefix from `size_t`.

Since it is not idiomatic in modern C++ (C++17 or later)  to use the std prefix on these types, let's drop it.