### PR TITLE
Prevent a crash when re-scanning an empty folder in SongManager::LoadSongDir [obsoleted by #633]

### DIFF
--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -436,10 +436,13 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 		RString group_base_name= Basename(sGroupDirName);
 		Group* group = new Group(sDir, sGroupDirName);
 
+		bool groupAdded = false;
+
 		// Add the group to the group mapping
 		if (m_mapNameToGroup.find(sGroupDirName) == m_mapNameToGroup.end())
 		{
 			m_mapNameToGroup[sGroupDirName] = group;
+			groupAdded = true;
 		} 
 
 		for( unsigned j=0; j< arraySongDirs.size(); ++j )	// for each song dir
@@ -488,10 +491,12 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 		// Don't add the group name if we didn't load any songs in this group.
 		if(!loaded) {
 			// Remove the group from the group mapping
-			auto it = m_mapNameToGroup.find(sGroupDirName);
-			if (it != m_mapNameToGroup.end())
-			{
-				m_mapNameToGroup.erase(it);
+			if (groupAdded) {
+				auto it = m_mapNameToGroup.find(sGroupDirName);
+				if (it != m_mapNameToGroup.end())
+				{
+					m_mapNameToGroup.erase(it);
+				}
 			}
 			delete group;
 			continue;


### PR DESCRIPTION
Resolves https://github.com/Simply-Love/Simply-Love-SM5/issues/608


Relevant commit: https://github.com/itgmania/itgmania/commit/8f6d5b44b9227e65540c72d5f3ce6e1f139a1e79


## description of error 

An empty folder (a folder without audio or simfile) can trigger this crash, because it might attempt to remove a group from the group mapping which was never added in the first place.  

## the fix 

Adding a boolean (groupAdded) to track whether or not we need to perform that removal prevents this crash.