### PR TITLE
Create a "GameplayHelpers" file and move the margin gathering code from ScreenGameplay

### DIFF
--- a/src/CMakeData-screen.cmake
+++ b/src/CMakeData-screen.cmake
@@ -3,13 +3,15 @@ list(APPEND SMDATA_SCREEN_GAMEPLAY_SRC
             "ScreenGameplayLesson.cpp"
             "ScreenGameplayNormal.cpp"
             "ScreenGameplayShared.cpp"
-            "ScreenGameplaySyncMachine.cpp")
+            "ScreenGameplaySyncMachine.cpp"
+            "GameplayHelpers.cpp")
 
 list(APPEND SMDATA_SCREEN_GAMEPLAY_HPP
             "ScreenGameplay.h"
             "ScreenGameplayNormal.h"
             "ScreenGameplayShared.h"
-            "ScreenGameplaySyncMachine.h")
+            "ScreenGameplaySyncMachine.h"
+            "GameplayHelpers.h")
 
 source_group("Screens\\\\Gameplay"
              FILES

--- a/src/GameplayHelpers.cpp
+++ b/src/GameplayHelpers.cpp
@@ -1,0 +1,57 @@
+#include <vector>
+
+#include "global.h"
+
+#include "EnumHelper.h"
+#include "GameplayHelpers.h"
+#include "GameState.h"
+#include "LuaManager.h"
+#include "ThemeManager.h"
+#include "Style.h"
+
+std::vector<NotefieldMargins> GetNotefieldMargins() {
+	LuaReference margin_func;
+	std::vector<NotefieldMargins> margins(2);
+
+	THEME->GetMetric("ScreenGameplay", "MarginFunction", margin_func);
+	if (margin_func.GetLuaType() != LUA_TFUNCTION)
+	{
+		LuaHelpers::ReportScriptErrorFmt("MarginFunction metric for %s must be a function.", "ScreenGameplay");
+		return margins;
+	}
+
+	// Setup the lua.
+	Lua* lua_ptr = LUA->Get();
+	margin_func.PushSelf(lua_ptr);
+	lua_createtable(lua_ptr, 0, 0);
+	int next_player_slot = 1;
+	FOREACH_EnabledPlayer(pn)
+	{
+		Enum::Push(lua_ptr, pn);
+		lua_rawseti(lua_ptr, -2, next_player_slot);
+		++next_player_slot;
+	}
+
+	Enum::Push(lua_ptr, GAMESTATE->GetCurrentStyle(PLAYER_INVALID)->m_StyleType);
+	RString err = "Error running MarginFunction: ";
+
+	// Run the lua code.
+	if (LuaHelpers::RunScriptOnStack(lua_ptr, /*Error=*/err, /*Args=*/2, /*ReturnValues*/3, /*ReportOnError*/true))
+	{
+		std::string margin_error_msg = "Margin value must be a number.";
+
+		// Pull the values off the lua stack. Note that the lua function is
+		// returning the margins of P1 + P2 combined. Therefore, we need to use
+		// the center to tell where P1's margin ends and P2's begins, if
+		// applicable.
+		margins[PLAYER_1].left = SafeFArg(lua_ptr, -3, margin_error_msg, 40);
+		float center = SafeFArg(lua_ptr, -2, margin_error_msg, 80);
+		margins[PLAYER_1].right = center / 2.0f;
+
+		margins[PLAYER_2].left = center / 2.0f;
+		margins[PLAYER_2].right = SafeFArg(lua_ptr, -1, margin_error_msg, 40);
+	}
+	lua_settop(lua_ptr, 0);
+	LUA->Release(lua_ptr);
+	return margins;
+}

--- a/src/GameplayHelpers.h
+++ b/src/GameplayHelpers.h
@@ -1,0 +1,16 @@
+#include <vector>
+
+
+// A very simple pair floats that represent the pixels of the left and right
+// sides of a player's notefield margins. 40 is an arbitrary default value for
+// the margins.
+struct NotefieldMargins {
+	float left = 40;
+	float right = 40;
+};
+
+// Use the lua MarginFunction (defined in metrics.ini) to calculate where the notefields
+// should be. This should (but doesn't have to) the engine's CenterP1 preference.
+// 
+// By default points to GameplayMargins in Themes/_fallback/Scripts/03 Gameplay.lua
+std::vector<NotefieldMargins> GetNotefieldMargins();


### PR DESCRIPTION
This can be thought of as a first step in simplifying the centering (or overall notefield positioning) code.

The code as written is fairly ambiguous about how it decides where notefields are placed during gameplay, and does not match the implementation in EditMode either. This is a small change intended to abstract the margin gathering code outside the main path of execution, with added comments about where the margins come from.

The intent is to eventually reuse this code for EditMode (and PracticeMode), move more common functions into `GameplayHelpers`, and make the notefield positioning code easier to understand. Spurred by the findings in https://github.com/itgmania/itgmania/pull/501#issuecomment-2381418131. 

As written, this PR is a functional no-op, and I've tested with P1, P2, centered and not, and P1 + P2 together.