### PR TITLE
Prevent infinite loop in Steps::MinimizedChartString()

### DIFF
--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -869,7 +869,7 @@ RString Steps::MinimizedChartString()
 		bool minimal = false;
 		std::vector<RString> lines;
 		split(measures[m], "\n", lines, true);
-		while (!minimal && lines.size() % 2 == 0)
+		while (lines.size() > 0 && !minimal && lines.size() % 2 == 0)
 		{
 			// If every other line is all 0s, we can minimize the measure
 			for (unsigned i = 1; i < lines.size(); i += 2)

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -864,7 +864,6 @@ RString Steps::MinimizedChartString()
 	{
 
 		Trim(measures[m]);
-		bool isEmpty = true;
 		bool allZeroes = true;
 		bool minimal = false;
 		std::vector<RString> lines;

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -841,10 +841,14 @@ RString Steps::MinimizedChartString()
 	// 		0000
 	// 		StepMania will always generate the former since quarter notes are
 	// 		the smallest quantization.
-
-	RString smNoteData = "";
 	
-	this->GetSMNoteData(smNoteData);
+	// Instead of calling GetSMNoteData(), call NoteDataUtil::GetSMNoteDataString()
+	// to ensure that we have a consistent, valid stepchart representation.
+	RString smNoteData = "";
+	NoteData noteData;
+	this->GetNoteData(noteData);
+	NoteDataUtil::GetSMNoteDataString( noteData, smNoteData );
+	
 	if( smNoteData == "")
 	{
 		return "";


### PR DESCRIPTION
Charts with either an empty measure, or a completely empty `#NOTES` field, would get stuck in an infinite loop.