### PR TITLE
Revert "Corrected order of hide light in player options"

### DIFF
--- a/src/PlayerOptions.h
+++ b/src/PlayerOptions.h
@@ -352,9 +352,9 @@ public:
 
 	PlayerNumber m_pn; // Needed for fetching the style.
 
+	HideLightType m_HideLightType;
 	LifeType m_LifeType;
 	DrainType m_DrainType;	// only used with LifeBar
-	HideLightType m_HideLightType;
 	ModTimerType m_ModTimerType;
 	int m_BatteryLives;
 	/* All floats have a corresponding speed setting, which determines how fast


### PR DESCRIPTION
This reverts commit 40e61bd32effeacad2d963786fabf92b22d863a8. 

Feel free to close this one if you're planning to rebase the beta branch and squash some commits.