### PR TITLE
𝗥𝗮𝗴𝗲𝗦𝗼𝘂𝗻𝗱𝗠𝗶𝘅𝗕𝘂𝗳𝗳𝗲𝗿: Using <vector> for automatic memory management

### DIFF
--- a/src/RageSoundMixBuffer.h
+++ b/src/RageSoundMixBuffer.h
@@ -15,13 +15,11 @@ public:
 	void read(int16_t* pBuf);
 	void read(float* pBuf);
 	void read_deinterlace(float** pBufs, int channels);
-	inline int64_t size() const { return m_iBufUsed; }
+	inline size_t size() const { return m_pMixbuf.size(); }
 
 private:
 	std::vector<float> m_pMixbuf;
-	int64_t m_iBufSize;
-	int64_t m_iBufUsed;
-	int64_t m_iOffset;
+	unsigned m_iOffset;
 };
 
 #endif // RAGESOUNDMIXBUFFER_H

--- a/src/RageSoundMixBuffer.h
+++ b/src/RageSoundMixBuffer.h
@@ -1,40 +1,30 @@
-/* RageSoundMixBuffer - Simple audio mixing. */
+#ifndef RAGESOUNDMIXBUFFER_H
+#define RAGESOUNDMIXBUFFER_H
 
-#ifndef RAGE_SOUND_MIX_BUFFER_H
-#define RAGE_SOUND_MIX_BUFFER_H
-
+#include <vector>
 #include <cstdint>
 
-class RageSoundMixBuffer
-{
+class RageSoundMixBuffer {
 public:
 	RageSoundMixBuffer();
 	~RageSoundMixBuffer();
 
-	// See how many samples we can stuff into 2MB.
-	static constexpr size_t BUF_SIZE = 2 * 1024 * 1024 / sizeof(float);
-
-	// Mix the given buffer of samples.
-	void write( const float *pBuf, unsigned iSize, int iSourceStride = 1, int iDestStride = 1 );
-
-	// Extend the buffer as if write() was called with a buffer of silence.
-	void Extend( unsigned iSamples );
-
-	void read( int16_t *pBuf );
-	void read( float *pBuf );
-	void read_deinterlace( float **pBufs, int channels );
-	float *read() { return m_pMixbuf; }
-	unsigned size() const { return m_iBufUsed; }
-	void SetWriteOffset( int iOffset );
+	void SetWriteOffset(int iOffset);
+	void Extend(unsigned iSamples);
+	void write(const float* pBuf, unsigned iSize, int iSourceStride = 1, int iDestStride = 1);
+	void read(int16_t* pBuf);
+	void read(float* pBuf);
+	void read_deinterlace(float** pBufs, int channels);
+	inline int64_t size() const { return m_iBufUsed; }
 
 private:
-	float *m_pMixbuf;
-	uint64_t m_iBufSize; // actual allocated samples
-	uint64_t m_iBufUsed; // used samples
-	int m_iOffset;
+	std::vector<float> m_pMixbuf;
+	int64_t m_iBufSize;
+	int64_t m_iBufUsed;
+	int64_t m_iOffset;
 };
 
-#endif
+#endif // RAGESOUNDMIXBUFFER_H
 
 /*
  * Copyright (c) 2002-2004 Glenn Maynard


### PR DESCRIPTION
This isn't prone to memory leaks like the original malloc/realloc code, but it's really best that the mixbuffer size doesn't change, as that provides better sync stability. Even so, this is nearly as good, and probably as performant as it can be for real-time use without being a fixed size, but top players may notice a difference between this and fixed-sized buffer builds (#543).

The problem with fixed-size buffer builds though is lack of stability across the board on different setups. Switching from WaveOut to DirectSound on Windows #580 takes care of many problems with performance the `Extend` method which that have plagued that OS.

This method is safer across a wider variety of setups and doesn't introduce a new preference. It's what is used in the 2025/01/06 build that's been in use without issues for almost 2 months now. I've fixed a few small things since then, and improved commentary so the code is less obtuse.

## Changes

Bringing in algorithm for std::copy, and vector for automatic memory management. Make `m_pMixbuf` type `std::vector<float>`.

Initializing the buffer with zeroes in the same operation as resizing the buffer.

Fixing type choices all around.

The constructor and destructor can be empty since the vector<float>'s own destructor will take care of freeing allocated memory.

Removed `m_iBufSize` and `m_iBufUsed` since they're not needed any longer with `m_pMixbuf.size()` available.