### PR TITLE
global.h / global.cpp: Create FailWithMessage/AssertWithMessage, prepare to move away from global.h

### DIFF
--- a/src/RageFileBasic.h
+++ b/src/RageFileBasic.h
@@ -100,12 +100,20 @@ public:
 	virtual int GetFileSize() const = 0;
 	virtual int GetFD() { return -1; }
 	virtual RString GetDisplayPath() const { return RString(); }
-	virtual RageFileBasic *Copy() const { FAIL_M( "Copying unimplemented" ); }
+	virtual RageFileBasic* Copy() const
+	{
+		FAIL_M("Copying unimplemented");
+		return nullptr; // Return a default value - the return value is unused
+	}
 
 protected:
-	virtual int SeekInternal( int /* iOffset */ ) { FAIL_M( "Seeking unimplemented" ); }
-	virtual int ReadInternal( void *pBuffer, size_t iBytes ) = 0;
-	virtual int WriteInternal( const void *pBuffer, size_t iBytes ) = 0;
+	virtual int SeekInternal(int /* iOffset */)
+	{
+		FAIL_M("Seeking unimplemented");
+		return -1; // Return a default value - the return value is unused
+	}
+	virtual int ReadInternal(void* pBuffer, size_t iBytes) = 0;
+	virtual int WriteInternal(const void* pBuffer, size_t iBytes) = 0;
 	virtual int FlushInternal() { return 0; }
 
 	void EnableReadBuffering();

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -25,6 +25,19 @@
     #include "archutils/Unix/CrashHandler.h"
 #endif
 
+void FailWithMessage(const char* message)
+{
+    CHECKPOINT_M(message);
+    sm_crash(message);
+}
+
+void AssertWithMessage(bool condition, const char* message)
+{
+    if (unlikely(!condition)) {
+        FailWithMessage(message);
+    }
+}
+
 void sm_crash( const char *reason )
 {
 #if ( defined(_WIN32) && defined(CRASH_HANDLER) ) || defined(MACOSX) || defined(_XDBG)

--- a/src/global.h
+++ b/src/global.h
@@ -66,13 +66,19 @@ void sm_crash( const char *reason = "Internal error" );
  *
  * This should probably be used instead of throwing an exception in most
  * cases we expect never to happen (but not in cases that we do expect,
- * such as DSound init failure.) */
-#define FAIL_M(MESSAGE) do { CHECKPOINT_M(MESSAGE); sm_crash(MESSAGE); } while(0)
-#define ASSERT_M(COND, MESSAGE) do { if(unlikely(!(COND))) { FAIL_M(MESSAGE); } } while(0)
+ * such as DSound init failure.)
+ * 
+ * There are macros here for legacy compatibility so we don't have
+ * to change or fix hundreds of calls to FAIL_M / ASSERT_M / ASSERT.
+ */
+void FailWithMessage(const char* message);
+#define FAIL_M(MESSAGE) FailWithMessage(MESSAGE)
 
+void AssertWithMessage(bool condition, const char* message);
+#define ASSERT_M(COND, MESSAGE) AssertWithMessage((COND), MESSAGE)
 
 #if !defined(CO_EXIST_WITH_MFC)
-#define ASSERT(COND) ASSERT_M((COND), "Assertion '" #COND "' failed")
+#define ASSERT(COND) AssertWithMessage((COND), "Assertion '" #COND "' failed")
 #endif
 
 /** @brief Use this to catch switching on invalid values */


### PR DESCRIPTION
This will help us move away from `global.h` and `global.cpp`, by beginning to migrate some of its most heavily depended on features to a new method that can easily be moved elsewhere, such as the RageUtil class or something else.

The `FAIL_M`, `ASSERT_M`, and `ASSERT` macros are used very widely and result in a bloated binary. I'm seeing a 43 KB reduction in the size of the executable on Windows just by moving the contents of FAIL_M and ASSERT_M into a `void` function. This follows similar principles to the migrating of inline functions from `StdString.h` into `StdString.cpp`.

For example, let's consider this `FAIL_M` call from `InputHandler_DirectInput.cpp`:

```
FAIL_M(ssprintf("Unsupported DI device type: %i", device.type));
```

at the time of compilation this expands to:

```
		do {
			(Checkpoints::SetCheckpoint("C:\\Users\\[Username]\\Documents\\GitHub\\itgmania\\src\\arch\\InputHandler\\InputHandler_DirectInput.cpp", 448, ssprintf("Unsupported DI device type: %i", device.type))); sm_crash(ssprintf("Unsupported DI device type: %i", device.type));
		} while (0);
```

Considering how frequently the macros ASSERT, ASSERT_M, and FAIL_M are called, this results in a lot of very messy code that is never seen. I'm seeing my average FPS increase a decent amount with this PR.

This PR:
![Screenshot 2024-10-05 215850](https://github.com/user-attachments/assets/83c06782-66c7-4db8-93b9-d2e1021de6f0)

10-4-2024 test build of `beta`:
![Screenshot 2024-10-05 193327](https://github.com/user-attachments/assets/33c9eae8-3dad-4355-a9d3-0a58d7910704)


A small tweak is needed in `RageFileBasic.h` following this change, but no other changes are needed.

### Note: this WILL expose lots of compiler warnings which were previously hidden by the macros:

![image](https://github.com/user-attachments/assets/046dc7d8-3a7f-4f56-9214-d6a4ecf8e453)