### PR TITLE
Additional HidDevice logging

### DIFF
--- a/src/arch/Lights/LightsDriver_PacDrive.h
+++ b/src/arch/Lights/LightsDriver_PacDrive.h
@@ -9,7 +9,11 @@
  * This driver needs user read/write access to PacDrive.
  * This can be achieved by using a udev rule like this:
  *
- * SUBSYSTEMS=="usb", ATTRS{idVendor}=="D209", ATTRS{idProduct}=="1500", OWNER="dance", GROUP="dance", MODE="0660"
+ * SUBSYSTEMS=="usb", ATTRS{idVendor}=="D209", ATTRS{idProduct}=="150[0-9]", OWNER="dance", GROUP="dance", MODE="0660"
+ *
+ * or
+ *
+ * KERNEL=="hidraw*", ATTRS{idVendor}=="D209", ATTRS{idProduct}=="150[0-9]", OWNER="dance", GROUP="dance", MODE="0660"
  *
  * Refer to your distribution's documentation on how to properly apply a udev rule.
  *

--- a/src/arch/Lights/LightsDriver_snek.h
+++ b/src/arch/Lights/LightsDriver_snek.h
@@ -11,6 +11,10 @@
  *
  * SUBSYSTEMS=="usb", ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="10a8", OWNER="dance", GROUP="dance", MODE="0660"
  *
+ * or
+ *
+ * KERNEL=="hidraw*", ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="10a8", OWNER="dance", GROUP="dance", MODE="0660"
+ *
  * Refer to your distribution's documentation on how to properly apply a udev rule.
  *
  * -------------------------- NOTE --------------------------

--- a/src/arch/Lights/LightsDriver_stac.h
+++ b/src/arch/Lights/LightsDriver_stac.h
@@ -13,6 +13,11 @@
  * SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="eb5b", OWNER="dance", GROUP="dance", MODE="0660"
  * SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="eb5a", OWNER="dance", GROUP="dance", MODE="0660"
  *
+ *  or
+ *
+ * KERNEL=="hidraw*", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="eb5b", OWNER="dance", GROUP="dance", MODE="0660"
+ * KERNEL=="hidraw*", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="eb5a", OWNER="dance", GROUP="dance", MODE="0660"
+ *
  * Refer to your distribution's documentation on how to properly apply a udev rule.
  *
  * -------------------------- NOTE --------------------------

--- a/src/archutils/Common/HidDevice.cpp
+++ b/src/archutils/Common/HidDevice.cpp
@@ -13,10 +13,12 @@ HidDevice::HidDevice(int vid, const std::vector<int> pids, int interfaceNum, boo
 
 	if (!result)
 	{
-		LOG->Warn("HidDevice with vendor_id %04x and pids %s: %d not found", vid, GetPidsString(pids).c_str(), interfaceNum);
+		LOG->Warn("HidDevice with vendor_id 0x%04x and pids 0x%s %d could not connect.", vid, GetPidsString(pids).c_str(), interfaceNum);
 	}
 	else
+	{
 		foundOnce = true;
+	}
 }
 
 HidDevice::HidDevice(int vid, int pid, int interfaceNum, bool autoReconnection, bool nonBlockingRead) :
@@ -49,7 +51,13 @@ bool HidDevice::Open(const char* path)
 		hid_set_nonblocking(handle, 1);
 
 	if (handle)
-		LOG->Info("HidDevice %04x:%04x: %d opened by path %s", foundDeviceInfo.vid, foundDeviceInfo.pid, foundDeviceInfo.interfaceNum, foundDeviceInfo.path);
+	{
+		LOG->Info("HidDevice 0x%04x:0x%04x %d opened by path %s", foundDeviceInfo.vid, foundDeviceInfo.pid, foundDeviceInfo.interfaceNum, foundDeviceInfo.path);
+	}
+	else
+	{
+		LOG->Warn("HidDevice 0x%04x:0x%04x %d could not be opened by path %s. Are permissions correct?", foundDeviceInfo.vid, foundDeviceInfo.pid, foundDeviceInfo.interfaceNum, foundDeviceInfo.path);
+	}
 
 	return handle != nullptr;
 }
@@ -148,6 +156,10 @@ void HidDevice::GetDeviceInfo(int vid, const std::vector<int> pids, int interfac
 			cur_dev = cur_dev->next;
 		}
 	}
+	else
+	{
+		LOG->Warn("HidDevice with vid 0x%04x not found, is it plugged in?", vid);
+	}
 
 	if (found && cur_dev != nullptr)
 	{
@@ -167,7 +179,7 @@ int HidDevice::Read(unsigned char* data, size_t length)
 
 	if (result == -1)
 	{
-		LOG->Warn("HidDevice %04x:%04x: %d read failed. Fail reason %ls", foundDeviceInfo.vid, foundDeviceInfo.pid, foundDeviceInfo.interfaceNum, GetError());
+		LOG->Warn("HidDevice 0x%04x:0x%04x %d read failed. Fail reason %ls", foundDeviceInfo.vid, foundDeviceInfo.pid, foundDeviceInfo.interfaceNum, GetError());
 		Close();
 	}
 
@@ -183,7 +195,7 @@ HidResults HidDevice::Write(const unsigned char* data, size_t length)
 
 	if (result != length)
 	{
-		LOG->Warn("HidDevice %04x:%04x: %d write failed. Fail reason %ls", foundDeviceInfo.vid, foundDeviceInfo.pid, foundDeviceInfo.interfaceNum, GetError());
+		LOG->Warn("HidDevice 0x%04x:0x%04x %d write failed. Fail reason %ls", foundDeviceInfo.vid, foundDeviceInfo.pid, foundDeviceInfo.interfaceNum, GetError());
 		Close();
 		return OperationFailed;
 	}


### PR DESCRIPTION
Addresses comments in PR https://github.com/itgmania/itgmania/pull/711 that @jsirex mentioned.

Where the error condition of the initial connection to an HidDevice with hidapi was not clear by the engine itself.

As if the device was found, but couldn't be opened for example.

Additional logging has been added to be more clear as to a disconnected device, a not found device, an error in opening the device, and a successful connection.

Sample udev rules in the code have been cleared up in the event the target system is using the hidraw backend of hidapi.


Example with disconnected:
```
00:00.273: Initializing lights drivers: pacdrive
/////////////////////////////////////////
00:00.275: WARNING: HidDevice with vid 0xd209 not found, is it plugged in?
/////////////////////////////////////////
/////////////////////////////////////////
00:00.275: WARNING: HidDevice with vendor_id 0xd209 and pids 0x1500,1501,1502,1503,1504,1505,1506,1507 0 could not connect.
/////////////////////////////////////////
```

Example with invalid permissions:
```
00:00.274: Initializing lights drivers: pacdrive
/////////////////////////////////////////
00:00.277: WARNING: HidDevice 0xd209:0x1500 0 could not be opened by path /dev/hidraw7. Are permissions correct?
/////////////////////////////////////////
/////////////////////////////////////////
00:00.277: WARNING: HidDevice with vendor_id d209 and pids 1500,1501,1502,1503,1504,1505,1506,1507: 0 could not connect.
/////////////////////////////////////////
```

Success:
```
00:00.280: Initializing lights drivers: pacdrive
00:00.284: HidDevice 0xd209:0x1500 0 opened by path /dev/hidraw7
```
