### PR TITLE
Add a new method to grab the current screen name, and then use it to only log audio buffer underrun errors when NOT in the song wheel.

### DIFF
--- a/src/RageSoundPosMap.cpp
+++ b/src/RageSoundPosMap.cpp
@@ -3,6 +3,7 @@
 #include "RageLog.h"
 #include "RageUtil.h"
 #include "RageTimer.h"
+#include "ScreenManager.h"
 
 #include <climits>
 #include <cmath>
@@ -160,7 +161,11 @@ int64_t pos_map_queue::Search( int64_t iSourceFrame ) const
 	if( last.PeekDeltaTime() >= 1.0f )
 	{
 		last.Touch();
-		LOG->Trace("Audio frame (%lld) was out of range of the data sent - possible buffer underflow? This is not always an error, however if you see it frequently there could be sound buffer problems.", iSourceFrame);
+		if (SCREENMAN->GetTopScreenName() != RString("ScreenSelectMusic"))
+		{
+			// The user is currently picking a song in the songwheel. Underruns are expected. Don't log them.
+			LOG->Trace("Audio buffer underrun at frame %lld, using closest known position instead.", iSourceFrame);
+		}
 	}
 
 	return iClosestPosition;

--- a/src/RageSoundPosMap.cpp
+++ b/src/RageSoundPosMap.cpp
@@ -156,6 +156,8 @@ int64_t pos_map_queue::Search( int64_t iSourceFrame ) const
 	 * 2. After GetDataToPlay returns EOF and the sound has flushed, but before
 	 *    SoundStopped has been called.
 	 * 3. Underflow; we'll be given a larger frame number than we know about.
+	 *    This is normal while the user is selecting a song in ScreenSelectMusic,
+	 *    so it's not necessary to log an error in that case.
 	 */
 	static RageTimer last;
 	if( last.PeekDeltaTime() >= 1.0f )
@@ -163,7 +165,6 @@ int64_t pos_map_queue::Search( int64_t iSourceFrame ) const
 		last.Touch();
 		if (SCREENMAN->GetTopScreenName() != RString("ScreenSelectMusic"))
 		{
-			// The user is currently picking a song in the songwheel. Underruns are expected. Don't log them.
 			LOG->Trace("Audio buffer underrun at frame %lld, using closest known position instead.", iSourceFrame);
 		}
 	}

--- a/src/ScreenManager.cpp
+++ b/src/ScreenManager.cpp
@@ -905,6 +905,16 @@ void ScreenManager::PlaySharedBackgroundOffCommand()
 	g_pSharedBGA->PlayCommand("Off");
 }
 
+RString ScreenManager::GetTopScreenName()
+{
+	Screen* topScreen = const_cast<ScreenManager*>(this)->GetTopScreen();
+	if (topScreen != nullptr)
+	{
+		return topScreen->GetName();
+	}
+	return "";
+}
+
 // lua start
 #include "LuaBinding.h"
 

--- a/src/ScreenManager.h
+++ b/src/ScreenManager.h
@@ -71,6 +71,8 @@ public:
 	bool get_input_redirected(PlayerNumber pn);
 	void set_input_redirected(PlayerNumber pn, bool redir);
 
+	RString GetTopScreenName();
+
 	// Lua
 	void PushSelf( lua_State *L );
 


### PR DESCRIPTION
## 9318dd7aa092789db1cdaab7e97c227da46600d6
A new function is added to **ScreenManager.cpp** which gets the name of the current screen, and returns it as an RString.

The function was carefully designed with safety of the `const_cast` in mind. The new function does not modify any states. We simply retrieve a pointer to the top screen in the stack, and then ask for its name.

## d30e7ad05d756577ad0843c47a4a947742992e58
I wanted to suppress the "Audio buffer underrun" error generated by **RageSoundPosMap.cpp** when the player is in the song wheel.

We know with certainty that when the user is in the song wheel, going through the songs, it will very likely trigger the "Audio buffer underrun" log warning once they settle on a song.

We can prevent this unnecessary log message with the new function introduced in the commit above. I use it to check if the current screen name is `ScreenSelectMusic`. If it is, we don't log the error. If it isn't, we log the error.

This change will make the log file cleaner as well as provide more accurate information relating to any audio issues the user may be having.