### PR TITLE
Added ClearCredits in lua

### DIFF
--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -3257,6 +3257,9 @@ end
 		Inserts one credit.  To deduct a credit, pass a negative integer representing the number
 		of coins per credit to <Link class='GameState' function='InsertCoin'>InsertCoin</Link>.
 	</Function>
+	<Function name='ClearCredits' return='void' arguments='' since='ITGmania 1.0.3'>
+		Clear all inserted credits.
+	</Function>
 	<Function name='IsAnExtraStage' return='bool' arguments=''>
 		Returns <code>true</code> if this is an extra stage.
 	</Function>

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -3133,6 +3133,11 @@ public:
 		StepMania::InsertCredit();
 		COMMON_RETURN_SELF;
 	}
+	static int ClearCredits(T* p, lua_State* L)
+	{
+		StepMania::ClearCredits();
+		COMMON_RETURN_SELF;
+	}
 	static int CurrentOptionsDisqualifyPlayer( T* p, lua_State *L )	{ lua_pushboolean(L, p->CurrentOptionsDisqualifyPlayer(Enum::Check<PlayerNumber>(L, 1))); return 1; }
 
 	static int ResetPlayerOptions( T* p, lua_State *L )
@@ -3482,6 +3487,7 @@ public:
 		ADD_METHOD( AddStageToPlayer );
 		ADD_METHOD( InsertCoin );
 		ADD_METHOD( InsertCredit );
+		ADD_METHOD( ClearCredits );
 		ADD_METHOD( CurrentOptionsDisqualifyPlayer );
 		ADD_METHOD( ResetPlayerOptions );
 		ADD_METHOD( RefreshNoteSkinData );


### PR DESCRIPTION
This lua function has been added for arcades. Up to now I added a preference (Arcade Options Screen) on theme side to decide if credits shall be reset at startup. 

Should i manage it at engine level?