### PR TITLE
Hold restart button

### DIFF
--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -769,8 +769,8 @@ bool ScreenEvaluation::Input(const InputEventPlus& input) {
     return false;
   }
 
-  if (input.MenuI == GAME_BUTTON_RESTART && input.type == IET_FIRST_PRESS &&
-      GAMESTATE->IsEventMode() && !GAMESTATE->IsCourseMode()) {
+  if (input.MenuI == GAME_BUTTON_RESTART && GAMESTATE->IsEventMode() &&
+      !GAMESTATE->IsCourseMode()) {
     return MenuRestart(input);
   }
 
@@ -844,7 +844,18 @@ bool ScreenEvaluation::MenuRestart(const InputEventPlus& input) {
     return false;
   }
 
-  SCREENMAN->GetTopScreen()->SetNextScreenName("ScreenGameplay");
+  float sHeld = INPUTFILTER->GetSecsHeld(input.DeviceI);
+
+  if (sHeld < 1.0f && input.type != IET_RELEASE) {
+    return false;
+  }
+
+  if (sHeld >= 1.0f) {
+    SCREENMAN->GetTopScreen()->SetNextScreenName("ScreenPlayerOptions");
+  } else {
+    SCREENMAN->GetTopScreen()->SetNextScreenName("ScreenGameplay");
+  }
+
   StartTransitioningScreen(SM_GoToNextScreen);
   return true;
 }

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -986,7 +986,18 @@ bool ScreenGameplay::MenuRestart(const InputEventPlus& input) {
     return false;
   }
 
-  SCREENMAN->GetTopScreen()->SetPrevScreenName("ScreenGameplay");
+  float sHeld = INPUTFILTER->GetSecsHeld(input.DeviceI);
+
+  if (sHeld < 1.0f && input.type != IET_RELEASE) {
+    return false;
+  }
+
+  if (sHeld >= 1.0f) {
+    SCREENMAN->GetTopScreen()->SetPrevScreenName("ScreenPlayerOptions");
+  } else {
+    SCREENMAN->GetTopScreen()->SetPrevScreenName("ScreenGameplay");
+  }
+
   BeginBackingOutFromGameplay();
   return true;
 }
@@ -2637,8 +2648,8 @@ bool ScreenGameplay::Input(const InputEventPlus& input) {
     return false;
   }
 
-  if (input.MenuI == GAME_BUTTON_RESTART && input.type == IET_FIRST_PRESS &&
-      GAMESTATE->IsEventMode() && !GAMESTATE->IsCourseMode()) {
+  if (input.MenuI == GAME_BUTTON_RESTART && GAMESTATE->IsEventMode() &&
+      !GAMESTATE->IsCourseMode()) {
     return MenuRestart(input);
   }
 


### PR DESCRIPTION
I'm sure, that ability to restart with changing options is really useful and worth it.

I often see (and faced myself):
1. Players started a song and realized they  forgot to change, for example C-mod to M-mod or speed. They have to go back. Classic restart does not help here
2. Players finished song, but decided re-play it with some slight adjustment. Current restart behavior does not help too.

I already applied patch on my machine and find my self using this feature really often. It became handy.

Also on DDR machines holding start brings to options, while just pressing it brings you to a game.
I don't see anything negative to have ability to hold a button. Let discuss.