### PR TITLE
Slow down frequency at which device strings are updated in controller mapping screen

### DIFF
--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -326,12 +326,7 @@ void GameLoop::RunGameLoop()
 
 		UpdateAllButDraw(false);
 		
-		// Check input devices every 255 frames (uint8_t can hold 0-255).
-		static uint8_t i_CheckInputDevices = 0;
-		if (++i_CheckInputDevices == 0)
-		{
-			CheckInputDevices();
-		}
+		CallEveryNFrames(500, CheckInputDevices);
 		
 		SCREENMAN->Draw();
 	}

--- a/src/ScreenMapControllers.cpp
+++ b/src/ScreenMapControllers.cpp
@@ -278,16 +278,14 @@ void ScreenMapControllers::Update( float fDeltaTime )
 		}
 	}
 
-	//
-	// Update devices text every 120ish frames
+	// Update devices text every 500 frames.
 	// This is NOT updating the actual text shown!
-	// it is updating the names of the devices here.
-	//
-	static uint8_t e= 0;
-	++e;
-	if (e == 0 || e == 127) {
+	// This is polling every active driver for an updated
+	// list of button to device mappings.
+	CallEveryNFrames(500, [this]() {
+		// If we don't pass the `this` pointer, the lambda can't get access to the ScreenMapControllers instance.
 		m_textDevices.SetText(INPUTMAN->GetDisplayDevicesString());
-	}
+		});
 
 	if( !m_WaitingForPress.IsZero() && m_DeviceIToMap.IsValid() ) // we're going to map an input
 	{

--- a/src/ScreenMapControllers.cpp
+++ b/src/ScreenMapControllers.cpp
@@ -278,12 +278,9 @@ void ScreenMapControllers::Update( float fDeltaTime )
 		}
 	}
 
-	// Update devices text every 500 frames.
-	// This is NOT updating the actual text shown!
-	// This is polling every active driver for an updated
-	// list of button to device mappings.
-	CallEveryNFrames(500, [this]() {
-		// If we don't pass the `this` pointer, the lambda can't get access to the ScreenMapControllers instance.
+	// We don't expect the connected devices to change frequently.
+	// As a result, delay how often we check for and update the device strings.
+	CallEveryNFrames(250, [this]() {
 		m_textDevices.SetText(INPUTMAN->GetDisplayDevicesString());
 		});
 

--- a/src/ScreenMapControllers.cpp
+++ b/src/ScreenMapControllers.cpp
@@ -279,9 +279,15 @@ void ScreenMapControllers::Update( float fDeltaTime )
 	}
 
 	//
-	// Update devices text
+	// Update devices text every 120ish frames
+	// This is NOT updating the actual text shown!
+	// it is updating the names of the devices here.
 	//
-	m_textDevices.SetText( INPUTMAN->GetDisplayDevicesString() );
+	static uint8_t e= 0;
+	++e;
+	if (e == 0 || e == 127) {
+		m_textDevices.SetText(INPUTMAN->GetDisplayDevicesString());
+	}
 
 	if( !m_WaitingForPress.IsZero() && m_DeviceIToMap.IsValid() ) // we're going to map an input
 	{

--- a/src/global.h
+++ b/src/global.h
@@ -108,6 +108,19 @@ typedef StdString::CStdString RString;
 
 #include "RageException.h"
 
+// Call a function every `n` frames.
+// Each call site will get its own counter.
+#include <utility>
+template <typename Func, typename... Args>
+void CallEveryNFrames(int n, Func&& f, Args&&... args) {
+	static int counter = 0;
+	++counter;
+	if (counter == n) {
+		counter = 0;
+		std::forward<Func>(f)(std::forward<Args>(args)...);
+	}
+}
+
 /* Don't include our own headers here, since they tend to change often. */
 
 #endif


### PR DESCRIPTION
We have lots of code (mostly 20+ years old) that is just running uncapped.  So lots of stuff is not scaling well with higher average framerates.  Introduces a macro to avoid repeating this logic frequently (I do anticipate adding this to more places other uncapped loops are found).