### PR TITLE
Precompute values & reserve memory in CreateFrameRects()

### DIFF
--- a/src/RageTexture.cpp
+++ b/src/RageTexture.cpp
@@ -28,15 +28,22 @@ void RageTexture::CreateFrameRects()
 
 	// Fill in the m_FrameRects with the bounds of each frame in the animation.
 	m_TextureCoordRects.clear();
+	m_TextureCoordRects.reserve(static_cast<size_t>(m_iFramesWide * m_iFramesHigh));
+
+	float frameWidth = (m_iImageWidth / static_cast<float>(m_iTextureWidth)) / m_iFramesWide;
+	float frameHeight = (m_iImageHeight / static_cast<float>(m_iTextureHeight)) / m_iFramesHigh;
 
 	for( int j=0; j<m_iFramesHigh; j++ )		// traverse along Y
 	{
+		float top = j * frameHeight;
+		float bottom = (j + 1) * frameHeight;
+
 		for( int i=0; i<m_iFramesWide; i++ )	// traverse along X (important that this is the inner loop)
 		{
-			RectF frect( (i+0)/(float)m_iFramesWide*m_iImageWidth /(float)m_iTextureWidth,	// these will all be between 0.0 and 1.0
-						 (j+0)/(float)m_iFramesHigh*m_iImageHeight/(float)m_iTextureHeight,
-						 (i+1)/(float)m_iFramesWide*m_iImageWidth /(float)m_iTextureWidth,
-						 (j+1)/(float)m_iFramesHigh*m_iImageHeight/(float)m_iTextureHeight );
+			float left = i * frameWidth;
+			float right = (i + 1) * frameWidth;
+
+			RectF frect(left, top, right, bottom);  // these will all be in the range [0.0,1.0]
 			m_TextureCoordRects.push_back( frect );	// the index of this array element will be (i + j*m_iFramesWide)
 
 			//LOG->Trace( "Adding frect%d %f %f %f %f", (i + j*m_iFramesWide), frect.left, frect.top, frect.right, frect.bottom );


### PR DESCRIPTION
This function is called in the MovieTexture init code among other places. Noticed when looking into functions the MovieTexture code relies on, to identify possible failure points. (though this is more of an optimization, though avoiding repeated reallocations is always good)