### PR TITLE
Add Recently Played and Most Played sorts by profile

### DIFF
--- a/Themes/_fallback/Graphics/Banner Popularity.redir
+++ b/Themes/_fallback/Graphics/Banner Popularity.redir
@@ -1,0 +1,1 @@
+Common fallback banner

--- a/Themes/_fallback/Graphics/Banner Recent.redir
+++ b/Themes/_fallback/Graphics/Banner Recent.redir
@@ -1,0 +1,1 @@
+Common fallback banner

--- a/Themes/_fallback/Languages/en.ini
+++ b/Themes/_fallback/Languages/en.ini
@@ -306,9 +306,13 @@ HardMeterText=Hard Meter
 LengthText=Length
 MediumMeterText=Medium Meter
 PopularityText=Player's Best!
+PopularityP1Text=P1's Most Played
+PopularityP2Text=P2's Most Played
 PreferredText=Preferred
 TitleText=Title
-RecentText=Recent
+RecentText=Recently Played
+RecentP1Text=P1's Recent Songs
+RecentP2Text=P2's Recent Songs
 TopGradesText=Top Grades
 TopP1GradesText=P1 Top Grades
 TopP2GradesText=P2 Top Grades
@@ -2035,6 +2039,8 @@ LowestGrades=Lowest Grades
 MostPlays=Most Plays
 Randomize=Randomize
 TopGrades=Top Grades
+RecentlyPlayed=Recently Played
+MostPlayed=Most Played
 
 [Sort]
 NotAvailable=N/A

--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -965,13 +965,15 @@ RecentSongsToShow=30
 
 UseEasyMarkerFlag=false
 
-ModeMenuChoiceNames="Preferred,Group,Title,Bpm,Popularity,TopGrades,TopP1Grades,TopP2Grades,Artist,EasyMeter,MediumMeter,HardMeter,ChallengeMeter,DoubleEasyMeter,DoubleMediumMeter,DoubleHardMeter,DoubleChallengeMeter,Genre,Length,Recent"
+ModeMenuChoiceNames="Preferred,Group,Title,Bpm,Popularity,PopularityP1,PopularityP2,TopGrades,TopP1Grades,TopP2Grades,Artist,EasyMeter,MediumMeter,HardMeter,ChallengeMeter,DoubleEasyMeter,DoubleMediumMeter,DoubleHardMeter,DoubleChallengeMeter,Genre,Length,Recent,RecentP1,RecentP2"
 # ModeMenuChoiceNames="Preferred,Group,Title,Bpm,Popularity,TopGrades,Artist,EasyMeter,MediumMeter,HardMeter,ChallengeMeter,DoubleEasyMeter,DoubleMediumMeter,DoubleHardMeter,DoubleChallengeMeter,Genre,Length,Recent,NormalMode,BattleMode"
 ChoicePreferred="sort,Preferred"
 ChoiceGroup="sort,Group"
 ChoiceTitle="sort,Title"
 ChoiceBpm="sort,BPM"
 ChoicePopularity="sort,Popularity"
+ChoicePopularityP1="sort,PopularityP1"
+ChoicePopularityP2="sort,PopularityP2"
 ChoiceTopGrades="sort,TopGrades"
 ChoiceTopP1Grades="sort,TopP1Grades"
 ChoiceTopP2Grades="sort,TopP2Grades"
@@ -987,6 +989,8 @@ ChoiceDoubleHardMeter="sort,DoubleHardMeter"
 ChoiceDoubleChallengeMeter="sort,DoubleChallengeMeter"
 ChoiceLength="sort,Length"
 ChoiceRecent="sort,Recent"
+ChoiceRecentP1="sort,RecentP1"
+ChoiceRecentP2="sort,RecentP2"
 ChoiceNormalMode="playmode,regular"
 ChoiceBattleMode="playmode,battle"
 

--- a/src/Banner.cpp
+++ b/src/Banner.cpp
@@ -224,14 +224,27 @@ void Banner::LoadRandom()
 void Banner::LoadFromSortOrder( SortOrder so )
 {
 	// TODO: See if the check for nullptr/PREFERRED(?) is needed.
-	if( so == SortOrder_Invalid )
+	switch( so )
 	{
-		LoadFallback();
-	}
-	else
-	{
-		if( so != SORT_GROUP && so != SORT_RECENT && so != SORT_RECENT_P1 && so != SORT_RECENT_P2 )
+		case SortOrder_Invalid:		
+			LoadFallback(); 
+			break;
+		case SORT_GROUP:
+			break;
+		// This is necessary to prevent multiple banners from matching for SORT_RECENT and SORT_POPULARITY
+		case SORT_RECENT:
+		case SORT_RECENT_P1:
+		case SORT_RECENT_P2:
+			Load( THEME->GetPathG("Banner",ssprintf("%s",SortOrderToString(SORT_RECENT).c_str())) );
+			break;
+		case SORT_POPULARITY:
+		case SORT_POPULARITY_P1:
+		case SORT_POPULARITY_P2:
+			Load( THEME->GetPathG("Banner",ssprintf("%s",SortOrderToString(SORT_POPULARITY).c_str())) );
+			break;
+		default: 			
 			Load( THEME->GetPathG("Banner",ssprintf("%s",SortOrderToString(so).c_str())) );
+			break;
 	}
 	m_bScrolling = (bool)SCROLL_SORT_ORDER;
 }

--- a/src/Banner.cpp
+++ b/src/Banner.cpp
@@ -230,7 +230,7 @@ void Banner::LoadFromSortOrder( SortOrder so )
 	}
 	else
 	{
-		if( so != SORT_GROUP && so != SORT_RECENT )
+		if( so != SORT_GROUP && so != SORT_RECENT && so != SORT_RECENT_P1 && so != SORT_RECENT_P2 )
 			Load( THEME->GetPathG("Banner",ssprintf("%s",SortOrderToString(so).c_str())) );
 	}
 	m_bScrolling = (bool)SCROLL_SORT_ORDER;

--- a/src/GameConstantsAndTypes.cpp
+++ b/src/GameConstantsAndTypes.cpp
@@ -163,6 +163,8 @@ static const char *SortOrderNames[] = {
 	"Title",
 	"BPM",
 	"Popularity",
+	"PopularityP1",
+	"PopularityP2",
 	"TopGrades",
 	"TopP1Grades",
 	"TopP2Grades",
@@ -186,6 +188,8 @@ static const char *SortOrderNames[] = {
 	"Length",
 	"Roulette",
 	"Recent",
+	"RecentP1",
+	"RecentP2",
 };
 XToString( SortOrder );
 StringToX( SortOrder );

--- a/src/GameConstantsAndTypes.h
+++ b/src/GameConstantsAndTypes.h
@@ -167,6 +167,8 @@ enum SortOrder
 	SORT_TITLE, /**< Sort by the Song's title. */
 	SORT_BPM, /**< Sort by the Song's BPM. */
 	SORT_POPULARITY, /**< Sort by how popular the Song is. */
+	SORT_POPULARITY_P1, /**< Sort by how popular the Song is for P1. */
+	SORT_POPULARITY_P2, /**< Sort by how popular the Song is for P2. */
 	SORT_TOP_GRADES, /**< Sort by the highest grades earned on a Song. */
 	SORT_TOP_GRADES_P1, /**< Sort by the highest grades earned on a Song for P1. */
 	SORT_TOP_GRADES_P2, /**< Sort by the highest grades earned on a Song for P2. */
@@ -192,6 +194,8 @@ enum SortOrder
 	SORT_LENGTH, /**< Sort the songs/courses by how long they would last. */
 	SORT_ROULETTE,
 	SORT_RECENT,
+	SORT_RECENT_P1, /**< Sort by the most recent play for P1. */
+	SORT_RECENT_P2, /**< Sort by the most recent play for P2. */
 	NUM_SortOrder,
 	SortOrder_Invalid
 };

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -625,7 +625,7 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 				case SORT_POPULARITY:
 					if( (int) arraySongs.size() > MOST_PLAYED_SONGS_TO_SHOW )
 						arraySongs.erase( arraySongs.begin()+MOST_PLAYED_SONGS_TO_SHOW, arraySongs.end() );
-					bUseSections = false;
+					bUseSections = true;
 					break;
 				case SORT_POPULARITY_P1:
 					if( PROFILEMAN->IsPersistentProfile(PLAYER_1) )
@@ -666,7 +666,7 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 					SongUtil::SortByMostRecentlyPlayedForMachine( arraySongs );
 					if( (int) arraySongs.size() > RECENT_SONGS_TO_SHOW )
 						arraySongs.erase( arraySongs.begin()+RECENT_SONGS_TO_SHOW, arraySongs.end() );
-					bUseSections = false;
+					bUseSections = true;
 					break;
 				case SORT_RECENT_P1:
 					if( PROFILEMAN->IsPersistentProfile(PLAYER_1) )

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -562,6 +562,8 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 		case SORT_TITLE:
 		case SORT_BPM:
 		case SORT_POPULARITY:
+		case SORT_POPULARITY_P1:
+		case SORT_POPULARITY_P2:
 		case SORT_TOP_GRADES:
 		case SORT_TOP_GRADES_P1:
 		case SORT_TOP_GRADES_P2:
@@ -578,6 +580,8 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 		case SORT_DOUBLE_CHALLENGE_METER:
 		case SORT_LENGTH:
 		case SORT_RECENT:
+		case SORT_RECENT_P1:
+		case SORT_RECENT_P2:
 		{
 			// Make an array of Song*, then sort them
 			std::vector<Song*> arraySongs;
@@ -623,6 +627,20 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 						arraySongs.erase( arraySongs.begin()+MOST_PLAYED_SONGS_TO_SHOW, arraySongs.end() );
 					bUseSections = false;
 					break;
+				case SORT_POPULARITY_P1:
+					if( PROFILEMAN->IsPersistentProfile(PLAYER_1) )
+						SongUtil::SortSongPointerArrayByNumPlays( arraySongs, ProfileSlot_Player1, true );
+					if( (int) arraySongs.size() > MOST_PLAYED_SONGS_TO_SHOW )
+						arraySongs.erase( arraySongs.begin()+MOST_PLAYED_SONGS_TO_SHOW, arraySongs.end() );
+					bUseSections = true;
+					break;
+				case SORT_POPULARITY_P2:
+					if( PROFILEMAN->IsPersistentProfile(PLAYER_2) )
+						SongUtil::SortSongPointerArrayByNumPlays( arraySongs, ProfileSlot_Player2, true );
+					if( (int) arraySongs.size() > MOST_PLAYED_SONGS_TO_SHOW )
+						arraySongs.erase( arraySongs.begin()+MOST_PLAYED_SONGS_TO_SHOW, arraySongs.end() );
+					bUseSections = true;
+					break;
 				case SORT_TOP_GRADES:
 						SongUtil::SortSongPointerArrayByGrades( arraySongs, true );
 					break;
@@ -649,6 +667,20 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 					if( (int) arraySongs.size() > RECENT_SONGS_TO_SHOW )
 						arraySongs.erase( arraySongs.begin()+RECENT_SONGS_TO_SHOW, arraySongs.end() );
 					bUseSections = false;
+					break;
+				case SORT_RECENT_P1:
+					if( PROFILEMAN->IsPersistentProfile(PLAYER_1) )
+						SongUtil::SortByMostRecentlyPlayedForProfile( arraySongs, PLAYER_1 );
+					if( (int) arraySongs.size() > RECENT_SONGS_TO_SHOW )
+						arraySongs.erase( arraySongs.begin()+RECENT_SONGS_TO_SHOW, arraySongs.end() );
+					bUseSections = true;
+					break;
+				case SORT_RECENT_P2:
+					if( PROFILEMAN->IsPersistentProfile(PLAYER_2) )
+						SongUtil::SortByMostRecentlyPlayedForProfile( arraySongs, PLAYER_2 );
+					if( (int) arraySongs.size() > RECENT_SONGS_TO_SHOW )
+						arraySongs.erase( arraySongs.begin()+RECENT_SONGS_TO_SHOW, arraySongs.end() );
+					bUseSections = true;
 					break;
 				case SORT_BEGINNER_METER:
 				case SORT_EASY_METER:
@@ -1142,7 +1174,8 @@ void MusicWheel::FilterWheelItemDatas(std::vector<MusicWheelItemData *> &aUnFilt
 	}
 
 	/* Update the popularity.  This is affected by filtering. */
-	if( so == SORT_POPULARITY )
+	if( so == SORT_POPULARITY || so == SORT_POPULARITY_P1 || so == SORT_POPULARITY_P2 )
+
 	{
 		for( unsigned i=0; i < std::min<unsigned int>(3u, aFilteredData.size()); i++ )
 		{

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -634,9 +634,6 @@ void SongUtil::SortSongPointerArrayByNumPlays( std::vector<Song*> &vpSongsInOut,
 	g_mapSongSortVal.clear();
 }
 
-static LocalizedString SECTION_RECENTLY_PLAYED("SongSort", "Recently Played");
-static LocalizedString SECTION_POPULAR_SONGS("SongSort", "Most Played");
-
 RString SongUtil::GetSectionNameFromSongAndSort( const Song* pSong, SortOrder so )
 {
 	if( pSong == nullptr )
@@ -705,11 +702,10 @@ RString SongUtil::GetSectionNameFromSongAndSort( const Song* pSong, SortOrder so
 	case SORT_POPULARITY:
 	case SORT_POPULARITY_P1:
 	case SORT_POPULARITY_P2:
-		return SECTION_POPULAR_SONGS.GetValue();
 	case SORT_RECENT:
 	case SORT_RECENT_P1:
 	case SORT_RECENT_P2:
-		return SECTION_RECENTLY_PLAYED.GetValue();
+		return THEME->GetString("MusicWheel", ssprintf("%s%s", SortOrderToString(so).c_str(), "Text"));
 	case SORT_TOP_GRADES_P1:
 			{
 			int iCounts[NUM_Grade];

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -700,7 +700,11 @@ RString SongUtil::GetSectionNameFromSongAndSort( const Song* pSong, SortOrder so
 				return RString();
 		}
 	case SORT_POPULARITY:
+	case SORT_POPULARITY_P1:
+	case SORT_POPULARITY_P2:
 	case SORT_RECENT:
+	case SORT_RECENT_P1:
+	case SORT_RECENT_P2:
 		return RString();
 	case SORT_TOP_GRADES_P1:
 			{
@@ -828,6 +832,19 @@ void SongUtil::SortByMostRecentlyPlayedForMachine( std::vector<Song*> &vpSongsIn
 		g_mapSongSortVal[s] = val;
 	}
 
+	stable_sort( vpSongsInOut.begin(), vpSongsInOut.end(), CompareSongPointersBySortValueDescending );
+	g_mapSongSortVal.clear();
+}
+
+void SongUtil::SortByMostRecentlyPlayedForProfile( std::vector<Song*> &vpSongsInOut, PlayerNumber pn )
+{
+	Profile *pProfile = PROFILEMAN->GetProfile(pn);
+	for (Song const *s : vpSongsInOut)
+	{
+		int iNumTimesPlayed = pProfile->GetSongNumTimesPlayed( s );
+		RString val = iNumTimesPlayed ? pProfile->GetSongLastPlayedDateTime(s).GetString() : RString("0");
+		g_mapSongSortVal[s] = val;
+	}
 	stable_sort( vpSongsInOut.begin(), vpSongsInOut.end(), CompareSongPointersBySortValueDescending );
 	g_mapSongSortVal.clear();
 }

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -634,6 +634,9 @@ void SongUtil::SortSongPointerArrayByNumPlays( std::vector<Song*> &vpSongsInOut,
 	g_mapSongSortVal.clear();
 }
 
+static LocalizedString SECTION_RECENTLY_PLAYED("SongSort", "Recently Played");
+static LocalizedString SECTION_POPULAR_SONGS("SongSort", "Most Played");
+
 RString SongUtil::GetSectionNameFromSongAndSort( const Song* pSong, SortOrder so )
 {
 	if( pSong == nullptr )
@@ -702,10 +705,11 @@ RString SongUtil::GetSectionNameFromSongAndSort( const Song* pSong, SortOrder so
 	case SORT_POPULARITY:
 	case SORT_POPULARITY_P1:
 	case SORT_POPULARITY_P2:
+		return SECTION_POPULAR_SONGS.GetValue();
 	case SORT_RECENT:
 	case SORT_RECENT_P1:
 	case SORT_RECENT_P2:
-		return RString();
+		return SECTION_RECENTLY_PLAYED.GetValue();
 	case SORT_TOP_GRADES_P1:
 			{
 			int iCounts[NUM_Grade];

--- a/src/SongUtil.h
+++ b/src/SongUtil.h
@@ -160,6 +160,7 @@ namespace SongUtil
 	RString GetSectionNameFromSongAndSort( const Song *pSong, SortOrder so );
 	void SortSongPointerArrayBySectionName( std::vector<Song*> &vpSongsInOut, SortOrder so );
 	void SortByMostRecentlyPlayedForMachine( std::vector<Song*> &vpSongsInOut );
+	void SortByMostRecentlyPlayedForProfile( std::vector<Song*> &vpSongsInOut, PlayerNumber pn);
 	void SortSongPointerArrayByLength( std::vector<Song*> &vpSongsInOut );
 
 	int CompareSongPointersByGroup(const Song *pSong1, const Song *pSong2);


### PR DESCRIPTION
This PR adds the ability to view Recently Played and Most Played by profile rather than just by machine. These sorts are added following the same naming convention of the TOP_GRADES sorts (i.e. TOP_GRADES_P1).

This also adds sections for Most Played and Recently Played as if you try to view these without Random/Portal/etc enabled. It's a bit difficult to know when the list ends/begins. 

![image](https://github.com/user-attachments/assets/910d3139-0ce7-45ed-97f8-f97ce5f79fd6)

![image](https://github.com/user-attachments/assets/40c5ccbb-af39-40ef-9167-304ff5b2757d)
