### PR TITLE
Add missing braces to `Song::ReloadFromSongDir`

### DIFF
--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -498,12 +498,18 @@ bool Song::ReloadFromSongDir( RString sDir )
 
 		// Reapply the Group Offset if the steps have their own timing data.
 		if( mNewSteps[id]->m_Timing.empty() )
+		{
 			continue;
+		}
 		if (SONGMAN->GetGroup(this) != nullptr)
+		{
 			mNewSteps[id]->m_Timing.m_fBeat0GroupOffsetInSeconds = SONGMAN->GetGroup(this)->GetSyncOffset();
+		}
 		else
+		{
 			m_SongTiming.m_fBeat0GroupOffsetInSeconds = PREFSMAN->m_fMachineSyncBias;
 			LOG->Warn("Song %s has no group, using machine sync bias.", m_sMainTitle.c_str());
+		}
 	}
 
 	// Now we wipe out the new pointers, which were shallow copied and not deep copied...


### PR DESCRIPTION
The `LOG->Warn` line is being executed unconditionally due to the the lack of braces. The indentation is misleading as a result. This adds braces to ensure the intended behavior is performed. Thanks to the GCC compiler for catching this, as the VS compiler didn't emit a warning for this.