### PR TITLE
Replace SCALE macros in NoteField::DrawBeatBar

### DIFF
--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -432,11 +432,11 @@ void NoteField::DrawBeatBar( const float fBeat, BeatBarType type, int iMeasureIn
 				iState = 1;
 				break;
 			case half_beat:
-				fAlpha = SCALE(fScrollSpeed,1.0f,2.0f,0.0f,m_fBar8thAlpha);
+				fAlpha = (fScrollSpeed - 1.0f) * (m_fBar8thAlpha / 1.0f);
 				iState = 2;
 				break;
 			case quarter_beat:
-				fAlpha = SCALE(fScrollSpeed,2.0f,4.0f,0.0f,m_fBar16thAlpha);
+				fAlpha = (fScrollSpeed - 2.0f) * (m_fBar16thAlpha / 2.0f);
 				iState = 3;
 				break;
 		}


### PR DESCRIPTION
https://godbolt.org/z/W5TToYY7c

ran a few times with a random float values to be sure it's consistent and identical

```
Program returned: 0
Program stdout
today's lucky number: 75.7811
SCALE(4, 1, 2, 0, 75.7811) as float = 227.343 | Type: f
inlined by MSVC:227.343
227.343
```

```
Program returned: 0
Program stdout
today's lucky number: -54.7759
SCALE(4, 1, 2, 0, -54.7759) as float = -164.328 | Type: float
inlined by MSVC:-164.328
-164.328
```
