### PR TITLE
(Win32 refresh) AppInstance

### DIFF
--- a/src/archutils/Win32/AppInstance.cpp
+++ b/src/archutils/Win32/AppInstance.cpp
@@ -1,12 +1,24 @@
 #include "global.h"
 #include "AppInstance.h"
+#include "RageLog.h"
+#include "ErrorStrings.h"
 
 AppInstance::AppInstance()
 {
 	// Little trick to get an HINSTANCE of ourself without having access to the hwnd.
-	TCHAR szFullAppPath[MAX_PATH];
-	GetModuleFileName(nullptr, szFullAppPath, MAX_PATH);
-	h = LoadLibrary(szFullAppPath);
+	WCHAR szFullAppPath[MAX_PATH];
+	if (GetModuleFileNameW(nullptr, szFullAppPath, MAX_PATH) == 0)
+	{
+		LOG->Warn("GetModuleFileName failed: %s", werr_ssprintf(GetLastError(), "GetModuleFileName").c_str());
+		h = nullptr;
+		return;
+	}
+
+	h = LoadLibraryW(szFullAppPath);
+	if (h == nullptr)
+	{
+		LOG->Warn("LoadLibrary failed: %s", werr_ssprintf(GetLastError(), "LoadLibrary").c_str());
+	}
 	/* h will be nullptr if this fails. Most operations that take an HINSTANCE
 	 * will still work without one (but may be missing graphics); that's OK. */
 }
@@ -14,7 +26,9 @@ AppInstance::AppInstance()
 AppInstance::~AppInstance()
 {
 	if(h)
+	{
 		FreeLibrary(h);
+	}
 }
 
 /*

--- a/src/archutils/Win32/AppInstance.h
+++ b/src/archutils/Win32/AppInstance.h
@@ -1,7 +1,7 @@
 #ifndef APP_INSTANCE_H
 #define APP_INSTANCE_H
 
-#include "windows.h"
+#include <windows.h>
 
 /** @brief get an HINSTANCE for starting dialog boxes. */
 class AppInstance


### PR DESCRIPTION
Upgrade to a non-deprecated API call (`GetModuleFileNameW` instead of `GetModuleFileName`), add some new logging to prevent silent failures, and updating to WCHAR so we can handle Unicode natively.
