### PR TITLE
Stack size discussion (not necessary with #647, will close after discussion is done)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,6 +151,7 @@ endif()
 if(MSVC)
   # TODO: Find a way to do this cleanly for non MSVC users.
   set(SM_COMPILE_FLAGS "${SM_COMPILE_FLAGS} /MP2 /utf-8")
+  set(SM_LINK_FLAGS "${SM_LINK_FLAGS} /STACK:4194304")
 endif()
 
 set_target_properties("${SM_EXE_NAME}"


### PR DESCRIPTION
Prevents crashes on files like "24 hours of 100 bpm stream", "Madness is Waiting" in Windows. Also tested with other files people reported having crashes on; this solves all of them.

The Windows default stack size is 1MB.
The macOS default stack size is 8MB, by comparison.
I didn't set this to 8MB or higher because 4MB is more than enough to handle loading these charts.