### PR TITLE
Use the RageSoundMixBuffer from ITGm 0.7.1

### DIFF
--- a/src/RageSoundMixBuffer.cpp
+++ b/src/RageSoundMixBuffer.cpp
@@ -8,41 +8,31 @@
 
 RageSoundMixBuffer::RageSoundMixBuffer()
 {
-	m_pMixbuf = static_cast<float*>(std::malloc(BUF_SIZE * sizeof(float)));
-	if (m_pMixbuf == nullptr)
-	{
-		ASSERT_M(false, "Failed to allocate memory for the sound mixing buffer");
-	}
-	m_iBufSize = BUF_SIZE;
-	std::memset(m_pMixbuf, 0, m_iBufSize * sizeof(float));
+	m_iBufSize = 0;
 	m_iBufUsed = 0;
+	m_pMixbuf = nullptr;
 	m_iOffset = 0;
 }
-
 
 RageSoundMixBuffer::~RageSoundMixBuffer()
 {
 	std::free(m_pMixbuf);
 }
 
-/* write() will start mixing iOffset samples into the buffer.  Be careful; this is
- * measured in samples, not frames, so if the data is stereo, multiply by two. */
-void RageSoundMixBuffer::SetWriteOffset( int iOffset )
+void RageSoundMixBuffer::Extend(unsigned iSamples) noexcept
 {
-	m_iOffset = iOffset;
-}
+	const int_fast64_t realsize = static_cast<int_fast64_t>(iSamples) + static_cast<int_fast64_t>(m_iOffset);
+	
+	/* We round the size to the next nearest multiple of 1024 to prevent memory leaks,
+	 * or buffer increases by a very small number of bytes. We are manually managing
+	 * memory here, so we need to take care to not accidentally cause memory leaks. */
+	const int_fast64_t chunkSize = 1024;
+	int_fast64_t newSize = ((realsize + chunkSize - 1) / chunkSize) * chunkSize;
 
-void RageSoundMixBuffer::Extend(unsigned iSamples)
-{
-	const uint64_t realsize = static_cast<uint64_t>(iSamples) + static_cast<uint64_t>(m_iOffset);
-	if( m_iBufSize < realsize )
+	if( m_iBufSize < newSize )
 	{
-		m_pMixbuf = static_cast<float*>(std::realloc(m_pMixbuf, sizeof(float) * realsize));
-		if (m_pMixbuf == nullptr)
-		{
-			ASSERT_M(false, "Failed to re-allocate memory for the sound mixing buffer.");
-		}
-		m_iBufSize = realsize;
+		m_pMixbuf = static_cast<float*>(std::realloc(m_pMixbuf, sizeof(float) * newSize));
+		m_iBufSize = newSize;
 	}
 
 	if( m_iBufUsed < realsize )
@@ -52,7 +42,7 @@ void RageSoundMixBuffer::Extend(unsigned iSamples)
 	}
 }
 
-void RageSoundMixBuffer::write( const float *pBuf, unsigned iSize, int iSourceStride, int iDestStride )
+void RageSoundMixBuffer::write( const float *pBuf, unsigned iSize, int iSourceStride, int iDestStride ) noexcept
 {
 	if( iSize == 0 )
 		return;
@@ -72,24 +62,7 @@ void RageSoundMixBuffer::write( const float *pBuf, unsigned iSize, int iSourceSt
 	}
 }
 
-void RageSoundMixBuffer::read( int16_t *pBuf )
-{
-	for( unsigned iPos = 0; iPos < m_iBufUsed; ++iPos )
-	{
-		float iOut = m_pMixbuf[iPos];
-		iOut = std::clamp( iOut, -1.0f, +1.0f );
-		pBuf[iPos] = static_cast<int>((iOut * 32767) + 0.5);
-	}
-	m_iBufUsed = 0;
-}
-
-void RageSoundMixBuffer::read( float *pBuf )
-{
-	std::memcpy( pBuf, m_pMixbuf, m_iBufUsed * sizeof(float) );
-	m_iBufUsed = 0;
-}
-
-void RageSoundMixBuffer::read_deinterlace( float **pBufs, int channels )
+void RageSoundMixBuffer::read_deinterlace( float **pBufs, int channels ) noexcept
 {
 	for( unsigned i = 0; i < m_iBufUsed / channels; ++i )
 		for( int ch = 0; ch < channels; ++ch )

--- a/src/RageSoundMixBuffer.h
+++ b/src/RageSoundMixBuffer.h
@@ -11,28 +11,45 @@ public:
 	RageSoundMixBuffer();
 	~RageSoundMixBuffer();
 
-	// See how many samples we can stuff into 2MB.
-	static constexpr size_t BUF_SIZE = 2 * 1024 * 1024 / sizeof(float);
-
-	// Mix the given buffer of samples.
-	void write( const float *pBuf, unsigned iSize, int iSourceStride = 1, int iDestStride = 1 );
-
-	// Extend the buffer as if write() was called with a buffer of silence.
-	void Extend( unsigned iSamples );
-
-	void read( int16_t *pBuf );
-	void read( float *pBuf );
-	void read_deinterlace( float **pBufs, int channels );
+	void write( const float *pBuf, unsigned iSize, int iSourceStride = 1, int iDestStride = 1 ) noexcept;
+	void Extend( unsigned iSamples ) noexcept;
+	void read_deinterlace( float **pBufs, int channels ) noexcept;
 	float *read() { return m_pMixbuf; }
 	unsigned size() const { return m_iBufUsed; }
-	void SetWriteOffset( int iOffset );
+
+	void SetWriteOffset(int iOffset) noexcept;
+	void read(int16_t *pBuf) noexcept;
+	void read(float *pBuf) noexcept;
 
 private:
 	float *m_pMixbuf;
-	uint64_t m_iBufSize; // actual allocated samples
-	uint64_t m_iBufUsed; // used samples
-	int m_iOffset;
+	int_fast64_t m_iBufSize; // actual allocated samples
+	int_fast64_t m_iBufUsed; // used samples
+	int_fast32_t m_iOffset;
 };
+
+inline void RageSoundMixBuffer::SetWriteOffset(int iOffset) noexcept
+{
+	m_iOffset = iOffset;
+}
+
+inline void RageSoundMixBuffer::read(int16_t *pBuf) noexcept
+{
+	constexpr int16_t MAX_INT16 = 32767;
+	for (unsigned iPos = 0; iPos < m_iBufUsed; ++iPos)
+	{
+		float iOut = m_pMixbuf[iPos];
+		iOut = std::max(-1.0f, std::min(iOut, 1.0f));
+		pBuf[iPos] = static_cast<int16_t>((iOut * MAX_INT16) + 0.5f);
+	}
+	m_iBufUsed = 0;
+}
+
+inline void RageSoundMixBuffer::read(float *pBuf) noexcept
+{
+	std::memcpy(pBuf, m_pMixbuf, m_iBufUsed * sizeof(float));
+	m_iBufUsed = 0;
+}
 
 #endif
 


### PR DESCRIPTION
The one fix that has not been ported back to `beta` from 0.7.1/0.9.0-SHINE is the changed **RageSoundMixBuffer**.

This PR brings back the RageSoundMixBuffer from that build. That build can be considered very well tested at this point.

https://github.com/sukibaby/itgmania/blob/SUKI%60S-FA%2B/src/RageSoundMixBuffer.cpp
https://github.com/sukibaby/itgmania/blob/SUKI%60S-FA%2B/src/RageSoundMixBuffer.h