### PR TITLE
Minor optimization, & fixed separator detection in NotesLoader

### DIFF
--- a/src/NotesLoader.cpp
+++ b/src/NotesLoader.cpp
@@ -11,23 +11,24 @@
 #include <cstddef>
 #include <vector>
 
-
 void NotesLoader::GetMainAndSubTitlesFromFullTitle( const RString &sFullTitle, RString &sMainTitleOut, RString &sSubTitleOut )
 {
-	const RString sLeftSeps[]  = { "\t", " -", " ~", " (", " [" };
+	static const std::string_view sLeftSeps[] = { "\t", " -", " ~", " (", " [" };
+	size_t fullTitleSize = sFullTitle.size();
 
-	for( unsigned i=0; i<ARRAYLEN(sLeftSeps); i++ )
+	for (const auto& sep : sLeftSeps)
 	{
-		size_t iBeginIndex = sFullTitle.find( sLeftSeps[i] );
-		if( iBeginIndex == std::string::npos )
-			continue;
-		sMainTitleOut = sFullTitle.Left( (int) iBeginIndex );
-		sSubTitleOut = sFullTitle.substr( iBeginIndex+1, sFullTitle.size()-iBeginIndex+1 );
-		return;
+		size_t iBeginIndex = sFullTitle.find(sep);
+		if (iBeginIndex != std::string::npos)
+		{
+			sMainTitleOut = sFullTitle.Left(static_cast<int>(iBeginIndex));
+			sSubTitleOut = sFullTitle.substr(iBeginIndex + sep.size(), fullTitleSize - iBeginIndex - sep.size());
+			return;
+		}
 	}
 	sMainTitleOut = sFullTitle;
 	sSubTitleOut = "";
-};
+}
 
 bool NotesLoader::LoadFromDir( const RString &sPath, Song &out, std::set<RString> &BlacklistedImages, bool load_autosave )
 {


### PR DESCRIPTION
Minor cleanup on `GetMainAndSubTitlesFromFullTitle` to use a range-based for loop, and also is slightly improved so that separators of any length will work, whereas the original code only works when the separator is one character long. 

The original code is prone to errors due to the way it processes the separator. Usually this manifests as an unwanted space or missing symbol at the beginning of a subtitle.