### PR TITLE
Handle group offset in AdjustSync

### DIFF
--- a/src/AdjustSync.cpp
+++ b/src/AdjustSync.cpp
@@ -201,7 +201,10 @@ void AdjustSync::AutosyncOffset()
 		{
 			case AutosyncType_Song:
 			{
+				// Group offset must be preserved and applied to each step.
+				float groupOffset = GAMESTATE->m_pCurSong->m_SongTiming.m_fBeat0GroupOffsetInSeconds;
 				GAMESTATE->m_pCurSong->m_SongTiming.m_fBeat0OffsetInSeconds += mean;
+				GAMESTATE->m_pCurSong->m_SongTiming.m_fBeat0GroupOffsetInSeconds = groupOffset;
 				const std::vector<Steps*>& vpSteps = GAMESTATE->m_pCurSong->GetAllSteps();
 				for (Steps *s : vpSteps)
 				{
@@ -210,6 +213,7 @@ void AdjustSync::AutosyncOffset()
 					if( s->m_Timing.empty() )
 						continue;
 					s->m_Timing.m_fBeat0OffsetInSeconds += mean;
+					s->m_Timing.m_fBeat0GroupOffsetInSeconds = groupOffset;
 				}
 				break;
 			}


### PR DESCRIPTION
This change ensures group offset is handled correctly. We need to make sure the group offset is maintained and not modified. Now that the function is aware of the group offset and properly applies it when considering each step's timing, the function works as expected.

Tested in several packs, ogg and mp3, which don't have Pack.ini as well as packs with Pack.ini. It works like it used to now.  👍 

Shout out to @CrashCringle12 for the guidance in finding this issue.