### PR TITLE
Clear credits at Startup

### DIFF
--- a/src/Bookkeeper.cpp
+++ b/src/Bookkeeper.cpp
@@ -18,6 +18,13 @@ static const RString COINS_DAT = "Save/Coins.xml";
 
 Bookkeeper::Bookkeeper()
 {
+	// GameState resets the coin count, but once the Bookkeeper is initialized, the coin count is overwritten by the ReadFromDisk function.
+	// Resetting the CoinsFile before reloading allows the game to start without credits.
+	if (PREFSMAN->m_bResetCoinsAtStartup)
+	{
+		WriteCoinsFile(0);
+	}
+
 	ClearAll();
 	ReadFromDisk();
 }

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -267,6 +267,7 @@ PrefsManager::PrefsManager() :
 	m_bCelShadeModels		( "CelShadeModels",			false ),	// Work-In-Progress.. disable by default.
 	m_bPreferredSortUsesGroups	( "PreferredSortUsesGroups",		true ),
 	m_fDebounceCoinInputTime	( "DebounceCoinInputTime",		0 ),
+	m_bResetCoinsAtStartup		( "ResetCoinsAtStartup", false ),
 
 	m_fPadStickSeconds		( "PadStickSeconds",			0 ),
 	m_EditRecordModeLeadIn		("EditRecordModeLeadIn",		1.0f ),

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -270,6 +270,7 @@ public:
 	Preference<bool>	m_bCelShadeModels;
 	Preference<bool>	m_bPreferredSortUsesGroups;
 	Preference<float>	m_fDebounceCoinInputTime; // allow users to apply a distinct debounce to coin input
+	Preference<bool>	m_bResetCoinsAtStartup;
 
 	// Number of seconds it takes for a button on the controller to release
 	// after pressed.

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -879,6 +879,7 @@ static void InitializeConfOptions()
 	ADD( ConfOption( "DefaultFailType", DefaultFailType, DefaultFailChoices ) );
 	ADD( ConfOption( "CoinsPerCredit",		CoinsPerCredit,		"|1","|2","|3","|4","|5","|6","|7","|8","|9","|10","|11","|12","|13","|14","|15","|16" ) );
 	ADD( ConfOption( "MaxNumCredits",		MaxNumCredits,		"|20","|40","|60","|80","|100" ) );
+	ADD( ConfOption( "ResetCoinsAtStartup", MovePref<bool>, "No", "Yes"));
 	ADD( ConfOption( "Premium",			MovePref<Premium>,	"Off","Double for 1 Credit","2 Players for 1 Credit" ) );
 	ADD( ConfOption( "JointPremium",		JointPremium,		"Off","2 Players for 1 Credit" ) );
 	g_ConfOptions.back().m_sPrefName = "Premium";


### PR DESCRIPTION
Since GameState constructor is invoked before Bookkeeper I moved coins reset in Bookkeeper itself. GameState always initialize coins data to 0, but it gets overridden when Bookkeeper invokes ReadFromDisk. Right before reading the coins file, reset the value in it.
Preference set to false as default guarantee that behaviour is not changed.

Tested by adding an arcade option menu and resetting the game to verify that credits are cleared. Set the perference back to No and tested if credits aren't reset after reboot.