### PR TITLE
Bugfix: Prevent invalid #MEASUREINFO tags from crashing application

### DIFF
--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -416,9 +416,15 @@ void SetMeasureInfo(StepsTagInfo& info)
 		split((*info.params)[1], "|", values, true);
 
 		MeasureInfo v[NUM_PLAYERS];
-		FOREACH_PlayerNumber(pn)
+		
+		// Sanity check that any data was actually loaded
+		// (invalid charts may end up with "#MEASUREINFO:|;" in the cache
+		if(values.size() == NUM_PLAYERS)
 		{
-			v[pn].FromString(values[pn]);
+			FOREACH_PlayerNumber(pn)
+			{
+				v[pn].FromString(values[pn]);
+			}
 		}
 		info.steps->SetCachedMeasureInfo(v);
 	}


### PR DESCRIPTION
This fixes the crashes that Lemone was describing on Discord.

Some simfiles have empty placeholder charts with what are now invalid dance types (eg para-versus, iidx-double7). When saving cache data for these simfiles, tags like `#RADARVALUES` and `#TECHCOUNTS` get filled out their default values of just all -1's. But `#MEASUREINFO` doesn't really have a default value, so it ends up getting written to file as `#MEASUREINFO:|;`. And upon loading the cache files, the game would crash while calling `NotesLoaderSSC:SetMeasureInfo()`, due to it trying to access an empty array.