### PR TITLE
Take measures to prevent screenshots from going missing

### DIFF
--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1064,14 +1064,30 @@ int sm_main(int argc, char* argv[])
 
 RString StepMania::SaveScreenshot( RString Dir, bool SaveCompressed, bool MakeSignature, RString NamePrefix, RString NameSuffix )
 {
-	/* As of sm-ssc v1.0 rc2, screenshots are no longer named by an arbitrary
-	 * index. This was causing naming issues for some unknown reason, so we have
-	 * changed the screenshot names to a non-blocking format: date and time.
-	 * As before, we ignore the extension. -aj */
-	RString FileNameNoExtension = NamePrefix + DateTime::GetNowDateTime().GetString() + NameSuffix;
-	// replace space with underscore.
+	/* If the screenshot button is mashed, it might play the success sound, but nothing
+	 * gets saved. This seems to occur if the button is repeatedly pushed, and less than
+	 * half a second has elapsed. In my testing, half a second is long enough to ensure
+	 * the next screenshot will save properly. So first, verify that half a second has
+	 * passed since the last screenshot attempt. */
+	static RageTimer screenshot_timer;
+
+	if (screenshot_timer.Ago() < 0.5f)
+	{
+		SCREENMAN->PlayInvalidSound();
+		LOG->Trace("Screenshot button pressed too fast. Couldn't save screenshot.");
+		return RString();
+	}
+	screenshot_timer.Touch();
+
+	/* NameSuffix is almost always empty, so only add NameSuffix if it contains something */
+	RString FileNameNoExtension = NamePrefix + DateTime::GetNowDateTime().GetString();
+	if( !NameSuffix.empty() )
+	{
+		FileNameNoExtension += NameSuffix;
+	}
+
+	/* Replace spaces with underscores, and remove colons entirely. */
 	FileNameNoExtension.Replace(" ","_");
-	// colons are illegal in filenames.
 	FileNameNoExtension.Replace(":","");
 
 	// Save the screenshot. If writing lossy to a memcard, use
@@ -1084,17 +1100,21 @@ RString StepMania::SaveScreenshot( RString Dir, bool SaveCompressed, bool MakeSi
 
 	RString FileName = FileNameNoExtension + "." + (SaveCompressed ? "jpg" : "png");
 	RString Path = Dir+FileName;
-	bool Result = DISPLAY->SaveScreenshot( Path, fmt );
-	if( !Result )
+
+	if( !DISPLAY->SaveScreenshot( Path, fmt ) )
 	{
 		SCREENMAN->PlayInvalidSound();
 		return RString();
 	}
-
-	SCREENMAN->PlayScreenshotSound();
+	else
+	{
+		SCREENMAN->PlayScreenshotSound();
+	}
 
 	if( PREFSMAN->m_bSignProfileData && MakeSignature )
+	{
 		CryptManager::SignFileToFile( Path );
+	}
 
 	return FileName;
 }


### PR DESCRIPTION
## Why this commit exists

It's possible for a screenshot to occasionally go missing.  This seems to usually be due to one of two reasons:

 - Something went wrong with the path construction
 - User pushed the screenshot button repeatedly too fast

I've had screenshots go missing numerous times, it's especially unfortunate when other players are playing on your setup and you can't get them their screenshot.

## How I proved screenshots are going missing

I did some tests at the results screen, where I would press the screenshot button 4 times, as quarter notes at 120-125bpm. 

I did this 5 times each.

- with the existing behavior, an average of 1 goes missing (average success: 3.2)
- if NameSuffix is explicitly added (see below), an average of 2 go missing  (average success: 2.2)
- with this PR, none go missing  (average success: 4)


## When something went wrong with the path construction

In my testing, NameSuffix is empty almost 100% of the time, and it's more likely that a screenshot fails to save if you explicitly add NameSuffix, like so:
```
	RString FileNameNoExtension = NamePrefix + DateTime::GetNowDateTime().GetString();
	FileNameNoExtension += NameSuffix;
```

So now we only add NameSuffix if it's not empty.

## When the user pushed the screenshot button repeatedly too fast

I've also tested how fast the screenshot button can be pushed for a screenshot to successfully save. It seems like just about 0.4 seconds is the threshold. Any faster and it won't save a screenshot, but will play a success sound.

This function makes an asynchronous call to either SavePNG or SaveJPG and does not wait for its response to confirm the screenshot was saved.

To keep things simple, I've simply had the function play the invalid sound if we've measured less than 0.5 seconds since the last SaveScreenshot call.

## Why remove the `Result` boolean

Lastly, really a no-op minor change, but removed a useless boolean since we can simply check if the `DISPLAY->SaveScreenshot` call failed and use that to return RString.

The successful screenshot sound is also now part of an else clause, to make the logic flow a bit more structured.