### PR TITLE
HideLights feature in player options

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -92,6 +92,7 @@
 		<Function name='HSVToColor'/>
 		<Function name='HSVToHex'/>
 		<Function name='HasAlpha'/>
+		<Function name='HideLightSetting' />
 		<Function name='HitCombo'/>
 		<Function name='HoldTiming'/>
 		<Function name='Hour'/>
@@ -2454,6 +2455,12 @@
 			<EnumValue name='&apos;HealthState_Alive&apos;' value='1'/>
 			<EnumValue name='&apos;HealthState_Danger&apos;' value='2'/>
 			<EnumValue name='&apos;HealthState_Dead&apos;' value='3'/>
+		</Enum>
+		<Enum name='HideLightType'>
+			<EnumValue name='&apos;HideLightType_NoHideLights&apos;' value='0'/>
+			<EnumValue name='&apos;HideLightType_HideAllLights&apos;' value='1'/>
+			<EnumValue name='&apos;HideLightType_HideMarqueeLights&apos;' value='2'/>
+			<EnumValue name='&apos;HideLightType_HideBassLights&apos;' value='3'/>
 		</Enum>
 		<Enum name='HighResolutionTextures'>
 			<EnumValue name='&apos;HighResolutionTextures_Auto&apos;' value='0'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -330,7 +330,7 @@ save yourself some time, copy this for undocumented things:
 	<Function name='HasAlpha' theme='_fallback' return='float' arguments='color c'>
 		[02 Colors.lua] Returns the color's alpha if it has any, otherwise returns 1.
 	</Function>
-	<Function name='HideLightSetting' return='HideLightType' arguments='arguments='HideLightType type'>
+	<Function name='HideLightSetting' return='HideLightType' arguments='arguments='HideLightType type' since='ITGmania 1.0.1'>
 		Sets which cabinet lights(Marquee,Bass,Both) shall be disabled for the player.  Returns the <Link class='ENUM' function='HideLightType' /> that was previously set.
 	</Function>
 	<Function name='HitCombo' theme='_fallback' return='int' arguments=''>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -330,6 +330,9 @@ save yourself some time, copy this for undocumented things:
 	<Function name='HasAlpha' theme='_fallback' return='float' arguments='color c'>
 		[02 Colors.lua] Returns the color's alpha if it has any, otherwise returns 1.
 	</Function>
+	<Function name='HideLightSetting' return='HideLightType' arguments='arguments='HideLightType type'>
+		Sets which cabinet lights(Marquee,Bass,Both) shall be disabled for the player.  Returns the <Link class='ENUM' function='HideLightType' /> that was previously set.
+	</Function>
 	<Function name='HitCombo' theme='_fallback' return='int' arguments=''>
 		[03 Gameplay.lua] Returns the value to start showing the combo at.
 	</Function>

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -34,6 +34,16 @@ XToString( DrainType );
 XToLocalizedString( DrainType );
 LuaXType( DrainType );
 
+static const char* HideLightTypeNames[] = {
+	"NoHideLights",
+	"HideAllLights",
+	"HideMarqueeLights",
+	"HideBassLights",
+};
+XToString(HideLightType);
+XToLocalizedString(HideLightType);
+LuaXType(HideLightType);
+
 static const char *ModTimerTypeNames[] = {
 	"Game",
 	"Beat",
@@ -65,6 +75,7 @@ void PlayerOptions::Init()
 {
 	m_LifeType = LifeType_Bar;
 	m_DrainType = DrainType_Normal;
+	m_HideLightType = HideLightType_NoHideLights;
 	m_ModTimerType = ModTimerType_Default;
 	m_BatteryLives = 4;
 	m_MinTNSToHideNotes= PREFSMAN->m_MinTNSToHideNotes;
@@ -127,6 +138,7 @@ void PlayerOptions::Approach( const PlayerOptions& other, float fDeltaSeconds )
 
 	DO_COPY( m_LifeType );
 	DO_COPY( m_DrainType );
+	DO_COPY( m_HideLightType );
 	DO_COPY( m_ModTimerType );
 	DO_COPY( m_BatteryLives );
 	APPROACH( fModTimerMult );
@@ -243,6 +255,24 @@ void PlayerOptions::GetMods( std::vector<RString> &AddTo, bool bForceNoteSkin ) 
 			break;
 		default:
 			FAIL_M(ssprintf("Invalid LifeType: %i", m_LifeType));
+	}
+
+	switch (m_HideLightType)
+	{
+		case HideLightType_NoHideLights:
+			AddTo.push_back("NoHideLights");
+			break;
+		case HideLightType_HideAllLights:
+			AddTo.push_back("HideAllLights");
+			break;
+		case HideLightType_HideMarqueeLights:
+			AddTo.push_back("HideMarqueeLights");
+			break;
+		case HideLightType_HideBassLights:
+			AddTo.push_back("HideBassLights");
+			break;
+		default:
+			FAIL_M(ssprintf("Invalid HideLightType: %i", m_HideLightType));
 	}
 
 	if( !m_fTimeSpacing )
@@ -747,6 +777,13 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 	else if( sBit == "norecover" || sBit == "power-drop" ) { m_DrainType= DrainType_NoRecover; }
 	else if( sBit == "suddendeath" || sBit == "death" ) { m_DrainType= DrainType_SuddenDeath; }
 	else if( sBit == "normal-drain" ) { m_DrainType= DrainType_Normal; }
+	else if (sBit.find("lights") != sBit.npos)
+	{
+		if (sBit == "nohidelights")				m_HideLightType = HideLightType_NoHideLights;
+		else if (sBit == "hidealllights")				m_HideLightType = HideLightType_HideAllLights;
+		else if (sBit == "hidemarqueelights")			m_HideLightType = HideLightType_HideMarqueeLights;
+		else if (sBit == "hidebasslights")			m_HideLightType = HideLightType_HideBassLights;
+	}
 	else if( sBit == "boost" )				SET_FLOAT( fAccels[ACCEL_BOOST] )
 	else if( sBit == "brake" || sBit == "land" )		SET_FLOAT( fAccels[ACCEL_BRAKE] )
 	else if( sBit.find("wave") != sBit.npos)
@@ -1412,6 +1449,7 @@ bool PlayerOptions::operator==( const PlayerOptions &other ) const
 #define COMPARE(x) { if( x != other.x ) return false; }
 	COMPARE(m_LifeType);
 	COMPARE(m_DrainType);
+	COMPARE(m_HideLightType);
 	COMPARE(m_ModTimerType);
 	COMPARE(m_fModTimerMult);
 	COMPARE(m_fModTimerOffset);
@@ -1495,6 +1533,7 @@ PlayerOptions& PlayerOptions::operator=(PlayerOptions const& other)
 #define CPY_SPEED(x) m_ ## x = other.m_ ## x; m_Speed ## x = other.m_Speed ## x;
 	CPY(m_LifeType);
 	CPY(m_DrainType);
+	CPY(m_HideLightType);
 	CPY(m_ModTimerType);
 	CPY_SPEED(fModTimerMult);
 	CPY_SPEED(fModTimerOffset);
@@ -1771,6 +1810,7 @@ void PlayerOptions::ResetPrefs( ResetPrefsType type )
 	}
 	CPY(m_LifeType);
 	CPY(m_DrainType);
+	CPY(m_HideLightType);
 	CPY(m_BatteryLives);
 	CPY(m_ModTimerType);
 	CPY(m_fModTimerMult);
@@ -1830,6 +1870,7 @@ public:
 
 	ENUM_INTERFACE(LifeSetting, LifeType, LifeType);
 	ENUM_INTERFACE(DrainSetting, DrainType, DrainType);
+	ENUM_INTERFACE(HideLightSetting, HideLightType, HideLightType);
 	ENUM_INTERFACE(ModTimerSetting, ModTimerType, ModTimerType)
 	INT_INTERFACE(BatteryLives, BatteryLives);
 	FLOAT_INTERFACE(ModTimerMult, ModTimerMult, true);
@@ -2391,6 +2432,7 @@ public:
 
 		ADD_METHOD(LifeSetting);
 		ADD_METHOD(DrainSetting);
+		ADD_METHOD(HideLightSetting);
 		ADD_METHOD(ModTimerSetting);
 		ADD_METHOD(ModTimerMult);
 		ADD_METHOD(ModTimerOffset);

--- a/src/PlayerOptions.h
+++ b/src/PlayerOptions.h
@@ -41,6 +41,18 @@ const RString& DrainTypeToString( DrainType cat );
 const RString& DrainTypeToLocalizedString( DrainType cat );
 LuaDeclareType( DrainType );
 
+enum HideLightType {
+	HideLightType_NoHideLights = 0,
+	HideLightType_HideAllLights,
+	HideLightType_HideMarqueeLights,
+	HideLightType_HideBassLights,
+	NUM_HideLightType,
+	HideLightType_Invalid
+};
+const RString& HideLightTypeToString(HideLightType cat);
+const RString& HideLightTypeToLocalizedString(HideLightType cat);
+LuaDeclareType(HideLightType);
+
 enum ModTimerType
 {
 	ModTimerType_Game,
@@ -62,7 +74,7 @@ public:
 	 * @brief Set up the PlayerOptions with some reasonable defaults.
 	 *
 	 * This code was taken from Init() to use proper initialization. */
-	PlayerOptions(): m_LifeType(LifeType_Bar), m_DrainType(DrainType_Normal),
+	PlayerOptions(): m_LifeType(LifeType_Bar), m_DrainType(DrainType_Normal), m_HideLightType(HideLightType_NoHideLights),
 		m_ModTimerType(ModTimerType_Default),
 		m_BatteryLives(4),
 		m_bSetScrollSpeed(false),
@@ -340,6 +352,7 @@ public:
 
 	PlayerNumber m_pn; // Needed for fetching the style.
 
+	HideLightType m_HideLightType;
 	LifeType m_LifeType;
 	DrainType m_DrainType;	// only used with LifeBar
 	ModTimerType m_ModTimerType;

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -288,6 +288,7 @@ PrefsManager::PrefsManager() :
 	m_iSoundPreferredSampleRate	( "SoundPreferredSampleRate",		0 ),
 	m_sLightsStepsDifficulty	( "LightsStepsDifficulty",		"hard,medium" ),
 	m_bLightsSimplifyBass		( "LightsSimplifyBass",		false),
+	m_bLightsBassParallel       ( "LightsBassParallel",     false),
 	m_bAllowUnacceleratedRenderer	( "AllowUnacceleratedRenderer",		false ),
 	m_bThreadedInput		( "ThreadedInput",			true ),
 	m_bThreadedMovieDecode		( "ThreadedMovieDecode",		true ),

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -314,6 +314,7 @@ public:
 	Preference<int>	m_iSoundPreferredSampleRate;
 	Preference<RString>	m_sLightsStepsDifficulty;
 	Preference<bool>	m_bLightsSimplifyBass;
+	Preference<bool>	m_bLightsBassParallel;
 	Preference<bool>	m_bAllowUnacceleratedRenderer;
 	Preference<bool>	m_bThreadedInput;
 	Preference<bool>	m_bThreadedMovieDecode;


### PR DESCRIPTION
From a dedicated option it is possible to decide which cabinet light shall be turned off:
 - Marquee
 - Bass
 - All
 
I also added a flag to specify when bass lights are in parallel since upgraded cabinets are connected in this way. Without this flag if you turn off lights and just one player is connected, bass lights would turn on anyway. I thought about adding this flag at lights driver level but in this way you don't have to do it for each lights driver.

Let me know if you have any suggestion.