### PR TITLE
Prefix some calls with std::

### DIFF
--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -660,7 +660,7 @@ XNode *LuaHelpers::GetLuaInformation()
 	{
 		RString sNamespace;
 		LuaHelpers::Pop( L, sNamespace );
-		if( find(BuiltInPackages, end, sNamespace) != end )
+		if( std::find(BuiltInPackages, end, sNamespace) != end )
 			continue;
 		std::vector<RString> &vNamespaceFunctions = mNamespaces[sNamespace];
 		FOREACH_LUATABLE( L, -1 )

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -2128,7 +2128,7 @@ void SongManager::AddSongToList(Song* new_song)
 	m_pSongs.push_back(new_song);
 	RString dir= new_song->GetSongDir();
 	dir.MakeLower();
-	m_SongsByDir.insert(make_pair(dir, new_song));
+	m_SongsByDir.insert(std::make_pair(dir, new_song));
 }
 
 void SongManager::FreeAllLoadedFromProfile( ProfileSlot slot )

--- a/src/XmlFile.cpp
+++ b/src/XmlFile.cpp
@@ -133,7 +133,7 @@ const XNode *XNode::GetChild( const RString &sName ) const
 XNode *XNode::AppendChild( XNode *node )
 {
 	DEBUG_ASSERT( node->m_sName.size() );
-	m_children_by_name.insert(make_pair(node->m_sName, node));
+	m_children_by_name.insert(std::make_pair(node->m_sName, node));
 	m_childs.push_back( node );
 	return node;
 }
@@ -171,7 +171,7 @@ void XNode::RemoveChildFromByName(XNode* node)
 void XNode::RenameChildInByName(XNode* node)
 {
 	RemoveChildFromByName(node);
-	m_children_by_name.insert(make_pair(node->m_sName, node));
+	m_children_by_name.insert(std::make_pair(node->m_sName, node));
 }
 
 
@@ -192,7 +192,7 @@ bool XNode::RemoveAttr( const RString &sName )
 XNodeValue *XNode::AppendAttrFrom( const RString &sName, XNodeValue *pValue, bool bOverwrite )
 {
 	DEBUG_ASSERT( sName.size() );
-	std::pair<XAttrs::iterator, bool> ret = m_attrs.insert( make_pair(sName, (XNodeValue *) nullptr) );
+	std::pair<XAttrs::iterator, bool> ret = m_attrs.insert( std::make_pair(sName, (XNodeValue *) nullptr) );
 	if( !ret.second ) // already existed
 	{
 		if( bOverwrite )
@@ -214,7 +214,7 @@ XNodeValue *XNode::AppendAttrFrom( const RString &sName, XNodeValue *pValue, boo
 XNodeValue *XNode::AppendAttr( const RString &sName )
 {
 	DEBUG_ASSERT( sName.size() );
-	std::pair<XAttrs::iterator, bool> ret = m_attrs.insert( make_pair(sName, (XNodeValue *) nullptr) );
+	std::pair<XAttrs::iterator, bool> ret = m_attrs.insert( std::make_pair(sName, (XNodeValue *) nullptr) );
 	if( ret.second )
 		ret.first->second = new XNodeStringValue;
 	return ret.first->second; // already existed


### PR DESCRIPTION
These depend on C++ argument dependent name lookup and won't work with an upcoming cleanup.