### PR TITLE
Update RageUtil::power_of_two

### DIFF
--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -122,25 +122,21 @@ float fmodfp(float x, float y)
 	return x;
 }
 
-int power_of_two( int input )
+/* https://graphics.stanford.edu/%7Eseander/bithacks.html#RoundUpPowerOf2 */
+int power_of_two( int v )
 {
-	int exp = 31, i = input;
-	if (i >> 16)
-		i >>= 16;
-	else exp -= 16;
-	if (i >> 8)
-		i >>= 8;
-	else exp -= 8;
-	if (i >> 4)
-		i >>= 4;
-	else exp -= 4;
-	if (i >> 2)
-		i >>= 2;
-	else exp -= 2;
-	if (i >> 1 == 0)
-		exp -= 1;
-	int value = 1 << exp;
-	return (input == value) ? value : (value << 1);
+	v--;
+	v |= v >> 1;
+	v |= v >> 2;
+	v |= v >> 4;
+	v |= v >> 8;
+	v |= v >> 16;
+	v++;
+
+	/* Always be sure to return a value of at least 1. In the event of any edge
+	 * cases, such as a zero or negative input, the returned value will be `1`. */
+	v += (v == 0);
+	return v;
 }
 
 bool IsAnInt( const RString &s )

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -328,7 +328,7 @@ void fapproach( float& val, float other_val, float to_move );
 /* Return a positive x mod y. */
 float fmodfp( float x, float y );
 
-int power_of_two( int input );
+int power_of_two( int v );
 bool IsAnInt( const RString &s );
 bool IsHexVal( const RString &s );
 RString BinaryToHex( const void *pData_, size_t iNumBytes );


### PR DESCRIPTION
Fixes a case where an input of `0` returns `2`.  Thanks to the commenter below for pointing out a mistake I made in the original commit & comment. :-)

This function [function used to](https://github.com/itgmania/itgmania/commit/5af37530d41a937b43892d199d706f935c5c0b7e) return 0 with an input of 0, and a negative number with a negative input, so I've replicated that behavior). In the case of a negative input I now have it returning `-1` and a logged error since `-1` is already used as an error code in much of the engine.

This function is called by:  LowLevelWindow_Win32, MovieTexture_Generic, MovieTexture_Null, ImageCache, RageBitmapTexture, RageDisplay_D3D & RageDisplay_OGL. 