### PR TITLE
Sextet Stream Fix for windows

### DIFF
--- a/src/arch/Lights/LightsDriver_SextetStream.h
+++ b/src/arch/Lights/LightsDriver_SextetStream.h
@@ -16,15 +16,18 @@
 
 #include "LightsDriver.h"
 #include "RageFile.h"
+#ifdef _WIN32
+#include "Windows.h"
+#endif
 
 class LightsDriver_SextetStream : public LightsDriver
 {
 public:
 	LightsDriver_SextetStream();
 	virtual ~LightsDriver_SextetStream();
-	virtual void Set(const LightsState *ls);
+	virtual void Set(const LightsState* ls);
 protected:
-	void * _impl;
+	void* _impl;
 };
 
 class LightsDriver_SextetStreamToFile : public LightsDriver_SextetStream
@@ -35,7 +38,11 @@ public:
 
 	// The file object passed here should already be open, and will be
 	// flushed, closed, and deleted in the destructor.
-	LightsDriver_SextetStreamToFile(RageFile * file);
+#ifdef _WIN32
+	LightsDriver_SextetStreamToFile(HANDLE file);
+#else
+	LightsDriver_SextetStreamToFile(RageFile* file);
+#endif
 };
 
 #endif


### PR DESCRIPTION
Hello everyone this is one of my first contributions in general so I hope I haven't done anything sacrilegious.

I noticed that on windows the SextetStream light driver doesn't seem to work correctly as it doesn't connect to the pipe properly. 
I'm sure there is a way to use the ragefile class to achieve the same thing but I wasn't able to so I just used regular windows file handles and looks like it works without any issue. 

Even if this pull request doesn't get accepted I'd love for this issue to be fixed since it's really useful for interfacing the pad with whatever software someone wants (in my case I use it to sync some artnet devices) :D