### PR TITLE
Replace other SCALE macro in NoteField::DrawBeatBar

### DIFF
--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -450,7 +450,7 @@ void NoteField::DrawBeatBar( const float fBeat, BeatBarType type, int iMeasureIn
 	m_sprBeatBars.SetY( fYPos );
 	m_sprBeatBars.SetDiffuse( RageColor(1,1,1,fAlpha) );
 	m_sprBeatBars.SetState( iState );
-	m_sprBeatBars.SetCustomTextureRect( RectF(0,SCALE(iState,0.f,4.f,0.f,1.f), fWidth/fFrameWidth, SCALE(iState+1,0.f,4.f,0.f,1.f)) );
+	m_sprBeatBars.SetCustomTextureRect(RectF(0, iState / 4.0f, fWidth / fFrameWidth, (iState + 1) / 4.0f));
 	m_sprBeatBars.SetZoomX( fWidth/m_sprBeatBars.GetUnzoomedWidth() );
 	m_sprBeatBars.Draw();
 


### PR DESCRIPTION
https://godbolt.org/z/KGY8qe8xh

✅ 

```
today's lucky number: 171
SCALE(171, 0, 4, 0, 1) as float = 42.75 | Type: float
inlined by MSVC:42.75
SCALE(172, 0, 4, 0, 1) as float = 43 | Type: float
inlined by MSVC:43
simplified 1st line 42.75
simplified 2nd line 43
```

```
today's lucky number: 294
SCALE(294, 0, 4, 0, 1) as float = 73.5 | Type: f
inlined by MSVC:73.5
SCALE(295, 0, 4, 0, 1) as float = 73.75 | Type: f
inlined by MSVC:73.75
simplified 1st line 73.5
simplified 2nd line 73.75
```