### PR TITLE
𝗖𝗿𝗶𝘁𝗶𝗰𝗮𝗹: Fix DirectSound, and set it to be the default Windows audio driver.

### DIFF
--- a/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
@@ -29,12 +29,12 @@ void RageSoundDriver_DSound_Software::MixerThread()
 
 	/* Fill a buffer before we start playing, so we don't play whatever junk is
 	 * in the buffer. */
-	char *locked_buf;
-	unsigned len;
-	while( m_pPCM->get_output_buf(&locked_buf, &len, chunksize()) )
+	char *locked_buf_init;
+	unsigned len_init;
+	while( m_pPCM->get_output_buf(&locked_buf_init, &len_init, chunksize()) )
 	{
-		memset( locked_buf, 0, len );
-		m_pPCM->release_output_buf(locked_buf, len);
+		memset( locked_buf_init, 0, len_init );
+		m_pPCM->release_output_buf(locked_buf_init, len_init);
 	}
 
 	/* Start playing. */
@@ -74,9 +74,8 @@ int RageSoundDriver_DSound_Software::MixerThread_start(void *p)
 }
 
 RageSoundDriver_DSound_Software::RageSoundDriver_DSound_Software()
+	: m_pPCM(nullptr), m_iSampleRate(0), m_bShutdownMixerThread(false)
 {
-	m_bShutdownMixerThread = false;
-	m_pPCM = nullptr;
 }
 
 RString RageSoundDriver_DSound_Software::Init()

--- a/src/arch/arch_default.h
+++ b/src/arch/arch_default.h
@@ -21,7 +21,7 @@ inline const std::vector<RString>& GetDefaultMovieDriverList() {
 }
 
 inline const std::vector<RString>& GetDefaultSoundDriverList() {
-	static const std::vector<RString> soundDriverList = { "WaveOut", "DirectSound-sw", "WDMKS", "Null" };
+	static const std::vector<RString> soundDriverList = { "DirectSound-sw", "WaveOut", "WDMKS", "Null" };
 	return soundDriverList;
 }
 


### PR DESCRIPTION
## Purpose

With the fix in this PR we can revert to using DirectSound as the preferred sound API as it was prior to 2016.

A variable shadowing issue caused confusion between which buffer was being used and was responsible for the phenomenon where DirectSound had unreliable sync.  Some variable names are changed so that the shadowing does not occur.

## Why change from WaveOut

We recently changed the default Linux audio driver due to new improvements in the driver. I'd like to also change the default Windows audio driver for the same reason. I've played a lot of sessions on this and I think it's just about perfect. Also I had sync testers try this change and all reports were **very positive** and users **strongly preferred DirectSound**. WaveOut is also running in a compatibility layer in recent Windows versions which is all the more reason to replace it as the main Windows driver.

## Background

StepMania commit bd19b1b29a8f6d31845863b0e74844e74617338f from 2016 changed the default SM5 audio driver for Windows to be WaveOut,  around the same time now-reverted changes to `GameLoop` and `RageSoundDriver_Generic_Software` to mitigate DirectSound issues. These issues were only relevant in the 32-bit era, as the PR's / commits they come from reference Windows XP / 32-bit driver issues. The DirectSound driver was also still flawed at this point in time. At this point in history it seems to have been common for people to define WaveOut as the preferred sound driver in their `Preferences.ini` to deal with the sync issue of old SM5. 

After extensive testing I am finding the fixed DirectSound is extremely stable for our purposes. The DirectSound driver was generally well designed, but this variable shadowing bug made it unusable. So I think we can safely change back what this used to be.