### PR TITLE
Update Windows-specific code in RageFileDriverDirectHelpers.cpp 

### DIFF
--- a/src/RageFileDriverDirectHelpers.cpp
+++ b/src/RageFileDriverDirectHelpers.cpp
@@ -29,43 +29,37 @@ RString DoPathReplace(const RString &sPath)
 static bool WinMoveFileInternal( const RString &sOldPath, const RString &sNewPath )
 {
 	if( MoveFileEx( sOldPath, sNewPath, MOVEFILE_REPLACE_EXISTING ) )
-		return true;
-
-	DWORD err = GetLastError();
-	// Possible error values stored by GetLastError():
-	//
-	// - ERROR_PATH_NOT_FOUND - 3 
-	//  - implies something in the file path does not exist
-	//
-	// - ERROR_SHARING_VIOLATION - 32 
-	//  - implies a need to use a temporary name somewhere
-	//
-	// - ERROR_FILE_EXISTS, ERROR_ALREADY_EXISTS - 80 
-	//  - implies MOVEFILE_REPLACE_EXISTING flag is not set,
-	//    but it is usually expected behavior when this occurs
-	//
-	// - ERROR_INVALID_PARAMETER - 87 
-	//  - implies the file paths are invalid
-	//
-	// - ERROR_NOT_SAME_DEVICE - 17 
-	//  - implies the file paths are on different devices
-
-	if( err )
+	// TODO(sukibaby): Use Unicode functions after migrating to std::string.
+	if (MoveFileExA(sOldPath.c_str(), sNewPath.c_str(), MOVEFILE_REPLACE_EXISTING))
 	{
-		// Log the error with the specific error code
-		WARN(ssprintf("MoveFileEx(%s, %s) failed: %lu", sOldPath.c_str(), sNewPath.c_str(), err));
-    
-		// Check if the error is related to the file not existing
-		if (err != ERROR_FILE_EXISTS && err != ERROR_ALREADY_EXISTS)
-		{
-			return false;
-		}
+		return true;
 	}
 
-	if( !DeleteFile( sNewPath ) )
-		return false;
+	DWORD err = GetLastError();
+	WARN(ssprintf("MoveFileEx(%s, %s) failed: %lu", sOldPath.c_str(), sNewPath.c_str(), err));
 
-	return !!MoveFile( sOldPath, sNewPath );
+	if( err != ERROR_FILE_EXISTS && err != ERROR_ALREADY_EXISTS )
+	{
+		return false;
+	}
+
+	if( !DeleteFileA(sNewPath.c_str()) )
+	{
+		DWORD deleteErr = GetLastError();
+		WARN(ssprintf("DeleteFile(%s) failed: %lu", sNewPath.c_str(), deleteErr));
+		return false;
+	}
+
+	if( !MoveFileA(sOldPath.c_str(), sNewPath.c_str()) )
+	{
+		DWORD moveErr = GetLastError();
+		WARN(ssprintf("MoveFile(%s, %s) failed: %lu", sOldPath.c_str(), sNewPath.c_str(), moveErr));
+		return false;
+	}
+
+	// If we reach this point, MoveFileExA failed with ERROR_FILE_EXISTS
+	// or ERROR_ALREADY_EXISTS, but either DeleteFileA or MoveFileA succeeded.
+	return true;
 }
 
 bool WinMoveFile( RString sOldPath, RString sNewPath )

--- a/src/RageFileDriverDirectHelpers.cpp
+++ b/src/RageFileDriverDirectHelpers.cpp
@@ -302,7 +302,7 @@ void DirectFilenameDB::PopulateFileSet( FileSet &fs, const RString &path )
 		else
 		{
 			f.dir = (st.st_mode & S_IFDIR);
-			f.size = (int)st.st_size;
+			f.size = static_cast<int>(st.st_size);
 			f.hash = st.st_mtime;
 		}
 

--- a/src/RageFileDriverDirectHelpers.cpp
+++ b/src/RageFileDriverDirectHelpers.cpp
@@ -65,11 +65,34 @@ static bool WinMoveFileInternal( const RString &sOldPath, const RString &sNewPat
 bool WinMoveFile( RString sOldPath, RString sNewPath )
 {
 	if( WinMoveFileInternal( DoPathReplace(sOldPath), DoPathReplace(sNewPath) ) )
+	{
 		return true;
-	if( GetLastError() != ERROR_ACCESS_DENIED )
+	}
+
+	DWORD err = GetLastError();
+	if (err != ERROR_ACCESS_DENIED)
+	{
+		WARN(ssprintf("WinMoveFileInternal(%s, %s) failed: %lu", sOldPath.c_str(), sNewPath.c_str(), err));
 		return false;
-	/* Try turning off the read-only bit on the file we're overwriting. */
-	SetFileAttributes( DoPathReplace(sNewPath), FILE_ATTRIBUTE_NORMAL );
+	}
+
+	// Get the current attributes of the file, and only remove the read-only attribute if set.
+	DWORD attributes = GetFileAttributes(DoPathReplace(sNewPath));
+	if (attributes == INVALID_FILE_ATTRIBUTES)
+	{
+		WARN(ssprintf("GetFileAttributes(%s) failed: %lu", sNewPath.c_str(), GetLastError()));
+		return false;
+	}
+
+	if (attributes & FILE_ATTRIBUTE_READONLY)
+	{
+		attributes &= ~FILE_ATTRIBUTE_READONLY;
+		if (!SetFileAttributes(DoPathReplace(sNewPath), attributes))
+		{
+			WARN(ssprintf("SetFileAttributes(%s) failed: %lu", sNewPath.c_str(), GetLastError()));
+			return false;
+		}
+	}
 
 	return WinMoveFileInternal( DoPathReplace(sOldPath), DoPathReplace(sNewPath) );
 }

--- a/src/RageFileDriverDirectHelpers.cpp
+++ b/src/RageFileDriverDirectHelpers.cpp
@@ -28,7 +28,6 @@ RString DoPathReplace(const RString &sPath)
 #if defined(_WIN32)
 static bool WinMoveFileInternal( const RString &sOldPath, const RString &sNewPath )
 {
-	if( MoveFileEx( sOldPath, sNewPath, MOVEFILE_REPLACE_EXISTING ) )
 	// TODO(sukibaby): Use Unicode functions after migrating to std::string.
 	if (MoveFileExA(sOldPath.c_str(), sNewPath.c_str(), MOVEFILE_REPLACE_EXISTING))
 	{
@@ -95,6 +94,15 @@ bool WinMoveFile( RString sOldPath, RString sNewPath )
 	}
 
 	return WinMoveFileInternal( DoPathReplace(sOldPath), DoPathReplace(sNewPath) );
+}
+
+static File CreateFileFromFindData(const WIN32_FIND_DATA& fd)
+{
+	File f(fd.cFileName);
+	f.dir = !!(fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY);
+	f.size = static_cast<int>(fd.nFileSizeLow);
+	f.hash = static_cast<int>(fd.ftLastWriteTime.dwLowDateTime);
+	return f;
 }
 #endif
 
@@ -204,12 +212,7 @@ void DirectFilenameDB::CacheFile( const RString &sPath )
 		m_Mutex.Unlock(); // Locked by GetFileSet()
 		return;
 	}
-	File f( fd.cFileName );
-	f.dir = !!(fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY);
-	f.size = static_cast<int64_t>(fd.nFileSizeHigh) << 32 | fd.nFileSizeLow;
-	f.hash = static_cast<int64_t>(fd.ftLastWriteTime.dwHighDateTime) << 32 | fd.ftLastWriteTime.dwLowDateTime;
-
-	pFileSet->files.insert( f );
+	File f = CreateFileFromFindData(fd);
 	FindClose( hFind );
 #else
 	File f( Basename(sPath) );
@@ -257,11 +260,7 @@ void DirectFilenameDB::PopulateFileSet( FileSet &fs, const RString &path )
 		if( !strcmp(fd.cFileName, ".") || !strcmp(fd.cFileName, "..") )
 			continue;
 
-		File f;
-		f.SetName( fd.cFileName );
-		f.dir = !!(fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY);
-		f.size = fd.nFileSizeLow;
-		f.hash = fd.ftLastWriteTime.dwLowDateTime;
+		File f = CreateFileFromFindData(fd);
 
 		fs.files.insert( f );
 	} while( FindNextFile( hFind, &fd ) );


### PR DESCRIPTION
## This likely isn't related to the `Unhandled Microsoft C++ Exception` crashes we've been seeing that refer to `RageFileDriverDirectHelpers.cpp`, but there were a few concerns I addressed in this file.
1.  Upgrade Windows API calls in WinMoveFileInternal

2.  Safer method of handling file attributes which is less prone to error (read the attributes, change the read-only attribute if necessary, and write the modified set of attributes back. The old code tried to brute-force remove the attribute without checks).

3. Consolidate repeated Windows logic to get file information into a static function.

4.  Use static cast to int where appropriate.