### PR TITLE
Give Actors optional immunity to tab or tilde scaling and apply it to banners

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -489,6 +489,8 @@
 			<Function name='ztest'/>
 			<Function name='ztestmode'/>
 			<Function name='zwrite'/>
+			<Function name='SetRateScalingEnabled'/>
+			<Function name='GetRateScalingEnabled'/>
 		</Class>
 		<Class base='Actor' name='ActorFrame'>
 			<Function name='AddChildFromPath'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -1641,6 +1641,12 @@ end
 	<Function name='zwrite' return='void' arguments='bool bWrite'>
 		Sets z writing to <code>true</code> or <code>false</code> based on <code>bWrite</code>.
 	</Function>
+	<Function name='SetRateScalingEnabled' return='void' arguments='bool b' since='ITGmania 1.0.0'>
+		Sets whether or not the actor should be affected by the system's rate scaling (i.e. Tab/Tiled).
+	</Function>
+	<Function name='GetRateScalingEnabled' return='bool' arguments='' since='ITGmania 1.0.0'>
+		Returns whether or not the actor is affected by the system's rate scaling.
+	</Function>
 	<!-- addons from scripts that come with sm-ssc (non-compat) -->
 	<Function name='bezier' theme='_fallback' return='' arguments='float time, table curve'>
 		[02 Actor.lua] Plays the commands that follow using a bezier curve to determine the rate.  The curve must have 4 or 8 elements.  This is a convenience wrapper around calling Actor:tween with TweenType_Bezier.

--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -13,6 +13,7 @@
 #include "LightsManager.h" // for NUM_CabinetLight
 #include "ActorUtil.h"
 #include "Preference.h"
+#include "GameLoop.h"
 
 #include <cmath>
 #include <cstddef>
@@ -166,9 +167,10 @@ Actor::Actor()
 	m_size = RageVector2( 1, 1 );
 	InitState();
 	m_pParent = nullptr;
-	m_FakeParent= nullptr;
+	m_FakeParent = nullptr;
 	m_bFirstUpdate = true;
-	m_tween_uses_effect_delta= false;
+	m_tween_uses_effect_delta = false;
+	tab_tilde_scaling_enabled_ = true;
 }
 
 Actor::~Actor()
@@ -872,6 +874,14 @@ bool Actor::IsFirstUpdate() const
 void Actor::Update( float fDeltaTime )
 {
 //	LOG->Trace( "Actor::Update( %f )", fDeltaTime );
+
+	float rate = GameLoop::GetUpdateRate();
+	if (rate != 1 && !tab_tilde_scaling_enabled_) {
+		if (rate != 0) {
+			fDeltaTime *= (1 / rate);
+		}
+	}
+
 	ASSERT_M( fDeltaTime >= 0, ssprintf("DeltaTime: %f",fDeltaTime) );
 
 	if( m_fHibernateSecondsLeft > 0 )

--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -170,7 +170,7 @@ Actor::Actor()
 	m_FakeParent = nullptr;
 	m_bFirstUpdate = true;
 	m_tween_uses_effect_delta = false;
-	tab_tilde_scaling_enabled_ = true;
+	rate_scaling_enabled_ = true;
 }
 
 Actor::~Actor()
@@ -876,7 +876,8 @@ void Actor::Update( float fDeltaTime )
 //	LOG->Trace( "Actor::Update( %f )", fDeltaTime );
 
 	float rate = GameLoop::GetUpdateRate();
-	if (rate != 1 && !tab_tilde_scaling_enabled_) {
+	if (rate != 1 && !rate_scaling_enabled_) {
+		// Prevent divide by 0 when tab + tilde are both pressed.
 		if (rate != 0) {
 			fDeltaTime *= (1 / rate);
 		}
@@ -2010,10 +2011,13 @@ public:
 		COMMON_RETURN_SELF;
 	}
 
+	static int SetRateScalingEnabled( T* p, lua_State *L )	{ p->SetRateScalingEnabled(BArg(1)); COMMON_RETURN_SELF; }
+	static int GetRateScalingEnabled( T* p, lua_State *L )		{ lua_pushboolean( L, p->GetRateScalingEnabled() ); return 1; }
+
 	LunaActor()
 	{
-  		ADD_METHOD( name );
-  		ADD_METHOD( sleep );
+		ADD_METHOD( name );
+		ADD_METHOD( sleep );
 		ADD_METHOD( linear );
 		ADD_METHOD( accelerate );
 		ADD_METHOD( decelerate );
@@ -2181,6 +2185,9 @@ public:
 		ADD_METHOD( RemoveWrapperState );
 		ADD_METHOD( GetNumWrapperStates );
 		ADD_METHOD( GetWrapperState );
+
+		ADD_METHOD( SetRateScalingEnabled );
+		ADD_METHOD( GetRateScalingEnabled );
 
 		ADD_METHOD( Draw );
 	}

--- a/src/Actor.h
+++ b/src/Actor.h
@@ -714,6 +714,9 @@ protected:
 	 * follow the effect clock.  Actor::Update must be called first. */
 	float GetEffectDeltaTime() const		{ return m_fEffectDelta; }
 
+	// Use this to disable scaling an actor's rate with tab or tilde.
+	void DisableTabTildeScaling() { tab_tilde_scaling_enabled_ = false; }
+
 	// todo: account for SSC_FUTURES by having these be vectors too -aj
 	RageColor	m_effectColor1;
 	RageColor	m_effectColor2;
@@ -753,6 +756,10 @@ protected:
 	static std::vector<float> g_vfCurrentBGMBeatPlayerNoOffset;
 
 private:
+	// Some actors shouldn't be scaled with tab or tilde. This bool does not
+	// guard against holding both at the same time (setting the rate to zero).
+	bool tab_tilde_scaling_enabled_;
+
 	// commands
 	std::map<RString, apActorCommands> m_mapNameToCommands;
 };

--- a/src/Actor.h
+++ b/src/Actor.h
@@ -622,6 +622,10 @@ public:
 	virtual void SetUpdateRate( float ) {}
 	virtual float GetUpdateRate() { return 1.0f; }
 
+	// Use this to enable/disable scaling an actor's rate with tab or tilde.
+	void SetRateScalingEnabled(bool b) { rate_scaling_enabled_ = b; }
+	bool GetRateScalingEnabled() { return rate_scaling_enabled_; }
+
 	HiddenPtr<LuaClass> m_pLuaInstance;
 
 protected:
@@ -714,9 +718,6 @@ protected:
 	 * follow the effect clock.  Actor::Update must be called first. */
 	float GetEffectDeltaTime() const		{ return m_fEffectDelta; }
 
-	// Use this to disable scaling an actor's rate with tab or tilde.
-	void DisableTabTildeScaling() { tab_tilde_scaling_enabled_ = false; }
-
 	// todo: account for SSC_FUTURES by having these be vectors too -aj
 	RageColor	m_effectColor1;
 	RageColor	m_effectColor2;
@@ -756,9 +757,10 @@ protected:
 	static std::vector<float> g_vfCurrentBGMBeatPlayerNoOffset;
 
 private:
-	// Some actors shouldn't be scaled with tab or tilde. This bool does not
-	// guard against holding both at the same time (setting the rate to zero).
-	bool tab_tilde_scaling_enabled_;
+	// Some actors shouldn't be scaled by the engine i.e. using with tab for
+	// speeding up or tilde for slowing down.
+	// In the case both are pressed (setting rate to 0), this bool does nothing.
+	bool rate_scaling_enabled_;
 
 	// commands
 	std::map<RString, apActorCommands> m_mapNameToCommands;

--- a/src/Banner.cpp
+++ b/src/Banner.cpp
@@ -25,6 +25,7 @@ Banner::Banner()
 {
 	m_bScrolling = false;
 	m_fPercentScrolling = 0;
+	Actor::DisableTabTildeScaling();
 }
 
 // Ugly: if sIsBanner is false, we're actually loading something other than a banner.

--- a/src/Banner.cpp
+++ b/src/Banner.cpp
@@ -25,7 +25,10 @@ Banner::Banner()
 {
 	m_bScrolling = false;
 	m_fPercentScrolling = 0;
-	Actor::DisableTabTildeScaling();
+
+	// By default, don't let banners scale their rate with tab/tilde.
+	// This helps with animated/video banners.
+	Actor::SetRateScalingEnabled(false);
 }
 
 // Ugly: if sIsBanner is false, we're actually loading something other than a banner.

--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -40,6 +40,10 @@ void GameLoop::SetUpdateRate( float fUpdateRate )
 	g_fUpdateRate = fUpdateRate;
 }
 
+float GameLoop::GetUpdateRate() {
+	return g_fUpdateRate;
+}
+
 static void CheckGameLoopTimerSkips( float fDeltaTime )
 {
 	static int iLastFPS = 0;

--- a/src/GameLoop.h
+++ b/src/GameLoop.h
@@ -5,7 +5,8 @@ namespace GameLoop
 {
 	void RunGameLoop();
 	void UpdateAllButDraw( bool bRunningFromVBLANK);
-	void SetUpdateRate( float fUpdateRate );
+	void SetUpdateRate(float fUpdateRate);
+	float GetUpdateRate();
 	void ChangeTheme(const RString &sNewTheme);
 	void ChangeGame(const RString& new_game, const RString& new_theme= "");
 	void StartConcurrentRendering();


### PR DESCRIPTION
~~Add a new `tab_tilde_scaling_enabled_` member variable to the `Sprite` class, which controls usage of a personal timer to determine `fDelta`. Enable it by default for banners, which can contain videos and shouldn't be subject to tab or tilde speed changes. At large scale, this code is not recommended since each `Actor` would calculate its `fDelta` independently.~~

~~A more permanent solution may involve passing in the rate in addition to an unmodified `fDelta` to all `Update` calls. Another option is getting the rate (which is a global) and undoing the operation--which won't work if tab and tilde are held together, as that sets the rate to 0. Or we could do a combination of both, never modifying `fDelta` and having each `Actor` optionally apply the global rate.~~

See my comment further down for the implementation details.