### PR TITLE
Don't constantly read from Machine Stats while on the bookkeeping screen...

### DIFF
--- a/src/ScreenBookkeeping.cpp
+++ b/src/ScreenBookkeeping.cpp
@@ -66,8 +66,6 @@ void ScreenBookkeeping::Init()
 
 void ScreenBookkeeping::Update( float fDelta )
 {
-	UpdateView();	// refresh so that counts change in real-time
-
 	ScreenWithMenuElements::Update( fDelta );
 }
 


### PR DESCRIPTION
Lol this is kinda cursed. This was constantly reading from Stats.xml and Coins.xml while you were on the bookkeeping screen which made it ungodly unbearably slow. I've ran this screen on our cab and we drop to like -2fps because our Stats and Coin files are pretty large. 

There is no need for this as the only thing that could change while on this screen is Coin data but that is already handled 

```
bool ScreenBookkeeping::MenuCoin( const InputEventPlus &input )
{
	UpdateView();

	return Screen::MenuCoin( input );
}
```

It also already updates for various inputs that are put in so the constant update is especially unneeded