### PR TITLE
Replace #MEASUREINFO with two separate tags

### DIFF
--- a/src/MeasureInfo.h
+++ b/src/MeasureInfo.h
@@ -4,11 +4,6 @@
 #include "GameConstantsAndTypes.h"
 #include "NoteData.h"
 
-/** This is a container for per-measure stats of a stepchart.
- This data is calculated and saved to the song cache files as the #MEASUREINFO tag.
- This data is provided to the theme via lua functions in Steps.cpp and Trail.cpp,
- */
-
 struct MeasureInfo
 {
 	int measureCount;

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -421,18 +421,20 @@ void SetNpsPerMeasure(StepsTagInfo& info)
 			LOG->Warn("#NPSPERMEASURE has more sections (%zu) than possible number of players (%d)!", valuesPerPlayer.size(), NUM_PlayerNumber);
 		}
 		
+		std::vector<std::vector<float>> npsPerMeasures;
 		for(std::size_t pn = 0; pn < valuesPerPlayer.size() && pn < NUM_PlayerNumber; pn++)
 		{
 			std::vector<RString> values;
 			split(valuesPerPlayer[pn], ",", values, true);
-			std::vector<int> npsPerMeasure;
+			std::vector<float> npsPerMeasure;
 			npsPerMeasure.resize(values.size());
 			for(std::size_t i = 0; i < values.size(); i++)
 			{
 				npsPerMeasure[i] = StringToFloat(values[i]);
 			}
-			info.steps->SetCachedNotesPerMeasure(npsPerMeasure, static_cast<PlayerNumber>(pn));
+			npsPerMeasures.push_back(npsPerMeasure);
 		}
+		info.steps->SetCachedNpsPerMeasure(npsPerMeasures);
 	}
 	else
 	{
@@ -454,6 +456,7 @@ void SetNotesPerMeasure(StepsTagInfo& info)
 			
 		}
 		
+		std::vector<std::vector<int>> notesPerMeasures;
 		for(std::size_t pn = 0; pn < valuesPerPlayer.size() && pn < NUM_PlayerNumber; pn++)
 		{
 			std::vector<RString> values;
@@ -464,8 +467,9 @@ void SetNotesPerMeasure(StepsTagInfo& info)
 			{
 				notesPerMeasure[i] = StringToInt(values[i]);
 			}
-			info.steps->SetCachedNotesPerMeasure(notesPerMeasure, static_cast<PlayerNumber>(pn));
+			notesPerMeasures.push_back(notesPerMeasure);
 		}
+		info.steps->SetCachedNotesPerMeasure(notesPerMeasures);
 	}
 	else
 	{

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -408,19 +408,52 @@ void SetTechCounts(StepsTagInfo& info)
 	info.ssc_format= true;
 }
 
-void SetMeasureInfo(StepsTagInfo& info)
+void SetNpsPerMeasure(StepsTagInfo& info)
 {
 	if (info.from_cache || info.for_load_edit)
 	{
 		std::vector<RString> values;
-		split((*info.params)[1], "|", values, true);
+		split((*info.params)[1], ",", values, true);
+		std::size_t measures_per_player = values.size() / NUM_PlayerNumber;
+		std::vector<std::vector<float>> npsPerMeasure;
+		npsPerMeasure.resize(NUM_PLAYERS);
 
-		MeasureInfo v[NUM_PLAYERS];
 		FOREACH_PlayerNumber(pn)
 		{
-			v[pn].FromString(values[pn]);
+			npsPerMeasure[pn].resize(measures_per_player, 0);
+			for(std::size_t i= 0; i < measures_per_player; ++i)
+			{
+				npsPerMeasure[pn][i]= StringToFloat(values[pn * measures_per_player + i]);
+			}
 		}
-		info.steps->SetCachedMeasureInfo(v);
+		info.steps->SetCachedNpsPerMeasure(npsPerMeasure);
+	}
+	else
+	{
+		// just recalc at time.
+	}
+	info.ssc_format= true;
+}
+
+void SetNotesPerMeasure(StepsTagInfo& info)
+{
+	if (info.from_cache || info.for_load_edit)
+	{
+		std::vector<RString> values;
+		split((*info.params)[1], ",", values, true);
+		std::size_t measures_per_player = values.size() / NUM_PlayerNumber;
+		std::vector<std::vector<int>> notesPerMeasure;
+		notesPerMeasure.resize(NUM_PLAYERS);
+
+		FOREACH_PlayerNumber(pn)
+		{
+			notesPerMeasure[pn].resize(measures_per_player, 0);
+			for(std::size_t i= 0; i < measures_per_player; ++i)
+			{
+				notesPerMeasure[pn][i]= StringToInt(values[pn * measures_per_player + i]);
+			}
+		}
+		info.steps->SetCachedNotesPerMeasure(notesPerMeasure);
 	}
 	else
 	{
@@ -670,7 +703,8 @@ struct ssc_parser_helper_t
 		steps_tag_handlers["FAKES"]= &SetStepsFakes;
 		steps_tag_handlers["LABELS"]= &SetStepsLabels;
 		steps_tag_handlers["TECHCOUNTS"] = &SetTechCounts;
-		steps_tag_handlers["MEASUREINFO"] = &SetMeasureInfo;
+		steps_tag_handlers["NPSPERMEASURE"] = &SetNpsPerMeasure;
+		steps_tag_handlers["NOTESPERMEASURE"] = &SetNotesPerMeasure;
 
 		/* If this is called, the chart does not use the same attacks
 		 * as the Song's timing. No other changes are required. */

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -412,21 +412,27 @@ void SetNpsPerMeasure(StepsTagInfo& info)
 {
 	if (info.from_cache || info.for_load_edit)
 	{
-		std::vector<RString> values;
-		split((*info.params)[1], ",", values, true);
-		std::size_t measures_per_player = values.size() / NUM_PlayerNumber;
-		std::vector<std::vector<float>> npsPerMeasure;
-		npsPerMeasure.resize(NUM_PLAYERS);
-
-		FOREACH_PlayerNumber(pn)
+		
+		std::vector<RString> valuesPerPlayer;
+		split((*info.params)[1], "|", valuesPerPlayer, true);
+		
+		if(valuesPerPlayer.size() > NUM_PlayerNumber)
 		{
-			npsPerMeasure[pn].resize(measures_per_player, 0);
-			for(std::size_t i= 0; i < measures_per_player; ++i)
-			{
-				npsPerMeasure[pn][i]= StringToFloat(values[pn * measures_per_player + i]);
-			}
+			LOG->Warn("#NPSPERMEASURE has more sections (%zu) than possible number of players (%d)!", valuesPerPlayer.size(), NUM_PlayerNumber);
 		}
-		info.steps->SetCachedNpsPerMeasure(npsPerMeasure);
+		
+		for(std::size_t pn = 0; pn < valuesPerPlayer.size() && pn < NUM_PlayerNumber; pn++)
+		{
+			std::vector<RString> values;
+			split(valuesPerPlayer[pn], ",", values, true);
+			std::vector<int> npsPerMeasure;
+			npsPerMeasure.resize(values.size());
+			for(std::size_t i = 0; i < values.size(); i++)
+			{
+				npsPerMeasure[i] = StringToFloat(values[i]);
+			}
+			info.steps->SetCachedNotesPerMeasure(npsPerMeasure, static_cast<PlayerNumber>(pn));
+		}
 	}
 	else
 	{
@@ -439,21 +445,27 @@ void SetNotesPerMeasure(StepsTagInfo& info)
 {
 	if (info.from_cache || info.for_load_edit)
 	{
-		std::vector<RString> values;
-		split((*info.params)[1], ",", values, true);
-		std::size_t measures_per_player = values.size() / NUM_PlayerNumber;
-		std::vector<std::vector<int>> notesPerMeasure;
-		notesPerMeasure.resize(NUM_PLAYERS);
-
-		FOREACH_PlayerNumber(pn)
+		std::vector<RString> valuesPerPlayer;
+		split((*info.params)[1], "|", valuesPerPlayer, true);
+		
+		if(valuesPerPlayer.size() > NUM_PlayerNumber)
 		{
-			notesPerMeasure[pn].resize(measures_per_player, 0);
-			for(std::size_t i= 0; i < measures_per_player; ++i)
-			{
-				notesPerMeasure[pn][i]= StringToInt(values[pn * measures_per_player + i]);
-			}
+			LOG->Warn("#NOTESPERMEASURE has more sections (%zu) than possible number of players (%d)!", valuesPerPlayer.size(), NUM_PlayerNumber);
+			
 		}
-		info.steps->SetCachedNotesPerMeasure(notesPerMeasure);
+		
+		for(std::size_t pn = 0; pn < valuesPerPlayer.size() && pn < NUM_PlayerNumber; pn++)
+		{
+			std::vector<RString> values;
+			split(valuesPerPlayer[pn], ",", values, true);
+			std::vector<int> notesPerMeasure;
+			notesPerMeasure.resize(values.size());
+			for(std::size_t i = 0; i < values.size(); i++)
+			{
+				notesPerMeasure[i] = StringToInt(values[i]);
+			}
+			info.steps->SetCachedNotesPerMeasure(notesPerMeasure, static_cast<PlayerNumber>(pn));
+		}
 	}
 	else
 	{

--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -439,16 +439,31 @@ static RString GetSSCNoteData( const Song &song, const Steps &in, bool bSavingCa
 			}
 		}
 		lines.push_back(ssprintf("#TECHCOUNTS:%s;", join(",", asTechCounts).c_str()));
-
-		std::vector<RString> asMeasureInfo;
-		FOREACH_PlayerNumber( pn )
+		
+		std::vector<RString> asNpsPerMeasure;
+		FOREACH_PlayerNumber(pn)
 		{
-			const MeasureInfo &ms = in.GetMeasureInfo(pn);
-			asMeasureInfo.push_back(ms.ToString());
+			const std::vector<float> &npsPerMeasure = in.GetNpsPerMeasure(pn);
+			for(unsigned i = 0; i < npsPerMeasure.size(); i++)
+			{
+				asNpsPerMeasure.push_back(ssprintf("%.3f", npsPerMeasure[i]));
+			}
 		}
-		RString allMeasureInfo = "#MEASUREINFO:" + join("|", asMeasureInfo) + ";";
-		lines.push_back(allMeasureInfo);
+		
+		lines.push_back( ssprintf( "#NPSPERMEASURE:%s;", join(",",asNpsPerMeasure).c_str() ) );
 
+		std::vector<RString> asNotesPerMeasure;
+		FOREACH_PlayerNumber(pn)
+		{
+			const std::vector<int> &notesPerMeasure = in.GetNotesPerMeasure(pn);
+			for(unsigned i = 0; i < notesPerMeasure.size(); i++)
+			{
+				asNotesPerMeasure.push_back(ssprintf("%d", notesPerMeasure[i]));
+			}
+		}
+		
+		lines.push_back( ssprintf( "#NOTESPERMEASURE:%s;", join(",",asNotesPerMeasure).c_str() ) );
+		
 		// NOTE(MV): #STEPFILENAME has to be at the end of the cache tags,
 		// because it's used in SSCLoader::LoadFromSimfile to determine when
 		// to switch the state back to GETTING_SONG_INFO, which means any tags

--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -440,29 +440,30 @@ static RString GetSSCNoteData( const Song &song, const Steps &in, bool bSavingCa
 		}
 		lines.push_back(ssprintf("#TECHCOUNTS:%s;", join(",", asTechCounts).c_str()));
 		
-		std::vector<RString> asNpsPerMeasure;
-		FOREACH_PlayerNumber(pn)
+		// NpsPerMeasure and NotesPerMeasure are stored differently from Radar Values and Tech Counts,
+		// because the number of measures is variable.
+		// For charts that have different steps per player, each set of values is separated
+		// with pipes "|".
+		// The vast majority of charts don't, so there's no reason to store duplicated data.
+		const std::vector<std::vector<float>> &allNpsPerMeasures = in.GetAllNpsPerMeasures();
+		std::vector<RString> npsPerMeasureStrings;
+		
+		for(std::vector<float> npsPerMeasure : allNpsPerMeasures)
 		{
-			const std::vector<float> &npsPerMeasure = in.GetNpsPerMeasure(pn);
-			for(unsigned i = 0; i < npsPerMeasure.size(); i++)
-			{
-				asNpsPerMeasure.push_back(ssprintf("%.3f", npsPerMeasure[i]));
-			}
+			npsPerMeasureStrings.push_back(serialize(npsPerMeasure, ",", 3));
 		}
 		
-		lines.push_back( ssprintf( "#NPSPERMEASURE:%s;", join(",",asNpsPerMeasure).c_str() ) );
+		lines.push_back( ssprintf( "#NPSPERMEASURE:%s;", join("|",npsPerMeasureStrings).c_str() ) );
 
-		std::vector<RString> asNotesPerMeasure;
-		FOREACH_PlayerNumber(pn)
+		const std::vector<std::vector<int>> &allNotesPerMeasures = in.GetAllNotesPerMeasures();
+		std::vector<RString> notesPerMeasureStrings;
+		
+		for(std::vector<int> notesPerMeasure : allNotesPerMeasures)
 		{
-			const std::vector<int> &notesPerMeasure = in.GetNotesPerMeasure(pn);
-			for(unsigned i = 0; i < notesPerMeasure.size(); i++)
-			{
-				asNotesPerMeasure.push_back(ssprintf("%d", notesPerMeasure[i]));
-			}
+			notesPerMeasureStrings.push_back(serialize(notesPerMeasure, ","));
 		}
 		
-		lines.push_back( ssprintf( "#NOTESPERMEASURE:%s;", join(",",asNotesPerMeasure).c_str() ) );
+		lines.push_back( ssprintf( "#NOTESPERMEASURE:%s;", join("|",notesPerMeasureStrings).c_str() ) );
 		
 		// NOTE(MV): #STEPFILENAME has to be at the end of the cache tags,
 		// because it's used in SSCLoader::LoadFromSimfile to determine when

--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -447,7 +447,7 @@ static RString GetSSCNoteData( const Song &song, const Steps &in, bool bSavingCa
 		// The vast majority of charts don't, so there's no reason to store duplicated data.
 		const std::vector<std::vector<float>> &allNpsPerMeasures = in.GetAllNpsPerMeasures();
 		std::vector<RString> npsPerMeasureStrings;
-		
+		npsPerMeasureStrings.reserve(allNpsPerMeasures.size());
 		for(std::vector<float> npsPerMeasure : allNpsPerMeasures)
 		{
 			npsPerMeasureStrings.push_back(serialize(npsPerMeasure, ",", 3));
@@ -457,7 +457,7 @@ static RString GetSSCNoteData( const Song &song, const Steps &in, bool bSavingCa
 
 		const std::vector<std::vector<int>> &allNotesPerMeasures = in.GetAllNotesPerMeasures();
 		std::vector<RString> notesPerMeasureStrings;
-		
+		notesPerMeasureStrings.reserve(allNotesPerMeasures.size());
 		for(std::vector<int> notesPerMeasure : allNotesPerMeasures)
 		{
 			notesPerMeasureStrings.push_back(serialize(notesPerMeasure, ","));

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -721,6 +721,28 @@ RString join( const RString &sDelimitor, std::vector<RString>::const_iterator be
 	return sRet;
 }
 
+RString serialize(const std::vector<float> & sSource, const RString &sDelimitor, int precision)
+{
+	std::vector<RString> values;
+	RString precisionStr = ssprintf("%%.%df", precision);
+	for(float s : sSource)
+	{
+		values.push_back(ssprintf(precisionStr, s));
+	}
+	return join(sDelimitor, values);
+}
+
+RString serialize(const std::vector<int> & sSource, const RString &sDelimitor)
+{
+	std::vector<RString> values;
+	for(int s : sSource)
+	{
+		values.push_back(ssprintf("%d", s));
+	}
+	return join(sDelimitor, values);
+}
+
+
 RString SmEscape( const RString &sUnescaped, const std::vector<char> charsToEscape )
 {
 	return SmEscape(sUnescaped.c_str(), sUnescaped.size(), charsToEscape);

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -724,6 +724,7 @@ RString join( const RString &sDelimitor, std::vector<RString>::const_iterator be
 RString serialize(const std::vector<float> & sSource, const RString &sDelimitor, int precision)
 {
 	std::vector<RString> values;
+	values.reserve(sSource.size());
 	RString precisionStr = ssprintf("%%.%df", precision);
 	for(float s : sSource)
 	{
@@ -735,6 +736,7 @@ RString serialize(const std::vector<float> & sSource, const RString &sDelimitor,
 RString serialize(const std::vector<int> & sSource, const RString &sDelimitor)
 {
 	std::vector<RString> values;
+	values.reserve(sSource.size());
 	for(int s : sSource)
 	{
 		values.push_back(ssprintf("%d", s));

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -435,6 +435,10 @@ void split( const std::wstring &sSource, const std::wstring &sDelimitor, int &iB
 RString join( const RString &sDelimitor, const std::vector<RString>& sSource );
 RString join( const RString &sDelimitor, std::vector<RString>::const_iterator begin, std::vector<RString>::const_iterator end );
 
+// Joins a vector of numbers to a serialized string of numbers separated by Delimitor.
+RString serialize(const std::vector<float> & sSource, const RString &sDelimitor, int precision);
+RString serialize(const std::vector<int> & sSource, const RString &sDelimitor);
+
 // These methods escapes a string for saving in a .sm or .crs file
 RString SmEscape(const RString &sUnescaped, const std::vector<char> charsToEscape = {'\\', ':', ';'});
 RString SmEscape( const char *cUnescaped, int len, const std::vector<char> charsToEscape = {'\\', ':', ';'} );

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -51,7 +51,7 @@
  * @brief The internal version of the cache for StepMania.
  *
  * Increment this value to invalidate the current cache. */
-const int FILE_CACHE_VERSION = 228;
+const int FILE_CACHE_VERSION = 229;
 
 /** @brief How long does a song sample last by default? */
 const float DEFAULT_MUSIC_SAMPLE_LENGTH = 12.f;

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -757,35 +757,29 @@ void Steps::SetCachedTechCounts( const TechCounts ts[NUM_PLAYERS] )
 	m_bAreCachedTechCountsValuesJustLoaded = true;
 }
 
-void Steps::SetCachedNpsPerMeasure(std::vector<float>& npsPerMeasure, PlayerNumber pn)
+void Steps::SetCachedNpsPerMeasure(std::vector<std::vector<float>>& npsPerMeasure)
 {
 	DeAutogen();
+	m_CachedNpsPerMeasure.assign(npsPerMeasure.begin(), npsPerMeasure.end());
+	m_PeakNps.clear();
 	
-	if(m_CachedNpsPerMeasure.size() <= pn)
+	for(std::vector<float> n : npsPerMeasure)
 	{
-		m_CachedNpsPerMeasure.resize(pn + 1);
-		m_PeakNps.resize(pn + 1);
+		std::vector<float>::iterator peakNps = std::max_element(n.begin(), n.end());
+		if(peakNps != n.end())
+		{
+			m_PeakNps.push_back(*peakNps);
+		}
 	}
 	
-	m_CachedNpsPerMeasure[pn].assign(npsPerMeasure.begin(), npsPerMeasure.end());
-	std::vector<float>::iterator peakNps = std::max_element(npsPerMeasure.begin(), npsPerMeasure.end());
-	if(peakNps != npsPerMeasure.end())
-	{
-		m_PeakNps[pn] = *peakNps;
-	}
 	m_AreCachedNpsPerMeasureJustLoaded = true;
 }
 
-void Steps::SetCachedNotesPerMeasure(std::vector<int>& notesPerMeasure, PlayerNumber pn)
+void Steps::SetCachedNotesPerMeasure(std::vector<std::vector<int>>& notesPerMeasure)
 {
 	DeAutogen();
 	
-	if(m_CachedNotesPerMeasure.size() <= pn)
-	{
-		m_CachedNotesPerMeasure.resize(pn + 1);
-	}
-	
-	m_CachedNotesPerMeasure[pn].assign(notesPerMeasure.begin(), notesPerMeasure.end());
+	m_CachedNotesPerMeasure.assign(notesPerMeasure.begin(), notesPerMeasure.end());
 	m_AreCachedNotesPerMeasureJustLoaded = true;
 }
 

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -145,8 +145,8 @@ public:
 	void SetMeter( int meter );
 	void SetCachedRadarValues( const RadarValues v[NUM_PLAYERS] );
 	void SetCachedTechCounts(const TechCounts ts[NUM_PLAYERS]);
-	void SetCachedNpsPerMeasure(std::vector<std::vector<float>>& npsPerMeasure);
-	void SetCachedNotesPerMeasure(std::vector<std::vector<int>>& notesPerMeasure);
+	void SetCachedNpsPerMeasure(std::vector<float>& npsPerMeasure, PlayerNumber pn);
+	void SetCachedNotesPerMeasure(std::vector<int>& notesPerMeasure, PlayerNumber pn);
 	float PredictMeter() const;
 
 	unsigned GetHash() const;
@@ -180,9 +180,12 @@ public:
 
 	void CalculateMeasureInfo();
 	
-	const std::vector<float> &GetNpsPerMeasure(PlayerNumber pn) const { return Real()->m_CachedNpsPerMeasure[pn]; }
-	const std::vector<int> &GetNotesPerMeasure(PlayerNumber pn) const { return Real()->m_CachedNotesPerMeasure[pn]; }
-	float GetPeakNps(PlayerNumber pn) const { return Real()->m_PeakNps[pn]; }
+	const std::vector<std::vector<float>> & GetAllNpsPerMeasures() const { return Real()->m_CachedNpsPerMeasure; }
+	const std::vector<float> &GetNpsPerMeasure(PlayerNumber pn) const;
+	const std::vector<std::vector<int>> & GetAllNotesPerMeasures() const { return Real()->m_CachedNotesPerMeasure; };
+	const std::vector<int> &GetNotesPerMeasure(PlayerNumber pn) const;
+	
+	float GetPeakNps(PlayerNumber pn) const;
 
 	/**
 	 * @brief The TimingData used by the Steps.
@@ -287,7 +290,7 @@ private:
 	std::vector<std::vector<int>> m_CachedNotesPerMeasure;
 	bool m_AreCachedNotesPerMeasureJustLoaded;
 	
-	float m_PeakNps[NUM_PLAYERS];
+	std::vector<float> m_PeakNps;
 	
 	
 	

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -145,7 +145,8 @@ public:
 	void SetMeter( int meter );
 	void SetCachedRadarValues( const RadarValues v[NUM_PLAYERS] );
 	void SetCachedTechCounts(const TechCounts ts[NUM_PLAYERS]);
-	void SetCachedMeasureInfo(const MeasureInfo ms[NUM_PLAYERS]);
+	void SetCachedNpsPerMeasure(std::vector<std::vector<float>>& npsPerMeasure);
+	void SetCachedNotesPerMeasure(std::vector<std::vector<int>>& notesPerMeasure);
 	float PredictMeter() const;
 
 	unsigned GetHash() const;
@@ -178,7 +179,10 @@ public:
 	const TechCounts &GetTechCounts(PlayerNumber pn) const { return Real()->m_CachedTechCounts[pn]; }
 
 	void CalculateMeasureInfo();
-	const MeasureInfo &GetMeasureInfo(PlayerNumber pn) const { return Real()->m_CachedMeasureInfo[pn]; }
+	
+	const std::vector<float> &GetNpsPerMeasure(PlayerNumber pn) const { return Real()->m_CachedNpsPerMeasure[pn]; }
+	const std::vector<int> &GetNotesPerMeasure(PlayerNumber pn) const { return Real()->m_CachedNotesPerMeasure[pn]; }
+	float GetPeakNps(PlayerNumber pn) const { return Real()->m_PeakNps[pn]; }
 
 	/**
 	 * @brief The TimingData used by the Steps.
@@ -276,9 +280,17 @@ private:
 	/** @brief The tech stats used for each player */
 	mutable TechCounts m_CachedTechCounts[NUM_PLAYERS];
 	bool m_bAreCachedTechCountsValuesJustLoaded;
-
-	mutable MeasureInfo m_CachedMeasureInfo[NUM_PLAYERS];
-	bool m_bAreCachedMeasureInfoJustLoaded;
+	
+	std::vector<std::vector<float>> m_CachedNpsPerMeasure;
+	bool m_AreCachedNpsPerMeasureJustLoaded;
+	
+	std::vector<std::vector<int>> m_CachedNotesPerMeasure;
+	bool m_AreCachedNotesPerMeasureJustLoaded;
+	
+	float m_PeakNps[NUM_PLAYERS];
+	
+	
+	
 
 	/** @brief The name of the person who created the Steps. */
 	RString				m_sCredit;

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -145,8 +145,8 @@ public:
 	void SetMeter( int meter );
 	void SetCachedRadarValues( const RadarValues v[NUM_PLAYERS] );
 	void SetCachedTechCounts(const TechCounts ts[NUM_PLAYERS]);
-	void SetCachedNpsPerMeasure(std::vector<float>& npsPerMeasure, PlayerNumber pn);
-	void SetCachedNotesPerMeasure(std::vector<int>& notesPerMeasure, PlayerNumber pn);
+	void SetCachedNpsPerMeasure(std::vector<std::vector<float>>& npsPerMeasure);
+	void SetCachedNotesPerMeasure(std::vector<std::vector<int>>& notesPerMeasure);
 	float PredictMeter() const;
 
 	unsigned GetHash() const;


### PR DESCRIPTION
This is an alternative to PR #617.
This replaces the `#MEASUREINFO` tag with two separate tags, `#NPSPERMEASURE` and `#NOTESPERMEASURE`.

The way that `#MEASUREINFO` was storing this data was just kind of complicated, all for the sake of avoiding having to write more saving/loading boilerplate. Invalid charts would result in a _nearly_ empty tag `#MEASUREINFO:|;`, which was then causing problems when loading cached data.

Splitting the data into two tags avoids that complication and allows the data to be handled similarly to other tags like `#RADARVALUES` and `#TECHCOUNTS`.

I'm like 99% certain that adding a new tag starting with "NOTES" won't cause any issues. All of the engine-side references to "NOTES" look to be direct comparisons. There is a regex is SL-ChartParser that looks like it should be fine (and it'll be looking at the actual simfile, not the cache file).