### PR TITLE
Reorganize machine sync bias handing in Group constructor

### DIFF
--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -57,7 +57,7 @@ Group::Group(const RString& sDir, const RString& sGroupDirName, bool bFromProfil
     m_sSortTitle = m_sGroupName;
     m_sTranslitTitle = m_sGroupName;
     m_sSeries = "";
-    m_fSyncOffset = PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL ? 0.0f : -0.009f;
+    m_fSyncOffset = 0.0f;
     m_bHasPackIni = false;
     m_iYearReleased = 0;
     m_sBannerPath = "";
@@ -102,13 +102,30 @@ Group::Group(const RString& sDir, const RString& sGroupDirName, bool bFromProfil
             RString sValue = "";
             ini.GetValue("Group", "SyncOffset", sValue);
             Trim(sValue);
+            // Handle the group offset application.
+            // 
+            // The goal of Pack.ini is to make everything NULL synced internally.
+            // 
+            // The machine sync offset preference corresponds to what offset the user
+            // would like to assume as a "default" for packs without a Pack.ini.
+            //
+            // If the machine sync bias is set to ITG, we want to remove the 9ms ITG bias
+            // for all packs without a Pack.ini.
+            // 
+            // If the Pack.ini is specified (regardless of the machine sync bias) with
+            // SyncOffset=ITG, we need to always remove the 9ms ITG bias.
+            // Otherwise, if SyncOffset=NULL, we don't need to do anything since it's
+            // already NULL synced.
+            m_fSyncOffset = (PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL) ? 0.0f : -0.009f;
             if (!sValue.empty()) {
                 if (sValue == "NULL") {
                     m_fSyncOffset = 0.0f;
-                } else if (sValue == "ITG") {
+                }
+                else if (sValue == "ITG") {
                     m_fSyncOffset = -0.009f;
-                } else {
-                    LOG->Warn("Group::Group: Invalid SyncOffset value: %s in Pack.ini. Valid values are NULL and ITG. Defaulting to NULL.", sValue.c_str());
+                }
+                else {
+                    LOG->Warn("Group::Group: Invalid SyncOffset value: %s in Pack.ini. Valid values are NULL and ITG. Using default value.", sValue.c_str());
                 }
             }
 


### PR DESCRIPTION
Reduce ambiguity when setting the machine sync bias by explicitly taking into account all possibilities when defining the sync bias of the group.

All logic is moved into one section now instead of being split between two places.

This is a minor change, but I'd be more comfortable with this because it more explicitly defines the different possibilities for group/machine offset combinations than the existing code.

The old code is harder to follow and I'm not sure if it's as robust in terms of handing all possibilities here, since it doesn't really matter what the initialization value is as it's being reassigned during the `if (!sValue.empty())` loop.