### PR TITLE
Revert "Add native restart menu button"

### DIFF
--- a/Themes/_fallback/Languages/en.ini
+++ b/Themes/_fallback/Languages/en.ini
@@ -133,7 +133,6 @@ EffectDown=EffectDown
 Right=Right
 Select=Select
 Start=Start
-Restart=Restart
 Up=Up
 UpLeft=UpLeft
 UpRight=UpRight

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -24,7 +24,6 @@ static const Game::PerButtonInfo g_CommonButtonInfo[] =
 	{ GameButtonType_Menu }, // GAME_BUTTON_START
 	{ GameButtonType_Menu }, // GAME_BUTTON_SELECT
 	{ GameButtonType_Menu }, // GAME_BUTTON_BACK
-	{ GameButtonType_Menu }, // GAME_BUTTON_RESTART
 	{ GameButtonType_Menu }, // GAME_BUTTON_COIN
 	{ GameButtonType_Menu }, // GAME_BUTTON_OPERATOR
 	{ GameButtonType_Menu }, // GAME_BUTTON_EFFECT_UP

--- a/src/GameInput.h
+++ b/src/GameInput.h
@@ -26,7 +26,6 @@ enum GameButton
 	GAME_BUTTON_START,
 	GAME_BUTTON_SELECT,
 	GAME_BUTTON_BACK,
-	GAME_BUTTON_RESTART,
 	GAME_BUTTON_COIN, /**< Insert a coin to play. */
 	GAME_BUTTON_OPERATOR, /**< Access the operator menu. */
 	GAME_BUTTON_EFFECT_UP,

--- a/src/InputMapper.cpp
+++ b/src/InputMapper.cpp
@@ -1208,7 +1208,6 @@ static const InputScheme::GameButtonInfo g_CommonGameButtonInfo[] =
 	{ "Start",	GAME_BUTTON_START },
 	{ "Select",	GAME_BUTTON_SELECT },
 	{ "Back",	GAME_BUTTON_BACK },
-	{ "Restart",	GAME_BUTTON_RESTART },
 	{ "Coin",	GAME_BUTTON_COIN },
 	{ "Operator",	GAME_BUTTON_OPERATOR },
 	{ "EffectUp",	GAME_BUTTON_EFFECT_UP },

--- a/src/Screen.cpp
+++ b/src/Screen.cpp
@@ -228,10 +228,9 @@ bool Screen::Input( const InputEventPlus &input )
 					return this->MenuBack( input );
 			}
 			return false;
-		case GAME_BUTTON_START:   return this->MenuStart  ( input );
-		case GAME_BUTTON_SELECT:  return this->MenuSelect ( input );
-		case GAME_BUTTON_RESTART: return this->MenuRestart( input );
-		case GAME_BUTTON_COIN:    return this->MenuCoin   ( input );
+		case GAME_BUTTON_START:  return this->MenuStart ( input );
+		case GAME_BUTTON_SELECT: return this->MenuSelect( input );
+		case GAME_BUTTON_COIN:   return this->MenuCoin  ( input );
 		default: return false;
 	}
 }

--- a/src/Screen.h
+++ b/src/Screen.h
@@ -141,7 +141,6 @@ public:
 	virtual bool MenuRight(const InputEventPlus &) { return false; }
 	virtual bool MenuStart(const InputEventPlus &) { return false; }
 	virtual bool MenuSelect(const InputEventPlus &) { return false; }
-	virtual bool MenuRestart(const InputEventPlus &) { return false; }
 	virtual bool MenuBack(const InputEventPlus &) { return false; }
 	virtual bool MenuCoin(const InputEventPlus &) { return false; }
 	// todo? -aj

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -729,13 +729,6 @@ bool ScreenEvaluation::Input( const InputEventPlus &input )
 	if( IsTransitioning() )
 		return false;
 
-	if (input.MenuI == GAME_BUTTON_RESTART && input.type == IET_FIRST_PRESS &&
-		GAMESTATE->IsEventMode() && !GAMESTATE->IsCourseMode())
-	{
-		return MenuRestart(input);
-	}
-
-
 	if( input.GameI.IsValid() )
 	{
 		if( CodeDetector::EnteredCode(input.GameI.controller, CODE_SAVE_SCREENSHOT1) ||
@@ -799,16 +792,6 @@ bool ScreenEvaluation::MenuStart( const InputEventPlus &input )
 	m_soundStart.Play(true);
 
 	HandleMenuStart();
-	return true;
-}
-
-bool ScreenEvaluation::MenuRestart( const InputEventPlus &input )
-{
-	if( IsTransitioning() )
-		return false;
-
-	SCREENMAN->GetTopScreen()->SetNextScreenName("ScreenGameplay");
-	StartTransitioningScreen( SM_GoToNextScreen );
 	return true;
 }
 

--- a/src/ScreenEvaluation.h
+++ b/src/ScreenEvaluation.h
@@ -57,7 +57,6 @@ public:
 
 	virtual bool MenuBack( const InputEventPlus &input );
 	virtual bool MenuStart( const InputEventPlus &input );
-	virtual bool MenuRestart( const InputEventPlus &input );
 	virtual void PushSelf( lua_State *L );
 	StageStats *GetStageStats() { return m_pStageStats; }
 

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -854,20 +854,6 @@ bool ScreenGameplay::Center1Player() const
 		GAMESTATE->GetCurrentStyle(PLAYER_INVALID)->m_StyleType == StyleType_OnePlayerOneSide;
 }
 
-bool ScreenGameplay::MenuRestart( const InputEventPlus &input )
-{
-	if( IsTransitioning() )
-		return false;
-
-	m_DancingState = STATE_OUTRO;
-	m_pSoundMusic->StopPlaying();
-	m_GameplayAssist.StopPlaying(); // Stop any queued assist ticks.
-
-	SCREENMAN->GetTopScreen()->SetNextScreenName("ScreenGameplay");
-	m_Cancel.StartTransitioning( SM_GoToNextScreen );
-	return true;
-}
-
 // fill in m_apSongsQueue, m_vpStepsQueue, m_asModifiersQueue
 void ScreenGameplay::InitSongQueues()
 {
@@ -2380,12 +2366,6 @@ bool ScreenGameplay::Input( const InputEventPlus &input )
 			}
 		}
 		return false;
-	}
-
-	if (input.MenuI == GAME_BUTTON_RESTART && input.type == IET_FIRST_PRESS &&
-		GAMESTATE->IsEventMode() && !GAMESTATE->IsCourseMode())
-	{
-		return MenuRestart(input);
 	}
 
 	if(m_DancingState != STATE_OUTRO  &&

--- a/src/ScreenGameplay.h
+++ b/src/ScreenGameplay.h
@@ -165,8 +165,6 @@ public:
 	 * @return true if we center the solo player, false otherwise. */
 	bool Center1Player() const;
 
-	bool MenuRestart( const InputEventPlus &input );
-
 	// Lua
 	virtual void PushSelf( lua_State *L );
 	Song *GetNextCourseSong() const;


### PR DESCRIPTION
Reverts itgmania/itgmania#374

This PR actually breaks pad lighting (according to git bisect this commit is the cause).

My guess is it's because the restart button is getting added in the middle of button definitions. I'll need to revert it for now but I'll try and figure out the cause before the release.