### PR TITLE
Use size_t and the respective %zu specifier for size-related/indexing variables in MovieTexture_FFMpeg

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -167,7 +167,7 @@ float MovieDecoder_FFMpeg::GetTimestamp() const
 	}
 
 	// In a logical situation, this means that display is outpacing decoding.
-	if (display_frame_num_ >= static_cast<int>(packet_buffer_.size())) {
+	if (display_frame_num_ >= packet_buffer_.size()) {
 		return 0;
 	}
 
@@ -185,7 +185,7 @@ float MovieDecoder_FFMpeg::GetTimestamp() const
 bool MovieDecoder_FFMpeg::IsCurrentFrameReady() {
 	// We're displaying faster than decoding. Do not even try to display the
 	// frame.
-	if (display_frame_num_ >= static_cast<int>(packet_buffer_.size())) {
+	if (display_frame_num_ >= packet_buffer_.size()) {
 		return false;
 	}
 
@@ -197,7 +197,7 @@ bool MovieDecoder_FFMpeg::IsCurrentFrameReady() {
 	// opposites. If the frame hasn't been displayed, it's ready. If it has
 	// been displayed, then it hasn't been overwritten and reset yet.
 	if (frame->displayed) {
-		LOG->Info("Frame %i not decoded, total frames: %i", display_frame_num_, total_frames_);
+		LOG->Info("Frame %zu not decoded, total frames: %zu", display_frame_num_, total_frames_);
 	}
 	return !frame->displayed;
 }
@@ -450,7 +450,7 @@ int MovieDecoder_FFMpeg::GetFrame(RageSurface* surface_out)
 		}
 	}
 
-	int display_frame_in_buffer = (display_frame_num_ + offset_) % frame_buffer_.size();
+	std::size_t display_frame_in_buffer = (display_frame_num_ + offset_) % frame_buffer_.size();
 	std::lock_guard<std::mutex> lock(frame_buffer_[display_frame_in_buffer]->lock);
 
 	// Sanity check.
@@ -468,7 +468,7 @@ int MovieDecoder_FFMpeg::GetFrame(RageSurface* surface_out)
 		}
 	}
 	else {
-		LOG->Warn("Unexpected frame trying to display! display_frame_num_ = %d, packet_num = %d", display_frame_num_, frame_buffer_[display_frame_in_buffer]->packet_num);
+		LOG->Warn("Unexpected frame trying to display! display_frame_num_ = %zu, packet_num = %zu", display_frame_num_, frame_buffer_[display_frame_in_buffer]->packet_num);
 	}
 
 	frame_buffer_[display_frame_in_buffer]->displayed = true;
@@ -594,7 +594,7 @@ RString MovieDecoder_FFMpeg::Open(RString file)
 		LOG->Trace("Video shorter than frame buffer, shrinking the buffer.");
 		frame_buffer_.resize(total_frames_);
 	}
-	LOG->Trace("Number of frames detected: %i", total_frames_);
+	LOG->Trace("Number of frames detected: %zu", total_frames_);
 
 	return RString();
 }

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -6,6 +6,7 @@
 #include "MovieTexture_Generic.h"
 
 #include <cstdint>
+#include <limits>
 #include <mutex>
 
 struct RageSurface;
@@ -27,7 +28,7 @@ static const int kSwsFlags = SWS_BICUBIC; // XXX: Reasonable default?
 struct FrameHolder {
 	avcodec::AVFrame* frame = avcodec::av_frame_alloc();
 	bool displayed = false;
-	int packet_num = -1; // Used as a sanity check during display.
+	std::size_t packet_num = std::numeric_limits<std::size_t>::max(); // Used as a sanity check during display.
 	std::mutex lock; // Protects the frame as it's being initialized.
 	~FrameHolder() {
 		if (frame != nullptr) {
@@ -147,7 +148,7 @@ private:
 	avcodec::SwsContext* av_sws_context_;
 	avcodec::AVCodecContext* av_stream_codec_;
 	avcodec::AVFormatContext* av_format_context_;
-	int total_frames_; // Total number of frames in the movie.
+	std::size_t total_frames_; // Total number of frames in the movie.
 
 	unsigned char* av_buffer_;
 	avcodec::AVIOContext* av_io_context_;
@@ -158,19 +159,19 @@ private:
 	// Therefore, the FrameBuffer represents a sliding window along the PacketBuffer.
 	std::vector<std::unique_ptr<PacketHolder>> packet_buffer_;
 	std::vector<std::unique_ptr<FrameHolder>> frame_buffer_;
-	int frame_buffer_position_ = 0;
-	int packet_buffer_position_ = 0;
+	std::size_t frame_buffer_position_ = 0;
+	std::size_t packet_buffer_position_ = 0;
 
 	// Offset for the frame_buffer_ when a looping movie goes back to
 	// the zeroeth frame. next_offset_ is written when the zeroeth frame
 	// is decoded, and when the last frame is displayed, it is applied to
 	// offset_.
-	int offset_ = 0;
-	int next_offset_ = 0;
+	std::size_t offset_ = 0;
+	std::size_t next_offset_ = 0;
 
 	// display_frame_num_ will often be the start of the sliding window,
 	// or the oldest Frame that is currently decoded.
-	int display_frame_num_ = 0;
+	std::size_t display_frame_num_ = 0;
 
 	// 0 = no EOF
 	// 1 = EOF while decoding


### PR DESCRIPTION
This change eliminates comparisons between signed and unsigned types, thus compilation warnings and extra casts in `MovieTexture_FFMpeg` are now gone.

Warnings on `beta`: https://github.com/itgmania/itgmania/actions/runs/12735723063/job/35494790275#step:7:1397

![image](https://github.com/user-attachments/assets/4774cd04-2de4-4f76-9525-c335935bd3cc)
