### PR TITLE
StepManiaX SDK Input Handler

### DIFF
--- a/src/CMakeData-arch.cmake
+++ b/src/CMakeData-arch.cmake
@@ -259,7 +259,8 @@ if(WIN32)
               "arch/InputHandler/InputHandler_Win32_Para.cpp"
               "arch/InputHandler/InputHandler_Win32_Pump.cpp"
               "arch/InputHandler/InputHandler_Win32_RTIO.cpp"
-              "arch/InputHandler/InputHandler_Win32_ddrio.cpp")
+              "arch/InputHandler/InputHandler_Win32_ddrio.cpp"
+			  "arch/InputHandler/InputHandler_Win32_SMX.cpp")
   list(APPEND SMDATA_ARCH_INPUT_HPP
               "arch/InputHandler/InputHandler_DirectInput.h"
               "arch/InputHandler/InputHandler_DirectInputHelper.h"
@@ -267,7 +268,8 @@ if(WIN32)
               "arch/InputHandler/InputHandler_Win32_Para.h"
               "arch/InputHandler/InputHandler_Win32_Pump.h"
               "arch/InputHandler/InputHandler_Win32_RTIO.h"
-              "arch/InputHandler/InputHandler_Win32_ddrio.h")
+              "arch/InputHandler/InputHandler_Win32_ddrio.h"
+			  "arch/InputHandler/InputHandler_Win32_SMX.h")
   if(NOT MSVC)
     list(APPEND SMDATA_ARCH_INPUT_SRC
                 "arch/InputHandler/InputHandler_SextetStream.cpp")

--- a/src/CMakeData-arch.cmake
+++ b/src/CMakeData-arch.cmake
@@ -260,7 +260,7 @@ if(WIN32)
               "arch/InputHandler/InputHandler_Win32_Pump.cpp"
               "arch/InputHandler/InputHandler_Win32_RTIO.cpp"
               "arch/InputHandler/InputHandler_Win32_ddrio.cpp"
-			  "arch/InputHandler/InputHandler_Win32_SMX.cpp")
+              "arch/InputHandler/InputHandler_Win32_SMX.cpp")
   list(APPEND SMDATA_ARCH_INPUT_HPP
               "arch/InputHandler/InputHandler_DirectInput.h"
               "arch/InputHandler/InputHandler_DirectInputHelper.h"
@@ -269,7 +269,7 @@ if(WIN32)
               "arch/InputHandler/InputHandler_Win32_Pump.h"
               "arch/InputHandler/InputHandler_Win32_RTIO.h"
               "arch/InputHandler/InputHandler_Win32_ddrio.h"
-			  "arch/InputHandler/InputHandler_Win32_SMX.h")
+              "arch/InputHandler/InputHandler_Win32_SMX.h")
   if(NOT MSVC)
     list(APPEND SMDATA_ARCH_INPUT_SRC
                 "arch/InputHandler/InputHandler_SextetStream.cpp")

--- a/src/RageInputDevice.cpp
+++ b/src/RageInputDevice.cpp
@@ -235,6 +235,7 @@ static const char *InputDeviceNames[] = {
 	"Midi",
 	"Mouse",
 	"PIUIO",
+	"SMX",
 };
 XToString( InputDevice );
 StringToX( InputDevice );

--- a/src/RageInputDevice.h
+++ b/src/RageInputDevice.h
@@ -51,6 +51,7 @@ enum InputDevice
 	DEVICE_MIDI,
 	DEVICE_MOUSE,
 	DEVICE_PIUIO,
+	DEVICE_SMX,
 	NUM_InputDevice,		// leave this at the end
 	InputDevice_Invalid		// means this is nullptr
 };

--- a/src/arch/InputHandler/InputHandler_DirectInput.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInput.cpp
@@ -187,8 +187,8 @@ static BOOL CALLBACK EnumDevicesCallback( const DIDEVICEINSTANCE *pdidInstance, 
 	}
 
 	// Check for SMX.dll upon encountering a StepManiaX platform.
-	const char* is_smx_platform = strstr(pdidInstance->tszProductName, "StepManiaX");
-	if (is_smx_platform && Is_SMX_DLL_Available()) {
+	bool is_smx_platform = (bool)strstr(pdidInstance->tszProductName, "StepManiaX");
+	if (is_smx_platform && InputHandler_Win32_SMX_Is_SMX_DLL_Available()) {
 		return DIENUM_CONTINUE; // Ignore SMX platform HID device if SMX.dll is available
 	}
 

--- a/src/arch/InputHandler/InputHandler_DirectInput.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInput.cpp
@@ -164,6 +164,12 @@ static BOOL CALLBACK EnumDevicesCallback( const DIDEVICEINSTANCE *pdidInstance, 
 
 	LOG->Info( "DInput: Enumerating device - Type: 0x%08X Instance Name: \"%s\" Product Name: \"%s\"", pdidInstance->dwDevType, pdidInstance->tszInstanceName, pdidInstance->tszProductName );
 
+	// Ignore if product name contains "StepManiaX" (TODO: Make it so this only happens if the DLL is loaded)
+	const char *output = strstr(pdidInstance->tszProductName, "StepManiaX");
+	if (output) {
+		return DIENUM_CONTINUE;
+	}
+
 	switch( GET_DIDEVICE_TYPE(pdidInstance->dwDevType) )
 	{
 		case DI8DEVTYPE_JOYSTICK:

--- a/src/arch/InputHandler/InputHandler_DirectInput.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInput.cpp
@@ -190,6 +190,7 @@ static BOOL CALLBACK EnumDevicesCallback( const DIDEVICEINSTANCE *pdidInstance, 
 	// If SMX.dll is available and usable, the SMX InputHandler should be used instead of DirectInput for SMX platforms.
 	bool is_smx_platform = (bool)strstr(pdidInstance->tszProductName, "StepManiaX");
 	if (is_smx_platform && InputHandler_Win32_SMX_Is_SMX_DLL_Available()) {
+		LOG->Info("DInput: Ignoring SMX Stage HID device in favor of the SMX driver.");
 		return DIENUM_CONTINUE; // Ignore SMX platform HID device if SMX.dll is available
 	}
 

--- a/src/arch/InputHandler/InputHandler_DirectInput.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInput.cpp
@@ -188,8 +188,8 @@ static BOOL CALLBACK EnumDevicesCallback( const DIDEVICEINSTANCE *pdidInstance, 
 
 	// Check for SMX.dll upon encountering a StepManiaX platform.
 	const char* is_smx_platform = strstr(pdidInstance->tszProductName, "StepManiaX");
-	if (is_smx_platform && Attempt_SMX_DLL_Load()) {
-		return DIENUM_CONTINUE; // Ignore smx pad if SMX.DLL successfully loaded.
+	if (is_smx_platform && Is_SMX_DLL_Available()) {
+		return DIENUM_CONTINUE; // Ignore SMX platform HID device if SMX.dll is available
 	}
 
 	device.JoystickInst = *pdidInstance;

--- a/src/arch/InputHandler/InputHandler_DirectInput.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInput.cpp
@@ -11,9 +11,9 @@
 #include "InputFilter.h"
 #include "PrefsManager.h"
 #include "GamePreferences.h" //needed for Axis Fix
+#include "InputHandler_Win32_SMX.h" // needed to check conditions around if SMX platforms should be loaded as HID devices
 
 #include "InputHandler_DirectInputHelper.h"
-#include "InputHandler_Win32_SMX.h"
 
 #ifdef NTDDI_WIN8 // Link to Xinput9_1_0.lib on Windows 8 SDK and above to ensure linkage to Xinput9_1_0.dll
 #pragma comment(lib, "Xinput9_1_0.lib")
@@ -187,6 +187,7 @@ static BOOL CALLBACK EnumDevicesCallback( const DIDEVICEINSTANCE *pdidInstance, 
 	}
 
 	// Check for SMX.dll upon encountering a StepManiaX platform.
+	// If SMX.dll is available and usable, the SMX InputHandler should be used instead of DirectInput for SMX platforms.
 	bool is_smx_platform = (bool)strstr(pdidInstance->tszProductName, "StepManiaX");
 	if (is_smx_platform && InputHandler_Win32_SMX_Is_SMX_DLL_Available()) {
 		return DIENUM_CONTINUE; // Ignore SMX platform HID device if SMX.dll is available

--- a/src/arch/InputHandler/InputHandler_DirectInput.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInput.cpp
@@ -13,6 +13,7 @@
 #include "GamePreferences.h" //needed for Axis Fix
 
 #include "InputHandler_DirectInputHelper.h"
+#include "InputHandler_Win32_SMX.h"
 
 #ifdef NTDDI_WIN8 // Link to Xinput9_1_0.lib on Windows 8 SDK and above to ensure linkage to Xinput9_1_0.dll
 #pragma comment(lib, "Xinput9_1_0.lib")
@@ -164,12 +165,6 @@ static BOOL CALLBACK EnumDevicesCallback( const DIDEVICEINSTANCE *pdidInstance, 
 
 	LOG->Info( "DInput: Enumerating device - Type: 0x%08X Instance Name: \"%s\" Product Name: \"%s\"", pdidInstance->dwDevType, pdidInstance->tszInstanceName, pdidInstance->tszProductName );
 
-	// Ignore if product name contains "StepManiaX" (TODO: Make it so this only happens if the DLL is loaded)
-	const char *output = strstr(pdidInstance->tszProductName, "StepManiaX");
-	if (output) {
-		return DIENUM_CONTINUE;
-	}
-
 	switch( GET_DIDEVICE_TYPE(pdidInstance->dwDevType) )
 	{
 		case DI8DEVTYPE_JOYSTICK:
@@ -189,6 +184,12 @@ static BOOL CALLBACK EnumDevicesCallback( const DIDEVICEINSTANCE *pdidInstance, 
 		case DI8DEVTYPE_KEYBOARD: device.type = device.KEYBOARD; break;
 		case DI8DEVTYPE_MOUSE: device.type = device.MOUSE; break;
 		default: LOG->Info( "DInput: Unrecognized device ignored." ); return DIENUM_CONTINUE;
+	}
+
+	// Check for SMX.dll upon encountering a StepManiaX platform.
+	const char* is_smx_platform = strstr(pdidInstance->tszProductName, "StepManiaX");
+	if (is_smx_platform && Attempt_SMX_DLL_Load()) {
+		return DIENUM_CONTINUE; // Ignore smx pad if SMX.DLL successfully loaded.
 	}
 
 	device.JoystickInst = *pdidInstance;

--- a/src/arch/InputHandler/InputHandler_DirectInput.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInput.cpp
@@ -190,6 +190,8 @@ static BOOL CALLBACK EnumDevicesCallback( const DIDEVICEINSTANCE *pdidInstance, 
 	// If SMX.dll is available and usable, the SMX InputHandler should be used instead of DirectInput for SMX platforms.
 	bool is_smx_platform = (bool)strstr(pdidInstance->tszProductName, "StepManiaX");
 	if (is_smx_platform && InputHandler_Win32_SMX_Is_SMX_DLL_Available()) {
+		InputHandler_Win32_SMX_Register_Pad();
+		
 		LOG->Info("DInput: Ignoring SMX Stage HID device in favor of the SMX driver.");
 		return DIENUM_CONTINUE; // Ignore SMX platform HID device if SMX.dll is available
 	}

--- a/src/arch/InputHandler/InputHandler_DirectInput.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInput.cpp
@@ -189,9 +189,7 @@ static BOOL CALLBACK EnumDevicesCallback( const DIDEVICEINSTANCE *pdidInstance, 
 	// Check for SMX.dll upon encountering a StepManiaX platform.
 	// If SMX.dll is available and usable, the SMX InputHandler should be used instead of DirectInput for SMX platforms.
 	bool is_smx_platform = (bool)strstr(pdidInstance->tszProductName, "StepManiaX");
-	if (is_smx_platform && InputHandler_Win32_SMX_Is_SMX_DLL_Available()) {
-		InputHandler_Win32_SMX_Register_Pad();
-		
+	if (is_smx_platform && InputHandler_Win32_SMX_Register_Pad()) {
 		LOG->Info("DInput: Ignoring SMX Stage HID device in favor of the SMX driver.");
 		return DIENUM_CONTINUE; // Ignore SMX platform HID device if SMX.dll is available
 	}

--- a/src/arch/InputHandler/InputHandler_DirectInput.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInput.cpp
@@ -188,7 +188,7 @@ static BOOL CALLBACK EnumDevicesCallback( const DIDEVICEINSTANCE *pdidInstance, 
 
 	// Check for SMX.dll upon encountering a StepManiaX platform.
 	// If SMX.dll is available and usable, the SMX InputHandler should be used instead of DirectInput for SMX platforms.
-	bool is_smx_platform = (bool)strstr(pdidInstance->tszProductName, "StepManiaX");
+	bool is_smx_platform = strstr(pdidInstance->tszProductName, "StepManiaX") != nullptr;
 	if (is_smx_platform && InputHandler_Win32_SMX_Register_Pad()) {
 		LOG->Info("DInput: Ignoring SMX Stage HID device in favor of the SMX driver.");
 		return DIENUM_CONTINUE; // Ignore SMX platform HID device if SMX.dll is available

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -14,6 +14,9 @@ typedef uint16_t(__stdcall* SMX_GetInputState_t)(
 );
 static SMX_GetInputState_t pSMX_GetInputState = nullptr;
 
+typedef VOID(__stdcall* SMX_Stop_t)();
+static SMX_Stop_t pSMX_Stop = nullptr;
+
 static HINSTANCE hSMXdll = nullptr;
 
 REGISTER_INPUT_HANDLER_CLASS2(SMX, Win32_SMX);
@@ -40,6 +43,7 @@ bool MapFunctions()
 	{
 		pSMX_Start = (SMX_Start_t)GetProcAddress(hSMXdll, "SMX_Start");
 		pSMX_GetInputState = (SMX_GetInputState_t)GetProcAddress(hSMXdll, "SMX_GetInputState");
+		pSMX_Stop = (SMX_Stop_t)GetProcAddress(hSMXdll, "SMX_Stop");
 	}
 	__except (smx_filter(GetExceptionCode(), GetExceptionInformation()))
 	{
@@ -67,19 +71,23 @@ bool Attempt_SMX_DLL_Load()
 	return MapFunctions();
 }
 
-void InputHandler_Win32_SMX::GetDevicesAndDescriptions( std::vector<InputDeviceInfo>& vDevicesOut )
-{
-	if (Attempt_SMX_DLL_Load()) {
-		vDevicesOut.push_back(InputDeviceInfo(InputDevice(DEVICE_SMX), "SMX"));
-	}
-}
-
 InputHandler_Win32_SMX::InputHandler_Win32_SMX() {
 	std::fill(std::begin(m_padInputStates), std::end(m_padInputStates), 0);
 
     if (Attempt_SMX_DLL_Load()) {
         SMX_Start(&SmxCallback, this);
     }
+}
+
+InputHandler_Win32_SMX::~InputHandler_Win32_SMX() {
+	SMX_Stop();
+}
+
+void InputHandler_Win32_SMX::GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut)
+{
+	if (Attempt_SMX_DLL_Load()) {
+		vDevicesOut.push_back(InputDeviceInfo(InputDevice(DEVICE_SMX), "SMX"));
+	}
 }
 
 void InputHandler_Win32_SMX::ProcessPoll(int pad) {
@@ -145,6 +153,12 @@ uint16_t InputHandler_Win32_SMX::SMX_GetInputState(int pad) {
     }
 	
 	return 0;
+}
+
+void InputHandler_Win32_SMX::SMX_Stop() {
+	if (pSMX_Stop != nullptr) {
+		pSMX_Stop();
+	}
 }
 
 /*

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -75,6 +75,7 @@ bool InputHandler_Win32_SMX::MapFunctions()
 	{
 		MessageBox(nullptr, "Could not map functions in SMX.dll", "ERROR", MB_OK);
 		FreeLibrary(hSMXdll);
+		return false;
 	}
 
 	return true;

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -81,16 +81,39 @@ bool InputHandler_Win32_SMX_Is_SMX_DLL_Available()
 	return _smxdll_loaded;
 }
 
+static bool __detected_pad = false;
+static InputHandler_Win32_SMX *__current_instance = nullptr;
+void InputHandler_Win32_SMX_Register_Pad() {
+	if (__detected_pad) {
+		return;
+	}
+	__detected_pad = true;
+
+	// Start the SMX SDK if a pad is being registered for the first time after the driver instance had already been initialized.
+	if (__current_instance != nullptr) {
+		__current_instance->SMX_Start();
+	}
+}
+
 InputHandler_Win32_SMX::InputHandler_Win32_SMX() {
 	std::fill(std::begin(m_padInputStates), std::end(m_padInputStates), 0);
 
-    if (InputHandler_Win32_SMX_Is_SMX_DLL_Available()) {
-        SMX_Start(&SmxCallback, this);
+	// Only start the SMX SDK if a pad has been detected already.
+	// The SDK can also be started on `__current_instance` if a pad gets registered after this point.
+    if (__detected_pad) {
+        SMX_Start();
+		return; // No need to hold `__current_instance` if SMX_Start has been called.
     }
+
+	// Hold onto this instance so static methods can call `SMX_Start` if need be
+	if (__current_instance == nullptr) {
+		__current_instance = this;
+	}
 }
 
 InputHandler_Win32_SMX::~InputHandler_Win32_SMX() {
 	SMX_Stop();
+	__current_instance = nullptr;
 }
 
 void InputHandler_Win32_SMX::GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut)
@@ -165,6 +188,10 @@ RString InputHandler_Win32_SMX::GetDeviceSpecificInputString(const DeviceInput &
 }
 
 bool InputHandler_Win32_SMX::IsPadConnected() {
+	if (!__detected_pad) {
+		return false;
+	}
+
 	if (!InputHandler_Win32_SMX_Is_SMX_DLL_Available()) {
 		return false;
 	}
@@ -181,14 +208,20 @@ bool InputHandler_Win32_SMX::IsPadConnected() {
 	return false;
 }
 
-void InputHandler_Win32_SMX::SMX_Start(SMXUpdateCallback UpdateCallback, void *pUser) {
+static bool Is_SMX_Started = false;
+void InputHandler_Win32_SMX::SMX_Start() {
+	if (Is_SMX_Started) {
+		return;
+	}
+
     if (pSMX_Start != nullptr) {
-        pSMX_Start(UpdateCallback, pUser);
+        pSMX_Start(&SmxCallback, this);
+		Is_SMX_Started = true;
     }
 }
 
 void InputHandler_Win32_SMX::SMX_GetInfo(int pad, struct SMXInfo *info) {
-	if (pSMX_GetInfo != nullptr) {
+	if (Is_SMX_Started && pSMX_GetInfo != nullptr) {
 		pSMX_GetInfo(pad, info);
 	}
 	else {
@@ -197,7 +230,7 @@ void InputHandler_Win32_SMX::SMX_GetInfo(int pad, struct SMXInfo *info) {
 }
 
 uint16_t InputHandler_Win32_SMX::SMX_GetInputState(int pad) {
-    if (pSMX_GetInputState != nullptr) {
+    if (Is_SMX_Started && pSMX_GetInputState != nullptr) {
         return pSMX_GetInputState(pad);
     }
 	
@@ -205,7 +238,12 @@ uint16_t InputHandler_Win32_SMX::SMX_GetInputState(int pad) {
 }
 
 void InputHandler_Win32_SMX::SMX_Stop() {
+	if (!Is_SMX_Started) {
+		return;
+	}
+
 	if (pSMX_Stop != nullptr) {
 		pSMX_Stop();
+		Is_SMX_Started = false;
 	}
 }

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -31,45 +31,16 @@ int smx_filter(unsigned int, struct _EXCEPTION_POINTERS*)
 	return EXCEPTION_EXECUTE_HANDLER;
 }
 
-void InputHandler_Win32_SMX::GetDevicesAndDescriptions( std::vector<InputDeviceInfo>& vDevicesOut )
+bool MapFunctions()
 {
-	vDevicesOut.push_back(InputDeviceInfo(InputDevice(DEVICE_SMX), "SMX"));
-}
-
-InputHandler_Win32_SMX::InputHandler_Win32_SMX() {
-	std::fill(std::begin(m_padInputStates), std::end(m_padInputStates), 0);
-
-    if (!_smxdll_loaded && LoadDLL())
-	{
-		_smxdll_loaded = MapFunctions();
+	if (_smxdll_loaded) {
+		return true;
 	}
 
-    if (_smxdll_loaded) {
-        SMX_Start(&SmxCallback, this);
-    }
-}
-
-bool InputHandler_Win32_SMX::LoadDLL()
-{
-	hSMXdll = LoadLibrary("SMX.dll");
-
-	if (hSMXdll == nullptr)
-	{
-		MessageBox(nullptr, "Could not load SMX.dll. Ensure it is in the Program directory, the proper C++ Visual C++ Redistributable Runtimes dependencies are installed, you have matched your architectures (x86/x64), and any additional dll dependencies of SMX.dll are available.", "ERROR", MB_OK);
-		return false;
-	}
-
-	_smxdll_loaded = true;
-
-	return true;
-}
-
-bool InputHandler_Win32_SMX::MapFunctions()
-{
 	__try
 	{
-        pSMX_Start = (SMX_Start_t)GetProcAddress(hSMXdll, "SMX_Start");
-        pSMX_GetInputState = (SMX_GetInputState_t)GetProcAddress(hSMXdll, "SMX_GetInputState");
+		pSMX_Start = (SMX_Start_t)GetProcAddress(hSMXdll, "SMX_Start");
+		pSMX_GetInputState = (SMX_GetInputState_t)GetProcAddress(hSMXdll, "SMX_GetInputState");
 	}
 	__except (smx_filter(GetExceptionCode(), GetExceptionInformation()))
 	{
@@ -78,7 +49,38 @@ bool InputHandler_Win32_SMX::MapFunctions()
 		return false;
 	}
 
+	_smxdll_loaded = true;
 	return true;
+}
+
+bool Attempt_SMX_DLL_Load()
+{
+	if (_smxdll_loaded) {
+		return true;
+	}
+
+	hSMXdll = LoadLibrary("SMX.dll");
+
+	if (hSMXdll == nullptr)
+	{
+		MessageBox(nullptr, "Could not load SMX.dll. Ensure it is in the Program directory, the proper C++ Visual C++ Redistributable Runtimes dependencies are installed, you have matched your architectures (x86/x64), and any additional dll dependencies of SMX.dll are available.", "ERROR", MB_OK);
+		return false;
+	}
+
+	return MapFunctions();
+}
+
+void InputHandler_Win32_SMX::GetDevicesAndDescriptions( std::vector<InputDeviceInfo>& vDevicesOut )
+{
+	vDevicesOut.push_back(InputDeviceInfo(InputDevice(DEVICE_SMX), "SMX"));
+}
+
+InputHandler_Win32_SMX::InputHandler_Win32_SMX() {
+	std::fill(std::begin(m_padInputStates), std::end(m_padInputStates), 0);
+
+    if (Attempt_SMX_DLL_Load()) {
+        SMX_Start(&SmxCallback, this);
+    }
 }
 
 void InputHandler_Win32_SMX::ProcessPoll(int pad) {

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -33,12 +33,11 @@ int smx_filter(unsigned int, struct _EXCEPTION_POINTERS*)
 	return EXCEPTION_EXECUTE_HANDLER;
 }
 
+static bool _smxdll_loaded = false;
+static bool _smxdll_attempted_load = false;
+
 bool MapFunctions()
 {
-	if (_smxdll_loaded) {
-		return true;
-	}
-
 	__try
 	{
 		pSMX_Start = (SMX_Start_t)GetProcAddress(hSMXdll, "SMX_Start");
@@ -55,11 +54,12 @@ bool MapFunctions()
 	return true;
 }
 
-bool Is_SMX_DLL_Available()
+bool InputHandler_Win32_SMX_Is_SMX_DLL_Available()
 {
-	if (_smxdll_loaded) {
-		return true;
+	if (_smxdll_attempted_load) {
+		return _smxdll_loaded;
 	}
+	_smxdll_attempted_load = true;
 
 	hSMXdll = LoadLibrary("SMX.dll");
 
@@ -74,7 +74,7 @@ bool Is_SMX_DLL_Available()
 InputHandler_Win32_SMX::InputHandler_Win32_SMX() {
 	std::fill(std::begin(m_padInputStates), std::end(m_padInputStates), 0);
 
-    if (Is_SMX_DLL_Available()) {
+    if (InputHandler_Win32_SMX_Is_SMX_DLL_Available()) {
         SMX_Start(&SmxCallback, this);
     }
 }
@@ -85,7 +85,7 @@ InputHandler_Win32_SMX::~InputHandler_Win32_SMX() {
 
 void InputHandler_Win32_SMX::GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut)
 {
-	if (Is_SMX_DLL_Available()) {
+	if (InputHandler_Win32_SMX_Is_SMX_DLL_Available()) {
 		vDevicesOut.push_back(InputDeviceInfo(InputDevice(DEVICE_SMX), "SMX"));
 	}
 }

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -1,6 +1,5 @@
 #include "global.h"
 #include "InputHandler_Win32_SMX.h"
-#define WIN32_LEAN_AND_MEAN
 #include "windows.h"
 
 static const int SMX_PANEL_COUNT = 9;
@@ -147,3 +146,28 @@ uint16_t InputHandler_Win32_SMX::SMX_GetInputState(int pad) {
 	
 	return 0;
 }
+
+/*
+ * (c) 2025 Caleb Lee
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -1,6 +1,7 @@
 #include "global.h"
 #include "InputHandler_Win32_SMX.h"
 #include "RageLog.h"
+
 #include <windows.h>
 
 static const int SMX_PANEL_COUNT = 9;
@@ -82,44 +83,25 @@ bool InputHandler_Win32_SMX_Is_SMX_DLL_Available()
 }
 
 static bool __detected_pad = false;
-static InputHandler_Win32_SMX *__current_instance = nullptr;
 void InputHandler_Win32_SMX_Register_Pad() {
 	if (__detected_pad) {
 		return;
 	}
 	__detected_pad = true;
-
-	// Start the SMX SDK if a pad is being registered for the first time after the driver instance had already been initialized.
-	if (__current_instance != nullptr) {
-		__current_instance->SMX_Start();
-	}
 }
 
 InputHandler_Win32_SMX::InputHandler_Win32_SMX() {
 	std::fill(std::begin(m_padInputStates), std::end(m_padInputStates), 0);
-
-	// Only start the SMX SDK if a pad has been detected already.
-	// The SDK can also be started on `__current_instance` if a pad gets registered after this point.
-    if (__detected_pad) {
-        SMX_Start();
-		return; // No need to hold `__current_instance` if SMX_Start has been called.
-    }
-
-	// Hold onto this instance so static methods can call `SMX_Start` if need be
-	if (__current_instance == nullptr) {
-		__current_instance = this;
-	}
 }
 
 InputHandler_Win32_SMX::~InputHandler_Win32_SMX() {
 	SMX_Stop();
-	__current_instance = nullptr;
 }
 
 void InputHandler_Win32_SMX::GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut)
 {
-	// Only register this as a device if SMX.dll is available, and if a pad is connected.
-	if (InputHandler_Win32_SMX_Is_SMX_DLL_Available() && IsPadConnected()) {
+	// Ensure that the SMX device is not registered unless a pad is connected.
+	if (IsPadConnected()) {
 		vDevicesOut.push_back(InputDeviceInfo(InputDevice(DEVICE_SMX), "SMX"));
 	}
 }
@@ -187,6 +169,8 @@ RString InputHandler_Win32_SMX::GetDeviceSpecificInputString(const DeviceInput &
     return ssprintf("SMX P%d, %s", pad, buttonString.c_str());
 }
 
+static bool Is_SMX_Started = false;
+
 bool InputHandler_Win32_SMX::IsPadConnected() {
 	if (!__detected_pad) {
 		return false;
@@ -194,6 +178,11 @@ bool InputHandler_Win32_SMX::IsPadConnected() {
 
 	if (!InputHandler_Win32_SMX_Is_SMX_DLL_Available()) {
 		return false;
+	}
+
+	// Lazy start the SMX SDK when the DLL is loaded and a pad has been detected
+	if (!Is_SMX_Started) {
+		this->SMX_Start();
 	}
 
 	for (int i = 0; i < SMX_PAD_COUNT; i++) {
@@ -208,7 +197,6 @@ bool InputHandler_Win32_SMX::IsPadConnected() {
 	return false;
 }
 
-static bool Is_SMX_Started = false;
 void InputHandler_Win32_SMX::SMX_Start() {
 	if (Is_SMX_Started) {
 		return;

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -54,6 +54,8 @@ bool MapFunctions()
 	return true;
 }
 
+// The only way to know for-sure if the DLL is available is to actually load it, so this method attempts to load the DLL the first time it is run.
+// Note: This is meant to fail silently - most people will not be using SMX.dll.
 bool InputHandler_Win32_SMX_Is_SMX_DLL_Available()
 {
 	if (_smxdll_attempted_load) {
@@ -91,30 +93,42 @@ void InputHandler_Win32_SMX::GetDevicesAndDescriptions(std::vector<InputDeviceIn
 }
 
 void InputHandler_Win32_SMX::ProcessInputEvent(int pad) {
-    if (pad >= SMX_PAD_COUNT) {
+	/*
+	The SMX SDK always sends callback events over the same thread, so thread safety is not a worry.
+	*/
+
+	// Fast-fail if somehow the pad is outside of range
+    if (pad < 0 || pad >= SMX_PAD_COUNT) {
         return;
     }
 
-    uint16_t inputState = SMX_GetInputState(pad);
-    uint16_t changedInputs = inputState ^ m_padInputStates[pad];
+	// Get new input state and compare with the old
+    uint16_t newInputState = SMX_GetInputState(pad);
+    uint16_t changedInputs = newInputState ^ m_padInputStates[pad];
 
+	// If inputs weren't updated, report the end of an empty poll and return
     if (changedInputs == 0) {
         InputHandler::UpdateTimer();
         return;
     }
 
-    DeviceButton startButton = enum_add2(JOY_BUTTON_1, pad * SMX_PANEL_COUNT);
+	// SMX events come in for multiple pads, but get translated into one device from SM's POV.
+	// Ensure P2's buttons begin from the correct `JOY_BUTTON`.
+    DeviceButton beginButton = enum_add2(JOY_BUTTON_1, pad * SMX_PANEL_COUNT);
 
+	// Process inputs
     for (int i = 0; i < SMX_PANEL_COUNT; i++) {
-        if ((changedInputs & (1 << i)) != 0) {
-            bool pressed = inputState & (1 << i);
-            DeviceInput di(DEVICE_SMX, enum_add2(startButton, i), pressed);
-			di.ts.Touch(); // SMX surfaces an input immediately when it occurs, so don't adjust for error
-            ButtonPressed(di);
+		bool didButtonStateChange = (changedInputs & (1 << i)) != 0;
+        if (didButtonStateChange) {
+            bool pressed = newInputState & (1 << i); // Get pressed state
+            DeviceInput di(DEVICE_SMX, enum_add2(beginButton, i), pressed); // Make input event with pressed state for this button
+			di.ts.Touch(); // Touch the timestamp timer to indicate the input happened *now*
+            ButtonPressed(di); // Report the input event
         }
     }
 
-    m_padInputStates[pad] = inputState;
+	// Save the new input state for later, and report the end of a poll.
+    m_padInputStates[pad] = newInputState;
     InputHandler::UpdateTimer();
 }
 

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -1,0 +1,146 @@
+#include "global.h"
+#include "InputHandler_Win32_SMX.h"
+#define WIN32_LEAN_AND_MEAN
+#include "windows.h"
+
+static const int SMX_PANEL_COUNT = 9;
+
+typedef VOID(__stdcall* SMX_Start_t)(
+    SMXUpdateCallback UpdateCallback, void *pUser
+);
+static SMX_Start_t pSMX_Start = nullptr;
+
+typedef uint16_t(__stdcall* SMX_GetInputState_t)(
+    int pad
+);
+static SMX_GetInputState_t pSMX_GetInputState = nullptr;
+
+static HINSTANCE hSMXdll = nullptr;
+
+REGISTER_INPUT_HANDLER_CLASS2(SMX, Win32_SMX);
+
+namespace {
+	static void SmxCallback(int pad, SMXUpdateCallbackReason reason, void* pUser) {
+		InputHandler_Win32_SMX* stage_info = static_cast<InputHandler_Win32_SMX*>(pUser);
+		stage_info->ProcessPoll(pad);
+	};
+}
+
+int smx_filter(unsigned int, struct _EXCEPTION_POINTERS*)
+{
+	return EXCEPTION_EXECUTE_HANDLER;
+}
+
+void InputHandler_Win32_SMX::GetDevicesAndDescriptions( std::vector<InputDeviceInfo>& vDevicesOut )
+{
+	vDevicesOut.push_back(InputDeviceInfo(InputDevice(DEVICE_SMX), "SMX"));
+}
+
+InputHandler_Win32_SMX::InputHandler_Win32_SMX() {
+	std::fill(std::begin(m_padInputStates), std::end(m_padInputStates), 0);
+
+    if (!_smxdll_loaded && LoadDLL())
+	{
+		_smxdll_loaded = MapFunctions();
+	}
+
+    if (_smxdll_loaded) {
+        SMX_Start(&SmxCallback, this);
+    }
+}
+
+bool InputHandler_Win32_SMX::LoadDLL()
+{
+	hSMXdll = LoadLibrary("SMX.dll");
+
+	if (hSMXdll == nullptr)
+	{
+		MessageBox(nullptr, "Could not load SMX.dll. Ensure it is in the Program directory, the proper C++ Visual C++ Redistributable Runtimes dependencies are installed, you have matched your architectures (x86/x64), and any additional dll dependencies of SMX.dll are available.", "ERROR", MB_OK);
+		return false;
+	}
+
+	_smxdll_loaded = true;
+
+	return true;
+}
+
+bool InputHandler_Win32_SMX::MapFunctions()
+{
+	__try
+	{
+        pSMX_Start = (SMX_Start_t)GetProcAddress(hSMXdll, "SMX_Start");
+        pSMX_GetInputState = (SMX_GetInputState_t)GetProcAddress(hSMXdll, "SMX_GetInputState");
+	}
+	__except (smx_filter(GetExceptionCode(), GetExceptionInformation()))
+	{
+		MessageBox(nullptr, "Could not map functions in SMX.dll", "ERROR", MB_OK);
+		FreeLibrary(hSMXdll);
+	}
+
+	return true;
+}
+
+void InputHandler_Win32_SMX::ProcessPoll(int pad) {
+    if (pad >= SMX_PAD_COUNT) {
+        return;
+    }
+
+    uint16_t inputState = SMX_GetInputState(pad);
+    uint16_t changedInputs = inputState ^ m_padInputStates[pad];
+
+    if (changedInputs == 0) {
+        InputHandler::UpdateTimer();
+        return;
+    }
+
+    DeviceButton startButton = enum_add2(JOY_BUTTON_1, pad * SMX_PANEL_COUNT);
+
+    for (int i = 0; i < SMX_PANEL_COUNT; i++) {
+        if ((changedInputs & (1 << i)) != 0) {
+            bool pressed = inputState & (1 << i);
+            DeviceInput di(DEVICE_SMX, enum_add2(startButton, i), pressed);
+			di.ts.Touch(); // SMX surfaces an input immediately when it occurs, so don't adjust for error
+            ButtonPressed(di);
+        }
+    }
+
+    m_padInputStates[pad] = inputState;
+    InputHandler::UpdateTimer();
+}
+
+RString InputHandler_Win32_SMX::GetDeviceSpecificInputString(const DeviceInput &di)
+{
+    int zeroIndexedButton = di.button - JOY_BUTTON_1;
+    int pad = (zeroIndexedButton / SMX_PANEL_COUNT) + 1;
+    int padRemovedButton = zeroIndexedButton % SMX_PANEL_COUNT;
+
+    RString buttonString;
+    switch (padRemovedButton) {
+        case 0: buttonString = "up left"; break;
+        case 1: buttonString = "up"; break;
+        case 2: buttonString = "up right"; break;
+        case 3: buttonString = "left"; break;
+        case 4: buttonString = "center"; break;
+        case 5: buttonString = "right"; break;
+        case 6: buttonString = "down left"; break;
+        case 7: buttonString = "down"; break;
+        case 8: buttonString = "down right"; break;
+        default: buttonString = "unknown"; break;
+    }
+
+    return ssprintf("SMX P%d, %s", pad, buttonString.c_str());
+}
+
+void InputHandler_Win32_SMX::SMX_Start(SMXUpdateCallback UpdateCallback, void *pUser) {
+    if (pSMX_Start != nullptr) {
+        pSMX_Start(UpdateCallback, pUser);
+    }
+}
+
+uint16_t InputHandler_Win32_SMX::SMX_GetInputState(int pad) {
+    if (pSMX_GetInputState != nullptr) {
+        return pSMX_GetInputState(pad);
+    }
+	
+	return 0;
+}

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -163,21 +163,15 @@ RString InputHandler_Win32_SMX::GetDeviceSpecificInputString(const DeviceInput &
     int pad = (zeroIndexedButton / SMX_PANEL_COUNT) + 1;
     int padRemovedButton = zeroIndexedButton % SMX_PANEL_COUNT;
 
-    RString buttonString;
-    switch (padRemovedButton) {
-        case 0: buttonString = "up left"; break;
-        case 1: buttonString = "up"; break;
-        case 2: buttonString = "up right"; break;
-        case 3: buttonString = "left"; break;
-        case 4: buttonString = "center"; break;
-        case 5: buttonString = "right"; break;
-        case 6: buttonString = "down left"; break;
-        case 7: buttonString = "down"; break;
-        case 8: buttonString = "down right"; break;
-        default: buttonString = "unknown"; break;
-    }
+    static const char* buttonStrings[SMX_PANEL_COUNT] =
+    {
+        "up left", "up", "up right", "left", "center",
+        "right", "down left", "down", "down right"
+    };
 
-    return ssprintf("SMX P%d, %s", pad, buttonString.c_str());
+    const char* buttonString = (padRemovedButton >= 0 && padRemovedButton < SMX_PANEL_COUNT) ? buttonStrings[padRemovedButton] : "unknown";
+
+    return ssprintf("SMX P%d, %s", pad, buttonString);
 }
 
 static bool Is_SMX_Started = false;

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -1,6 +1,7 @@
 #include "global.h"
 #include "InputHandler_Win32_SMX.h"
-#include "windows.h"
+#include "RageLog.h"
+#include <windows.h>
 
 static const int SMX_PANEL_COUNT = 9;
 
@@ -52,6 +53,7 @@ bool MapFunctions()
 	}
 	__except (smx_filter(GetExceptionCode(), GetExceptionInformation()))
 	{
+		LOG->Warn("SMX.dll is not valid. The SMX driver will not be used.");
 		FreeLibrary(hSMXdll);
 		return false;
 	}
@@ -61,7 +63,6 @@ bool MapFunctions()
 }
 
 // The only way to know for-sure if the DLL is available is to actually load it, so this method attempts to load the DLL the first time it is run.
-// Note: This is meant to fail silently - most people will not be using SMX.dll.
 bool InputHandler_Win32_SMX_Is_SMX_DLL_Available()
 {
 	if (_smxdll_attempted_load) {
@@ -71,12 +72,13 @@ bool InputHandler_Win32_SMX_Is_SMX_DLL_Available()
 
 	hSMXdll = LoadLibrary("SMX.dll");
 
-	if (hSMXdll == nullptr)
-	{
+	if (hSMXdll == nullptr) {
+		LOG->Warn("SMX.dll not found. The SMX driver will not be used.");
+		_smxdll_loaded = false;
 		return false;
 	}
-
-	return MapFunctions();
+	_smxdll_loaded = MapFunctions();
+	return _smxdll_loaded;
 }
 
 InputHandler_Win32_SMX::InputHandler_Win32_SMX() {
@@ -207,28 +209,3 @@ void InputHandler_Win32_SMX::SMX_Stop() {
 		pSMX_Stop();
 	}
 }
-
-/*
- * (c) 2025 Caleb Lee
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons to
- * whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies of
- * the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
- * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
- * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
- * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
- * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
- */

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -21,6 +21,11 @@ typedef uint16_t(__stdcall* SMX_GetInputState_t)(
 );
 static SMX_GetInputState_t pSMX_GetInputState = nullptr;
 
+typedef VOID(__stdcall* SMX_SetLogCallback_t)(
+	SMXLogCallback callback
+);
+static SMX_SetLogCallback_t pSMX_SetLogCallback = nullptr;
+
 typedef VOID(__stdcall* SMX_Stop_t)();
 static SMX_Stop_t pSMX_Stop = nullptr;
 
@@ -32,6 +37,10 @@ namespace {
 	static void SmxCallback(int pad, SMXUpdateCallbackReason reason, void* pUser) {
 		InputHandler_Win32_SMX* inputHandler = static_cast<InputHandler_Win32_SMX*>(pUser);
 		inputHandler->ProcessInputEvent(pad);
+	};
+
+	static void LogCallback(const char *log) {
+		LOG->Info("SMX SDK Log: %s", log);
 	};
 }
 
@@ -50,6 +59,7 @@ bool MapFunctions()
 		pSMX_Start = (SMX_Start_t)GetProcAddress(hSMXdll, "SMX_Start");
 		pSMX_GetInfo = (SMX_GetInfo_t)GetProcAddress(hSMXdll, "SMX_GetInfo");
 		pSMX_GetInputState = (SMX_GetInputState_t)GetProcAddress(hSMXdll, "SMX_GetInputState");
+		pSMX_SetLogCallback = (SMX_SetLogCallback_t)GetProcAddress(hSMXdll, "SMX_SetLogCallback");
 		pSMX_Stop = (SMX_Stop_t)GetProcAddress(hSMXdll, "SMX_Stop");
 	}
 	__except (smx_filter(GetExceptionCode(), GetExceptionInformation()))
@@ -92,6 +102,7 @@ void InputHandler_Win32_SMX_Register_Pad() {
 
 InputHandler_Win32_SMX::InputHandler_Win32_SMX() {
 	std::fill(std::begin(m_padInputStates), std::end(m_padInputStates), 0);
+	SMX_SetLogCallback();
 }
 
 InputHandler_Win32_SMX::~InputHandler_Win32_SMX() {
@@ -182,7 +193,7 @@ bool InputHandler_Win32_SMX::IsPadConnected() {
 
 	// Lazy start the SMX SDK when the DLL is loaded and a pad has been detected
 	if (!Is_SMX_Started) {
-		this->SMX_Start();
+		SMX_Start();
 	}
 
 	for (int i = 0; i < SMX_PAD_COUNT; i++) {
@@ -223,6 +234,12 @@ uint16_t InputHandler_Win32_SMX::SMX_GetInputState(int pad) {
     }
 	
 	return 0;
+}
+
+void InputHandler_Win32_SMX::SMX_SetLogCallback() {
+	if (pSMX_SetLogCallback != nullptr) {
+		pSMX_SetLogCallback(&LogCallback);
+	}
 }
 
 void InputHandler_Win32_SMX::SMX_Stop() {

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -23,8 +23,8 @@ REGISTER_INPUT_HANDLER_CLASS2(SMX, Win32_SMX);
 
 namespace {
 	static void SmxCallback(int pad, SMXUpdateCallbackReason reason, void* pUser) {
-		InputHandler_Win32_SMX* stage_info = static_cast<InputHandler_Win32_SMX*>(pUser);
-		stage_info->ProcessPoll(pad);
+		InputHandler_Win32_SMX* inputHandler = static_cast<InputHandler_Win32_SMX*>(pUser);
+		inputHandler->ProcessInputEvent(pad);
 	};
 }
 
@@ -55,7 +55,7 @@ bool MapFunctions()
 	return true;
 }
 
-bool Attempt_SMX_DLL_Load()
+bool Is_SMX_DLL_Available()
 {
 	if (_smxdll_loaded) {
 		return true;
@@ -74,7 +74,7 @@ bool Attempt_SMX_DLL_Load()
 InputHandler_Win32_SMX::InputHandler_Win32_SMX() {
 	std::fill(std::begin(m_padInputStates), std::end(m_padInputStates), 0);
 
-    if (Attempt_SMX_DLL_Load()) {
+    if (Is_SMX_DLL_Available()) {
         SMX_Start(&SmxCallback, this);
     }
 }
@@ -85,12 +85,12 @@ InputHandler_Win32_SMX::~InputHandler_Win32_SMX() {
 
 void InputHandler_Win32_SMX::GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut)
 {
-	if (Attempt_SMX_DLL_Load()) {
+	if (Is_SMX_DLL_Available()) {
 		vDevicesOut.push_back(InputDeviceInfo(InputDevice(DEVICE_SMX), "SMX"));
 	}
 }
 
-void InputHandler_Win32_SMX::ProcessPoll(int pad) {
+void InputHandler_Win32_SMX::ProcessInputEvent(int pad) {
     if (pad >= SMX_PAD_COUNT) {
         return;
     }

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -9,6 +9,11 @@ typedef VOID(__stdcall* SMX_Start_t)(
 );
 static SMX_Start_t pSMX_Start = nullptr;
 
+typedef VOID(__stdcall* SMX_GetInfo_t)(
+	int pad, struct SMXInfo *info
+);
+static SMX_GetInfo_t pSMX_GetInfo = nullptr;
+
 typedef uint16_t(__stdcall* SMX_GetInputState_t)(
     int pad
 );
@@ -41,6 +46,7 @@ bool MapFunctions()
 	__try
 	{
 		pSMX_Start = (SMX_Start_t)GetProcAddress(hSMXdll, "SMX_Start");
+		pSMX_GetInfo = (SMX_GetInfo_t)GetProcAddress(hSMXdll, "SMX_GetInfo");
 		pSMX_GetInputState = (SMX_GetInputState_t)GetProcAddress(hSMXdll, "SMX_GetInputState");
 		pSMX_Stop = (SMX_Stop_t)GetProcAddress(hSMXdll, "SMX_Stop");
 	}
@@ -87,7 +93,8 @@ InputHandler_Win32_SMX::~InputHandler_Win32_SMX() {
 
 void InputHandler_Win32_SMX::GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut)
 {
-	if (InputHandler_Win32_SMX_Is_SMX_DLL_Available()) {
+	// Only register this as a device if SMX.dll is available, and if a pad is connected.
+	if (InputHandler_Win32_SMX_Is_SMX_DLL_Available() && IsPadConnected()) {
 		vDevicesOut.push_back(InputDeviceInfo(InputDevice(DEVICE_SMX), "SMX"));
 	}
 }
@@ -155,10 +162,36 @@ RString InputHandler_Win32_SMX::GetDeviceSpecificInputString(const DeviceInput &
     return ssprintf("SMX P%d, %s", pad, buttonString.c_str());
 }
 
+bool InputHandler_Win32_SMX::IsPadConnected() {
+	if (!InputHandler_Win32_SMX_Is_SMX_DLL_Available()) {
+		return false;
+	}
+
+	for (int i = 0; i < SMX_PAD_COUNT; i++) {
+		struct SMXInfo info;
+		SMX_GetInfo(i, &info);
+
+		if (info.m_bConnected) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void InputHandler_Win32_SMX::SMX_Start(SMXUpdateCallback UpdateCallback, void *pUser) {
     if (pSMX_Start != nullptr) {
         pSMX_Start(UpdateCallback, pUser);
     }
+}
+
+void InputHandler_Win32_SMX::SMX_GetInfo(int pad, struct SMXInfo *info) {
+	if (pSMX_GetInfo != nullptr) {
+		pSMX_GetInfo(pad, info);
+	}
+	else {
+		info->m_bConnected = false;
+	}
 }
 
 uint16_t InputHandler_Win32_SMX::SMX_GetInputState(int pad) {

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -44,7 +44,6 @@ bool MapFunctions()
 	}
 	__except (smx_filter(GetExceptionCode(), GetExceptionInformation()))
 	{
-		MessageBox(nullptr, "Could not map functions in SMX.dll", "ERROR", MB_OK);
 		FreeLibrary(hSMXdll);
 		return false;
 	}
@@ -63,7 +62,6 @@ bool Attempt_SMX_DLL_Load()
 
 	if (hSMXdll == nullptr)
 	{
-		MessageBox(nullptr, "Could not load SMX.dll. Ensure it is in the Program directory, the proper C++ Visual C++ Redistributable Runtimes dependencies are installed, you have matched your architectures (x86/x64), and any additional dll dependencies of SMX.dll are available.", "ERROR", MB_OK);
 		return false;
 	}
 
@@ -72,7 +70,9 @@ bool Attempt_SMX_DLL_Load()
 
 void InputHandler_Win32_SMX::GetDevicesAndDescriptions( std::vector<InputDeviceInfo>& vDevicesOut )
 {
-	vDevicesOut.push_back(InputDeviceInfo(InputDevice(DEVICE_SMX), "SMX"));
+	if (Attempt_SMX_DLL_Load()) {
+		vDevicesOut.push_back(InputDeviceInfo(InputDevice(DEVICE_SMX), "SMX"));
+	}
 }
 
 InputHandler_Win32_SMX::InputHandler_Win32_SMX() {

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -74,7 +74,7 @@ bool MapFunctions()
 }
 
 // The only way to know for-sure if the DLL is available is to actually load it, so this method attempts to load the DLL the first time it is run.
-bool InputHandler_Win32_SMX_Is_SMX_DLL_Available()
+bool IsSmxDllAvailable()
 {
 	if (_smxdll_attempted_load) {
 		return _smxdll_loaded;
@@ -93,11 +93,17 @@ bool InputHandler_Win32_SMX_Is_SMX_DLL_Available()
 }
 
 static bool __detected_pad = false;
-void InputHandler_Win32_SMX_Register_Pad() {
+bool InputHandler_Win32_SMX_Register_Pad() {
 	if (__detected_pad) {
-		return;
+		return true;
 	}
+
+	if (!IsSmxDllAvailable()) {
+		return false;
+	}
+
 	__detected_pad = true;
+	return true;
 }
 
 InputHandler_Win32_SMX::InputHandler_Win32_SMX() {
@@ -112,8 +118,10 @@ InputHandler_Win32_SMX::~InputHandler_Win32_SMX() {
 void InputHandler_Win32_SMX::GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut)
 {
 	// Ensure that the SMX device is not registered unless a pad is connected.
-	if (IsPadConnected()) {
+	if (__detected_pad) {
 		vDevicesOut.push_back(InputDeviceInfo(InputDevice(DEVICE_SMX), "SMX"));
+
+		SMX_Start();
 	}
 }
 
@@ -175,33 +183,6 @@ RString InputHandler_Win32_SMX::GetDeviceSpecificInputString(const DeviceInput &
 }
 
 static bool Is_SMX_Started = false;
-
-bool InputHandler_Win32_SMX::IsPadConnected() {
-	if (!__detected_pad) {
-		return false;
-	}
-
-	if (!InputHandler_Win32_SMX_Is_SMX_DLL_Available()) {
-		return false;
-	}
-
-	// Lazy start the SMX SDK when the DLL is loaded and a pad has been detected
-	if (!Is_SMX_Started) {
-		SMX_Start();
-	}
-
-	for (int i = 0; i < SMX_PAD_COUNT; i++) {
-		struct SMXInfo info;
-		SMX_GetInfo(i, &info);
-
-		if (info.m_bConnected) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
 void InputHandler_Win32_SMX::SMX_Start() {
 	if (Is_SMX_Started) {
 		return;

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -48,8 +48,8 @@ namespace {
 		// 2) if the static vars `__p1_pads` and `__p2_pads` are no longer used in the new solution, remove them. (if they are reused, note that outside this method, they are reset to 0 in the destructor too.)
 		
 		// Just return after printing if it's not a device log.
-		bool isDeviceInfoLog = strstr(log, "Received device info.  Master version:");
-		bool containsP = strstr(log, "P");
+		bool isDeviceInfoLog = strstr(log, "Received device info.  Master version:") != nullptr;
+		bool containsP = strstr(log, "P") != nullptr;
 		if (!isDeviceInfoLog || !containsP) {
 			return;
 		}

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -4,8 +4,6 @@
 
 #include <windows.h>
 
-static const int SMX_PANEL_COUNT = 9;
-
 typedef VOID(__stdcall* SMX_Start_t)(
     SMXUpdateCallback UpdateCallback, void *pUser
 );
@@ -44,13 +42,16 @@ namespace {
 	};
 }
 
+constexpr int SMX_PANEL_COUNT = 9;
+static bool _smxdll_attempted_load = false;
+static bool _smxdll_loaded = false;
+static bool __detected_pad = false;
+static bool __is_smx_started = false;
+
 int smx_filter(unsigned int, struct _EXCEPTION_POINTERS*)
 {
 	return EXCEPTION_EXECUTE_HANDLER;
 }
-
-static bool _smxdll_loaded = false;
-static bool _smxdll_attempted_load = false;
 
 bool MapFunctions()
 {
@@ -92,7 +93,6 @@ bool IsSmxDllAvailable()
 	return _smxdll_loaded;
 }
 
-static bool __detected_pad = false;
 bool InputHandler_Win32_SMX_Register_Pad() {
 	if (__detected_pad) {
 		return true;
@@ -113,6 +113,11 @@ InputHandler_Win32_SMX::InputHandler_Win32_SMX() {
 
 InputHandler_Win32_SMX::~InputHandler_Win32_SMX() {
 	SMX_Stop();
+
+	// Only one InputHandler should be active at a time.
+	// If we reset `__detected_pad` here, it allows us to stop reporting the device in `GetDevicesAndDescriptions` when a pad is disconnected. 
+	// If (a) pad(s) is still connected, it'll re-register before the next constructor runs.
+	__detected_pad = false;
 }
 
 void InputHandler_Win32_SMX::GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut)
@@ -121,6 +126,7 @@ void InputHandler_Win32_SMX::GetDevicesAndDescriptions(std::vector<InputDeviceIn
 	if (__detected_pad) {
 		vDevicesOut.push_back(InputDeviceInfo(InputDevice(DEVICE_SMX), "SMX"));
 
+		// Start the SMX SDK if needed when a pad is detected. (It's okay to call this repeatedly)
 		SMX_Start();
 	}
 }
@@ -182,20 +188,19 @@ RString InputHandler_Win32_SMX::GetDeviceSpecificInputString(const DeviceInput &
     return ssprintf("SMX P%d, %s", pad, buttonString);
 }
 
-static bool Is_SMX_Started = false;
 void InputHandler_Win32_SMX::SMX_Start() {
-	if (Is_SMX_Started) {
+	if (__is_smx_started) {
 		return;
 	}
 
     if (pSMX_Start != nullptr) {
         pSMX_Start(&SmxCallback, this);
-		Is_SMX_Started = true;
+		__is_smx_started = true;
     }
 }
 
 void InputHandler_Win32_SMX::SMX_GetInfo(int pad, struct SMXInfo *info) {
-	if (Is_SMX_Started && pSMX_GetInfo != nullptr) {
+	if (__is_smx_started && pSMX_GetInfo != nullptr) {
 		pSMX_GetInfo(pad, info);
 	}
 	else {
@@ -204,7 +209,7 @@ void InputHandler_Win32_SMX::SMX_GetInfo(int pad, struct SMXInfo *info) {
 }
 
 uint16_t InputHandler_Win32_SMX::SMX_GetInputState(int pad) {
-    if (Is_SMX_Started && pSMX_GetInputState != nullptr) {
+    if (__is_smx_started && pSMX_GetInputState != nullptr) {
         return pSMX_GetInputState(pad);
     }
 	
@@ -218,12 +223,12 @@ void InputHandler_Win32_SMX::SMX_SetLogCallback() {
 }
 
 void InputHandler_Win32_SMX::SMX_Stop() {
-	if (!Is_SMX_Started) {
+	if (!__is_smx_started) {
 		return;
 	}
 
 	if (pSMX_Stop != nullptr) {
 		pSMX_Stop();
-		Is_SMX_Started = false;
+		__is_smx_started = false;
 	}
 }

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -9,11 +9,6 @@ typedef VOID(__stdcall* SMX_Start_t)(
 );
 static SMX_Start_t pSMX_Start = nullptr;
 
-typedef VOID(__stdcall* SMX_GetInfo_t)(
-	int pad, struct SMXInfo *info
-);
-static SMX_GetInfo_t pSMX_GetInfo = nullptr;
-
 typedef uint16_t(__stdcall* SMX_GetInputState_t)(
     int pad
 );
@@ -31,7 +26,6 @@ static HINSTANCE hSMXdll = nullptr;
 
 REGISTER_INPUT_HANDLER_CLASS2(SMX, Win32_SMX);
 
-constexpr int SMX_PANEL_COUNT = 9;
 static bool _smxdll_attempted_load = false;
 static bool _smxdll_loaded = false;
 static bool __detected_pad = false;
@@ -53,8 +47,6 @@ namespace {
 		// 1) delete all code below this comment.
 		// 2) if the static vars `__p1_pads` and `__p2_pads` are no longer used in the new solution, remove them. (if they are reused, note that outside this method, they are reset to 0 in the destructor too.)
 		
-		//TODO: Once a better solution is found and tested, pop up a UI window when multiple pads of the same value are detected.
-
 		// Just return after printing if it's not a device log.
 		bool isDeviceInfoLog = strstr(log, "Received device info.  Master version:");
 		bool containsP = strstr(log, "P");
@@ -71,11 +63,9 @@ namespace {
 		}
 
 		// If too many of a particular player connected, issue a warning.
-		if (__p1_pads > 1) {
-			LOG->Warn("Multiple P1 SMX pads are connected, which will not work correctly. Please set the jumper on the right pad to P2, then remap.");
-		}
-		if (__p2_pads > 1) {
-			LOG->Warn("Multiple P2 SMX pads are connected, which will not work correctly. Please set the jumper on the left pad to P1, then remap.");
+		if (__p1_pads > 1 || __p2_pads > 1) {
+			LOG->Warn("Both SMX stages are set to the same player ID. Please unplug one of the stages from power and USB, change the jumper position, and then restart the game.");
+			MessageBox(nullptr, "Both SMX stages are set to the same player ID. Please unplug one of the stages from power and USB, change the jumper position, and then restart the game.", "Error", MB_OK );
 		}
 	};
 }
@@ -89,11 +79,10 @@ bool MapFunctions()
 {
 	__try
 	{
-		pSMX_Start = (SMX_Start_t)GetProcAddress(hSMXdll, "SMX_Start");
-		pSMX_GetInfo = (SMX_GetInfo_t)GetProcAddress(hSMXdll, "SMX_GetInfo");
-		pSMX_GetInputState = (SMX_GetInputState_t)GetProcAddress(hSMXdll, "SMX_GetInputState");
-		pSMX_SetLogCallback = (SMX_SetLogCallback_t)GetProcAddress(hSMXdll, "SMX_SetLogCallback");
-		pSMX_Stop = (SMX_Stop_t)GetProcAddress(hSMXdll, "SMX_Stop");
+		pSMX_Start = reinterpret_cast<SMX_Start_t>(GetProcAddress(hSMXdll, "SMX_Start"));
+		pSMX_GetInputState = reinterpret_cast<SMX_GetInputState_t>(GetProcAddress(hSMXdll, "SMX_GetInputState"));
+		pSMX_SetLogCallback = reinterpret_cast<SMX_SetLogCallback_t>(GetProcAddress(hSMXdll, "SMX_SetLogCallback"));
+		pSMX_Stop = reinterpret_cast<SMX_Stop_t>(GetProcAddress(hSMXdll, "SMX_Stop"));
 	}
 	__except (smx_filter(GetExceptionCode(), GetExceptionInformation()))
 	{
@@ -231,15 +220,6 @@ void InputHandler_Win32_SMX::SMX_Start() {
         pSMX_Start(&SmxCallback, this);
 		__is_smx_started = true;
     }
-}
-
-void InputHandler_Win32_SMX::SMX_GetInfo(int pad, struct SMXInfo *info) {
-	if (__is_smx_started && pSMX_GetInfo != nullptr) {
-		pSMX_GetInfo(pad, info);
-	}
-	else {
-		info->m_bConnected = false;
-	}
 }
 
 uint16_t InputHandler_Win32_SMX::SMX_GetInputState(int pad) {

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -31,6 +31,14 @@ static HINSTANCE hSMXdll = nullptr;
 
 REGISTER_INPUT_HANDLER_CLASS2(SMX, Win32_SMX);
 
+constexpr int SMX_PANEL_COUNT = 9;
+static bool _smxdll_attempted_load = false;
+static bool _smxdll_loaded = false;
+static bool __detected_pad = false;
+static bool __is_smx_started = false;
+static int __p1_pads = 0;
+static int __p2_pads = 0;
+
 namespace {
 	static void SmxCallback(int pad, SMXUpdateCallbackReason reason, void* pUser) {
 		InputHandler_Win32_SMX* inputHandler = static_cast<InputHandler_Win32_SMX*>(pUser);
@@ -39,14 +47,31 @@ namespace {
 
 	static void LogCallback(const char *log) {
 		LOG->Info("SMX SDK Log: %s", log);
+
+		// Just return after printing if it's not a device log.
+		bool isDeviceInfoLog = strstr(log, "Received device info.  Master version:");
+		bool containsP = strstr(log, "P");
+		if (!isDeviceInfoLog || !containsP) {
+			return;
+		}
+
+		// If this is a device log, check which player just connected.
+		bool isP2 = strstr(log, "P2") != nullptr;
+		if (isP2) {
+			__p2_pads += 1;
+		} else {
+			__p1_pads += 1;
+		}
+
+		// If too many of a particular player connected, issue a warning.
+		if (__p1_pads > 1) {
+			LOG->Warn("Two P1 SMX pads are connected, which will not work correctly. Please set the jumper on the right pad to P2, then remap.");
+		}
+		if (__p2_pads > 1) {
+			LOG->Warn("Two P2 SMX pads are connected, which will not work correctly. Please set the jumper on the left pad to P1, then remap.");
+		}
 	};
 }
-
-constexpr int SMX_PANEL_COUNT = 9;
-static bool _smxdll_attempted_load = false;
-static bool _smxdll_loaded = false;
-static bool __detected_pad = false;
-static bool __is_smx_started = false;
 
 int smx_filter(unsigned int, struct _EXCEPTION_POINTERS*)
 {
@@ -118,6 +143,8 @@ InputHandler_Win32_SMX::~InputHandler_Win32_SMX() {
 	// If we reset `__detected_pad` here, it allows us to stop reporting the device in `GetDevicesAndDescriptions` when a pad is disconnected. 
 	// If (a) pad(s) is still connected, it'll re-register before the next constructor runs.
 	__detected_pad = false;
+	__p1_pads = 0;
+	__p2_pads = 0;
 }
 
 void InputHandler_Win32_SMX::GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut)

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -179,13 +179,13 @@ RString InputHandler_Win32_SMX::GetDeviceSpecificInputString(const DeviceInput &
 
     static const char* buttonStrings[SMX_PANEL_COUNT] =
     {
-        "up left", "up", "up right", "left", "center",
-        "right", "down left", "down", "down right"
+        "UpLeft", "Up", "UpRight", "Left", "Center",
+        "Right", "DownLeft", "Down", "DownRight"
     };
 
     const char* buttonString = (padRemovedButton >= 0 && padRemovedButton < SMX_PANEL_COUNT) ? buttonStrings[padRemovedButton] : "unknown";
 
-    return ssprintf("SMX P%d, %s", pad, buttonString);
+    return ssprintf("SMX P%d %s", pad, buttonString);
 }
 
 void InputHandler_Win32_SMX::SMX_Start() {

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.cpp
@@ -48,6 +48,13 @@ namespace {
 	static void LogCallback(const char *log) {
 		LOG->Info("SMX SDK Log: %s", log);
 
+		//TODO: Find more graceful means of surfacing a warning when multiple pads of the same value are detected.
+		// Note: when this happens, to remove this logic:
+		// 1) delete all code below this comment.
+		// 2) if the static vars `__p1_pads` and `__p2_pads` are no longer used in the new solution, remove them. (if they are reused, note that outside this method, they are reset to 0 in the destructor too.)
+		
+		//TODO: Once a better solution is found and tested, pop up a UI window when multiple pads of the same value are detected.
+
 		// Just return after printing if it's not a device log.
 		bool isDeviceInfoLog = strstr(log, "Received device info.  Master version:");
 		bool containsP = strstr(log, "P");
@@ -65,10 +72,10 @@ namespace {
 
 		// If too many of a particular player connected, issue a warning.
 		if (__p1_pads > 1) {
-			LOG->Warn("Two P1 SMX pads are connected, which will not work correctly. Please set the jumper on the right pad to P2, then remap.");
+			LOG->Warn("Multiple P1 SMX pads are connected, which will not work correctly. Please set the jumper on the right pad to P2, then remap.");
 		}
 		if (__p2_pads > 1) {
-			LOG->Warn("Two P2 SMX pads are connected, which will not work correctly. Please set the jumper on the left pad to P1, then remap.");
+			LOG->Warn("Multiple P2 SMX pads are connected, which will not work correctly. Please set the jumper on the left pad to P1, then remap.");
 		}
 	};
 }

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.h
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.h
@@ -7,6 +7,8 @@
 static bool _smxdll_loaded = false;
 static const int SMX_PAD_COUNT = 2;
 
+bool Attempt_SMX_DLL_Load();
+
 enum SMXUpdateCallbackReason {
 	SMXUpdateCallback_Updated,
 	SMXUpdateCallback_FactoryResetCommandComplete
@@ -24,8 +26,6 @@ public:
 private:
 	uint16_t m_padInputStates[SMX_PAD_COUNT];
 
-	bool LoadDLL();
-	bool MapFunctions();
 	void SMX_Start( SMXUpdateCallback UpdateCallback, void *pUser );
     uint16_t SMX_GetInputState( int pad );
 };

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.h
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.h
@@ -18,6 +18,7 @@ struct SMXInfo {
 	char m_Serial[33];
 	uint16_t m_iFirmwareVersion;
 };
+typedef void SMXLogCallback(const char *log);
 
 class InputHandler_Win32_SMX: public InputHandler
 {
@@ -36,6 +37,7 @@ private:
 
 	void SMX_GetInfo( int pad, struct SMXInfo *info );
     uint16_t SMX_GetInputState( int pad );
+	void SMX_SetLogCallback();
 	void SMX_Stop();
 };
 

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.h
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.h
@@ -6,6 +6,7 @@
 static const int SMX_PAD_COUNT = 2;
 
 bool InputHandler_Win32_SMX_Is_SMX_DLL_Available();
+void InputHandler_Win32_SMX_Register_Pad();
 
 enum SMXUpdateCallbackReason {
 	SMXUpdateCallback_Updated,
@@ -27,11 +28,12 @@ public:
 	RString GetDeviceSpecificInputString( const DeviceInput &di );
 	void ProcessInputEvent( int pad );
 
+	void SMX_Start();
+
 private:
 	uint16_t m_padInputStates[SMX_PAD_COUNT];
 	bool IsPadConnected();
 
-	void SMX_Start( SMXUpdateCallback UpdateCallback, void *pUser );
 	void SMX_GetInfo( int pad, struct SMXInfo *info );
     uint16_t SMX_GetInputState( int pad );
 	void SMX_Stop();

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.h
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.h
@@ -1,6 +1,5 @@
 #ifndef INPUT_HANDLER_WIN32_SMX_H
 #define INPUT_HANDLER_WIN32_SMX_H
-#endif
 
 #include "InputHandler.h"
 
@@ -29,3 +28,30 @@ private:
 	void SMX_Start( SMXUpdateCallback UpdateCallback, void *pUser );
     uint16_t SMX_GetInputState( int pad );
 };
+
+/*
+ * (c) 2025 Caleb Lee
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+ #endif

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.h
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.h
@@ -12,6 +12,11 @@ enum SMXUpdateCallbackReason {
 	SMXUpdateCallback_FactoryResetCommandComplete
 };
 typedef void SMXUpdateCallback(int pad, SMXUpdateCallbackReason reason, void* pUser);
+struct SMXInfo {
+    bool m_bConnected = false;
+	char m_Serial[33];
+	uint16_t m_iFirmwareVersion;
+};
 
 class InputHandler_Win32_SMX: public InputHandler
 {
@@ -24,8 +29,10 @@ public:
 
 private:
 	uint16_t m_padInputStates[SMX_PAD_COUNT];
+	bool IsPadConnected();
 
 	void SMX_Start( SMXUpdateCallback UpdateCallback, void *pUser );
+	void SMX_GetInfo( int pad, struct SMXInfo *info );
     uint16_t SMX_GetInputState( int pad );
 	void SMX_Stop();
 };

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.h
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.h
@@ -3,10 +3,9 @@
 
 #include "InputHandler.h"
 
-static bool _smxdll_loaded = false;
 static const int SMX_PAD_COUNT = 2;
 
-bool Is_SMX_DLL_Available();
+bool InputHandler_Win32_SMX_Is_SMX_DLL_Available();
 
 enum SMXUpdateCallbackReason {
 	SMXUpdateCallback_Updated,

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.h
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.h
@@ -1,0 +1,31 @@
+#ifndef INPUT_HANDLER_WIN32_SMX_H
+#define INPUT_HANDLER_WIN32_SMX_H
+#endif
+
+#include "InputHandler.h"
+
+static bool _smxdll_loaded = false;
+static const int SMX_PAD_COUNT = 2;
+
+enum SMXUpdateCallbackReason {
+	SMXUpdateCallback_Updated,
+	SMXUpdateCallback_FactoryResetCommandComplete
+};
+typedef void SMXUpdateCallback(int pad, SMXUpdateCallbackReason reason, void* pUser);
+
+class InputHandler_Win32_SMX: public InputHandler
+{
+public:
+	InputHandler_Win32_SMX();
+	void GetDevicesAndDescriptions( std::vector<InputDeviceInfo>& vDevicesOut );
+	RString GetDeviceSpecificInputString( const DeviceInput &di );
+	void ProcessPoll( int pad );
+
+private:
+	uint16_t m_padInputStates[SMX_PAD_COUNT];
+
+	bool LoadDLL();
+	bool MapFunctions();
+	void SMX_Start( SMXUpdateCallback UpdateCallback, void *pUser );
+    uint16_t SMX_GetInputState( int pad );
+};

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.h
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.h
@@ -41,4 +41,4 @@ private:
 	void SMX_Stop();
 };
 
- #endif
+#endif

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.h
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.h
@@ -6,7 +6,7 @@
 static bool _smxdll_loaded = false;
 static const int SMX_PAD_COUNT = 2;
 
-bool Attempt_SMX_DLL_Load();
+bool Is_SMX_DLL_Available();
 
 enum SMXUpdateCallbackReason {
 	SMXUpdateCallback_Updated,
@@ -21,7 +21,7 @@ public:
 	~InputHandler_Win32_SMX();
 	void GetDevicesAndDescriptions( std::vector<InputDeviceInfo>& vDevicesOut );
 	RString GetDeviceSpecificInputString( const DeviceInput &di );
-	void ProcessPoll( int pad );
+	void ProcessInputEvent( int pad );
 
 private:
 	uint16_t m_padInputStates[SMX_PAD_COUNT];

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.h
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.h
@@ -18,6 +18,7 @@ class InputHandler_Win32_SMX: public InputHandler
 {
 public:
 	InputHandler_Win32_SMX();
+	~InputHandler_Win32_SMX();
 	void GetDevicesAndDescriptions( std::vector<InputDeviceInfo>& vDevicesOut );
 	RString GetDeviceSpecificInputString( const DeviceInput &di );
 	void ProcessPoll( int pad );
@@ -27,6 +28,7 @@ private:
 
 	void SMX_Start( SMXUpdateCallback UpdateCallback, void *pUser );
     uint16_t SMX_GetInputState( int pad );
+	void SMX_Stop();
 };
 
 /*

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.h
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.h
@@ -37,29 +37,4 @@ private:
 	void SMX_Stop();
 };
 
-/*
- * (c) 2025 Caleb Lee
- * All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, and/or sell copies of the Software, and to permit persons to
- * whom the Software is furnished to do so, provided that the above
- * copyright notice(s) and this permission notice appear in all copies of
- * the Software and that both the above copyright notice(s) and this
- * permission notice appear in supporting documentation.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
- * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
- * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
- * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
- * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
- * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
- * PERFORMANCE OF THIS SOFTWARE.
- */
-
  #endif

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.h
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.h
@@ -5,8 +5,7 @@
 
 static const int SMX_PAD_COUNT = 2;
 
-bool InputHandler_Win32_SMX_Is_SMX_DLL_Available();
-void InputHandler_Win32_SMX_Register_Pad();
+bool InputHandler_Win32_SMX_Register_Pad();
 
 enum SMXUpdateCallbackReason {
 	SMXUpdateCallback_Updated,
@@ -33,7 +32,6 @@ public:
 
 private:
 	uint16_t m_padInputStates[SMX_PAD_COUNT];
-	bool IsPadConnected();
 
 	void SMX_GetInfo( int pad, struct SMXInfo *info );
     uint16_t SMX_GetInputState( int pad );

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.h
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.h
@@ -4,6 +4,7 @@
 #include "InputHandler.h"
 
 constexpr int SMX_PAD_COUNT = 2;
+constexpr int SMX_PANEL_COUNT = 9;
 
 bool InputHandler_Win32_SMX_Register_Pad();
 
@@ -33,7 +34,6 @@ public:
 private:
 	uint16_t m_padInputStates[SMX_PAD_COUNT];
 
-	void SMX_GetInfo( int pad, struct SMXInfo *info );
     uint16_t SMX_GetInputState( int pad );
 	void SMX_SetLogCallback();
 	void SMX_Stop();

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.h
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.h
@@ -3,7 +3,7 @@
 
 #include "InputHandler.h"
 
-static const int SMX_PAD_COUNT = 2;
+constexpr int SMX_PAD_COUNT = 2;
 
 bool InputHandler_Win32_SMX_Register_Pad();
 

--- a/src/arch/InputHandler/InputHandler_Win32_SMX.h
+++ b/src/arch/InputHandler/InputHandler_Win32_SMX.h
@@ -13,11 +13,6 @@ enum SMXUpdateCallbackReason {
 	SMXUpdateCallback_FactoryResetCommandComplete
 };
 typedef void SMXUpdateCallback(int pad, SMXUpdateCallbackReason reason, void* pUser);
-struct SMXInfo {
-    bool m_bConnected = false;
-	char m_Serial[33];
-	uint16_t m_iFirmwareVersion;
-};
 typedef void SMXLogCallback(const char *log);
 
 class InputHandler_Win32_SMX: public InputHandler
@@ -29,11 +24,10 @@ public:
 	RString GetDeviceSpecificInputString( const DeviceInput &di );
 	void ProcessInputEvent( int pad );
 
-	void SMX_Start();
-
 private:
 	uint16_t m_padInputStates[SMX_PAD_COUNT];
 
+	void SMX_Start();
     uint16_t SMX_GetInputState( int pad );
 	void SMX_SetLogCallback();
 	void SMX_Stop();

--- a/src/arch/arch_default.h
+++ b/src/arch/arch_default.h
@@ -11,7 +11,7 @@
 #include "MemoryCard/MemoryCardDriverThreaded_Windows.h"
 
 inline const std::vector<RString>& GetDefaultInputDriverList() {
-	static const std::vector<RString> inputDriverList = { "DirectInput", "Pump", "Para" };
+	static const std::vector<RString> inputDriverList = { "DirectInput", "Pump", "Para", "SMX"};
 	return inputDriverList;
 }
 


### PR DESCRIPTION
This PR adds functionality to ITGMania on Windows to be able to communicate with StepManiaX pads via the [StepManiaX SDK](https://github.com/steprevolution/stepmaniax-sdk). The StepManiaX SDK communicates with the pad more directly, skipping Windows input overhead, and (if I understand correctly?) makes it so the pad initiates input changes as opposed to polling for input changes. If using the SMX SDK, input appears to be cleaner and more accurate, though it's hard to tell for-sure.

This functionality is optional, depending on if SMX.dll is present in the Program folder. If it is not present, there should be no change to ITGM functionality compared to vanilla. OSes other than Windows shouldn't be affected.

If SMX.dll IS in the folder, SMX platform devices are denylisted from the DirectInput InputHandler to ensure that the SMX SDK is used instead (I had conflicting issues trying to map when both were enabled).

I've taken the necessary steps to ensure `SMX` does not show on the device list if a pad isn't plugged in and turned on.

No lights support. It could be added fairly easily in a basic way, but I'm unsure if ITGM does anything very special with lights, it apparently adds a little overhead to the SMX SDK input routine, and I'm not sure I'm up to pick light colors for everyone or make a UI to let people pick their own.

Tested for hours on my own pad. Telperion smoke tested two pads and didn't have issues.

I'm assuming `beta` is probably the branch I want to merge into. I'm quite happy to make changes for code standards, etc. C++ isn't my normal jam so there might be a couple weird things to iron out. Let me know :)