### PR TITLE
Ensure a consistent definition of TimingSegment::EPSILON

### DIFF
--- a/src/TimingSegments.cpp
+++ b/src/TimingSegments.cpp
@@ -4,9 +4,6 @@
 
 #include <vector>
 
-
-const double TimingSegment::EPSILON = 1e-6;
-
 static const char *TimingSegmentTypeNames[] = {
 	"BPM",
 	"Stop",

--- a/src/TimingSegments.h
+++ b/src/TimingSegments.h
@@ -64,7 +64,7 @@ struct TimingSegment
 		m_iStartRow( other.GetRow() ) { }
 
 	// for our purposes, two floats within this level of error are equal
-	static const double EPSILON;
+	static constexpr double EPSILON = 1e-6;
 
 	virtual ~TimingSegment() { }
 


### PR DESCRIPTION
Since this value is used within a macro, and is defined slightly differently both places, we have no way of knowing if there are any errors related to a potentially incorrect use of `EPSILON`.

I'm replacing its two conflicting definitions with a single `constexpr` which adds safety by determining this value at compile time to ensure we absolutely know its value and status.