### PR TITLE
Ensure Group offset is always applied

### DIFF
--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -30,7 +30,7 @@ Group::Group() {
     m_sGroupName = "";
     m_sTranslitTitle = "";
     m_sSeries = "";
-    m_fSyncOffset = 0;
+    m_fSyncOffset = 0.0f;
     m_bHasPackIni = false;
     m_iYearReleased = 0;
     m_sBannerPath = "";
@@ -57,7 +57,7 @@ Group::Group(const RString& sDir, const RString& sGroupDirName, bool bFromProfil
     m_sSortTitle = m_sGroupName;
     m_sTranslitTitle = m_sGroupName;
     m_sSeries = "";
-    m_fSyncOffset = PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL ? 0 : -0.009;
+    m_fSyncOffset = PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL ? 0.0f : -0.009f;
     m_bHasPackIni = false;
     m_iYearReleased = 0;
     m_sBannerPath = "";

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -386,7 +386,6 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
 		LoadEditsFromSongDir(sDir);
 
 		TidyUpData(false, true);
-
 		// Don't save a cache file if the autosave is being loaded, because the
 		// cache file would contain the autosave filename. -Kyz
 		// Songs loaded from removable profile are never cached, on the
@@ -429,8 +428,20 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
 		m_sCDTitleFile.clear();
 	}
 
+	// Normally TidyUpData would handle setting the m_fBeat0GroupOffsetInSeconds.
+	// That is to keep the song start and end times become inaccurate in some cases.
+	// SInce there are cases where TidyUpData isn't called, we still want to guarantee the
+	// m_fBeat0GroupOffsetInSeconds is always set so we do that here. 
+	float fOffset = PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL ? 0 : -0.009;
+	if (SONGMAN->GetGroupFromName(m_sGroupName) != nullptr)
+	{
+		fOffset = SONGMAN->GetGroupFromName(m_sGroupName)->GetSyncOffset();
+	}
+	m_SongTiming.m_fBeat0GroupOffsetInSeconds = fOffset;
+
 	for (Steps *s : m_vpSteps)
 	{
+		s->m_Timing.m_fBeat0GroupOffsetInSeconds = fOffset;
 		if(m_LoadedFromProfile != ProfileSlot_Invalid)
 		{
 			s->ChangeFilenamesForCustomSong();

--- a/src/TimingData.h
+++ b/src/TimingData.h
@@ -415,7 +415,7 @@ public:
 			}
 		}
 
-		return this->m_fBeat0OffsetInSeconds == other.m_fBeat0OffsetInSeconds;
+		return this->m_fBeat0OffsetInSeconds == other.m_fBeat0OffsetInSeconds && this->m_fBeat0GroupOffsetInSeconds == other.m_fBeat0GroupOffsetInSeconds;
 	}
 
 	/**


### PR DESCRIPTION
Group offset was previously only being set within TidyUpData(). This is to ensure that the music start and end times are accurate. This commit also makes sure that the group offset is being set even if TidyUpData is not called.

Makes sure syncOffset is always set as a float.

Creds to @sukibaby for pointing this out initially here: https://github.com/itgmania/itgmania/pull/692