### PR TITLE
Pack.ini sync fix [replaced by 693]

### DIFF
--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -57,7 +57,7 @@ Group::Group(const RString& sDir, const RString& sGroupDirName, bool bFromProfil
     m_sSortTitle = m_sGroupName;
     m_sTranslitTitle = m_sGroupName;
     m_sSeries = "";
-    m_fSyncOffset = PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL ? 0 : -0.009;
+    m_fSyncOffset = 0.0f;  // default to NULL
     m_bHasPackIni = false;
     m_iYearReleased = 0;
     m_sBannerPath = "";
@@ -102,15 +102,12 @@ Group::Group(const RString& sDir, const RString& sGroupDirName, bool bFromProfil
             RString sValue = "";
             ini.GetValue("Group", "SyncOffset", sValue);
             Trim(sValue);
-            if (!sValue.empty()) {
-                if (sValue == "NULL") {
-                    m_fSyncOffset = 0.0f;
-                } else if (sValue == "ITG") {
-                    m_fSyncOffset = -0.009f;
-                } else {
-                    LOG->Warn("Group::Group: Invalid SyncOffset value: %s in Pack.ini. Valid values are NULL and ITG. Defaulting to NULL.", sValue.c_str());
-                }
-            }
+			if (sValue == "ITG") {
+				m_fSyncOffset = -0.009f;
+			}
+			else if (sValue != "NULL" && !sValue.empty()) {
+				LOG->Warn("Group::Group: Invalid SyncOffset value: %s in Pack.ini. Valid values are NULL and ITG. Defaulting to NULL.", sValue.c_str());
+			}
 
             ini.GetValue("Group", "Year", m_iYearReleased);
         } else {

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -449,6 +449,15 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
 		}
 	}
 
+	// Apply the group offset to the song's timing data
+	Group* pGroup = SONGMAN->GetGroupByName(m_sGroupName);
+	if (pGroup != nullptr) {
+		m_SongTiming.m_fBeat0GroupOffsetInSeconds = pGroup->GetSyncOffset();
+	}
+	else {
+		m_SongTiming.m_fBeat0GroupOffsetInSeconds = 0.0f; // Default to NULL
+	}
+
 	// Add AutoGen pointers. (These aren't cached.)
 	AddAutoGenNotes();
 

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -521,6 +521,15 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 	}
 }
 
+Group* SongManager::GetGroupByName(const RString& groupName) const {
+	for (const auto& group : m_vGroups) {
+		if (group.GetGroupName() == groupName) {
+			return const_cast<Group*>(&group);
+		}
+	}
+	return nullptr; // if group is not found
+}
+
 // Instead of "symlinks", songs should have membership in multiple groups. -Chris
 void SongManager::LoadGroupSymLinks(RString sDir, RString sGroupFolder)
 {

--- a/src/SongManager.h
+++ b/src/SongManager.h
@@ -203,6 +203,8 @@ public:
 	void UpdateRankingCourses();	// courses shown on the ranking screen
 	void RefreshCourseGroupInfo();
 
+	Group* GetGroupByName(const RString& groupName) const;
+
 	// Lua
 	void PushSelf( lua_State *L );
 
@@ -277,6 +279,8 @@ protected:
 	ThemeMetric1D<RageColor>	COURSE_GROUP_COLOR;
 	ThemeMetric<int> num_profile_song_group_colors;
 	ThemeMetric1D<RageColor> profile_song_group_colors;
+private:
+	std::vector<Group> m_vGroups;
 };
 
 extern SongManager*	SONGMAN;	// global and accessible from anywhere in our program

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -1001,6 +1001,14 @@ RString Steps::GenerateChartKey(NoteData &nd, TimingData *td)
 	}
 	k = firstHalf + secondHalf;
 
+	Group* pGroup = SONGMAN->GetGroupByName(m_pSong->m_sGroupName);
+	if (pGroup != nullptr) {
+		td->m_fBeat0GroupOffsetInSeconds = pGroup->GetSyncOffset();
+	}
+	else {
+		td->m_fBeat0GroupOffsetInSeconds = 0.0f; // Default to NULL
+	}
+
 	//ChartKeyRecord = k;
 	o.append("X");	// I was thinking of using "C" to indicate chart.. however.. X is cooler... - Mina
 	o.append(BinaryToHex(CryptManager::GetSHA1ForString(k)));


### PR DESCRIPTION
Closes #676


Note I didn't see an existing function with identical behavior to `Group* GetGroupByName(const RString& groupName) const` but if I missed something like that,  feel free to undo the SongManager.cpp / SongManager.h changes & edit Song/Steps accordingly