### PR TITLE
Add #PEAKNPS to cache

### DIFF
--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -478,6 +478,32 @@ void SetNotesPerMeasure(StepsTagInfo& info)
 	info.ssc_format= true;
 }
 
+void SetPeakNps(StepsTagInfo& info)
+{
+	if (info.from_cache || info.for_load_edit)
+	{
+		std::vector<RString> valuesPerPlayer;
+		split((*info.params)[1], "|", valuesPerPlayer, true);
+		
+		if(valuesPerPlayer.size() > NUM_PlayerNumber)
+		{
+			LOG->Warn("#PEAKNPS has more sections (%zu) than possible number of players (%d)!", valuesPerPlayer.size(), NUM_PlayerNumber);
+		}
+		
+		std::vector<float> peakNps;
+		for(std::size_t pn = 0; pn < valuesPerPlayer.size() && pn < NUM_PlayerNumber; pn++)
+		{
+			peakNps.push_back(StringToFloat(valuesPerPlayer[pn]));
+		}
+		info.steps->SetPeakNps(peakNps);
+	}
+	else
+	{
+		// just recalc at time.
+	}
+	info.ssc_format= true;
+}
+
 void SetCredit(StepsTagInfo& info)
 {
 	info.steps->SetCredit((*info.params)[1]);
@@ -721,7 +747,7 @@ struct ssc_parser_helper_t
 		steps_tag_handlers["TECHCOUNTS"] = &SetTechCounts;
 		steps_tag_handlers["NPSPERMEASURE"] = &SetNpsPerMeasure;
 		steps_tag_handlers["NOTESPERMEASURE"] = &SetNotesPerMeasure;
-
+		steps_tag_handlers["PEAKNPS"] = &SetPeakNps;
 		/* If this is called, the chart does not use the same attacks
 		 * as the Song's timing. No other changes are required. */
 		steps_tag_handlers["ATTACKS"]= &SetStepsAttacks;

--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -465,6 +465,9 @@ static RString GetSSCNoteData( const Song &song, const Steps &in, bool bSavingCa
 		
 		lines.push_back( ssprintf( "#NOTESPERMEASURE:%s;", join("|",notesPerMeasureStrings).c_str() ) );
 		
+		const std::vector<float> &peakNps = in.GetAllPeakNps();
+		lines.push_back("#PEAKNPS:" + serialize(peakNps, "|", 3) + ";");
+		
 		// NOTE(MV): #STEPFILENAME has to be at the end of the cache tags,
 		// because it's used in SSCLoader::LoadFromSimfile to determine when
 		// to switch the state back to GETTING_SONG_INFO, which means any tags

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -52,7 +52,7 @@
  * @brief The internal version of the cache for StepMania.
  *
  * Increment this value to invalidate the current cache. */
-const int FILE_CACHE_VERSION = 229;
+const int FILE_CACHE_VERSION = 230;
 
 /** @brief How long does a song sample last by default? */
 const float DEFAULT_MUSIC_SAMPLE_LENGTH = 12.f;

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -761,26 +761,19 @@ void Steps::SetCachedNpsPerMeasure(std::vector<std::vector<float>>& npsPerMeasur
 {
 	DeAutogen();
 	m_CachedNpsPerMeasure.assign(npsPerMeasure.begin(), npsPerMeasure.end());
-	m_PeakNps.clear();
-	
-	for(std::vector<float> n : npsPerMeasure)
-	{
-		std::vector<float>::iterator peakNps = std::max_element(n.begin(), n.end());
-		if(peakNps != n.end())
-		{
-			m_PeakNps.push_back(*peakNps);
-		}
-	}
-	
 	m_AreCachedNpsPerMeasureJustLoaded = true;
 }
 
 void Steps::SetCachedNotesPerMeasure(std::vector<std::vector<int>>& notesPerMeasure)
 {
 	DeAutogen();
-	
 	m_CachedNotesPerMeasure.assign(notesPerMeasure.begin(), notesPerMeasure.end());
 	m_AreCachedNotesPerMeasureJustLoaded = true;
+}
+
+void Steps::SetPeakNps(std::vector<float> &peakNps)
+{
+	m_PeakNps.assign(peakNps.begin(), peakNps.end());
 }
 
 RString Steps::GenerateChartKey()

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -147,6 +147,7 @@ public:
 	void SetCachedTechCounts(const TechCounts ts[NUM_PLAYERS]);
 	void SetCachedNpsPerMeasure(std::vector<std::vector<float>>& npsPerMeasure);
 	void SetCachedNotesPerMeasure(std::vector<std::vector<int>>& notesPerMeasure);
+	void SetPeakNps(std::vector<float>& peakNps);
 	float PredictMeter() const;
 
 	unsigned GetHash() const;
@@ -186,7 +187,7 @@ public:
 	const std::vector<int> &GetNotesPerMeasure(PlayerNumber pn) const;
 	
 	float GetPeakNps(PlayerNumber pn) const;
-
+	const std::vector<float> & GetAllPeakNps() const { return Real()->m_PeakNps; }
 	/**
 	 * @brief The TimingData used by the Steps.
 	 *


### PR DESCRIPTION
Explicitly caches peak NPS instead of deriving it from #NPSPERMEASURE.