### PR TITLE
Raise pull requests for version updates against the 'beta' branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
   - package-ecosystem: "github-actions"
     # Look for GitHub Actions workflows in the `root` directory
     directory: "/"
+    # Raise pull requests for version updates
+    # against the `beta` branch
+    target-branch: "beta"
     # Check the for updates once a week
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Reference https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependabot-prs#targeting-pull-requests-against-a-non-default-branch