### PR TITLE
(Win32 refresh) LoadingWindow_Win32

### DIFF
--- a/src/arch/LoadingWindow/LoadingWindow_Win32.cpp
+++ b/src/arch/LoadingWindow/LoadingWindow_Win32.cpp
@@ -27,7 +27,7 @@ static HBITMAP g_hBitmap = nullptr;
 /* Load a RageSurface into a GDI surface. */
 static HBITMAP LoadWin32Surface( const RageSurface *pSplash, HWND hWnd )
 {
-	RageSurface *s = CreateSurface( pSplash->w, pSplash->h, 24,
+	RageSurface *s = CreateSurface( pSplash->w, pSplash->h, 32,
 		0x00FF0000, 0x0000FF00, 0x000000FF, 0 );
 	RageSurfaceUtils::Blit( pSplash, s, -1, -1 );
 


### PR DESCRIPTION
No perceptible difference in loading window behavior, but is faster, reducing load times. The main bottleneck of this is actually the writing of the text.

- Speed up the loading window by drawing 24 bit instead of 32 bit.
- Always process three lines at a time in SetText, and just insert a blank line if there's nothing there, instead of checking if we have three lines to print each time.
- Use BitBlt instead of SetPixelV for the surface, as it is much faster - BitBlt directly writes to memory whereas SetPixelV calls a function for each pixel.