### PR TITLE
Remove unnecessary loop from NoteField::Update

### DIFF
--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -378,11 +378,7 @@ void NoteField::Update( float fDeltaTime )
 	NoteDisplay::Update( fDeltaTime );
 	/* Update all NoteDisplays. Hack: We need to call this once per frame, not
 	 * once per player. */
-	// TODO: Remove use of PlayerNumber.
-
-	PlayerNumber pn = m_pPlayerState->m_PlayerNumber;
-	if( pn == GAMESTATE->GetMasterPlayerNumber() )
-		NoteDisplay::Update( fDeltaTime );
+	NoteDisplay::Update( fDeltaTime );
 }
 
 float NoteField::GetWidth() const


### PR DESCRIPTION
# Comments welcome.

Resolves an ancient TODO,  actually the loop being removed here is completely unnecessary. It was part of a large commit from 21 years ago which was moving around `PlayerNumber` info. The information we need is already provided by the `PlayerState` object, so there's no need to loop thru `PlayerNumber` here, we can just call `NoteDisplay::Update`.

There is not a clear reason why we update the `NoteDisplay` twice consecutively, there is no comment or hint in the commit it came from either, but it's what the engine has been doing for the last 21 years, so I'm going to leave it be and simply remove the unneeded loop.

Would like to see more thorough testing before merging; probably not going to look into this more until after the next release.