### PR TITLE
Streamline message processing logic in LoadingWindow_Win32::Paint()

### DIFF
--- a/src/arch/LoadingWindow/LoadingWindow_Win32.cpp
+++ b/src/arch/LoadingWindow/LoadingWindow_Win32.cpp
@@ -169,13 +169,16 @@ void LoadingWindow_Win32::Paint()
 {
 	SendMessage( hwnd, WM_PAINT, 0, 0 );
 
-	/* Process all queued messages since the last paint.  This allows the window to
-	 * come back if it loses focus during load. */
+	/* Process all queued messages since the last paint. If the window loses focus,
+	 * skip the missed messages and process only the current message. */
 	MSG msg;
-	while( PeekMessage( &msg, hwnd, 0, 0, PM_NOREMOVE ) )
+	HWND foregroundWindow = GetForegroundWindow();
+	while (PeekMessage(&msg, hwnd, 0, 0, PM_REMOVE))
 	{
-		GetMessage(&msg, hwnd, 0, 0 );
-		DispatchMessage( &msg );
+		if (foregroundWindow == hwnd || msg.message == WM_PAINT)
+		{
+			DispatchMessage(&msg);
+		}
 	}
 }
 


### PR DESCRIPTION
## Please note - this change was initially intended to resolve a Windows-specific issue teejusb reported to me. This ended up being unrelated to that problem. Still, this reduces the amount of cpu load in the loading window incurs when it loses and regains focus (via reducing # of function calls) so I've left this PR open.

A potential bottleneck in this code is the window behavior when it regains focus after losing it for a while, where it will briefly max out the CPU trying to process all the missed messages from when it didn't have focus. This commit changes that logic to always process the current message while in focus, and skip everything else if the window does not have focus.

Calling PeekMessage with the PM_REMOVE flag simply discards the message if the loading window doesn't have focus, which allows it to continue song loading without getting bogged down.

The comment is rewritten both to reflect the new logic and because the hacky behavior of needing to process missed paints to prevent a window from disappearing isn't true, or at least isn't on any relatively modern Windows. The code in this commit handles losing and regaining focus very gracefully.