### PR TITLE
Linux: Detect joystick hotplug (#73)

### DIFF
--- a/src/RageInput.cpp
+++ b/src/RageInput.cpp
@@ -6,6 +6,11 @@
 #include "LuaManager.h"
 #include "LocalizedString.h"
 
+#if LINUX
+// FIXME: bit gross to include this here, see GH issue #73
+#include "arch/InputHandler/LinuxInputManager.h"
+#endif
+
 #include <vector>
 
 
@@ -59,6 +64,11 @@ void RageInput::LoadDrivers()
 		delete m_InputHandlers[i].m_pDevice;
 	m_InputHandlers.clear();
 	g_mapDeviceToHandler.clear();
+
+#if LINUX
+	// Recreating this forces it to re-scan for devices.
+	LINUXINPUT = new LinuxInputManager;
+#endif
 
 	// Init optional devices.
 	std::vector<InputHandler *> apDevices;

--- a/src/RageInput.cpp
+++ b/src/RageInput.cpp
@@ -7,7 +7,8 @@
 #include "LocalizedString.h"
 
 #if LINUX
-// FIXME: bit gross to include this here, see GH issue #73
+// FIXME: bit gross to include this here, see GH issue #73:
+// https://github.com/itgmania/itgmania/issues/73#issuecomment-2597176788
 #include "arch/InputHandler/LinuxInputManager.h"
 #endif
 

--- a/src/RageInput.cpp
+++ b/src/RageInput.cpp
@@ -68,6 +68,8 @@ void RageInput::LoadDrivers()
 
 #if LINUX
 	// Recreating this forces it to re-scan for devices.
+	if( LINUXINPUT != nullptr )
+		delete LINUXINPUT;
 	LINUXINPUT = new LinuxInputManager;
 #endif
 

--- a/src/arch/InputHandler/InputHandler_Linux_Event.h
+++ b/src/arch/InputHandler/InputHandler_Linux_Event.h
@@ -25,8 +25,14 @@ private:
 	void InputThread();
 
 	RageThread m_InputThread;
+	// Currently only m_bDevicesChanged is guarded by this mutex
+	RageMutex m_InputMutex;
 	InputDevice m_NextDevice;
 	bool m_bShutdown, m_bDevicesChanged;
+	// Used to monitor for new devices
+	int m_udev_fd;
+	struct udev* m_udev;
+	struct udev_monitor* m_udev_monitor;
 };
 #define USE_INPUT_HANDLER_LINUX_JOYSTICK
 

--- a/src/arch/InputHandler/LinuxInputManager.cpp
+++ b/src/arch/InputHandler/LinuxInputManager.cpp
@@ -91,6 +91,9 @@ LinuxInputManager::LinuxInputManager()
 	closedir(sysClassInput);
 }
 
+LinuxInputManager::~LinuxInputManager()
+{
+}
 
 static bool presort_cmpDevices(LinuxInputSort a, LinuxInputSort b)
 {


### PR DESCRIPTION
Interface with libudev to get notified when a new joystick appears.

The code is in IH_Linux_Event rather than IH_Linux_Joystick because it seemed like the former uses evdev (standard for most devices nowadays) whereas the latter uses the old joydev API. The result should be the same in any case...

In any case, implementation is messy due to LinuxInputManager only scanning for devices from its constructor, this forces RageInput to have an exception for LinuxInputManager. Possibly with more involved surgery a cleaner solution could be devised...


----

Tested on my Debian Bookworm setup using a USB pad (SMX). Not sure how to test other platforms to ensure they're not broken? Edit: CI did pass here: https://github.com/tscalvert/itgmania/actions/runs/12820146536