### PR TITLE
Fix spaghetti music wheel when two Pack.ini s have the same sort title

### DIFF
--- a/Themes/_fallback/Languages/en.ini
+++ b/Themes/_fallback/Languages/en.ini
@@ -535,7 +535,7 @@ Transfer Edits to USB=Transfer Edits to USB
 Transfer Edits from USB=Transfer Edits from USB
 UseUnlockSystem=Enable or disable the unlock system.
 VisualDelaySeconds=Calibrate display lag.
-MachineSyncBias=Set the default Sync Bias for content on this machine. \nITG = +9ms.\n Null = 0ms.
+MachineSyncBias=Set the default Sync Bias for content on this machine. \nITG = +9ms.\n NULL = 0ms.
 Vsync=Cap your frame rate your display's refresh rate.  This option only has an effect when the Display Mode is set to &oq;Full Screen&cq;.
 WideScreen16_9=Enable widescreen display.
 WideScreen16_10=Enable widescreen display.
@@ -843,7 +843,7 @@ NoLifts=No Lifts
 NoFakes=No Fakes
 None=None
 Normal=Normal
-Null=Null
+NULL=NULL
 Num Songs=Num Songs
 Off=Off
 Old=Old

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -728,6 +728,9 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 				/* We're using sections, so use the section name as the top-level sort. */
 				switch( so )
 				{
+					case SORT_GROUP:
+						SongUtil::SortSongPointerArrayByGroup(arraySongs);
+						break;
 					case SORT_METER:
 					case SORT_PREFERRED:
 					case SORT_TOP_GRADES:
@@ -799,7 +802,7 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 								unsigned j;
 								for( j=i; j < arraySongs.size(); j++ )
 								{
-									if( SongUtil::GetSectionNameFromSongAndSort( arraySongs[j], so ) != sThisSection )
+									if( SONGMAN->GetGroup(arraySongs[j])->GetGroupName() != sThisSection )
 										break;
 								}
 								iSectionCount = j-i;

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -802,8 +802,12 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 								unsigned j;
 								for( j=i; j < arraySongs.size(); j++ )
 								{
-									if( SONGMAN->GetGroup(arraySongs[j])->GetGroupName() != sThisSection )
+									if ( SONGMAN->GetGroup(arraySongs[j]) == nullptr ) {
+										LOG->Warn( "Song %s has no group!", arraySongs[j]->GetSongDir().c_str() );
+										continue;
+									} else if ( SONGMAN->GetGroup(arraySongs[j])->GetGroupName() != sThisSection ) {
 										break;
+									}
 								}
 								iSectionCount = j-i;
 
@@ -847,7 +851,7 @@ void MusicWheel::BuildWheelItemDatas( std::vector<MusicWheelItemData *> &arrayWh
 								sLastSection = sThisSection;
 							}
 						}
-						arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Song, pSong, sLastSection, nullptr, SONGMAN->GetGroup(pSong), SONGMAN->GetSongColor(pSong), 0) );
+						arrayWheelItemDatas.push_back( new MusicWheelItemData(WheelItemDataType_Song, pSong, sLastSection, nullptr, nullptr, SONGMAN->GetSongColor(pSong), 0) );
 					}
 					break;
 			}

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -477,7 +477,13 @@ bool Song::ReloadFromSongDir( RString sDir )
 		return false;
 	copy.RemoveAutoGenNotes();
 	*this = copy;
-	m_SongTiming.m_fBeat0GroupOffsetInSeconds = SONGMAN->GetGroup(this)->GetSyncOffset();
+	
+	if (SONGMAN->GetGroup(this) != nullptr) {
+		m_SongTiming.m_fBeat0GroupOffsetInSeconds = SONGMAN->GetGroup(this)->GetSyncOffset();
+	} else {
+		m_SongTiming.m_fBeat0GroupOffsetInSeconds = PREFSMAN->m_fMachineSyncBias;
+		LOG->Warn("Song %s has no group, using machine sync bias.", m_sMainTitle.c_str());
+	}
 
 	/* Go through the steps, first setting their Song pointer to this song
 	 * (instead of the copy used above), and constructing a map to let us
@@ -493,7 +499,11 @@ bool Song::ReloadFromSongDir( RString sDir )
 		// Reapply the Group Offset if the steps have their own timing data.
 		if( mNewSteps[id]->m_Timing.empty() )
 			continue;
-		mNewSteps[id]->m_Timing.m_fBeat0GroupOffsetInSeconds = SONGMAN->GetGroup(this)->GetSyncOffset();
+		if (SONGMAN->GetGroup(this) != nullptr)
+			mNewSteps[id]->m_Timing.m_fBeat0GroupOffsetInSeconds = SONGMAN->GetGroup(this)->GetSyncOffset();
+		else
+			m_SongTiming.m_fBeat0GroupOffsetInSeconds = PREFSMAN->m_fMachineSyncBias;
+			LOG->Warn("Song %s has no group, using machine sync bias.", m_sMainTitle.c_str());
 	}
 
 	// Now we wipe out the new pointers, which were shallow copied and not deep copied...

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -593,31 +593,48 @@ void SongUtil::SortSongPointerArrayByGenre( std::vector<Song*> &vpSongsInOut )
 	stable_sort( vpSongsInOut.begin(), vpSongsInOut.end(), CompareSongPointersByGenre );
 }
 
+void SongUtil::SortSongPointerArrayByGroup( std::vector<Song*> &vpSongsInOut )
+{
+	stable_sort( vpSongsInOut.begin(), vpSongsInOut.end(), CompareSongPointersByGroup );
+}
+
 int SongUtil::CompareSongPointersByGroup(const Song *pSong1, const Song *pSong2)
 {
-	// Check if the sort title exists
-	if( SONGMAN->GetGroup(pSong1)->GetSortTitle().empty() || SONGMAN->GetGroup(pSong2)->GetSortTitle().empty() ) {
+	
+	RString s1 = SONGMAN->GetGroup(pSong1)->GetSortTitle();
+	RString s2 = SONGMAN->GetGroup(pSong2)->GetSortTitle();
+	// Sort Titles are the same, fall back on group folder name
+	if( s1 == s2 )
+	{
 		return pSong1->m_sGroupName < pSong2->m_sGroupName;
-	} else {
-		return SONGMAN->GetGroup(pSong1)->GetSortTitle() < SONGMAN->GetGroup(pSong2)->GetSortTitle();
 	}
+
+	s1 = SongUtil::MakeSortString(s1);
+	s2 = SongUtil::MakeSortString(s2);
+
+	int ret = strcmp( s1, s2 );
+	return ret < 0;
 }
 
 static int CompareSongPointersByGroupAndTitle( const Song *pSong1, const Song *pSong2 )
 {
+	RString s1 = SONGMAN->GetGroup(pSong1)->GetSortTitle();
+	RString s2 = SONGMAN->GetGroup(pSong2)->GetSortTitle();
+	// Sort Titles are the same, fall back on group folder name
+	if( s1 == s2 )
+	{
+		/* Same group; compare by name. */
+		if( pSong1->m_sGroupName == pSong2->m_sGroupName )
+			return CompareSongPointersByTitle( pSong1, pSong2 );
+		else
+			return pSong1->m_sGroupName < pSong2->m_sGroupName;
+	}
 
-	// Check if the sort title exists
-	const RString &sGroup1 = SONGMAN->GetGroup(pSong1)->GetSortTitle();
-	const RString &sGroup2 = SONGMAN->GetGroup(pSong2)->GetSortTitle();
+	s1 = SongUtil::MakeSortString(s1);
+	s2 = SongUtil::MakeSortString(s2);
 
-	if( sGroup1 < sGroup2 )
-		return true;
-	if( sGroup1 > sGroup2 )
-		return false;
-
-	/* Same group; compare by name. */
-	return CompareSongPointersByTitle( pSong1, pSong2 );
-	
+	int ret = strcmp( s1, s2 );
+	return ret < 0;
 }
 
 void SongUtil::SortSongPointerArrayByGroupAndTitle( std::vector<Song*> &vpSongsInOut )
@@ -653,7 +670,7 @@ RString SongUtil::GetSectionNameFromSongAndSort( const Song* pSong, SortOrder so
 		return SONGMAN->SongToPreferredSortSectionName( pSong );
 	case SORT_GROUP:
 		// guaranteed not empty
-		return SONGMAN->GetGroup(pSong)->GetSortTitle();
+		return SONGMAN->GetGroup(pSong)->GetGroupName();
 	case SORT_TITLE:
 	case SORT_ARTIST:
 		{

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -600,9 +600,19 @@ void SongUtil::SortSongPointerArrayByGroup( std::vector<Song*> &vpSongsInOut )
 
 int SongUtil::CompareSongPointersByGroup(const Song *pSong1, const Song *pSong2)
 {
+	RString s1 = "";
+	RString s2 = "";
+
+	if( SONGMAN->GetGroup(pSong1) != nullptr )
+		s1 = SONGMAN->GetGroup(pSong1)->GetSortTitle();
+	else
+		LOG->Warn("SongUtil::CompareSongPointersByGroup: %s has no group", pSong1->GetSongDir().c_str());
+
+	if( SONGMAN->GetGroup(pSong2) != nullptr )
+		s2 = SONGMAN->GetGroup(pSong2)->GetSortTitle();
+	else
+		LOG->Warn("SongUtil::CompareSongPointersByGroup: %s has no group", pSong2->GetSongDir().c_str());
 	
-	RString s1 = SONGMAN->GetGroup(pSong1)->GetSortTitle();
-	RString s2 = SONGMAN->GetGroup(pSong2)->GetSortTitle();
 	// Sort Titles are the same, fall back on group folder name
 	if( s1 == s2 )
 	{
@@ -618,8 +628,19 @@ int SongUtil::CompareSongPointersByGroup(const Song *pSong1, const Song *pSong2)
 
 static int CompareSongPointersByGroupAndTitle( const Song *pSong1, const Song *pSong2 )
 {
-	RString s1 = SONGMAN->GetGroup(pSong1)->GetSortTitle();
-	RString s2 = SONGMAN->GetGroup(pSong2)->GetSortTitle();
+	RString s1 = "";
+	RString s2 = "";
+
+	if( SONGMAN->GetGroup(pSong1) != nullptr )
+		s1 = SONGMAN->GetGroup(pSong1)->GetSortTitle();
+	else
+		LOG->Warn("SongUtil::CompareSongPointersByGroup: %s has no group", pSong1->GetSongDir().c_str());
+
+	if( SONGMAN->GetGroup(pSong2) != nullptr )
+		s2 = SONGMAN->GetGroup(pSong2)->GetSortTitle();
+	else
+		LOG->Warn("SongUtil::CompareSongPointersByGroup: %s has no group", pSong2->GetSongDir().c_str());
+	
 	// Sort Titles are the same, fall back on group folder name
 	if( s1 == s2 )
 	{
@@ -669,8 +690,12 @@ RString SongUtil::GetSectionNameFromSongAndSort( const Song* pSong, SortOrder so
 	case SORT_PREFERRED:
 		return SONGMAN->SongToPreferredSortSectionName( pSong );
 	case SORT_GROUP:
-		// guaranteed not empty
-		return SONGMAN->GetGroup(pSong)->GetGroupName();
+		if ( SONGMAN->GetGroup(pSong) == nullptr ) {
+			LOG->Warn("SongUtil::GetSectionNameFromSongAndSort: %s has no group", pSong->GetSongDir().c_str());
+			return RString();
+		} else {
+			return SONGMAN->GetGroup(pSong)->GetGroupName();
+		}
 	case SORT_TITLE:
 	case SORT_ARTIST:
 		{

--- a/src/SongUtil.h
+++ b/src/SongUtil.h
@@ -162,6 +162,7 @@ namespace SongUtil
 	void SortByMostRecentlyPlayedForMachine( std::vector<Song*> &vpSongsInOut );
 	void SortByMostRecentlyPlayedForProfile( std::vector<Song*> &vpSongsInOut, PlayerNumber pn);
 	void SortSongPointerArrayByLength( std::vector<Song*> &vpSongsInOut );
+	void SortSongPointerArrayByGroup( std::vector<Song*> &vpSongsInOut );
 
 	int CompareSongPointersByGroup(const Song *pSong1, const Song *pSong2);
 


### PR DESCRIPTION
Rework Pack.ini Sort Title sorting logic to better handle duplicate sort titles (falls back on group name)

Changed the sorting logic a bit. The new logic aligns with the other song pointer comparisons like artist and title. When sorting by group it uses ``SortSongPointerArrayByGroup`` now which calls the already existing ``CompareSongPointersByGroup`` with the adjusted handling.

