### PR TITLE
Replace SCALE macro in RageSoundReader_Resample_Good

### DIFF
--- a/src/RageSoundReader_Resample_Good.cpp
+++ b/src/RageSoundReader_Resample_Good.cpp
@@ -648,7 +648,7 @@ RageSoundReader_Resample_Good::~RageSoundReader_Resample_Good()
 int RageSoundReader_Resample_Good::SetPosition( int iFrame )
 {
 	Reset();
-	iFrame = (int) SCALE( iFrame, 0, (int64_t) m_iSampleRate, 0, (int64_t) m_pSource->GetSampleRate() );
+	iFrame = static_cast<int>(iFrame * static_cast<int64_t>(m_pSource->GetSampleRate()) / static_cast<int64_t>(m_iSampleRate));
 	return m_pSource->SetPosition( iFrame );
 }
 


### PR DESCRIPTION
will hold off on adding any more of these for a bit until these get merged.

https://godbolt.org/z/T5x7d8n9n

Note that this function only works up to a frame size of about 2000000000. That would equate to somewhere around 11 to 12 hours of gameplay. I believe it'd explain why sync totally falls off around that point.

```
iFrame = 1814264740
SCALE(1814264740, 0, 48000, 0, 44100) as int = 1666855729 | Type: i
inlined_iFrame = 1666855729
simplified = 1666855729
```