### PR TITLE
Debug Menu Overlay toggle, disabling unwanted debug options (Monkey Input etc)

### DIFF
--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -307,6 +307,7 @@ PrefsManager::PrefsManager() :
 	m_custom_songs_max_megabytes("CustomSongsMaxMegabytes", 5.f),
 
 	/* Debug: */
+	m_bDebugMenuEnabled("DebugMenuEnabled", true, nullptr, PreferenceType::Immutable),
 	m_bLogToDisk			( "LogToDisk",		true ),
 #if defined(DEBUG)
 	m_bForceLogFlush		( "ForceLogFlush",	true ),

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -334,6 +334,7 @@ public:
 	Preference<float> m_custom_songs_max_megabytes;
 
 	// Debug:
+	Preference<bool>	m_bDebugMenuEnabled;
 	Preference<bool>	m_bLogToDisk;
 	Preference<bool>	m_bForceLogFlush;
 	Preference<bool>	m_bShowLogOutput;


### PR DESCRIPTION
This is far from an ideal solution, I don't really love how hacky it is, but gets the job done for now.

Problems preventing a more elegant solution are:
- We can't just comment out the relevant `DECLARE_ONE` lines, because it will change the keys associated with each option.
- These also can't be toggled with booleans, due to the structure of `ScreenDebugOverlay.cpp`, there is no way to control the static instances of classes without a significant refactoring.
- Due to the way the lists are initialized, there is no way to link a keycode to its debug line without rewriting this to make use of a map.
- We need to avoid a redefinition error when passing a fake class to `DECLARE_ONE` more than once.

Thus, I've made these few unwanted optons (Monkey Input, Clear Profile Scores, Fill Profile Scores, Force Creash) unavailable for now. I've also created a preference to disable the debug screen entirely, if desired, but this also breaks F6 for AutoSync, F7 for Assist Tick and F8 for AutoPlay (It may be worth moving those to another screen, so they can be used even if the debug menu is disabled).

![image](https://github.com/user-attachments/assets/a2d28914-a6cd-4ab9-8c0b-3f7f484ae8ac)
![image](https://github.com/user-attachments/assets/3ba3b3d6-8234-4ca1-95ec-343e82f3d9e5)
![image](https://github.com/user-attachments/assets/59995eaf-b22d-4083-b0e2-d0ac7b9eb9c6)
