### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/CMake/SMDefs.cmake
+++ b/CMake/SMDefs.cmake
@@ -1,7 +1,7 @@
 # Set up version numbers according to the new scheme.
 set(SM_VERSION_MAJOR 1)
 set(SM_VERSION_MINOR 0)
-set(SM_VERSION_PATCH 1)
+set(SM_VERSION_PATCH 2)
 set(SM_VERSION_TRADITIONAL
     "${SM_VERSION_MAJOR}.${SM_VERSION_MINOR}.${SM_VERSION_PATCH}")
 


### PR DESCRIPTION
Because 1.0.1 already exists as a test build. There would be too much confusion if the "real" 1.0.1 isn't the same as the 1.0.1 installers that have already gone out.