### PR TITLE
Couples Primer - Account for AutoSetStyle in the MusicWheel

### DIFF
--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -504,8 +504,14 @@ void MusicWheel::GetSongList( std::vector<Song*> &arraySongs, SortOrder so )
 			if( pSong->HasStepsTypeAndDifficulty( GAMESTATE->GetCurrentStyle(PLAYER_INVALID)->m_StepsType,GAMESTATE->m_PreferredDifficulty[GAMESTATE->GetFirstHumanPlayer()] ) )
 				arraySongs.push_back( pSong );
 		}
-		else
+		else if( CommonMetrics::AUTO_SET_STYLE || GAMESTATE->GetCurrentStyle(PLAYER_INVALID) == nullptr )
 		{
+			if (SongUtil::IsSongPlayable(pSong))
+				arraySongs.push_back( pSong );
+				
+		} else
+		{
+
 			// If the song has at least one steps, add it.
 			if( pSong->HasStepsType(GAMESTATE->GetCurrentStyle(PLAYER_INVALID)->m_StepsType) )
 				arraySongs.push_back( pSong );


### PR DESCRIPTION
When using auto set style we need to ensure that we're showing all the songs that we're telling the user that they're able to see.

- If AutoSetStyle is true then we're showing all compatible styles at once (compatible styles determined by number of players joined).
- Sooooo if 1 player is joined then we'd see Singles, Doubles, & 3-panel charts. (Maybe solo as well?)
- If 2 players are joined we'll see Singles (versus), Routine, and couples charts.

This needs to be reflected in the music wheel so that we're seeing songs with compatible styles. Previously it was checking if the song had steps in the current style which doesn't really apply for AutoSetStyle being toggled. Basically if a song didn't have at least 1 singles chart it wouldn't show up.

This is relevant for couples because I imagine that AutoSetStyle will become much more desirable as it can remove the need for ScreenSelectStyle entirely + let's you see couples charts at the same time as singles charts instead of having to go back and forth.

(cherry picked from commit 1fc4a805b497aa93a965547c688844a30018527a)