### PR TITLE
GameState: Expose GetPlayerFailType() to Lua

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -926,6 +926,7 @@
 			<Function name='GetNumStagesLeft'/>
 			<Function name='GetPlayMode'/>
 			<Function name='GetPlayerDisplayName'/>
+			<Function name='GetPlayerFailType'/>
 			<Function name='GetPlayerState'/>
 			<Function name='GetPreferredDifficulty'/>
 			<Function name='GetPreferredSong'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -3151,6 +3151,9 @@ end
 	<Function name='GetPlayerDisplayName' return='string' arguments='PlayerNumber pn'>
 		Returns the display name for player <code>pn</code>.
 	</Function>
+	<Function name='GetPlayerFailType' return='FailType' arguments='PlayerNumber pn' since='ITGmania 1.0.0'>
+		Returns the effective <Link class='ENUM' function='FailType' /> for player <code>pn</code>.
+	</Function>
 	<Function name='GetPlayerState' return='PlayerState' arguments='PlayerNumber pn'>
 		Returns the PlayerState for player <code>pn</code>.
 	</Function>

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -3357,6 +3357,13 @@ public:
 		p->m_autogen_fargs[si]= v;
 		COMMON_RETURN_SELF;
 	}
+
+	static int GetPlayerFailType(T* p, lua_State* L)
+	{
+		Enum::Push(L, p->GetPlayerFailType(Enum::Check<PlayerNumber>(L, 1)));
+		return 1;
+	}
+
 	static int prepare_song_for_gameplay(T* p, lua_State* L)
 	{
 		int result= p->prepare_song_for_gameplay();
@@ -3490,6 +3497,7 @@ public:
 		ADD_METHOD( SetStepsForEditMode );
 		ADD_METHOD( GetAutoGenFarg );
 		ADD_METHOD( SetAutoGenFarg );
+		ADD_METHOD( GetPlayerFailType );
 		ADD_METHOD(prepare_song_for_gameplay);
 	}
 };

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -336,6 +336,7 @@ public:
 	bool PlayerIsUsingModifier( PlayerNumber pn, const RString &sModifier );
 
 	FailType GetPlayerFailType( const PlayerState *pPlayerState ) const;
+	FailType GetPlayerFailType( PlayerNumber pn ) const { return GetPlayerFailType( m_pPlayerState[pn] ); }
 
 	// character stuff
 	Character* m_pCurCharacters[NUM_PLAYERS];


### PR DESCRIPTION
`FailType` for a given Player can be overriden with respect to preferences, but Lua has no way to check it. Expose a function to allow doing that, in order to not accidentally submit invalid scores to GrooveStats.