### PR TITLE
Add CMake option to change userpath for Flatpaks

### DIFF
--- a/CMake/DefineOptions.cmake
+++ b/CMake/DefineOptions.cmake
@@ -61,6 +61,8 @@ if(LINUX)
   option(WITH_XRANDR "Build with Xrandr support" ON)
   option(WITH_LIBXTST "Build with libXtst support" ON)
   option(WITH_X11 "Build with X11 support" ON)
+  # right now this just changes the path of the user dir
+  option(IS_FLATPAK "Build with Flatpak fixes." OFF)
 endif()
 
 option(WITH_MINIMAID "Build with Minimaid support." ON)

--- a/CMake/DefineOptions.cmake
+++ b/CMake/DefineOptions.cmake
@@ -62,7 +62,7 @@ if(LINUX)
   option(WITH_LIBXTST "Build with libXtst support" ON)
   option(WITH_X11 "Build with X11 support" ON)
   # right now this just changes the path of the user dir
-  option(IS_FLATPAK "Build with Flatpak fixes." OFF)
+  option(IS_FLATPAK "Build with alternative userpath for Flatpak." OFF)
 endif()
 
 option(WITH_MINIMAID "Build with Minimaid support." ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -438,6 +438,10 @@ else() # Unix / Linux TODO: Remember to find and locate the zip archive files.
     list(APPEND SMDATA_LINK_LIB ${LIBXTST_LIBRARY})
   endif()
 
+  if(IS_FLATPAK)
+    add_definitions(-DIS_FLATPAK)
+  endif()
+
   list(APPEND SMDATA_LINK_LIB ${LIBUSB_LIBRARY})
 
   list(APPEND SMDATA_LINK_LIB ${XRANDR_LIBRARIES} ${XINERAMA_LIBRARIES})

--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -128,7 +128,7 @@ namespace
 	void OpenGetTime()
 	{
 		static bool bInitialized = false;
-		
+
 		if( bInitialized )
 			return;
 		bInitialized = true;
@@ -408,8 +408,13 @@ void ArchHooks::MountUserFilesystems( const RString &sDirOfExecutable )
 	/* Path to write general mutable user data when not Portable
 	 * Lowercase the PRODUCT_ID; dotfiles and directories are almost always lowercase.
 	 */
-	const char *szHome = getenv( "HOME" );
-	RString sUserDataPath = ssprintf( "%s/.%s", szHome? szHome:".", "itgmania" );
+	#ifdef IS_FLATPAK
+		const char *szHome = getenv( "XDG_DATA_HOME" );
+		RString sUserDataPath = ssprintf( "%s/%s", szHome? szHome:".", "itgmania" );
+	#else
+		const char *szHome = getenv( "HOME" );
+		RString sUserDataPath = ssprintf( "%s/.%s", szHome? szHome:".", "itgmania" );
+	#endif
 	FILEMAN->Mount( "dir", sUserDataPath + "/Announcers", "/Announcers" );
 	FILEMAN->Mount( "dir", sUserDataPath + "/BGAnimations", "/BGAnimations" );
 	FILEMAN->Mount( "dir", sUserDataPath + "/BackgroundEffects", "/BackgroundEffects" );

--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -408,13 +408,13 @@ void ArchHooks::MountUserFilesystems( const RString &sDirOfExecutable )
 	/* Path to write general mutable user data when not Portable
 	 * Lowercase the PRODUCT_ID; dotfiles and directories are almost always lowercase.
 	 */
-	#ifdef IS_FLATPAK
-		const char *szHome = getenv( "XDG_DATA_HOME" );
-		RString sUserDataPath = ssprintf( "%s/%s", szHome? szHome:".", "itgmania" );
-	#else
-		const char *szHome = getenv( "HOME" );
-		RString sUserDataPath = ssprintf( "%s/.%s", szHome? szHome:".", "itgmania" );
-	#endif
+#ifdef IS_FLATPAK
+	const char *szHome = getenv( "XDG_DATA_HOME" );
+	RString sUserDataPath = ssprintf( "%s/%s", szHome? szHome:".", "itgmania" );
+#else
+	const char *szHome = getenv( "HOME" );
+	RString sUserDataPath = ssprintf( "%s/.%s", szHome? szHome:".", "itgmania" );
+#endif
 	FILEMAN->Mount( "dir", sUserDataPath + "/Announcers", "/Announcers" );
 	FILEMAN->Mount( "dir", sUserDataPath + "/BGAnimations", "/BGAnimations" );
 	FILEMAN->Mount( "dir", sUserDataPath + "/BackgroundEffects", "/BackgroundEffects" );


### PR DESCRIPTION
I'm currently in the process of writing Flatpak buildscripts for ITGmania and noticed that as it is right now, it's impossible to access the user directory (`$HOME/.itgmania`) with the Flatpak build. This patch adds a new CMake option that changes the user path from `$HOME/.itgmania` to `$XDG_DATA_HOME/itgmania`, which is `$HOME/.local/share/` by default (or `$HOME/.var/app/$FLATPAK_ID/data/` in the case of a Flatpak). 

This is only intended to be activated by the Flatpak buildscript to put all the user files where they're expected from a Flatpak, but of course there's nothing stopping other users from compiling with this on if they want to change the location of their userpath.