### PR TITLE
(Win32 refresh) Threads_Win32

### DIFF
--- a/src/arch/Threads/Threads_Win32.cpp
+++ b/src/arch/Threads/Threads_Win32.cpp
@@ -43,9 +43,16 @@ HANDLE Win32ThreadIdToHandle(uint64_t iID)
 	return nullptr;
 }
 
-void ThreadImpl_Win32::Halt(bool /*Kill*/)
+void ThreadImpl_Win32::Halt(bool Kill)
 {
-	SuspendThread(ThreadHandle);
+	if (Kill)
+	{
+		ExitThread(0); // 0 indicates the thread was terminated
+	}
+	else
+	{
+		SuspendThread(ThreadHandle);
+	}
 }
 
 void ThreadImpl_Win32::Resume()


### PR DESCRIPTION
This file handles OS side interaction as well as the creation of threads within the game -  std::unique_ptr and std::mutex are introduced here for their safety and memory management benefits.

Mostly removal of compatibility code targeting Windows XP and earlier. For example a custom wrapper `PortableSignalObjectAndWait` was removed in favor of directly calling `SignalObjectAndWait`.

The `TerminateThread` call in ThreadImpl_Win32::Halt has been replaced with SuspendThread since it's the proper way to do it in the Windows API. This should resolve a Windows specific issue where the game might start acting strangely indefinitely until the system is rebooted. Also  we'll use ExitProcess if the `Kill` flag is passed.

Don't bother with the try-catch in SetThreadName unless this is a debug build (since exceptions are disabled in ITGm, so it won't work as expected).