### PR TITLE
Fix printf format specifiers

### DIFF
--- a/src/ActorFrameTexture.cpp
+++ b/src/ActorFrameTexture.cpp
@@ -5,6 +5,7 @@
 #include "RageLog.h"
 #include "ActorUtil.h"
 
+#include <cinttypes>
 #include <cstdint>
 
 REGISTER_ACTOR_CLASS_WITH_NAME( ActorFrameTextureAutoDeleteChildren, ActorFrameTexture );
@@ -18,7 +19,7 @@ ActorFrameTexture::ActorFrameTexture()
 	m_bPreserveTexture = false;
 	static uint64_t i = 0;
 	++i;
-	m_sTextureName = ssprintf( ConvertI64FormatString("ActorFrameTexture %lli"), i );
+	m_sTextureName = ssprintf( "ActorFrameTexture %" PRIu64, i );
 
 	m_pRenderTarget = nullptr;
 }

--- a/src/RageSoundPosMap.cpp
+++ b/src/RageSoundPosMap.cpp
@@ -4,6 +4,7 @@
 #include "RageUtil.h"
 #include "RageTimer.h"
 
+#include <cinttypes>
 #include <climits>
 #include <cmath>
 #include <cstdint>
@@ -160,7 +161,7 @@ int64_t pos_map_queue::Search( int64_t iSourceFrame ) const
 	if( last.PeekDeltaTime() >= 1.0f )
 	{
 		last.Touch();
-		LOG->Trace("Audio frame (%lld) was out of range of the data sent - possible buffer underflow? This is not always an error, however if you see it frequently there could be sound buffer problems.", iSourceFrame);
+		LOG->Trace("Audio frame (%" PRId64 ") was out of range of the data sent - possible buffer underflow? This is not always an error, however if you see it frequently there could be sound buffer problems.", iSourceFrame);
 	}
 
 	return iClosestPosition;

--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -17,6 +17,7 @@
 #include "RageUtil.h"
 
 #include <cerrno>
+#include <cinttypes>
 #include <cstdint>
 #include <set>
 
@@ -690,7 +691,7 @@ void LockMutex::Unlock()
 		const uint64_t dur_usecs = current_usecs - locked_at;
 
 		if (dur_usecs > THRESHOLD_USEC)
-			LOG->Trace("Lock at %s:%i took %llu microseconds", file, line, dur_usecs);
+			LOG->Trace("Lock at %s:%i took %" PRIu64 " microseconds", file, line, dur_usecs);
 	}
 }
 

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -13,6 +13,7 @@
 #include <pcre.h>
 
 #include <cfloat>
+#include <cinttypes>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -254,7 +255,7 @@ RString MicrosecondsToMMSSMsMs(uint64_t usecs)
     const uint64_t iMinsDisplay = totalSeconds / 60;
     const uint64_t iSecsDisplay = totalSeconds % 60;
     const uint64_t iLeftoverDisplay = (usecs % 1000000) / 10000; // Adjusted for two decimal places
-    RString sReturn = ssprintf("%02llu:%02llu.%02llu", iMinsDisplay, iSecsDisplay, std::min<uint64_t>(99, iLeftoverDisplay));
+    RString sReturn = ssprintf("%02" PRIu64 ":%02" PRIu64 ".%02" PRIu64, iMinsDisplay, iSecsDisplay, std::min<uint64_t>(99, iLeftoverDisplay));
     return sReturn;
 }
 
@@ -273,7 +274,7 @@ RString MicrosecondsToMMSSMsMsMs(uint64_t usecs)
     const uint64_t iMinsDisplay = totalSeconds / 60;
     const uint64_t iSecsDisplay = totalSeconds % 60;
     const uint64_t iLeftoverDisplay = (usecs % 1000000) / 1000;
-    RString sReturn = ssprintf("%02llu:%02llu.%03llu", iMinsDisplay, iSecsDisplay, std::min<uint64_t>(999, iLeftoverDisplay));
+    RString sReturn = ssprintf("%02" PRIu64 ":%02" PRIu64 ".%03" PRIu64, iMinsDisplay, iSecsDisplay, std::min<uint64_t>(999, iLeftoverDisplay));
     return sReturn;
 }
 

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -465,47 +465,6 @@ RString vssprintf( const char *szFormat, va_list argList )
 	return sStr;
 }
 
-/* Windows uses %I64i to format a 64-bit int, instead of %lli. Convert "a b %lli %-3llu c d"
- * to "a b %I64 %-3I64u c d". This assumes a well-formed format string; invalid format strings
- * should not crash, but the results are undefined. */
-#if defined(WIN32)
-RString ConvertI64FormatString( const RString &sStr )
-{
-	RString sRet;
-	sRet.reserve( sStr.size() + 16 );
-
-	size_t iOffset = 0;
-	while( iOffset < sStr.size() )
-	{
-		size_t iPercent = sStr.find( '%', iOffset );
-		if( iPercent != sStr.npos )
-		{
-			sRet.append( sStr, iOffset, iPercent - iOffset );
-			iOffset = iPercent;
-		}
-
-		size_t iEnd = sStr.find_first_of( "diouxXeEfFgGaAcsCSpnm%", iOffset + 1 );
-		if( iEnd != sStr.npos && iEnd - iPercent >= 3 && iPercent > 2 && sStr[iEnd-2] == 'l' && sStr[iEnd-1] == 'l' )
-		{
-			sRet.append( sStr, iPercent, iEnd - iPercent - 2 ); // %
-			sRet.append( "I64" ); // %I64
-			sRet.append( sStr, iEnd, 1 ); // %I64i
-			iOffset = iEnd + 1;
-		}
-		else
-		{
-			if( iEnd == sStr.npos )
-				iEnd = sStr.size() - 1;
-			sRet.append( sStr, iOffset, iEnd - iOffset + 1 );
-			iOffset = iEnd + 1;
-		}
-	}
-	return sRet;
-}
-#else
-RString ConvertI64FormatString( const RString &sStr ) { return sStr; }
-#endif
-
 /* ISO-639-1 codes: http://www.loc.gov/standards/iso639-2/php/code_list.php
  * We don't use 3-letter codes, so we don't bother supporting them. */
 static const LanguageInfo g_langs[] =

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -355,7 +355,6 @@ struct tm GetLocalTime();
 
 RString ssprintf( const char *fmt, ...) PRINTF(1,2);
 RString vssprintf( const char *fmt, va_list argList );
-RString ConvertI64FormatString( const RString &sStr );
 
 /*
  * Splits a Path into 4 parts (Directory, Drive, Filename, Extention).  Supports UNC path names.


### PR DESCRIPTION
Different platforms can use different sizes for standard types, so GCC emits a warning when using "%llu" or "%lld" for uint64_t or int64_t respectively. Switch to using specifiers from <cinttypes> to prevent the warning.