### PR TITLE
Use `SetPosition_hard` instead of `SetPosition_toc` for the mp3 position, add needed error handling to `SetPosition_hard`

### DIFF
--- a/src/RageSoundReader_MP3.cpp
+++ b/src/RageSoundReader_MP3.cpp
@@ -785,8 +785,14 @@ int RageSoundReader_MP3::SetPosition_hard( int iFrame )
 	/* If we're already past the requested position, rewind. */
 	if(mad_timer_compare(mad->Timer, desired) > 0)
 	{
-		MADLIB_rewind();
-		do_mad_frame_decode();
+		if (!MADLIB_rewind())
+		{
+			return -1;
+		}
+		if (do_mad_frame_decode() <= 0)
+		{
+			return -1;
+		}
 		synthed = false;
 	}
 

--- a/src/RageSoundReader_MP3.h
+++ b/src/RageSoundReader_MP3.h
@@ -41,7 +41,6 @@ private:
 
 
 	bool MADLIB_rewind();
-	int SetPosition_toc( int iSample, bool Xing );
 	int SetPosition_hard( int iSample );
 	int SetPosition_estimate( int iSample );
 


### PR DESCRIPTION
Resolves #610.

## About this commit

`RageSoundReader_MP3` has three different methods of setting the position. The default choice of `SetPosition_toc` is unable to provide an accurate result. The reason Edit Mode has such a severe desync when working with MP3's is due to the preference of using `SetPosition_toc`.

We can prevent this by using `SetPosition_hard` which works very well.  Judging by comments in the file, it seems like `SetPosition_hard` was too resource intensive to use as the default method, 20+ years ago.

The reason for removing the TOC method entirely is because it has a different concept of the "start" of the audio compared to `SetPosition_hard` or `MADLIB_rewind` (due to how madlib works it has to rewind to the start of the stream and then count up from there to find where it has to be).

## Fixing the glitched audio / crackling sound when starting from an arbitrary point

`SetPosition_hard` was not accounting for the case where `do_mad_frame_decode` returns with an error state. I added the new commit 178a165 which resolves this by properly handling the case where `do_mad_frame_decode` returns a zero or negative value. This commit completely fixes the glitch/crackling/etc that was happening when starting playback from certain offsets.

## Further details

When we start from the beginning of a file, such as playing a song, or using `Play whole song` in edit mode, `MADLIB_rewind` will be used; this is the same behavior as SM5.1.

`SetPosition_hard` provides an accurate result, and uses `MADLIB_rewind` internally. The result is a consistent sync experience whether the MP3 is started from the beginning, or from an arbitrary position midway thru the file. It's also as accurate as possible, because instead of using a TOC map with 1/256 accuracy, we're now doing a hard seek to precisely where we need to be, each time, no exceptions.

The `m_bAccurateSync` boolean dependency has been removed from SetPosition. It was previously needed because `SetPosition_toc` might set MAD's timer to low accuracy mode. The boolean check is now removed so that we can call `MADLIB_rewind` or `SetPosition_hard` as fast as possible.

In my testing I never got `SetPosition_estimate` to be used, but I've left it in as a backup option. This is because `mad->has_xing` will return true whether the file has a VBR Xing tag or a CBR INFO tag, so in most cases `mad->has_xing` will never fail, even with MP3's from very old packs, so `SetPosition_estimate` should never get called.