### PR TITLE
Only save jpeg's as high quality;  fix an invalid jpeg quality parameter

### DIFF
--- a/src/RageSurface_Save_JPEG.cpp
+++ b/src/RageSurface_Save_JPEG.cpp
@@ -117,7 +117,7 @@ bool RageSurfaceUtils::SaveJPEG( RageSurface *surface, RageFile &f, bool bHighQu
 	jpeg::jpeg_set_defaults(&cinfo);
 
 	if( bHighQual )
-		jpeg::jpeg_set_quality( &cinfo, 150, TRUE );
+		jpeg::jpeg_set_quality( &cinfo, 95, TRUE );
 	else
 		jpeg::jpeg_set_quality( &cinfo, 70, TRUE );
 

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1077,9 +1077,7 @@ RString StepMania::SaveScreenshot( RString Dir, bool SaveCompressed, bool MakeSi
 	// Save the screenshot. If writing lossy to a memcard, use
 	// SAVE_LOSSY_LOW_QUAL, so we don't eat up lots of space.
 	RageDisplay::GraphicsFileFormat fmt;
-	if( SaveCompressed && MEMCARDMAN->PathIsMemCard(Dir) )
-		fmt = RageDisplay::SAVE_LOSSY_LOW_QUAL;
-	else if( SaveCompressed )
+	if( SaveCompressed )
 		fmt = RageDisplay::SAVE_LOSSY_HIGH_QUAL;
 	else
 		fmt = RageDisplay::SAVE_LOSSLESS_SENSIBLE;


### PR DESCRIPTION
### These changes were originally featured in #639 "Improve reliability of screenshot code", but then I realized that these changes really should be in their own PR.

---

## 98c1f0d486b90edffe2596b164145773809b4d72

Removing the case where `StepMania::SaveScreenshot` may request to save a low quality jpeg. The file size difference between a quality 70 and quality 95 jpeg is very small by modern storage standards.

## fb31bd595da7f90fd00415ba0a68b28cc3f84b8e

With our new libjpeg_turbo library, a quality of 150 doesn't seem to be valid, so I'm changing this to 95. I chose 95 over 100 because the libjpeg_turbo project uses a quality of 95 for all testing and benchmarking shown in their documentation, and notes that a quality of 95 "[has been determined to be perceptually lossless under most viewing conditions](https://libjpeg-turbo.org/About/SmartScale-Lossy)".