### PR TITLE
Optimization in BitmapText::AddAttribute

### DIFF
--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -911,43 +911,43 @@ BitmapText::Attribute BitmapText::GetDefaultAttribute() const
 	return attr;
 }
 
-std::pair<size_t, int> BitmapText::AdjustPositionForNewLines(size_t iPos) const
+std::pair<size_t, int> BitmapText::AdjustPositionForNewLines(size_t inputPosition) const
 {
-	auto lineIter = m_wTextLines.cbegin();
-	int iLines = 0;
-	size_t iAdjustedPos = iPos;
+	auto lineIterator = m_wTextLines.cbegin();
+	int lineCount = 0;
+	size_t adjustedPosition = inputPosition;
 
-	for( ; lineIter != m_wTextLines.cend(); ++lineIter )
+	for (; lineIterator != m_wTextLines.cend(); ++lineIterator)
 	{
-		size_t length = lineIter->length() + 1; // +1 to account for implicit newline at the end
-		if (length > iAdjustedPos)
+		size_t lineLength = lineIterator->length() + 1; // +1 to account for implicit newline at the end
+		if (lineLength > adjustedPosition)
 		{
 			break;
 		}
-		iAdjustedPos -= length;
-		++iLines;
+		adjustedPosition -= lineLength;
+		++lineCount;
 	}
 
-	return { iAdjustedPos, iLines };
+	return { adjustedPosition, lineCount };
 }
 
-std::pair<size_t, size_t> BitmapText::FixupLengthForNewLines(size_t iAdjustedPos, size_t length) const
+std::pair<size_t, size_t> BitmapText::FixupLengthForNewLines(size_t adjustedPos, size_t inputLength) const
 {
 	auto lineIter = m_wTextLines.cbegin();
-	size_t iAdjustedEndPos = iAdjustedPos + length;
+	size_t adjustedEndPos = adjustedPos + inputLength;
 
 	for (; lineIter != m_wTextLines.cend(); ++lineIter)
 	{
-		size_t length = lineIter->length() + 1; // +1 to account for implicit newline at the end
-		if (length > iAdjustedEndPos || length == 0)
+		size_t lineLength = lineIter->length() + 1; // +1 to account for implicit newline at the end
+		if (lineLength > adjustedEndPos || lineLength == 0)
 		{
 			break;
 		}
-		iAdjustedEndPos -= length;
-		length -= 1;
+		adjustedEndPos -= lineLength;
+		inputLength -= 1;
 	}
 
-	return { iAdjustedEndPos, length };
+	return { adjustedEndPos, inputLength };
 }
 
 void BitmapText::AddAttribute( size_t iPos, const Attribute &attr )

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -911,8 +911,7 @@ BitmapText::Attribute BitmapText::GetDefaultAttribute() const
 	return attr;
 }
 
-std::pair<size_t, int> BitmapText::AdjustPositionForNewLines(size_t inputPosition) const
-{
+std::pair<size_t, int> BitmapText::AdjustPositionForNewLines(size_t inputPosition) const {
 	auto lineIterator = m_wTextLines.cbegin();
 	int lineCount = 0;
 	size_t adjustedPosition = inputPosition;
@@ -931,8 +930,7 @@ std::pair<size_t, int> BitmapText::AdjustPositionForNewLines(size_t inputPositio
 	return { adjustedPosition, lineCount };
 }
 
-std::pair<size_t, size_t> BitmapText::FixupLengthForNewLines(size_t adjustedPos, size_t inputLength) const
-{
+std::pair<size_t, size_t> BitmapText::FixupLengthForNewLines(size_t adjustedPos, size_t inputLength) const {
 	auto lineIter = m_wTextLines.cbegin();
 	size_t adjustedEndPos = adjustedPos + inputLength;
 

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -911,40 +911,62 @@ BitmapText::Attribute BitmapText::GetDefaultAttribute() const
 	return attr;
 }
 
-void BitmapText::AddAttribute( size_t iPos, const Attribute &attr )
+std::pair<size_t, int> BitmapText::AdjustPositionForNewLines(size_t iPos) const
 {
-	// Fixup position for new lines.
-	Attribute newAttr = attr;
 	auto lineIter = m_wTextLines.cbegin();
-
 	int iLines = 0;
 	size_t iAdjustedPos = iPos;
 
 	for( ; lineIter != m_wTextLines.cend(); ++lineIter )
 	{
 		size_t length = lineIter->length() + 1; // +1 to account for implicit newline at the end
-		if( length > iAdjustedPos )
+		if (length > iAdjustedPos)
+		{
 			break;
+		}
 		iAdjustedPos -= length;
 		++iLines;
 	}
 
-	if( newAttr.length > 0 )
+	return { iAdjustedPos, iLines };
+}
+
+std::pair<size_t, size_t> BitmapText::FixupLengthForNewLines(size_t iAdjustedPos, size_t length) const
+{
+	auto lineIter = m_wTextLines.cbegin();
+	size_t iAdjustedEndPos = iAdjustedPos + length;
+
+	for (; lineIter != m_wTextLines.cend(); ++lineIter)
+	{
+		size_t length = lineIter->length() + 1; // +1 to account for implicit newline at the end
+		if (length > iAdjustedEndPos || length == 0)
+		{
+			break;
+		}
+		iAdjustedEndPos -= length;
+		length -= 1;
+	}
+
+	return { iAdjustedEndPos, length };
+}
+
+void BitmapText::AddAttribute( size_t iPos, const Attribute &attr )
+{
+	// Fixup position for new lines.
+	Attribute newAttr = attr;
+	auto [iAdjustedPos, iLines] = AdjustPositionForNewLines(iPos);
+
+	if (newAttr.length > 0)
 	{
 		// Fixup length for new lines.
-		size_t iAdjustedEndPos = iAdjustedPos + newAttr.length;
-		for( ; lineIter != m_wTextLines.cend(); ++lineIter )
-		{
-			size_t length = lineIter->length() + 1; // +1 to account for implicit newline at the end
-			if( length > iAdjustedEndPos || newAttr.length == 0 )
-				break;
-			iAdjustedEndPos -= length;
-			newAttr.length -= 1;
-		}
+		auto [iAdjustedEndPos, remainingLength] = FixupLengthForNewLines(iAdjustedPos, newAttr.length);
+		newAttr.length = remainingLength;
 	}
 
 	if( newAttr.length == 0 ) // Attribute doesn't cover any printable characters
+	{
 		return;
+	}
 
 	// Check if there are existing attributes overlapping this one. We might need to remove or fix them up.
 	const size_t iStartPos = iPos - iLines;
@@ -973,7 +995,9 @@ void BitmapText::AddAttribute( size_t iPos, const Attribute &attr )
 		auto iterEraseEnd = iterLastBeforeEnd;
 		// If it's overlapping completely, erase it as well
 		if( lastAttrOverlappingCompletely )
+		{
 			++iterEraseEnd;
+		}
 		m_mAttributes.erase( iterFirstAfterStart, iterEraseEnd );
 
 		// Otherwise it's only overlapping partially so fix it up

--- a/src/BitmapText.h
+++ b/src/BitmapText.h
@@ -136,6 +136,9 @@ protected:
 	std::map<size_t, Attribute>	m_mAttributes;
 	bool								m_bHasGlowAttribute;
 
+	std::pair<size_t, int> AdjustPositionForNewLines(size_t iPos) const;
+	std::pair<size_t, size_t> FixupLengthForNewLines(size_t iAdjustedPos, size_t length) const;
+
 	TextGlowMode	m_TextGlowMode;
 
 	// recalculate the items in SetText()


### PR DESCRIPTION
Should be a no-op.  Just a performance optimization.

It is a simple change:  take two of the complex loops which do calculations out of AddAttribute, and make them into dedicated functions. This can be optimized much better.

 - The goal was to minimize the function runtime, as this function runs on every note tap.
 - I profiled a 50-100% reduction in runtime of AddAttribute with this change over the course of a few songs with Step Statistics enabled.  
 - The local variables are then renamed to follow the Google Style Guide for C++ more closely.