### PR TITLE
Fix resolution handling code which needed fixing (very low priority)

### DIFF
--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -86,22 +86,21 @@ static Preference<bool> g_bAllowMultipleInstances( "AllowMultipleInstances", fal
 
 void StepMania::GetPreferredVideoModeParams( VideoModeParams &paramsOut )
 {
-	// resolution handling code that probably needs fixing
-	int iWidth = PREFSMAN->m_iDisplayWidth;
-	if( PREFSMAN->m_bWindowed )
+	// Always make the width an even number to avoid rounding errors.
+	int displayWidth = PREFSMAN->m_iDisplayWidth;
+	if (PREFSMAN->m_bWindowed)
 	{
-		//float fRatio = PREFSMAN->m_iDisplayHeight;
-		//iWidth = PREFSMAN->m_iDisplayHeight * fRatio;
-		iWidth = std::ceil(PREFSMAN->m_iDisplayHeight * PREFSMAN->m_fDisplayAspectRatio);
-		// ceil causes the width to come out odd when it shouldn't.
-		// 576 * 1.7778 = 1024.0128, which is rounded to 1025. -Kyz
-		iWidth-= iWidth % 2;
+		displayWidth = static_cast<int>(std::round(PREFSMAN->m_iDisplayHeight * PREFSMAN->m_fDisplayAspectRatio));
+		if (displayWidth % 2 != 0)
+		{
+			displayWidth += 1;
+		}
 	}
 
 	paramsOut = VideoModeParams(
 		PREFSMAN->m_bWindowed || PREFSMAN->m_bFullscreenIsBorderlessWindow,
 		PREFSMAN->m_sDisplayId,
-		iWidth,
+		displayWidth,
 		PREFSMAN->m_iDisplayHeight,
 		PREFSMAN->m_iDisplayColorDepth,
 		PREFSMAN->m_iRefreshRate,


### PR DESCRIPTION
Sometimes, you might get a weird set of display resolutions in game - this is due to an incorrect implementation of `std::ceil` (which seems to have been known to be bad, even). We now use `std::round` instead of `std::ceil` to ensure the width is correctly rounded to the nearest integer, whereas `std::ceil` will always round up. We then make sure we got the number we calculated is even. If it isn't, we will increase its value by a factor of one.

In my testing on a few different machines and monitors (a few 16:9, one 16:10, one 5:4), we always get the correct resolutions supported by that monitor.