### PR TITLE
Implement ability to track theme version

### DIFF
--- a/CMake/SMDefs.cmake
+++ b/CMake/SMDefs.cmake
@@ -5,6 +5,11 @@ set(SM_VERSION_PATCH 1)
 set(SM_VERSION_TRADITIONAL
     "${SM_VERSION_MAJOR}.${SM_VERSION_MINOR}.${SM_VERSION_PATCH}")
 
+# Track the Simply Love version number as it correlates to the engine release.
+set(THEME_VERSION_MAJOR 5)
+set(THEME_VERSION_MINOR 6)
+set(THEME_VERSION_PATCH 0)
+
 execute_process(COMMAND git rev-parse --short HEAD
                 WORKING_DIRECTORY "${SM_ROOT_DIR}"
                 OUTPUT_VARIABLE SM_VERSION_GIT_HASH

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,11 @@ if(WITH_NO_ROLC_TOMCRYPT)
   target_compile_definitions("${SM_EXE_NAME}" PRIVATE LTC_NO_ROLC)
 endif()
 
+# For tracking Simply Love version.
+target_compile_definitions("${SM_EXE_NAME}" PRIVATE THEME_VERSION_MAJOR=${THEME_VERSION_MAJOR})
+target_compile_definitions("${SM_EXE_NAME}" PRIVATE THEME_VERSION_MINOR=${THEME_VERSION_MINOR})
+target_compile_definitions("${SM_EXE_NAME}" PRIVATE THEME_VERSION_PATCH=${THEME_VERSION_PATCH})
+
 # Compilation flags per project here.
 target_compile_definitions("${SM_EXE_NAME}" PRIVATE $<$<CONFIG:Debug>:DEBUG>)
 target_compile_definitions("${SM_EXE_NAME}" PRIVATE $<$<CONFIG:Release>:RELEASE>)

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -1039,6 +1039,21 @@ void LuaHelpers::PushValueFunc( lua_State *L, int iArgs )
 	lua_pushcclosure( L, lua_pushvalues, iArgs+1 );
 }
 
+void CheckThemeVersion(int major, int minor, int patch) {
+	const int REQUIRED_MAJOR = THEME_VERSION_MAJOR;
+	const int REQUIRED_MINOR = THEME_VERSION_MINOR;
+	const int REQUIRED_PATCH = THEME_VERSION_PATCH;
+
+	// Simply Love theme version check
+	if (major < REQUIRED_MAJOR ||
+		(major == REQUIRED_MAJOR && minor < REQUIRED_MINOR) ||
+		(major == REQUIRED_MAJOR && minor == REQUIRED_MINOR && patch < REQUIRED_PATCH)) {
+		std::string assembled_ver_num = ssprintf("%d.%d.%d", REQUIRED_MAJOR, REQUIRED_MINOR, REQUIRED_PATCH);
+		std::string msg = "The Simply Love theme version is out of date. Please update to version " + assembled_ver_num + " or later.";
+		LuaHelpers::ReportScriptErrorFmt("%s", msg.c_str());
+	}
+}
+
 #include "ProductInfo.h"
 LuaFunction( ProductFamily, (RString) PRODUCT_FAMILY );
 LuaFunction( ProductVersion, (RString) product_version );


### PR DESCRIPTION
I haven't actually implemented this - this commit simply provides the framework for a version check, so people don't accidentally play with an old theme version without realizing it.

I don't know if I chose the best place in CMakeLists.txt to put that,  but I didn't really think anywhere else was any better...