### PR TITLE
Don't exit the game if a song folder is found with groups

### DIFF
--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -423,11 +423,8 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 	}
 
 	songIndex = 0;
-	for (auto const &pair : mapGroupSongDirs)	// foreach dir in /Songs/
+	for (const auto& [sGroupDirName, arraySongDirs] : mapGroupSongDirs)	// foreach dir in /Songs/
 	{
-		RString sGroupDirName = pair.first;
-		std::vector<RString> arraySongDirs = pair.second;
-
 		LOG->Trace("Attempting to load %i songs from \"%s\"", int(arraySongDirs.size()),
 				   (sDir+sGroupDirName).c_str() );
 		int loaded = 0;

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -381,7 +381,7 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 	StripCvsAndSvn( arrayGroupDirs );
 	StripMacResourceForks( arrayGroupDirs );
 
-	std::vector<std::vector<RString>> arrayGroupSongDirs;
+	std::map<RString, std::vector<RString>> mapGroupSongDirs;
 	int groupIndex, songCount, songIndex;
 
 	groupIndex = 0;
@@ -410,7 +410,7 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 			StripMacResourceForks( arraySongDirs );
 			SortRStringArray( arraySongDirs );
 
-			arrayGroupSongDirs.push_back(arraySongDirs);
+			mapGroupSongDirs[sGroupDirName] = arraySongDirs;
 			songCount += arraySongDirs.size();
 		}
 	}
@@ -422,12 +422,11 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 		ld->SetTotalWork( songCount );
 	}
 
-	groupIndex = 0;
 	songIndex = 0;
-	
-	for (RString const &sGroupDirName : arrayGroupDirs)	// foreach dir in /Songs/
+	for (auto const &pair : mapGroupSongDirs)	// foreach dir in /Songs/
 	{
-		std::vector<RString> &arraySongDirs = arrayGroupSongDirs[groupIndex++];
+		RString sGroupDirName = pair.first;
+		std::vector<RString> arraySongDirs = pair.second;
 
 		LOG->Trace("Attempting to load %i songs from \"%s\"", int(arraySongDirs.size()),
 				   (sDir+sGroupDirName).c_str() );

--- a/src/SongManager.h
+++ b/src/SongManager.h
@@ -216,7 +216,7 @@ protected:
 	 */
 	void LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditions );
 	bool GetExtraStageInfoFromCourse( bool bExtra2, RString sPreferredGroup, Song*& pSongOut, Steps*& pStepsOut, StepsType stype );
-	void SanityCheckGroupDir( RString sDir ) const;
+	bool SanityCheckGroupDir( RString sDir ) const;
 	void AddGroup( RString sDir, RString sGroupDirName, Group* group );
 	int GetNumEditsLoadedFromProfile( ProfileSlot slot ) const;
 


### PR DESCRIPTION
Update SanityCheckGroup to return whether the group has passed the check or not rather and log a warning if failed rather than exit the game. We use this bool to determine whether to add the directory to our group list or not. If it returns true then we can add this group dir to our mapping and use it in the rest of the method.

See issue: https://github.com/itgmania/itgmania/issues/714