### PR TITLE
Add fix and note for Routine mode loading in edit mode.

### DIFF
--- a/src/EditModePlayerManager.cpp
+++ b/src/EditModePlayerManager.cpp
@@ -10,7 +10,13 @@
 
 
 void EditModePlayerManager::AddPlayers(const NoteData& note_data) {
-	FOREACH_EnabledPlayer(pn){
+	FOREACH_EnabledPlayer(pn) {
+		// In case of a routine chart, both players are actually seen as
+		// enabled. This isn't desired, since the playerState and inputs in
+		// routine charts eventually collapse down only to P1.
+		if ((GAMESTATE->GetCurrentStyle(GAMESTATE->GetMasterPlayerNumber())->m_StyleType == StyleType_TwoPlayersSharedSides) && pn != PLAYER_1) {
+			continue;
+		}
 		players_[pn] = std::make_shared<PlayerPlus>();
 
 		PlayerPlus& player = *players_[pn];


### PR DESCRIPTION
Routine style only uses one PlayerPlus object. This change ensures that is the case in EditMode. Gameplay inputs and visibility is already only set to P1 in Routine style. Without this change, P2 will try and load song information with garbage data (inconsistently causing crashes).

This fixes the Routine mode crash in #600.