### PR TITLE
Account for a null terminator in archutils/Win32/CommandLine.cpp

### DIFF
--- a/src/archutils/Win32/CommandLine.cpp
+++ b/src/archutils/Win32/CommandLine.cpp
@@ -28,12 +28,14 @@ int GetWin32CmdLine( char** &argv )
 
 	LocalFree(argvW);
 
-	argv = new char* [args.size()];
+	// args.size() + 1 to account for a null terminator
+	argv = new char* [args.size() + 1];
 	for (size_t i = 0; i < args.size(); ++i)
 	{
 		argv[i] = new char[args[i].size() + 1];
 		strcpy(argv[i], args[i].c_str());
 	}
+	argv[args.size()] = nullptr;
 
 	return argc;
 }


### PR DESCRIPTION
Prevents a possible buffer overrun if a null terminator is present, which could overflow the buffer by the size of the null terminator. Thanks to a Visual Studio compiler warning for pointing out the necessity of handling that extra 8 bytes here.