### PR TITLE
Replace SCALE macro in NoteField::DrawPrimitives

### DIFF
--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -1061,8 +1061,8 @@ void NoteField::DrawPrimitives()
 	if(*m_FieldRenderArgs.selection_begin_marker != -1 &&
 		*m_FieldRenderArgs.selection_end_marker != -1)
 	{
-		m_FieldRenderArgs.selection_glow= SCALE(
-			std::cos(RageTimer::GetTimeSinceStartFast()*2), -1, 1, 0.1f, 0.3f);
+		float cosValue = std::cos(RageTimer::GetTimeSinceStartFast() * 2);
+		m_FieldRenderArgs.selection_glow = 0.1f + (cosValue + 1.0f) * 0.1f;
 	}
 	m_FieldRenderArgs.fade_before_targets= FADE_BEFORE_TARGETS_PERCENT;
 


### PR DESCRIPTION
https://godbolt.org/z/57Tsz4Ka1

```
SCALE(-0.788179, -1, 1, 0.1, 0.3) as float = 0.121182 | Type: f
inlined by MSVC:0.121182
Simplified function: 0.121182
```


In order to emulate a `RageTimer::GetTimeSinceStartFast()` call, the above test returns the same value  that function would return at 20 minutes, 40 minutes, and 75 minutes of uptime respectively. 