### PR TITLE
Revert "global.h / global.cpp: Create FailWithMessage/AssertWithMessage, prepare to move away from global.h"

### DIFF
--- a/src/RageFileBasic.h
+++ b/src/RageFileBasic.h
@@ -100,20 +100,12 @@ public:
 	virtual int GetFileSize() const = 0;
 	virtual int GetFD() { return -1; }
 	virtual RString GetDisplayPath() const { return RString(); }
-	virtual RageFileBasic* Copy() const
-	{
-		FAIL_M("Copying unimplemented");
-		return nullptr; // Return a default value - the return value is unused
-	}
+	virtual RageFileBasic *Copy() const { FAIL_M( "Copying unimplemented" ); }
 
 protected:
-	virtual int SeekInternal(int /* iOffset */)
-	{
-		FAIL_M("Seeking unimplemented");
-		return -1; // Return a default value - the return value is unused
-	}
-	virtual int ReadInternal(void* pBuffer, size_t iBytes) = 0;
-	virtual int WriteInternal(const void* pBuffer, size_t iBytes) = 0;
+	virtual int SeekInternal( int /* iOffset */ ) { FAIL_M( "Seeking unimplemented" ); }
+	virtual int ReadInternal( void *pBuffer, size_t iBytes ) = 0;
+	virtual int WriteInternal( const void *pBuffer, size_t iBytes ) = 0;
 	virtual int FlushInternal() { return 0; }
 
 	void EnableReadBuffering();

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -25,19 +25,6 @@
     #include "archutils/Unix/CrashHandler.h"
 #endif
 
-void FailWithMessage(const char* message)
-{
-    CHECKPOINT_M(message);
-    sm_crash(message);
-}
-
-void AssertWithMessage(bool condition, const char* message)
-{
-    if (unlikely(!condition)) {
-        FailWithMessage(message);
-    }
-}
-
 void sm_crash( const char *reason )
 {
 #if ( defined(_WIN32) && defined(CRASH_HANDLER) ) || defined(MACOSX) || defined(_XDBG)

--- a/src/global.h
+++ b/src/global.h
@@ -66,19 +66,13 @@ void sm_crash( const char *reason = "Internal error" );
  *
  * This should probably be used instead of throwing an exception in most
  * cases we expect never to happen (but not in cases that we do expect,
- * such as DSound init failure.)
- * 
- * There are macros here for legacy compatibility so we don't have
- * to change or fix hundreds of calls to FAIL_M / ASSERT_M / ASSERT.
- */
-void FailWithMessage(const char* message);
-#define FAIL_M(MESSAGE) FailWithMessage(MESSAGE)
+ * such as DSound init failure.) */
+#define FAIL_M(MESSAGE) do { CHECKPOINT_M(MESSAGE); sm_crash(MESSAGE); } while(0)
+#define ASSERT_M(COND, MESSAGE) do { if(unlikely(!(COND))) { FAIL_M(MESSAGE); } } while(0)
 
-void AssertWithMessage(bool condition, const char* message);
-#define ASSERT_M(COND, MESSAGE) AssertWithMessage((COND), MESSAGE)
 
 #if !defined(CO_EXIST_WITH_MFC)
-#define ASSERT(COND) AssertWithMessage((COND), "Assertion '" #COND "' failed")
+#define ASSERT(COND) ASSERT_M((COND), "Assertion '" #COND "' failed")
 #endif
 
 /** @brief Use this to catch switching on invalid values */


### PR DESCRIPTION
Reverts itgmania/itgmania#518

## Summary
1. This commit introduced a significant performance hit caused by the unconditional call to a function instead of letting the compiler perform an optimization with `unlikely` when the code was inlined with the macro. 
2. This commit lacks proper annotation with `[[noreturn]]` attribute which `sm_crash` had, thus there are a lot of warnings during compilation. Adding it doesn't seem to make any difference performance-wise.

## Raw performance comparison
`Beta` refers to the current tip of the beta branch, which is e372dd6360815526265521072f3f6004022e5e43. `reverted` means that the fbe0e0b6587ecdf3af7d9373f5ad6333837f10a8 was reverted on top of `beta`.

|cpu|gpu| resolution |compiler|beta gameplay fps|reverted gameplay fps| notes |
|----|----|----|---|---|---|---|
| i9-10850k | NVIDIA RTX 2070 Super | 1440p | g++ 12.2 | 800 | 1700| my main PC |
| i7-10750H | NVIDIA RTX 2060 | 1080p | g++ 9.4 | 615 | 1330 | work laptop with dedicated gpu |
| i5-4690k | Radeon R9 280X | 720p | g++ 13.2 | 370 | 520 | my backup PC |
| i5-6440HQ | Intel HD Graphics 530 | 1080p | g++ 14.2 | 85 | 115 | travel laptop with integrated gpu |
|RPi5| - | 720p | g++ 12. 2| 200 | 200 | there's no visible difference whatsoever |

## Closing thoughts
While the differences in the raw comparison might seem huge, what I believe this really changes is that the CPU becomes the bottleneck of the processing pipeline. In case of my main computer, the 800 fps should be more than enough for comfortable playing but the game is extremely choppy, the frame pacing is not consistent.

## Screenshots
<details>
  <summary>hidden for brevity, click to show</summary>

![image](https://github.com/user-attachments/assets/3caf8ecb-8a8b-497b-94d8-0fb9693cf8f7)
![image](https://github.com/user-attachments/assets/f3e1f9ee-cb54-44f9-8ae9-6a772b83cf18)
![image](https://github.com/user-attachments/assets/69b5aef7-3a13-4027-9b2e-528ec409750d)
![image](https://github.com/user-attachments/assets/a871eb00-0fbb-4950-bb83-e7e57610d5df)
![image](https://github.com/user-attachments/assets/83460f5b-7621-4bce-8ba3-37b2795e9b73)
</details>