### PR TITLE
Resolve compiler warnings in TechCounts/StepParity code

### DIFF
--- a/src/StepParityCost.h
+++ b/src/StepParityCost.h
@@ -26,15 +26,15 @@ namespace StepParity
 
 	// 0.1 = 1/16th note at 150bpm. Jacks quicker than this are harder.
 	// Above this speed, footswitches should be prioritized
-	const float JACK_THRESHOLD = 0.1;
+	constexpr float JACK_THRESHOLD = 0.1f;
 	// 0.15 = 1/8th at 200bpm, or 3/16th at 150bpm. Below this speed, jumps should be prioritized
-	const float SLOW_BRACKET_THRESHOLD = 0.15;
+	constexpr float SLOW_BRACKET_THRESHOLD = 0.15f;
 	// 0.2 = 1/8th at 150bpm. Footswitches slower than this are harder.
 	// Below this speed, jacks should be prioritized
-	const float SLOW_FOOTSWITCH_THRESHOLD = 0.2;
+	constexpr float SLOW_FOOTSWITCH_THRESHOLD = 0.2f;
 	// 0.4 = 1/4th at 150bpm. Once a footswitch gets slow enough, though,
 	// just ignore it.
-	const float SLOW_FOOTSWITCH_IGNORE = 0.4;
+	constexpr float SLOW_FOOTSWITCH_IGNORE = 0.4f;
 	
 	class StepParityCost
 	{

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -9,7 +9,7 @@ using namespace StepParity;
 
 bool StepParityGenerator::analyzeNoteData(const NoteData &in)
 {
-	columnCount = in.GetNumTracks();
+	columnCount_ = in.GetNumTracks();
 	
 	CreateRows(in);
 
@@ -42,7 +42,7 @@ void StepParityGenerator::buildStateGraph()
 {
 	// The first node of the graph is beginningState, which represents the time before
 	// the first note (and so it's roIndex is considered -1)
-	beginningState = new State(columnCount);
+	beginningState = new State(columnCount_);
 	startNode = addNode(beginningState, rows[0].second - 1, -1);
 	
 	std::queue<StepParityNode *> previousNodes;
@@ -78,7 +78,7 @@ void StepParityGenerator::buildStateGraph()
 	
 	// at this point, previousStates holds all of the states for the very last row,
 	// which just get connected to the endState
-	endingState = new State(columnCount);
+	endingState = new State(columnCount_);
 	endNode = addNode(endingState, rows[rows.size() - 1].second + 1, rows.size());
 	
 	while(!previousNodes.empty())
@@ -540,12 +540,12 @@ void StepParityGenerator::CreateRows(const NoteData &in)
 			counter.lastColumnBeat = note.beat;
 			counter.nextMines.assign(counter.mines.begin(), counter.mines.end());
 			counter.nextFakeMines.assign(counter.fakeMines.begin(), counter.fakeMines.end());
-			counter.notes = std::vector<IntermediateNoteData>(columnCount);
-			counter.mines = std::vector<float>(columnCount);
-			counter.fakeMines = std::vector<float>(columnCount);
+			counter.notes = std::vector<IntermediateNoteData>(columnCount_);
+			counter.mines = std::vector<float>(columnCount_);
+			counter.fakeMines = std::vector<float>(columnCount_);
 
 			// Reset any now-inactive holds to empty values.
-			for (int c = 0; c < columnCount; c++)
+			for (int c = 0; c < columnCount_; c++)
 			{
 				if (counter.activeHolds[c].type == TapNoteType_Empty || note.beat > counter.activeHolds[c].beat + counter.activeHolds[c].hold_length)
 				{
@@ -573,14 +573,14 @@ void StepParityGenerator::AddRow(RowCounter &counter)
 
 Row StepParityGenerator::CreateRow(RowCounter &counter)
 {
-	Row row = Row(columnCount);
+	Row row = Row(columnCount_);
 	row.notes.assign(counter.notes.begin(), counter.notes.end());
 	row.mines.assign(counter.nextMines.begin(), counter.nextMines.end());
 	row.fakeMines.assign(counter.nextFakeMines.begin(), counter.nextFakeMines.end());
 	row.second = counter.lastColumnSecond;
 	row.beat = counter.lastColumnBeat;
 
-	for (int c = 0; c < columnCount; c++)
+	for (int c = 0; c < columnCount_; c++)
 	{
 		// save any active holds
 		if (counter.activeHolds[c].type == TapNoteType_Empty || counter.activeHolds[c].second >= counter.lastColumnSecond)

--- a/src/StepParityGenerator.h
+++ b/src/StepParityGenerator.h
@@ -47,7 +47,7 @@ namespace StepParity {
 		std::vector<StepParity::StepParityNode*> nodes;
 		std::vector<Row> rows;
 		std::vector<int> nodes_for_rows;
-		int columnCount;
+		int columnCount_;
 		
 		StepParityGenerator(const StageLayout & l) : layout(l) {
 			

--- a/src/TechCounts.cpp
+++ b/src/TechCounts.cpp
@@ -28,13 +28,13 @@ LuaXType( TechCountsCategory );
 
 // 0.176 ~= 1/8th at 175bpm
 // Anything slower isn't counted as a jack
-const float JACK_CUTOFF = 0.176;
+constexpr float JACK_CUTOFF = 0.176f;
 // 0.3 = 1/4th at 200bpm (or 3/16th at 150bpm)
 // Anything slower isn't counted as a footswitch
-const float FOOTSWITCH_CUTOFF = 0.3;
+constexpr float FOOTSWITCH_CUTOFF = 0.3f;
 // 0.235 ~= 1/8th at 128bpm
 // Anything slower isn't counted as a doublestep
-const float DOUBLESTEP_CUTOFF = 0.235;
+constexpr float DOUBLESTEP_CUTOFF = 0.235f;
 
 // TechCounts methods
 TechCounts::TechCounts()


### PR DESCRIPTION
There is nothing major or serious here, but the code does emit a lot of warnings on MSVC as is.

This PR introduces two commits to resolve all these warnings

```
D:\a\itgmania\itgmania\src\TechCounts.cpp(31,27): warning C4305: 'initializing': truncation from 'double' to 'float' [D:\a\itgmania\itgmania\Build\src\ITGmania.vcxproj]
  (compiling source file '../../src/TechCounts.cpp')
  
D:\a\itgmania\itgmania\src\TechCounts.cpp(34,33): warning C4305: 'initializing': truncation from 'double' to 'float' [D:\a\itgmania\itgmania\Build\src\ITGmania.vcxproj]
  (compiling source file '../../src/TechCounts.cpp')
  
D:\a\itgmania\itgmania\src\TechCounts.cpp(37,33): warning C4305: 'initializing': truncation from 'double' to 'float' [D:\a\itgmania\itgmania\Build\src\ITGmania.vcxproj]
  (compiling source file '../../src/TechCounts.cpp')
  
  StepParityGenerator.cpp
  StepParityDatastructs.cpp
D:\a\itgmania\itgmania\src\StepParityCost.h(29,31): warning C4305: 'initializing': truncation from 'double' to 'float' [D:\a\itgmania\itgmania\Build\src\ITGmania.vcxproj]
  (compiling source file '../../src/StepParityGenerator.cpp')
  
D:\a\itgmania\itgmania\src\StepParityCost.h(31,39): warning C4305: 'initializing': truncation from 'double' to 'float' [D:\a\itgmania\itgmania\Build\src\ITGmania.vcxproj]
  (compiling source file '../../src/StepParityGenerator.cpp')
  
D:\a\itgmania\itgmania\src\StepParityCost.h(34,42): warning C4305: 'initializing': truncation from 'double' to 'float' [D:\a\itgmania\itgmania\Build\src\ITGmania.vcxproj]
  (compiling source file '../../src/StepParityGenerator.cpp')
  
D:\a\itgmania\itgmania\src\StepParityCost.h(37,39): warning C4305: 'initializing': truncation from 'double' to 'float' [D:\a\itgmania\itgmania\Build\src\ITGmania.vcxproj]
  (compiling source file '../../src/StepParityGenerator.cpp')
  
  StepParityCost.cpp
D:\a\itgmania\itgmania\src\StepParityGenerator.cpp(196,104): warning C4458: declaration of 'columnCount' hides class member [D:\a\itgmania\itgmania\Build\src\ITGmania.vcxproj]
  (compiling source file '../../src/StepParityGenerator.cpp')
      D:\a\itgmania\itgmania\src\StepParityGenerator.h(50,7):
      see declaration of 'StepParity::StepParityGenerator::columnCount'
  
D:\a\itgmania\itgmania\src\StepParityGenerator.cpp(419,6): warning C4458: declaration of 'columnCount' hides class member [D:\a\itgmania\itgmania\Build\src\ITGmania.vcxproj]
  (compiling source file '../../src/StepParityGenerator.cpp')
      D:\a\itgmania\itgmania\src\StepParityGenerator.h(50,7):
      see declaration of 'StepParity::StepParityGenerator::columnCount'
  
D:\a\itgmania\itgmania\src\StepParityGenerator.cpp(456,6): warning C4458: declaration of 'columnCount' hides class member [D:\a\itgmania\itgmania\Build\src\ITGmania.vcxproj]
  (compiling source file '../../src/StepParityGenerator.cpp')
      D:\a\itgmania\itgmania\src\StepParityGenerator.h(50,7):
      see declaration of 'StepParity::StepParityGenerator::columnCount'
  
D:\a\itgmania\itgmania\src\StepParityCost.h(29,31): warning C4305: 'initializing': truncation from 'double' to 'float' [D:\a\itgmania\itgmania\Build\src\ITGmania.vcxproj]
  (compiling source file '../../src/StepParityCost.cpp')
  
D:\a\itgmania\itgmania\src\StepParityCost.h(31,39): warning C4305: 'initializing': truncation from 'double' to 'float' [D:\a\itgmania\itgmania\Build\src\ITGmania.vcxproj]
  (compiling source file '../../src/StepParityCost.cpp')
  
D:\a\itgmania\itgmania\src\StepParityCost.h(34,42): warning C4305: 'initializing': truncation from 'double' to 'float' [D:\a\itgmania\itgmania\Build\src\ITGmania.vcxproj]
  (compiling source file '../../src/StepParityCost.cpp')
  
D:\a\itgmania\itgmania\src\StepParityCost.h(37,39): warning C4305: 'initializing': truncation from 'double' to 'float' [D:\a\itgmania\itgmania\Build\src\ITGmania.vcxproj]
  (compiling source file '../../src/StepParityCost.cpp')
  
```