### PR TITLE
Fix for #524 - Save crashlog.txt to ./itgmania/Logs instead of /tmp

### DIFF
--- a/src/archutils/Unix/CrashHandler.cpp
+++ b/src/archutils/Unix/CrashHandler.cpp
@@ -186,8 +186,17 @@ static void parent_process( int to_child, const CrashData *crash )
 		return;
 	if( !parent_write(to_child, p, size) )
 		return;
-}
 
+	#if defined(LINUX)
+	/* 7. Send Home directory to child. */
+	const char *home = getenv( "HOME" );
+	size = strlen(home) + 1;
+	if (!parent_write(to_child, &size, sizeof(size)))
+		return;
+	if (!parent_write(to_child, home, size))
+		return;
+	#endif
+}
 
 /* The parent process is the crashed process.  It'll send data to the
  * child, who will do stuff with it.  The parent then waits for the

--- a/src/archutils/Unix/CrashHandlerChild.cpp
+++ b/src/archutils/Unix/CrashHandlerChild.cpp
@@ -195,7 +195,7 @@ static void child_process()
 		}
 	}
 
-	RString sCrashInfoPath = "./tmp";
+	RString sCrashInfoPath = "/tmp";
 
 #if defined(MACOSX)
 	sCrashInfoPath = CrashHandler::GetLogsDirectory();
@@ -286,7 +286,6 @@ static void child_process()
 	/* stdout may have been inadvertently closed by the crash in the parent;
 	 * write to /dev/tty instead. */
 	FILE *tty = fopen( "/dev/tty", "w" );
-
 	if( tty == nullptr )
 		tty = stderr;
 

--- a/src/archutils/Unix/CrashHandlerChild.cpp
+++ b/src/archutils/Unix/CrashHandlerChild.cpp
@@ -148,6 +148,17 @@ static void child_process()
 	const RString CrashedThread(temp);
 	delete[] temp;
 
+	#if defined(LINUX)
+	/* 7. Read Home Directory from parent thread. */
+	if (!child_read(3, &size, sizeof(size)))
+		return;
+	temp = new char[size];
+	if (!child_read(3, temp, size))
+		return;
+	const RString home(temp);
+	delete[] temp;
+	#endif
+
 	/* Wait for the child to either finish cleaning up or die. */
 	fd_set rs;
 	struct timeval timeout = { 5, 0 }; // 5 seconds
@@ -184,13 +195,15 @@ static void child_process()
 		}
 	}
 
-	RString sCrashInfoPath = "/tmp";
+	RString sCrashInfoPath = "./tmp";
+
 #if defined(MACOSX)
 	sCrashInfoPath = CrashHandler::GetLogsDirectory();
-#else
-	const char *home = getenv( "HOME" );
-	if( home )
+#elif defined(LINUX)
+	if( home ) {
 		sCrashInfoPath = home;
+		sCrashInfoPath += "/.itgmania/Logs";
+	}
 #endif
 	sCrashInfoPath += "/crashinfo.txt";
 
@@ -273,6 +286,7 @@ static void child_process()
 	/* stdout may have been inadvertently closed by the crash in the parent;
 	 * write to /dev/tty instead. */
 	FILE *tty = fopen( "/dev/tty", "w" );
+
 	if( tty == nullptr )
 		tty = stderr;
 


### PR DESCRIPTION
Ref: #524
Turns out if you use getenv() in child process nothing really happens, always returns NULL. Now Grabbing home from parent and sending it over.