### PR TITLE
Bring back fixes from 0.9.0-SHINE build

### DIFF
--- a/src/RageSoundPosMap.cpp
+++ b/src/RageSoundPosMap.cpp
@@ -50,11 +50,9 @@ pos_map_queue::pos_map_queue( const pos_map_queue &cpy )
 
 pos_map_queue &pos_map_queue::operator=( const pos_map_queue &rhs )
 {
-	if (this != &rhs)
-	{
-		pos_map_impl* tempImpl = new pos_map_impl(*rhs.m_pImpl);
-		std::swap(m_pImpl, tempImpl);
-		delete tempImpl;
+	if (this != &rhs){
+		delete m_pImpl;
+		m_pImpl = new pos_map_impl( *rhs.m_pImpl );
 	}
 	return *this;
 }

--- a/src/arch/Sound/RageSoundDriver_Null.cpp
+++ b/src/arch/Sound/RageSoundDriver_Null.cpp
@@ -25,7 +25,8 @@ void RageSoundDriver_Null::Update()
 
 int64_t RageSoundDriver_Null::GetPosition() const
 {
-	return (RageTimer::GetTimeSinceStartMicroseconds() * m_iSampleRate) / 1000000;
+	uint64_t microseconds = RageTimer::GetTimeSinceStartMicroseconds();
+	return static_cast<int64_t>(microseconds * m_iSampleRate / 1000000);
 }
 
 RageSoundDriver_Null::RageSoundDriver_Null()

--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -275,6 +275,8 @@ static int GetWindowStyle( bool bWindowed , bool bWindowIsFullscreenBorderless)
  * window. */
 void GraphicsWindow::CreateGraphicsWindow( const VideoModeParams &p, bool bForceRecreateWindow )
 {
+	SetProcessDPIAware(); // prevents DPI mismatch when Windows DPI is above 100%
+
 	auto resetDeviceMode = [=](DEVMODE& mode)
 	{
 		ZeroMemory(&mode, sizeof(DEVMODE));

--- a/src/archutils/Win32/StepMania.in.manifest
+++ b/src/archutils/Win32/StepMania.in.manifest
@@ -4,7 +4,6 @@
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
     </windowsSettings>
   </application>
 </assembly>


### PR DESCRIPTION
`beta` has an awful compounding drift problem and none of the beta builds have been preferred over 0.9.0-SHINE for some months. Many people are still playing on 0.9.0-SHINE. This PR will bring back the majority of code which differs between the beta and 0.9.0-SHINE.

One of the RSMB PR's is needed in addition to this.