### PR TITLE
Round RageSoundMixBuffer buffer size to nearest KiB

### DIFF
--- a/src/RageSoundMixBuffer.cpp
+++ b/src/RageSoundMixBuffer.cpp
@@ -6,19 +6,17 @@
 #include <cstdint>
 #include <cstdlib>
 
+// Size of one kibibyte (1024 bytes)
+constexpr uint_fast64_t kOneKiB = 1024;
+
 RageSoundMixBuffer::RageSoundMixBuffer()
 {
-	m_pMixbuf = static_cast<float*>(std::malloc(BUF_SIZE * sizeof(float)));
-	if (m_pMixbuf == nullptr)
-	{
-		ASSERT_M(false, "Failed to allocate memory for the sound mixing buffer");
-	}
-	m_iBufSize = BUF_SIZE;
-	std::memset(m_pMixbuf, 0, m_iBufSize * sizeof(float));
+	static const size_t initBufSize = kOneKiB * sizeof(float);
+	m_pMixbuf = static_cast<float*>(std::malloc(initBufSize));
+	m_iBufSize = kOneKiB;
 	m_iBufUsed = 0;
 	m_iOffset = 0;
 }
-
 
 RageSoundMixBuffer::~RageSoundMixBuffer()
 {
@@ -32,23 +30,26 @@ void RageSoundMixBuffer::SetWriteOffset( int iOffset )
 	m_iOffset = iOffset;
 }
 
-void RageSoundMixBuffer::Extend(unsigned iSamples)
-{
-	const uint64_t realsize = static_cast<uint64_t>(iSamples) + static_cast<uint64_t>(m_iOffset);
-	if( m_iBufSize < realsize )
+/* Find the needed buffer size, and then find the next nearest multiple of 1024,
+ * so that the buffer size can be stored in memory. */
+void RageSoundMixBuffer::Extend(unsigned iSamples) noexcept
+{	
+	const uint_fast64_t requiredBufferSize = static_cast<uint_fast64_t>(iSamples) + static_cast<uint_fast64_t>(m_iOffset);
+	const uint_fast64_t allocatedBufferSize = ((requiredBufferSize + kOneKiB - 1) / kOneKiB) * kOneKiB;
+
+	if( m_iBufSize < allocatedBufferSize )
 	{
-		m_pMixbuf = static_cast<float*>(std::realloc(m_pMixbuf, sizeof(float) * realsize));
-		if (m_pMixbuf == nullptr)
-		{
-			ASSERT_M(false, "Failed to re-allocate memory for the sound mixing buffer.");
-		}
-		m_iBufSize = realsize;
+		m_pMixbuf = static_cast<float*>(std::realloc(m_pMixbuf, allocatedBufferSize * sizeof(float)));
+		m_iBufSize = allocatedBufferSize;
 	}
 
-	if( m_iBufUsed < realsize )
+	if( m_iBufUsed < requiredBufferSize )
 	{
-		std::memset(m_pMixbuf + m_iBufUsed, 0, (realsize - m_iBufUsed) * sizeof(float));
-		m_iBufUsed = realsize;
+		if (m_pMixbuf)
+		{
+			std::memset(m_pMixbuf + m_iBufUsed, 0, (requiredBufferSize - m_iBufUsed) * sizeof(float));
+		}
+		m_iBufUsed = requiredBufferSize;
 	}
 }
 

--- a/src/RageSoundMixBuffer.h
+++ b/src/RageSoundMixBuffer.h
@@ -11,14 +11,11 @@ public:
 	RageSoundMixBuffer();
 	~RageSoundMixBuffer();
 
-	// See how many samples we can stuff into 2MB.
-	static constexpr size_t BUF_SIZE = 2 * 1024 * 1024 / sizeof(float);
-
 	// Mix the given buffer of samples.
 	void write( const float *pBuf, unsigned iSize, int iSourceStride = 1, int iDestStride = 1 );
 
 	// Extend the buffer as if write() was called with a buffer of silence.
-	void Extend( unsigned iSamples );
+	void Extend( unsigned iSamples ) noexcept;
 
 	void read( int16_t *pBuf );
 	void read( float *pBuf );
@@ -29,8 +26,8 @@ public:
 
 private:
 	float *m_pMixbuf;
-	uint64_t m_iBufSize; // actual allocated samples
-	uint64_t m_iBufUsed; // used samples
+	uint_fast64_t m_iBufSize;
+	uint_fast64_t m_iBufUsed;
 	int m_iOffset;
 };
 


### PR DESCRIPTION
RageSoundMixBuffer improvements:
1. Ensure buffer size is a multiple of 1024 (this fixes a long standing memory leak issue)
2. Use uint_fast_64, because it's imperative that this executes as fast as possible
3. Remove memory pre-allocation from the constructor

Replaces #515, which couldn't be merged cleanly due to the commits removing `std::` prefixes on int/uint types, but the changes in the commit are identical.