### PR TITLE
Bail out earlier when dealing with certain types of malformed DWI charts.

### DIFF
--- a/src/NotesLoaderDWI.cpp
+++ b/src/NotesLoaderDWI.cpp
@@ -436,7 +436,14 @@ static bool LoadFromDWITokens(
 	const RString &sPath )
 {
 	CHECKPOINT_M( "DWILoader::LoadFromDWITokens()" );
-
+	
+	if (sStepData1.size() < 2 && sStepData2.size() < 2)
+	{
+		// If there's no step data to load for this chart, bail out here, instead of letting
+		// SetNoteData() throw an assertion.
+		LOG->Warn("Song file \"%s\" has malformed chart data for chart %s:%s:%s. Skipping chart.", sPath.c_str(), sMode.c_str(), sDescription.c_str(), sNumFeet.c_str());
+		return false;
+	}
 	out.m_StepsType = GetTypeFromMode(sMode);
 
 	// if the meter is empty, force it to 1.

--- a/src/NotesLoaderDWI.cpp
+++ b/src/NotesLoaderDWI.cpp
@@ -437,10 +437,12 @@ static bool LoadFromDWITokens(
 {
 	CHECKPOINT_M( "DWILoader::LoadFromDWITokens()" );
 	
+	// If there's no step data to load for this chart, bail out here, instead of letting
+	// SetNoteData() throw an assertion.
+	// If the step data isn't at least 2 characters long, ParseNoteData() runs the risk
+	// of trying to read past the end of the string.
 	if (sStepData1.size() < 2 && sStepData2.size() < 2)
 	{
-		// If there's no step data to load for this chart, bail out here, instead of letting
-		// SetNoteData() throw an assertion.
 		LOG->Warn("Song file \"%s\" has malformed chart data for chart %s:%s:%s. Skipping chart.", sPath.c_str(), sMode.c_str(), sDescription.c_str(), sNumFeet.c_str());
 		return false;
 	}


### PR DESCRIPTION
This was an issue noted in the ITC discord: https://discord.com/channels/292111865658474496/1360378823077531749

"PERSEUS (Short Version)" from DDRei TournaMix 5 has bad chart data for one of it's charts, which is causing the game to crash while loading. The crash happens due to changes that were made to `NotesLoaderDWI::ParseNoteData()` last year, where it bails out and returns an empty `NoteData` object after checking whether any steps data exists to parse. Then the assertion in `Steps::SetNoteData()` fails, because the chart data is just well-formed enough for the `Steps` object to know how many tracks it should expect.

I suspect that the bail-out in `NotesLoaderDWI::ParseNoteData()` was added to prevent a different crash, so I figured we might as well just bail out even earlier, since we know that there's no steps data to even try to parse.