### PR TITLE
Simplify RageTimer

### DIFF
--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -682,12 +682,12 @@ void LockMutex::Unlock()
 
 	mutex.Unlock();
 
-	constexpr uint_fast64_t THRESHOLD_USEC = 15000;
+	constexpr uint64_t THRESHOLD_USEC = 15000;
 
-	if (file && locked_at != FAST_ULL_MAX)
+	if (file && locked_at != UINT64_MAX)
 	{
-		const uint_fast64_t current_usecs = RageTimer::GetTimeSinceStartMicroseconds();
-		const uint_fast64_t dur_usecs = current_usecs - locked_at;
+		const uint64_t current_usecs = RageTimer::GetTimeSinceStartMicroseconds();
+		const uint64_t dur_usecs = current_usecs - locked_at;
 
 		if (dur_usecs > THRESHOLD_USEC)
 			LOG->Trace("Lock at %s:%i took %llu microseconds", file, line, dur_usecs);

--- a/src/RageThreads.h
+++ b/src/RageThreads.h
@@ -4,8 +4,6 @@
 #include <cstdint>
 #include <limits>
 
-static constexpr uint_fast64_t FAST_ULL_MAX = std::numeric_limits<uint_fast64_t>::max();
-
 struct ThreadSlot;
 class RageTimer;
 /** @brief Thread, mutex, semaphore, and event classes. */
@@ -131,12 +129,12 @@ class LockMutex
 
 	const char *file;
 	int line;
-	uint_fast64_t locked_at;
+	uint64_t locked_at;
 	bool locked;
 
 public:
 	LockMutex(RageMutex &mut, const char *file, int line);
-	LockMutex(RageMutex &mut): mutex(mut), file(nullptr), line(-1), locked_at(FAST_ULL_MAX), locked(true) { mutex.Lock(); }
+	LockMutex(RageMutex &mut): mutex(mut), file(nullptr), line(-1), locked_at(UINT64_MAX), locked(true) { mutex.Lock(); }
 	~LockMutex();
 	LockMutex(LockMutex &cpy): mutex(cpy.mutex), file(nullptr), line(-1), locked_at(cpy.locked_at), locked(true) { mutex.Lock(); }
 

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -30,16 +30,14 @@
 #include <cmath>
 #include <cstdint>
 
-const uint64_t ONE_SECOND_IN_MICROSECONDS_ULL = 1000000ULL;
-const int64_t ONE_SECOND_IN_MICROSECONDS_LL = 1000000LL;
-const uint_fast64_t ONE_SECOND_IN_MICROSECONDS_FAST_ULL = 1000000ULL;
-const double ONE_SECOND_IN_MICROSECONDS_DBL = 1000000.0;
-
+// Intialize important variables and definitions
+constexpr uint64_t ONE_SECOND_IN_MICROSECONDS_ULL = 1000000ULL;
+constexpr int64_t ONE_SECOND_IN_MICROSECONDS_LL = 1000000LL;
+constexpr double ONE_SECOND_IN_MICROSECONDS_DBL = 1000000.0;
 const RageTimer RageZeroTimer(0,0);
 static const uint64_t g_iStartTime = ArchHooks::GetSystemTimeInMicroseconds();
-static uint_fast64_t g_iStartTimeFast64 = g_iStartTime;
 
-static uint64_t GetTime()
+static inline uint64_t GetTime() noexcept
 {
 	return ArchHooks::GetSystemTimeInMicroseconds();
 }
@@ -54,19 +52,19 @@ static uint64_t GetTime()
  * and do thorough testing if you change anything here. -sukibaby */
 double RageTimer::GetTimeSinceStart()
 {
-	constexpr double USEC_TO_SEC = 1.0 / 1000000.0;
-	return static_cast<double>(RageTimer::GetTimeSinceStartMicroseconds()) * USEC_TO_SEC;
+	const uint64_t usecs = (GetTime() - g_iStartTime);
+	return static_cast<double>(usecs / ONE_SECOND_IN_MICROSECONDS_DBL);
 }
 
 int RageTimer::GetTimeSinceStartSeconds()
 {
-    uint_fast64_t usec = RageTimer::GetTimeSinceStartMicroseconds();
-    return static_cast<int>(usec / ONE_SECOND_IN_MICROSECONDS_FAST_ULL);
+	const uint64_t usecs = (GetTime() - g_iStartTime);
+	return static_cast<int>(usecs / ONE_SECOND_IN_MICROSECONDS_ULL);
 }
 
-uint_fast64_t RageTimer::GetTimeSinceStartMicroseconds()
+uint64_t RageTimer::GetTimeSinceStartMicroseconds()
 {
-	return GetTime() - g_iStartTimeFast64;
+	return (GetTime() - g_iStartTime);
 }
 
 void RageTimer::Touch()

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -24,9 +24,9 @@ public:
 	float PeekDeltaTime() const { return Ago(); }
 
 	static double GetTimeSinceStart();	// seconds since the program was started
-	static float GetTimeSinceStartFast() { return GetTimeSinceStart(); }
-	static int GetTimeSinceStartSeconds();
-	static uint_fast64_t GetTimeSinceStartMicroseconds();
+	static double GetTimeSinceStartFast() { return GetTimeSinceStart(); }
+	static int GetTimeSinceStartSeconds(); 	// This is used where GetTimeSinceStart would be cast to an int without rounding.
+	static uint64_t GetTimeSinceStartMicroseconds();
 
 	/* Get a timer representing half of the time ago as this one. */
 	RageTimer Half() const;

--- a/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
@@ -301,8 +301,8 @@ void RageSoundDriver::Update()
 //		LOG->Trace("set (#%i) %p from STOPPING to HALTING", i, m_Sounds[i].m_pSound);
 	}
 
-	constexpr uint_fast64_t iUsecs = 1000000;
-	static uint_fast64_t fNextUsecs = 0;
+	constexpr uint64_t iUsecs = 1000000;
+	static uint64_t fNextUsecs = 0;
 	if (RageTimer::GetTimeSinceStartMicroseconds() >= fNextUsecs)
 	{
 		/* Lockless: only Mix() can write to underruns. */


### PR DESCRIPTION
Follows up on #528 . Replaces fast data type with plain `int64_t` or `uint64_t` everywhere except audio processing.

This PR should resolve a number of smaller issues discovered in bug testing related to not using a fixed width data type.

For example, this PR fixes an issue where video banners might play at the wrong rate.