### PR TITLE
Bring Windows thread polling interval down to 1ms from ~10ms

### DIFF
--- a/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
@@ -35,6 +35,9 @@ static void InitTimer()
 	
 	g_bTimerInitialized = true;
 
+	// Set the thread scheduler to let us update every 1ms.
+	timeBeginPeriod(1);
+	
 	// Retrieve the number of ticks per second.
 	QueryPerformanceFrequency(&g_liFrequency);
 }


### PR DESCRIPTION
Thanks to evbo from the ITC discord for pointing out this improvement.  It does take bring the thread polling interval down from every 10ms to every 1ms.


Here was the code I ran from within Archhooks_Win32Static. SHOWVAR is a custom macro I use which shows the file name/value/type of a given variable.

```
int ArchHooks::TestThreadSchedulerDelay()
{
	LARGE_INTEGER before, after, frequency, before2, after2;
	QueryPerformanceFrequency(&frequency);

        // TEST BEFORE SETTING TIMEBEGINPERIOD
	QueryPerformanceCounter(&before);
	Sleep(1);
	QueryPerformanceCounter(&after);
	double before_timeset = (after.QuadPart - before.QuadPart) * 1000.0 / frequency.QuadPart;
	SHOWVAR(before_timeset);

        // SET TIMEBEGINPERIOD
	timeBeginPeriod(1);

        // TEST AFTER SETTING TIMEBEGINPERIOD
	QueryPerformanceCounter(&before2);
	Sleep(1);
	QueryPerformanceCounter(&after2);
	double after_timeset = (after2.QuadPart - before2.QuadPart) * 1000.0 / frequency.QuadPart;
	SHOWVAR(after_timeset);

	return static_cast<int>(after_timeset);
}
```

and the output:
```
ArchHooks_Win32Static: before_timeset = 9.8977 (Type: double)
ArchHooks_Win32Static: after_timeset = 1.6929 (Type: double)
```
