### PR TITLE
Fix the crash when a WebSocketHandle is closed.

### DIFF
--- a/src/NetworkManager.h
+++ b/src/NetworkManager.h
@@ -110,7 +110,8 @@ class WebSocketHandle
 {
 public:
 	WebSocketHandle() {};
-
+	~WebSocketHandle();
+	
 	static int Collect(lua_State *L);
 	static int Close(lua_State *L);
 	static int Send(lua_State *L);
@@ -146,6 +147,8 @@ private:
 
 	static Preference<bool> httpEnabled;
 	static Preference<RString> httpAllowHosts;
+
+	std::vector<std::shared_ptr<WebSocketHandle>> webSocketHandles;
 };
 
 extern NetworkManager*	NETWORK;

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -298,10 +298,10 @@ void ShutdownGame()
 		LIGHTSMAN->TurnOffAllLights();
 	}
 
+	RageUtil::SafeDelete( NETWORK );
 	RageUtil::SafeDelete( SCREENMAN );
 	RageUtil::SafeDelete( STATSMAN );
 	RageUtil::SafeDelete( MESSAGEMAN );
-	RageUtil::SafeDelete( NETWORK );
 	/* Delete INPUTMAN before the other INPUTFILTER handlers, or an input
 	 * driver may try to send a message to INPUTFILTER after we delete it. */
 	RageUtil::SafeDelete( INPUTMAN );


### PR DESCRIPTION
First, there are 3 commits here.  The first two 74aeacbc5410622f656da4cea942ea3f376db85c and f11851d11eb4eb3c1bc3473e7efc0045ac34a078 may not be wanted/needed so I've added them as separate commits if they're unwanted.

The first adds a status for the NetworkManager which can be exposed to Lua, so the theme can tell what the network status is.

The second rearranges the order the managers are shut down in, which prevented a crash when the game was quit before the attempt to connect to GrooveStats was completed before implementing the fixes below. This may not be needed ultimately.

The last is the major change which resolves this crash. We needed to add a destructor for WebSocketHandle, a way to keep track of the open handles, and slightly change `Collect` to only call `onClose` if it's valid.  Lastly we return 1 instead of 0 to indicate the closing of the socket was a success.
 
Resolves #106 and #129.