### PR TITLE
(Win32 refresh) Update DirectXHelpers.cpp

### DIFF
--- a/src/archutils/Win32/DirectXHelpers.cpp
+++ b/src/archutils/Win32/DirectXHelpers.cpp
@@ -1,6 +1,14 @@
 #include "global.h"
 #include "DirectXHelpers.h"
 #include "RageUtil.h"
+#include <cstdarg>
+#include <dinput.h>
+#include <d3d9.h>
+#include <mmsystem.h> // dsound.h needs this
+#include <dsound.h>
+#include <stdexcept>
+
+RString GetErrorString(HRESULT hr);
 
 RString hr_ssprintf( int hr, const char *fmt, ... )
 {
@@ -9,17 +17,9 @@ RString hr_ssprintf( int hr, const char *fmt, ... )
 	RString s = vssprintf( fmt, va );
 	va_end(va);
 
-	const char *szError = GetErrorString( hr );
-	return s + ssprintf( " (%s)", szError );
+	RString szError = GetErrorString(hr);
+	return s + ssprintf(" (%s)", szError.c_str());
 }
-
-// needed for defines
-#define DIRECTINPUT_VERSION 0x0800
-#define DIRECTSOUND_VERSION 0x0700
-#include <dinput.h>
-#include <d3d9.h>
-#include <mmsystem.h> // dsound.h needs this
-#include <dsound.h>
 
 #define DXERRMSG(hrcode, dummy) case hrcode: return #hrcode;
 

--- a/src/archutils/Win32/DirectXHelpers.h
+++ b/src/archutils/Win32/DirectXHelpers.h
@@ -7,6 +7,10 @@ RString hr_ssprintf( int hr, const char *fmt, ... );
 
 RString GetErrorString(HRESULT hr);
 
+// These defined need to be exposed anywhere this is included.
+#define DIRECTINPUT_VERSION 0x0800
+#define DIRECTSOUND_VERSION 0x0700
+
 #endif
 
 /*


### PR DESCRIPTION
The DirectInput / DirectSound version defs need to be exposed to other parts of the engine, so they are moved to the header instead of the cpp file.

Also using an RString instead of const char here is slightly safer as well.