### PR TITLE
𝗥𝗮𝗴𝗲𝗦𝗼𝘂𝗻𝗱𝗠𝗶𝘅𝗕𝘂𝗳𝗳𝗲𝗿: Storing buffer size in Preferences.ini, & new method to reinitialize the buffer on demand.

### DIFF
--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -17,6 +17,13 @@
 
 PrefsManager*	PREFSMAN = nullptr;	// global and accessible from anywhere in our program
 
+/* DEFAULT_AUDIO_BUFFER_SIZE is measured in bytes. It is used
+ * by RageSoundMixBuffer, which handles real-time audio
+ * mixing). The default buffer size of 70560 equals 0.4 seconds
+ * of 44.1KHz audio. A smaller size means lower latency, but
+ * requires more processing power (as a wide generalization). */
+constexpr unsigned DEFAULT_AUDIO_BUFFER_SIZE = 70560;
+
 static const char *MusicWheelUsesSectionsNames[] = {
 	"Never",
 	"Always",
@@ -305,6 +312,7 @@ PrefsManager::PrefsManager() :
 	m_custom_songs_load_timeout("CustomSongsLoadTimeout", 5.f),
 	m_custom_songs_max_seconds("CustomSongsMaxSeconds", 120.f),
 	m_custom_songs_max_megabytes("CustomSongsMaxMegabytes", 5.f),
+	m_AudioBufferSize("AudioBufferSize", DEFAULT_AUDIO_BUFFER_SIZE),
 
 	/* Debug: */
 	m_bLogToDisk			( "LogToDisk",		true ),
@@ -373,6 +381,7 @@ void PrefsManager::StoreGamePrefs()
 	gp.m_sAnnouncer = m_sAnnouncer;
 	gp.m_sTheme = m_sTheme;
 	gp.m_sDefaultModifiers = m_sDefaultModifiers;
+	gp.m_AudioBufferSize = m_AudioBufferSize.Get();
 }
 
 void PrefsManager::RestoreGamePrefs()
@@ -383,7 +392,9 @@ void PrefsManager::RestoreGamePrefs()
 	GamePrefs gp;
 	std::map<RString, GamePrefs>::const_iterator iter = m_mapGameNameToGamePrefs.find( m_sCurrentGame );
 	if( iter != m_mapGameNameToGamePrefs.end() )
+	{
 		gp = iter->second;
+	}
 
 	m_sAnnouncer		.Set( gp.m_sAnnouncer );
 	m_sTheme		.Set( gp.m_sTheme );
@@ -393,7 +404,10 @@ void PrefsManager::RestoreGamePrefs()
 	ReadPrefsFromFile( SpecialFiles::STATIC_INI_PATH, GetPreferencesSection(), true );
 }
 
-PrefsManager::GamePrefs::GamePrefs() : m_sAnnouncer(""), m_sTheme(SpecialFiles::BASE_THEME_NAME), m_sDefaultModifiers("") {}
+PrefsManager::GamePrefs::GamePrefs()
+	: m_sAnnouncer(""), m_sTheme(SpecialFiles::BASE_THEME_NAME), m_sDefaultModifiers(""), m_AudioBufferSize(DEFAULT_AUDIO_BUFFER_SIZE)
+{
+}
 
 void PrefsManager::ReadPrefsFromDisk()
 {
@@ -407,8 +421,11 @@ void PrefsManager::ReadPrefsFromDisk()
 	TranslateDeprecatedFlags();
 
 	if( !m_sCurrentGame.Get().empty() )
+	{
 		RestoreGamePrefs();
+	}
 }
+
 
 void PrefsManager::ResetToFactoryDefaults()
 {
@@ -465,7 +482,10 @@ void PrefsManager::ReadGamePrefsFromIni( const RString &sIni )
 {
 	IniFile ini;
 	if( !ini.ReadFile(sIni) )
+	{
+		LOG->Warn("Failed to read game preferences from file: %s", sIni.c_str());
 		return;
+	}
 
 	FOREACH_CONST_Child( &ini, section )
 	{
@@ -476,10 +496,22 @@ void PrefsManager::ReadGamePrefsFromIni( const RString &sIni )
 		RString sGame = section_name.Right( section_name.length() - GAME_SECTION_PREFIX.length() );
 		GamePrefs &gp = m_mapGameNameToGamePrefs[ sGame ];
 
-		// todo: read more prefs here? -aj
-		ini.GetValue(section_name, "Announcer",		gp.m_sAnnouncer);
-		ini.GetValue(section_name, "Theme",		gp.m_sTheme);
-		ini.GetValue(section_name, "DefaultModifiers",	gp.m_sDefaultModifiers);
+		ini.GetValue(section_name, "Announcer", gp.m_sAnnouncer);
+		ini.GetValue(section_name, "Theme", gp.m_sTheme);
+		ini.GetValue(section_name, "DefaultModifiers", gp.m_sDefaultModifiers);
+
+		unsigned bufferSize = gp.m_AudioBufferSize;
+		if (ini.GetValue(section_name, "AudioBufferSize", bufferSize))
+		{
+			if (bufferSize == 0)
+			{
+				gp.m_AudioBufferSize = DEFAULT_AUDIO_BUFFER_SIZE;
+			}
+		}
+		else
+		{
+			gp.m_AudioBufferSize = DEFAULT_AUDIO_BUFFER_SIZE;
+		}
 	}
 }
 
@@ -535,9 +567,10 @@ void PrefsManager::SavePrefsToIni( IniFile &ini )
 		RString sSection = "Game-" + RString( iter.first );
 
 		// todo: write more values here? -aj
-		ini.SetValue( sSection, "Announcer",		iter.second.m_sAnnouncer );
-		ini.SetValue( sSection, "Theme",		iter.second.m_sTheme );
-		ini.SetValue( sSection, "DefaultModifiers",	iter.second.m_sDefaultModifiers );
+		ini.SetValue(sSection, "Announcer", iter.second.m_sAnnouncer);
+		ini.SetValue(sSection, "Theme", iter.second.m_sTheme);
+		ini.SetValue(sSection, "DefaultModifiers", iter.second.m_sDefaultModifiers);
+		ini.SetValue(sSection, "AudioBufferSize", iter.second.m_AudioBufferSize);
 	}
 }
 

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -154,6 +154,7 @@ protected:
 		RString	m_sAnnouncer;
 		RString m_sTheme;
 		RString	m_sDefaultModifiers;
+		unsigned int m_AudioBufferSize;
 	};
 	std::map<RString, GamePrefs> m_mapGameNameToGamePrefs;
 
@@ -332,6 +333,9 @@ public:
 	Preference<float> m_custom_songs_load_timeout;
 	Preference<float> m_custom_songs_max_seconds;
 	Preference<float> m_custom_songs_max_megabytes;
+
+	// RageSoundMixBuffer buffer size
+	Preference<unsigned int> m_AudioBufferSize;
 
 	// Debug:
 	Preference<bool>	m_bLogToDisk;

--- a/src/RageSoundMixBuffer.cpp
+++ b/src/RageSoundMixBuffer.cpp
@@ -1,49 +1,42 @@
 #include "global.h"
 #include "RageSoundMixBuffer.h"
 #include "RageUtil.h"
+#include "PrefsManager.h"
+#include "RageLog.h"
 
-#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 
-RageSoundMixBuffer::RageSoundMixBuffer()
-{
-	m_pMixbuf = static_cast<float*>(std::malloc(BUF_SIZE * sizeof(float)));
-	if (m_pMixbuf == nullptr)
-	{
-		ASSERT_M(false, "Failed to allocate memory for the sound mixing buffer");
+static size_t size_in_bytes_ = 70560;
+
+static void GetBufferSizeFromPreference() {
+	size_in_bytes_ = static_cast<size_t>(PREFSMAN->m_AudioBufferSize.Get());
+	if (size_in_bytes_ < 4409) {
+		LOG->Warn("The value of AudioBufferSize is too small (%zu) - changing the buffer size to 4410.", size_in_bytes_);
+		size_in_bytes_ = 4410;
 	}
-	m_iBufSize = BUF_SIZE;
-	std::memset(m_pMixbuf, 0, m_iBufSize * sizeof(float));
-	m_iBufUsed = 0;
-	m_iOffset = 0;
 }
 
+RageSoundMixBuffer::RageSoundMixBuffer() {
+	GetBufferSizeFromPreference();
+	LOG->Info("Audio mix buffer size: %.1f seconds @ 44.1kHz (%zu bytes)", static_cast<float>(size_in_bytes_) / (44100.0f * sizeof(float)), size_in_bytes_);
+	m_iBufSize = size_in_bytes_;
+	m_iBufUsed = 0;
+	m_iOffset = 0;
+	m_pMixbuf = static_cast<float*>(std::malloc(size_in_bytes_));
+	if (!(m_pMixbuf)) {
+		FAIL_M("Failed to allocate memory for the audio mix buffer");
+	}
+	std::memset(m_pMixbuf, 0, size_in_bytes_);
+}
 
-RageSoundMixBuffer::~RageSoundMixBuffer()
-{
+RageSoundMixBuffer::~RageSoundMixBuffer() {
 	std::free(m_pMixbuf);
 }
 
-/* write() will start mixing iOffset samples into the buffer.  Be careful; this is
- * measured in samples, not frames, so if the data is stereo, multiply by two. */
-void RageSoundMixBuffer::SetWriteOffset( int iOffset )
-{
-	m_iOffset = iOffset;
-}
-
-void RageSoundMixBuffer::Extend(unsigned iSamples)
-{
-	const uint64_t realsize = static_cast<uint64_t>(iSamples) + static_cast<uint64_t>(m_iOffset);
-	if( m_iBufSize < realsize )
-	{
-		m_pMixbuf = static_cast<float*>(std::realloc(m_pMixbuf, sizeof(float) * realsize));
-		if (m_pMixbuf == nullptr)
-		{
-			ASSERT_M(false, "Failed to re-allocate memory for the sound mixing buffer.");
-		}
-		m_iBufSize = realsize;
-	}
+// Initialize any unused part of the buffer with zeroes, if it exists.
+void RageSoundMixBuffer::Extend(unsigned iSamples) noexcept {
+	const int_fast64_t realsize = iSamples + m_iOffset;
 
 	if( m_iBufUsed < realsize )
 	{
@@ -52,10 +45,10 @@ void RageSoundMixBuffer::Extend(unsigned iSamples)
 	}
 }
 
-void RageSoundMixBuffer::write( const float *pBuf, unsigned iSize, int iSourceStride, int iDestStride )
-{
-	if( iSize == 0 )
+void RageSoundMixBuffer::write( const float *pBuf, unsigned iSize, int iSourceStride, int iDestStride ) noexcept {
+	if( iSize == 0 ) {
 		return;
+	}
 
 	// iSize = 3, iDestStride = 2 uses 4 frames.  Don't allocate the stride of the last sample.
 	Extend( iSize * iDestStride - (iDestStride-1) );
@@ -63,8 +56,7 @@ void RageSoundMixBuffer::write( const float *pBuf, unsigned iSize, int iSourceSt
 	// Scale volume and add.
 	float *pDestBuf = m_pMixbuf+m_iOffset;
 
-	while( iSize )
-	{
+	while( iSize ) {
 		*pDestBuf += *pBuf;
 		pBuf += iSourceStride;
 		pDestBuf += iDestStride;
@@ -72,30 +64,40 @@ void RageSoundMixBuffer::write( const float *pBuf, unsigned iSize, int iSourceSt
 	}
 }
 
-void RageSoundMixBuffer::read( int16_t *pBuf )
-{
-	for( unsigned iPos = 0; iPos < m_iBufUsed; ++iPos )
-	{
-		float iOut = m_pMixbuf[iPos];
-		iOut = std::clamp( iOut, -1.0f, +1.0f );
-		pBuf[iPos] = static_cast<int>((iOut * 32767) + 0.5);
+/*
+ * Example usage:
+ * rsmb.Reinitialize(); // No argument, calls GetBufferSizeFromPreference()
+ * rsmb.Reinitialize(17640); // With arugment, updates size_in_bytes_ to be 17640
+ */
+void RageSoundMixBuffer::Reinitialize(unsigned new_size = 0) {
+	// Check if we were given a buffer size
+	size_in_bytes_ = (new_size > 0) ? new_size : size_in_bytes_;
+	if (new_size == 0) { GetBufferSizeFromPreference(); }
+	// Set up the temporary buffer, switch, & free old memory
+	float* temp_buf = static_cast<float*>(std::malloc(size_in_bytes_));
+	if (!(temp_buf)) {
+		FAIL_M("Failed to allocate memory for the audio mix buffer");
+	}
+	std::memset(temp_buf, 0, size_in_bytes_);
+	float* old_buf = m_pMixbuf;
+	m_pMixbuf = temp_buf;
+	m_iBufSize = size_in_bytes_;
+	m_iBufUsed = 0;
+	m_iOffset = 0;
+	std::free(old_buf);
+	LOG->Info("Audio mix buffer size: %.1f seconds @ 44.1kHz (%zu bytes)", static_cast<float>(size_in_bytes_) / (44100.0f * sizeof(float)), size_in_bytes_);
+}
+
+void RageSoundMixBuffer::read_deinterlace( float **pBufs, int channels ) noexcept {
+	for( unsigned i = 0; i < m_iBufUsed / channels; ++i ) {
+		for( int ch = 0; ch < channels; ++ch ) {
+			pBufs[ch][i] = m_pMixbuf[channels * i + ch];
+		}
 	}
 	m_iBufUsed = 0;
 }
 
-void RageSoundMixBuffer::read( float *pBuf )
-{
-	std::memcpy( pBuf, m_pMixbuf, m_iBufUsed * sizeof(float) );
-	m_iBufUsed = 0;
-}
-
-void RageSoundMixBuffer::read_deinterlace( float **pBufs, int channels )
-{
-	for( unsigned i = 0; i < m_iBufUsed / channels; ++i )
-		for( int ch = 0; ch < channels; ++ch )
-			pBufs[ch][i] = m_pMixbuf[channels * i + ch];
-	m_iBufUsed = 0;
-}
+/* New code by sukibaby, 2024 - rewritten for fixed buffer size. */
 
 /*
  * Copyright (c) 2002-2004 Glenn Maynard

--- a/src/RageSoundMixBuffer.h
+++ b/src/RageSoundMixBuffer.h
@@ -11,28 +11,48 @@ public:
 	RageSoundMixBuffer();
 	~RageSoundMixBuffer();
 
-	// See how many samples we can stuff into 2MB.
-	static constexpr size_t BUF_SIZE = 2 * 1024 * 1024 / sizeof(float);
-
-	// Mix the given buffer of samples.
-	void write( const float *pBuf, unsigned iSize, int iSourceStride = 1, int iDestStride = 1 );
-
-	// Extend the buffer as if write() was called with a buffer of silence.
-	void Extend( unsigned iSamples );
-
-	void read( int16_t *pBuf );
-	void read( float *pBuf );
-	void read_deinterlace( float **pBufs, int channels );
+	void write( const float *pBuf, unsigned iSize, int iSourceStride = 1, int iDestStride = 1 ) noexcept;
+	void Extend( unsigned iSamples ) noexcept;
+	void read_deinterlace( float **pBufs, int channels ) noexcept;
 	float *read() { return m_pMixbuf; }
 	unsigned size() const { return m_iBufUsed; }
-	void SetWriteOffset( int iOffset );
+
+	void SetWriteOffset(int iOffset) noexcept;
+	void read(int16_t *pBuf) noexcept;
+	void read(float *pBuf) noexcept;
+	void Reinitialize(unsigned new_size);
 
 private:
 	float *m_pMixbuf;
-	uint64_t m_iBufSize; // actual allocated samples
-	uint64_t m_iBufUsed; // used samples
-	int m_iOffset;
+	int_fast64_t m_iBufSize; // actual allocated samples
+	int_fast64_t m_iBufUsed; // used samples
+	int_fast32_t m_iOffset;
 };
+
+/* write() will start mixing iOffset samples into the buffer.  Be careful; this is
+ * measured in samples, not frames, so if the data is stereo, multiply by two. */
+inline void RageSoundMixBuffer::SetWriteOffset(int iOffset) noexcept
+{
+	m_iOffset = iOffset;
+}
+
+inline void RageSoundMixBuffer::read(int16_t *pBuf) noexcept
+{
+	constexpr int16_t MAX_INT16 = 32767;
+	for (unsigned iPos = 0; iPos < m_iBufUsed; ++iPos)
+	{
+		float iOut = m_pMixbuf[iPos];
+		iOut = std::max(-1.0f, std::min(iOut, 1.0f));
+		pBuf[iPos] = static_cast<int16_t>((iOut * MAX_INT16) + 0.5f);
+	}
+	m_iBufUsed = 0;
+}
+
+inline void RageSoundMixBuffer::read(float *pBuf) noexcept
+{
+	std::memcpy(pBuf, m_pMixbuf, m_iBufUsed * sizeof(float));
+	m_iBufUsed = 0;
+}
 
 #endif
 


### PR DESCRIPTION
Sync testers favored this, generally speaking,  since the mix buffer is objectively fastest if resizing operations never take place.  A few users had to change their buffer size to be larger or smaller, so this isn't perfect in that regard.  

This method introduces a function to reinitialize the buffer with any specified size, which could be exposed to Lua if needed, so the user doesn't necessarily have to close the game to change the buffer size.

The vector based method is just about as reliable, sync testers still think it's very good, but this was considered the best in terms of the sync experience.