### PR TITLE
Prevent a crash when loading a group with no additions when reloading

### DIFF
--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -435,12 +435,16 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 		SongPointerVector& index_entry = m_mapSongGroupIndex[sGroupDirName];
 		RString group_base_name= Basename(sGroupDirName);
 		Group* group = new Group(sDir, sGroupDirName);
-
+		
+		// We need to keep track of previously loaded groups so we don't delete them if we're only loading additions
+		bool groupAlreadyLoaded = false;
 		// Add the group to the group mapping
 		if (m_mapNameToGroup.find(sGroupDirName) == m_mapNameToGroup.end())
 		{
 			m_mapNameToGroup[sGroupDirName] = group;
-		} 
+		} else {
+			groupAlreadyLoaded = true;
+		}
 
 		for( unsigned j=0; j< arraySongDirs.size(); ++j )	// for each song dir
 		{
@@ -484,6 +488,11 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 		}
 
 		LOG->Trace("Loaded %i songs from \"%s\"", loaded, (sDir+sGroupDirName).c_str() );
+
+		// If we're only loading additions, already loaded groups should neither be added nor deleted
+		if (groupAlreadyLoaded && onlyAdditions) {
+			continue;
+		}
 
 		// Don't add the group name if we didn't load any songs in this group.
 		if(!loaded) {
@@ -593,7 +602,7 @@ void SongManager::FreeSongs()
 	{
 		RageUtil::SafeDelete( song );
 	}
-    // Loop through all groups in the mapand delete them.
+    // Loop through all groups in the map and delete them.
 	for (auto it = m_mapNameToGroup.begin(); it != m_mapNameToGroup.end(); ++it)
 	{
 		Group* group = it->second;


### PR DESCRIPTION
When reloading and only loading additions, ensure we do not delete/readd groups that were already loaded.

Problem: 
When Loading new songs, if a Group had no additions, it was then deleted as it was perceived to be empty. See:
![image](https://github.com/user-attachments/assets/069b5533-70cf-46fa-b8a3-f1207773d286)

This is ``valid`` when ``onlyAdditions`` is ``false``, but when we're loading ``onlyAdditions`` (when it's ``true``) most groups will have 0 songs loaded because they were unchanged. This adds some additional handling for when ``onlyAdditions`` is true.

We skip both group deletion and addition when ``onlyAdditions`` and ``groupAlreadyLoaded`` are true

See: https://github.com/Simply-Love/Simply-Love-SM5/issues/608
