### PR TITLE
Revert Crash.cpp changes from Windows select display output

### DIFF
--- a/src/archutils/Win32/Crash.cpp
+++ b/src/archutils/Win32/Crash.cpp
@@ -349,45 +349,13 @@ static DWORD WINAPI MainExceptionHandler( LPVOID lpParameter )
 		/* The thread that crashed was the thread that created the main window.
 		 * Hide the window. This will also restore the video mode, if necessary. */
 		ShowWindow( g_hForegroundWnd, SW_HIDE );
-	}
-	else {
+	} else {
 		/* A different thread crashed. Simply kill all other windows. We can't
 		 * safely call ShowWindow; the main thread might be deadlocked. */
-		RageThread::HaltAllThreads(true);
-		auto deviceModeIsValid = [=](const DEVMODE& mode) {
-			return (mode.dmFields & DM_PELSWIDTH) && (mode.dmFields & DM_PELSHEIGHT)
-				&& (mode.dmFields & DM_DISPLAYFREQUENCY)
-				&& (mode.dmBitsPerPel >= 32 || !(mode.dmFields & DM_BITSPERPEL));
-			};
-
-		DEVMODE devmode;
-		ZeroMemory(&devmode, sizeof(DEVMODE));
-		devmode.dmSize = sizeof(DEVMODE);
-		devmode.dmDriverExtra = 0;
-
-		DWORD deviceIter = 0;
-		DISPLAY_DEVICE dd;
-		ZeroMemory(&dd, sizeof(dd));
-		dd.cb = sizeof(dd);
-
-		/* Since we don't know which display was modified for fullscreen exclusive mode,
-		 * loop through all displays it could have been to restore the video mode. */
-		while (EnumDisplayDevices(NULL, deviceIter++, &dd, 0))
-		{
-			while (EnumDisplaySettingsEx(dd.DeviceName, ENUM_CURRENT_SETTINGS, &devmode, 0))
-			{
-				if (deviceModeIsValid(devmode))
-				{
-					ChangeDisplaySettingsEx(dd.DeviceName, nullptr, nullptr, 0, nullptr);
-				}
-				ZeroMemory(&devmode, sizeof(DEVMODE));
-				devmode.dmSize = sizeof(DEVMODE);
-				devmode.dmDriverExtra = 0;
-			}
-		}
-		ZeroMemory(&dd, sizeof(dd));
-		dd.cb = sizeof(dd);
+		RageThread::HaltAllThreads( true );
+		ChangeDisplaySettings( nullptr, 0 );
 	}
+
 	InHere = false;
 
 	SetUnhandledExceptionFilter(nullptr);


### PR DESCRIPTION
Crash handler changes were causing instability after crashes as noted in #600.

This reverts parts of commit b46f929.

Reverting it means that certain crashes may not restore display settings on the selected output display to what they were before launching the game. I've reproduced the crash on Win10 that was mentioned in #600 after reverting the crash handler changes, and the display settings get restored correctly. So either native Windows crash handling is taking care of it or the graphics window is safely shutting down and restoring the settings during the crash.