### PR TITLE
Remove COMPARE and COMPARE_FLOAT macros for equivalent if statements.

### DIFF
--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -1455,22 +1455,20 @@ void Actor::TweenState::Init()
 	aux = 0;
 }
 
-bool Actor::TweenState::operator==( const TweenState &other ) const
-{
-#define COMPARE( x )	if( x != other.x ) return false;
-	COMPARE( pos );
-	COMPARE( rotation );
-	COMPARE( quat );
-	COMPARE( scale );
-	COMPARE( fSkewX );
-	COMPARE( fSkewY );
-	COMPARE( crop );
-	COMPARE( fade );
-	for( unsigned i=0; i<ARRAYLEN(diffuse); i++ )
-		COMPARE( diffuse[i] );
-	COMPARE( glow );
-	COMPARE( aux );
-#undef COMPARE
+bool Actor::TweenState::operator==(const TweenState& other) const {
+	if (pos != other.pos) return false;
+	if (rotation != other.rotation) return false;
+	if (quat != other.quat) return false;
+	if (scale != other.scale) return false;
+	if (fSkewX != other.fSkewX) return false;
+	if (fSkewY != other.fSkewY) return false;
+	if (crop != other.crop) return false;
+	if (fade != other.fade) return false;
+	for (unsigned i = 0; i < ARRAYLEN(diffuse); i++) {
+		if (diffuse[i] != other.diffuse[i]) return false;
+	}
+	if (glow != other.glow) return false;
+	if (aux != other.aux) return false;
 	return true;
 }
 

--- a/src/BackgroundUtil.cpp
+++ b/src/BackgroundUtil.cpp
@@ -13,15 +13,17 @@
 #include <vector>
 
 
-bool BackgroundDef::operator<( const BackgroundDef &other ) const
-{
-#define COMPARE(x) if( x < other.x ) return true; else if( x > other.x ) return false;
-	COMPARE( m_sEffect );
-	COMPARE( m_sFile1 );
-	COMPARE( m_sFile2 );
-	COMPARE( m_sColor1 );
-	COMPARE( m_sColor2 );
-#undef COMPARE
+bool BackgroundDef::operator<(const BackgroundDef& other) const {
+	if (m_sEffect != other.m_sEffect)
+		return m_sEffect < other.m_sEffect;
+	if (m_sFile1 != other.m_sFile1)
+		return m_sFile1 < other.m_sFile1;
+	if (m_sFile2 != other.m_sFile2)
+		return m_sFile2 < other.m_sFile2;
+	if (m_sColor1 != other.m_sColor1)
+		return m_sColor1 < other.m_sColor1;
+	if (m_sColor2 != other.m_sColor2)
+		return m_sColor2 < other.m_sColor2;
 	return false;
 }
 

--- a/src/DateTime.cpp
+++ b/src/DateTime.cpp
@@ -15,45 +15,48 @@ void DateTime::Init()
 	ZERO( *this );
 }
 
-bool DateTime::operator<( const DateTime& other ) const
-{
-#define COMPARE( v ) if(v!=other.v) return v<other.v;
-	COMPARE( tm_year );
-	COMPARE( tm_mon );
-	COMPARE( tm_mday );
-	COMPARE( tm_hour );
-	COMPARE( tm_min );
-	COMPARE( tm_sec );
-#undef COMPARE
-	// they're equal
+bool DateTime::operator<(const DateTime& other) const {
+	if (tm_year != other.tm_year) return tm_year < other.tm_year;
+	if (tm_mon != other.tm_mon) return tm_mon < other.tm_mon;
+	if (tm_mday != other.tm_mday) return tm_mday < other.tm_mday;
+	if (tm_hour != other.tm_hour) return tm_hour < other.tm_hour;
+	if (tm_min != other.tm_min) return tm_min < other.tm_min;
+	if (tm_sec != other.tm_sec) return tm_sec < other.tm_sec;
 	return false;
 }
 
-bool DateTime::operator==( const DateTime& other ) const 
-{
-#define COMPARE(x)	if( x!=other.x )	return false;
-	COMPARE( tm_year );
-	COMPARE( tm_mon );
-	COMPARE( tm_mday );
-	COMPARE( tm_hour );
-	COMPARE( tm_min );
-	COMPARE( tm_sec );
-#undef COMPARE
+bool DateTime::operator==(const DateTime& other) const {
+	if (tm_year != other.tm_year) return false;
+	if (tm_mon != other.tm_mon) return false;
+	if (tm_mday != other.tm_mday) return false;
+	if (tm_hour != other.tm_hour) return false;
+	if (tm_min != other.tm_min) return false;
+	if (tm_sec != other.tm_sec) return false;
 	return true;
 }
 
-bool DateTime::operator>( const DateTime& other ) const
-{
-#define COMPARE( v ) if(v!=other.v) return v>other.v;
-	COMPARE( tm_year );
-	COMPARE( tm_mon );
-	COMPARE( tm_mday );
-	COMPARE( tm_hour );
-	COMPARE( tm_min );
-	COMPARE( tm_sec );
-#undef COMPARE
-	// they're equal
+
+bool DateTime::operator!=(const DateTime& other) const {
+	return !(*this == other);
+}
+
+bool DateTime::operator>(const DateTime& other) const {
+	if (tm_year != other.tm_year) return tm_year > other.tm_year;
+	if (tm_mon != other.tm_mon) return tm_mon > other.tm_mon;
+	if (tm_mday != other.tm_mday) return tm_mday > other.tm_mday;
+	if (tm_hour != other.tm_hour) return tm_hour > other.tm_hour;
+	if (tm_min != other.tm_min) return tm_min > other.tm_min;
+	if (tm_sec != other.tm_sec) return tm_sec > other.tm_sec;
 	return false;
+}
+
+
+bool DateTime::operator<=(const DateTime& other) const {
+	return !(*this > other); // Reuse the > operator
+}
+
+bool DateTime::operator>=(const DateTime& other) const {
+	return !(*this < other); // Reuse the < operator
 }
 
 DateTime DateTime::GetNowDateTime()

--- a/src/DateTime.h
+++ b/src/DateTime.h
@@ -109,18 +109,18 @@ struct DateTime
 	 * @brief Determine if this DateTime is not equal to some other time.
 	 * @param other the other DateTime to check.
 	 * @return true if this is not equal to the other time, or false otherwise. */
-	bool operator!=( const DateTime& other ) const { return !operator==(other); }
+	bool operator!=(const DateTime& other) const;
 	/**
 	 * @brief Determine if this DateTime is less than or equal to some other time.
 	 * @param other the other DateTime to check.
 	 * @return true if this is less than or equal to the other time, or false otherwise. */
-	bool operator<=( const DateTime& other ) const { return !operator>(other); }
+	bool operator<=(const DateTime& other) const;
 	
 	/**
 	 * @brief Determine if this DateTime is greater than or equal to some other time.
 	 * @param other the other DateTime to check.
 	 * @return true if this is greater than or equal to the other time, or false otherwise. */
-	bool operator>=( const DateTime& other ) const { return !operator<(other); }
+	bool operator>=(const DateTime& other) const;
 
 	/** 
 	 * @brief Retrieve the current date and time.

--- a/src/DisplayResolutions.h
+++ b/src/DisplayResolutions.h
@@ -17,16 +17,13 @@ public:
 	 * @brief Determine if one DisplayResolution is less than the other.
 	 * @param other the other DisplayResolution to check.
 	 * @return true if this DisplayResolution is less than the other, or false otherwise. */
-	bool operator<( const DisplayResolution &other ) const
-	{
-/** @brief A quick way to compare the two DisplayResolutions. */
-#define COMPARE(x) if( x != other.x ) return x < other.x;
-		COMPARE( iWidth );
-		COMPARE( iHeight );
-		COMPARE( bStretched );
-#undef COMPARE
+	bool operator<(const DisplayResolution& other) const {
+		if (iWidth != other.iWidth) return iWidth < other.iWidth;
+		if (iHeight != other.iHeight) return iHeight < other.iHeight;
+		if (bStretched != other.bStretched) return bStretched < other.bStretched;
 		return false;
 	}
+
 };
 /** @brief The collection of DisplayResolutions available within the program. */
 typedef std::set<DisplayResolution> DisplayResolutions;

--- a/src/DisplaySpec.h
+++ b/src/DisplaySpec.h
@@ -22,16 +22,13 @@ struct DisplayMode {
 	 * configuration
 	 */
 
-	bool operator<( const DisplayMode &other ) const
-	{
-/** @brief A quick way to compare the two DisplayResolutions. */
-#define COMPARE(x) if( x != other.x ) return x < other.x;
-		COMPARE( width );
-		COMPARE( height );
-		COMPARE( refreshRate );
-#undef COMPARE
+	bool operator<(const DisplayMode& other) const {
+		if (width != other.width) return width < other.width;
+		if (height != other.height) return height < other.height;
+		if (refreshRate != other.refreshRate) return refreshRate < other.refreshRate;
 		return false;
 	}
+
 
 	// Lua
 	void PushSelf( lua_State *L );

--- a/src/HighScore.cpp
+++ b/src/HighScore.cpp
@@ -44,33 +44,32 @@ struct HighScoreImpl
 	bool operator!=( const HighScoreImpl& other ) const { return !(*this == other); }
 };
 
-bool HighScoreImpl::operator==( const HighScoreImpl& other ) const
-{
-#define COMPARE(x)	if( x!=other.x )	return false;
-	COMPARE( sName );
-	COMPARE( grade );
-	COMPARE( iScore );
-	COMPARE( iMaxCombo );
-	COMPARE( stageAward );
-	COMPARE( peakComboAward );
-	COMPARE( fPercentDP );
-	COMPARE( fSurviveSeconds );
-	COMPARE( sModifiers );
-	COMPARE( dateTime );
-	COMPARE( sPlayerGuid );
-	COMPARE( sMachineGuid );
-	COMPARE( iProductID );
-	FOREACH_ENUM( TapNoteScore, tns )
-		COMPARE( iTapNoteScores[tns] );
-	FOREACH_ENUM( HoldNoteScore, hns )
-		COMPARE( iHoldNoteScores[hns] );
-	COMPARE( radarValues );
-	COMPARE( fLifeRemainingSeconds );
-	COMPARE( bDisqualified );
-#undef COMPARE
-
+bool HighScoreImpl::operator==(const HighScoreImpl& other) const {
+	if (sName != other.sName) return false;
+	if (grade != other.grade) return false;
+	if (iScore != other.iScore) return false;
+	if (iMaxCombo != other.iMaxCombo) return false;
+	if (stageAward != other.stageAward) return false;
+	if (peakComboAward != other.peakComboAward) return false;
+	if (fPercentDP != other.fPercentDP) return false;
+	if (fSurviveSeconds != other.fSurviveSeconds) return false;
+	if (sModifiers != other.sModifiers) return false;
+	if (dateTime != other.dateTime) return false;
+	if (sPlayerGuid != other.sPlayerGuid) return false;
+	if (sMachineGuid != other.sMachineGuid) return false;
+	if (iProductID != other.iProductID) return false;
+	FOREACH_ENUM(TapNoteScore, tns) {
+		if (iTapNoteScores[tns] != other.iTapNoteScores[tns]) return false;
+	}
+	FOREACH_ENUM(HoldNoteScore, hns) {
+		if (iHoldNoteScores[hns] != other.iHoldNoteScores[hns]) return false;
+	}
+	if (radarValues != other.radarValues) return false;
+	if (fLifeRemainingSeconds != other.fLifeRemainingSeconds) return false;
+	if (bDisqualified != other.bDisqualified) return false;
 	return true;
 }
+
 
 HighScoreImpl::HighScoreImpl()
 {

--- a/src/NoteTypes.h
+++ b/src/NoteTypes.h
@@ -209,18 +209,15 @@ struct TapNote
 	 * @brief Determine if the two TapNotes are equal to each other.
 	 * @param other the other TapNote we're checking.
 	 * @return true if the two TapNotes are equal, or false otherwise. */
-	bool operator==( const TapNote &other ) const
-	{
-#define COMPARE(x)	if(x!=other.x) return false
-		COMPARE(type);
-		COMPARE(subType);
-		COMPARE(source);
-		COMPARE(sAttackModifiers);
-		COMPARE(fAttackDurationSeconds);
-		COMPARE(iKeysoundIndex);
-		COMPARE(iDuration);
-		COMPARE(pn);
-#undef COMPARE
+	bool operator==(const TapNote& other) const {
+		if (type != other.type) return false;
+		if (subType != other.subType) return false;
+		if (source != other.source) return false;
+		if (sAttackModifiers != other.sAttackModifiers) return false;
+		if (fAttackDurationSeconds != other.fAttackDurationSeconds) return false;
+		if (iKeysoundIndex != other.iKeysoundIndex) return false;
+		if (iDuration != other.iDuration) return false;
+		if (pn != other.pn) return false;
 		return true;
 	}
 	/**

--- a/src/RageTypes.h
+++ b/src/RageTypes.h
@@ -315,16 +315,14 @@ public:
 		T GetCenterX() const	{ return (left+right)/2; };
 		T GetCenterY() const	{ return (top+bottom)/2; };
 
-		bool operator==( const Rect &other ) const
-		{
-#define COMPARE( x )	if( x != other.x ) return false
-			COMPARE( left );
-			COMPARE( top );
-			COMPARE( right );
-			COMPARE( bottom );
-#undef COMPARE
+		bool operator==(const Rect& other) const {
+			if (left != other.left) return false;
+			if (top != other.top) return false;
+			if (right != other.right) return false;
+			if (bottom != other.bottom) return false;
 			return true;
 		}
+
 		bool operator!=( const Rect &other ) const { return !operator==(other); }
 
 		T left, top, right, bottom;

--- a/src/SongOptions.cpp
+++ b/src/SongOptions.cpp
@@ -183,20 +183,17 @@ bool SongOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut )
 	return true;
 }
 
-bool SongOptions::operator==( const SongOptions &other ) const
-{
-#define COMPARE(x) { if( x != other.x ) return false; }
-	COMPARE( m_fMusicRate );
-	COMPARE( m_fHaste );
-	COMPARE( m_bAssistClap );
-	COMPARE( m_bAssistMetronome );
-	COMPARE( m_AutosyncType );
-	COMPARE( m_SoundEffectType );
-	COMPARE( m_bStaticBackground );
-	COMPARE( m_bRandomBGOnly );
-	COMPARE( m_bSaveScore );
-	COMPARE( m_bSaveReplay );
-#undef COMPARE
+bool SongOptions::operator==(const SongOptions& other) const {
+	if (m_fMusicRate != other.m_fMusicRate) return false;
+	if (m_fHaste != other.m_fHaste) return false;
+	if (m_bAssistClap != other.m_bAssistClap) return false;
+	if (m_bAssistMetronome != other.m_bAssistMetronome) return false;
+	if (m_AutosyncType != other.m_AutosyncType) return false;
+	if (m_SoundEffectType != other.m_SoundEffectType) return false;
+	if (m_bStaticBackground != other.m_bStaticBackground) return false;
+	if (m_bRandomBGOnly != other.m_bRandomBGOnly) return false;
+	if (m_bSaveScore != other.m_bSaveScore) return false;
+	if (m_bSaveReplay != other.m_bSaveReplay) return false;
 	return true;
 }
 

--- a/src/TimingSegments.h
+++ b/src/TimingSegments.h
@@ -40,9 +40,6 @@ const RString& TimingSegmentTypeToString( TimingSegmentType tst );
 
 const int ROW_INVALID = -1;
 
-#define COMPARE(x) if( this->x!=other.x ) return false
-#define COMPARE_FLOAT(x) if( std::abs(this->x - other.x) > EPSILON ) return false
-
 /**
  * @brief The base timing segment for make glorious benefit wolfman
  * XXX: this should be an abstract class.
@@ -65,6 +62,11 @@ struct TimingSegment
 
 	// for our purposes, two floats within this level of error are equal
 	static constexpr double EPSILON = 1e-6;
+
+	// A helper for testing equality of two floats within a level of error epsilon.
+	bool AreEqual(float f1, float f2) const {
+		return std::abs(f1 - f2) < EPSILON;
+	}
 
 	virtual ~TimingSegment() { }
 
@@ -161,7 +163,9 @@ struct FakeSegment : public TimingSegment
 
 	bool operator==( const FakeSegment &other ) const
 	{
-		COMPARE( m_iLengthRows );
+		if (m_iLengthRows != other.m_iLengthRows) {
+			return false;
+		}
 		return true;
 	}
 
@@ -219,7 +223,9 @@ struct WarpSegment : public TimingSegment
 
 	bool operator==( const WarpSegment &other ) const
 	{
-		COMPARE( m_iLengthRows );
+		if (m_iLengthRows != other.m_iLengthRows) {
+			return false;
+		}
 		return true;
 	}
 
@@ -274,7 +280,9 @@ struct TickcountSegment : public TimingSegment
 
 	bool operator==( const TickcountSegment &other ) const
 	{
-		COMPARE( m_iTicksPerBeat );
+		if (m_iTicksPerBeat != other.m_iTicksPerBeat) {
+			return false;
+		}
 		return true;
 	}
 
@@ -326,8 +334,12 @@ struct ComboSegment : public TimingSegment
 
 	bool operator==( const ComboSegment &other ) const
 	{
-		COMPARE( m_iCombo );
-		COMPARE( m_iMissCombo );
+		if (m_iCombo != other.m_iCombo) {
+			return false;
+		}
+		if (m_iMissCombo != other.m_iMissCombo) {
+			return false;
+		}
 		return true;
 	}
 
@@ -379,7 +391,9 @@ struct LabelSegment : public TimingSegment
 
 	bool operator==( const LabelSegment &other ) const
 	{
-		COMPARE( m_sLabel );
+		if (m_sLabel != other.m_sLabel) {
+			return false;
+		}
 		return true;
 	}
 
@@ -427,8 +441,7 @@ struct BPMSegment : public TimingSegment
 
 	bool operator==( const BPMSegment &other ) const
 	{
-		COMPARE_FLOAT( m_fBPS );
-		return true;
+		return AreEqual(m_fBPS, other.m_fBPS);
 	}
 
 	bool operator==( const TimingSegment &other ) const
@@ -499,8 +512,12 @@ struct TimeSignatureSegment : public TimingSegment
 
 	bool operator==( const TimeSignatureSegment &other ) const
 	{
-		COMPARE( m_iNumerator );
-		COMPARE( m_iDenominator );
+		if (m_iNumerator != other.m_iNumerator) {
+			return false;
+		}
+		if (m_iDenominator != other.m_iDenominator) {
+			return false;
+		}
 		return true;
 	}
 
@@ -566,9 +583,15 @@ struct SpeedSegment : public TimingSegment
 
 	bool operator==( const SpeedSegment &other ) const
 	{
-		COMPARE_FLOAT( m_fRatio );
-		COMPARE_FLOAT( m_fDelay );
-		COMPARE( m_Unit );
+		if (!AreEqual(m_fRatio, other.m_fRatio)) {
+			return false;
+		}
+		if (!AreEqual(m_fDelay, other.m_fDelay)) {
+			return false;
+		}
+		if (m_Unit != other.m_Unit) {
+			return false;
+		}
 		return true;
 	}
 
@@ -626,8 +649,7 @@ struct ScrollSegment : public TimingSegment
 
 	bool operator==( const ScrollSegment &other ) const
 	{
-		COMPARE_FLOAT( m_fRatio );
-		return true;
+		return AreEqual(m_fRatio, other.m_fRatio);
 	}
 
 	bool operator==( const TimingSegment &other ) const
@@ -671,8 +693,7 @@ struct StopSegment : public TimingSegment
 
 	bool operator==( const StopSegment &other ) const
 	{
-		COMPARE_FLOAT( m_fSeconds );
-		return true;
+		return AreEqual(m_fSeconds, other.m_fSeconds);
 	}
 
 	bool operator==( const TimingSegment &other ) const
@@ -715,8 +736,7 @@ struct DelaySegment : public TimingSegment
 
 	bool operator==( const DelaySegment &other ) const
 	{
-		COMPARE_FLOAT( m_fSeconds );
-		return true;
+		return AreEqual(m_fSeconds, other.m_fSeconds);
 	}
 
 	bool operator==( const TimingSegment &other ) const
@@ -730,9 +750,6 @@ private:
 	/** @brief The number of seconds to pause at the segment's row. */
 	float m_fSeconds;
 };
-
-#undef COMPARE
-#undef COMPARE_FLOAT
 
 #endif
 

--- a/src/arch/MemoryCard/MemoryCardDriver.cpp
+++ b/src/arch/MemoryCard/MemoryCardDriver.cpp
@@ -26,18 +26,12 @@ LuaXType(MemoryCardDriverType);
 
 Preference<MemoryCardDriverType> g_MemoryCardDriver("MemoryCardDriver", MemoryCardDriverType_Usb, nullptr, PreferenceType::Immutable);
 
-bool UsbStorageDevice::operator==(const UsbStorageDevice& other) const
-{
-  //  LOG->Trace( "Comparing %d %d %d %s %s to %d %d %d %s %s",
-  //	      iBus, iPort, iLevel, sName.c_str(), sOsMountDir.c_str(),
-  //	      other.iBus, other.iPort, other.iLevel, other.sName.c_str(), other.sOsMountDir.c_str() );
-#define COMPARE(x) if( x != other.x ) return false
-  COMPARE( iBus );
-  COMPARE( iPort );
-  COMPARE( iLevel );
-  COMPARE( sOsMountDir );
-  return true;
-#undef COMPARE
+bool UsbStorageDevice::operator==(const UsbStorageDevice& other) const {
+	if (iBus != other.iBus) return false;
+	if (iPort != other.iPort) return false;
+	if (iLevel != other.iLevel) return false;
+	if (sOsMountDir != other.sOsMountDir) return false;
+	return true;
 }
 
 void UsbStorageDevice::SetOsMountDir( const RString &s )


### PR DESCRIPTION
This is both for clarity, and to conform with the google c++ style guide.

https://google.github.io/styleguide/cppguide.html#Preprocessor_Macros