### PR TITLE
Revert commit which introduced `std::optional` to `archutils/Win32/GraphicsWindow.cpp`

### DIFF
--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -15,7 +15,6 @@
 #include "DirectXHelpers.h"
 #include "PrefsManager.h"
 
-#include <optional>
 #include <set>
 
 static const RString g_sClassName = PRODUCT_ID;
@@ -50,19 +49,6 @@ static RString GetNewWindow()
 	sName = Basename(sName);
 
 	return sName;
-}
-
-static std::optional<DEVMODE> GetDisplaySettings(const RString& displayId)
-{
-	DEVMODE dm;
-	ZERO( dm );
-	dm.dmSize = sizeof(dm);
-	if (!EnumDisplaySettings(displayId, ENUM_CURRENT_SETTINGS, &dm))
-	{
-		LOG->Warn("%s", werr_ssprintf(GetLastError(), "EnumDisplaySettings failed").c_str());
-		return std::nullopt;
-	}
-	return dm;
 }
 
 static LRESULT CALLBACK GraphicsWindow_WndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam )
@@ -201,26 +187,35 @@ static LRESULT CALLBACK GraphicsWindow_WndProc( HWND hWnd, UINT msg, WPARAM wPar
 	CHECKPOINT_M( ssprintf("%p, %u, %08x, %08x", hWnd, msg, wParam, lParam) );
 
 	if( m_bWideWindowClass )
-	{
 		return DefWindowProcW( hWnd, msg, wParam, lParam );
-	}
 	else
-	{
 		return DefWindowProcA( hWnd, msg, wParam, lParam );
-	}
 }
 
 static void AdjustVideoModeParams( VideoModeParams &p )
 {
-	std::optional<DEVMODE> dmOpt = GetDisplaySettings(p.sDisplayId);
-	if (!dmOpt.has_value())
+	DEVMODE dm;
+	ZERO( dm );
+	dm.dmSize = sizeof(dm);
+	if (!EnumDisplaySettings(p.sDisplayId, ENUM_CURRENT_SETTINGS, &dm))
 	{
 		p.rate = 60;
+		LOG->Warn( "%s", werr_ssprintf(GetLastError(), "EnumDisplaySettings failed").c_str() );
 		return;
 	}
 
-	const DEVMODE& dm = *dmOpt;
-	if (!(dm.dmFields & DM_DISPLAYFREQUENCY) || dm.dmDisplayFrequency == 0 || dm.dmDisplayFrequency == 1)
+	/* On a nForce 2 IGP on Windows 98, dm.dmDisplayFrequency sometimes 
+	 * (but not always) is 0.
+	 *
+	 * MSDN: When you call the EnumDisplaySettings function, the 
+	 * dmDisplayFrequency member may return with the value 0 or 1. 
+	 * These values represent the display hardware's default refresh rate. 
+	 * This default rate is typically set by switches on a display card or 
+	 * computer motherboard, or by a configuration program that does not 
+	 * use Win32 display functions such as ChangeDisplaySettings. */
+	if( !(dm.dmFields & DM_DISPLAYFREQUENCY) ||
+		dm.dmDisplayFrequency == 0 ||
+		dm.dmDisplayFrequency == 1 )
 	{
 		p.rate = 60;
 		LOG->Warn( "EnumDisplaySettings doesn't know what the refresh rate is. %d %d %d", dm.dmPelsWidth, dm.dmPelsHeight, dm.dmBitsPerPel );
@@ -243,13 +238,9 @@ RString GraphicsWindow::SetScreenMode( const VideoModeParams &p )
 		return RString();
 	}
 
-	std::optional<DEVMODE> dmOpt = GetDisplaySettings(p.sDisplayId);
-	if (!dmOpt.has_value())
-	{
-		return "Couldn't retrieve display settings";
-	}
-
-	DEVMODE DevMode = *dmOpt;
+	DEVMODE DevMode;
+	ZERO( DevMode );
+	DevMode.dmSize = sizeof(DEVMODE);
 	DevMode.dmPelsWidth = p.width;
 	DevMode.dmPelsHeight = p.height;
 	DevMode.dmBitsPerPel = p.bpp;
@@ -269,11 +260,9 @@ RString GraphicsWindow::SetScreenMode( const VideoModeParams &p )
 		ret = ChangeDisplaySettingsEx( p.sDisplayId, &DevMode, nullptr, CDS_FULLSCREEN, nullptr );
 	}
 
+	// XXX: append error
 	if( ret != DISP_CHANGE_SUCCESSFUL )
-	{
-		LOG->Warn("ChangeDisplaySettingsEx failed with error code: %d", ret);
 		return "Couldn't set screen mode";
-	}
 
 	g_FullScreenDevMode = DevMode;
 	return RString();


### PR DESCRIPTION
This reverts commit 6aa81a9dd2d368dc25347af0956fb95dff427807 to resolve issue #681 - we're seeing cases where `!dmOpt.has_value()` is executing when it's not expected so let's roll this back. The regression seems to be unique to the case of using the forced-refresh-rate setting in conjunction with exclusive full screen.