### PR TITLE
ScreenSelectMusic - check if is video file accorting to FT_Movie extensions list

### DIFF
--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -1746,12 +1746,7 @@ void ScreenSelectMusic::SwitchToPreferredDifficulty()
 // NOTE: This could a be a bit more robust than just looking at the extension,
 // but it's good enough for now.
 static bool IsVideoFile(const RString& path) {
-	const RString extension = GetExtension(path);
-	return extension == "mp4" ||
-		extension == "avi" ||
-		extension == "mov" ||
-		extension == "mkv" ||
-		extension == "mpg";
+	return ActorUtil::GetFileType(path) == FT_Movie;
 }
 
 void ScreenSelectMusic::AfterMusicChange()


### PR DESCRIPTION
Based on the check used in Sprite.cpp to decodeMovie

https://github.com/itgmania/itgmania/blob/2dc61769fc2b12cf3b9aa510130e9d5d052ab85d/src/Sprite.cpp#L371-L374
