### PR TITLE
Native submodule checkout in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
+        with:
+          submodules: true
       - name: Cache CMake build directory
         uses: actions/cache@v4
         with:
@@ -47,8 +47,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
+        with:
+          submodules: recursive
       - name: Cache CMake build directory
         uses: actions/cache@v4
         with:
@@ -70,8 +70,8 @@ jobs:
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
+        with:
+          submodules: recursive
       - name: Cache CMake build directory
         uses: actions/cache@v4
         with:
@@ -93,8 +93,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
+        with:
+          submodules: recursive
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1
       - name: Set up Visual Studio environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: recursive
       - name: Cache CMake build directory
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Removing a separate step in favor of actions/checkout's native recursive submodule checkouts - https://github.com/actions/checkout?tab=readme-ov-file#usage

Translates to
```
Fetching submodules
  /usr/local/bin/git submodule sync --recursive
  /usr/local/bin/git -c protocol.version=2 submodule update --init --force --depth=1 --recursive
...
```
from https://github.com/itgmania/itgmania/actions/runs/12530035495/job/34946194469?pr=567#step:2:130