### PR TITLE
Replace confusing buffer calls in vssprintf

### DIFF
--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -405,8 +405,8 @@ RString vssprintf( const char *szFormat, va_list argList )
 	va_end(tmp);
 
 	RString sRet;
-	std::vsnprintf( sRet.GetBuffer(iNeeded), iNeeded+1, szFormat, argList );
-	sRet.ReleaseBuffer( iNeeded );
+	sRet.resize(iNeeded);
+	std::vsnprintf( &sRet.front(), iNeeded+1, szFormat, argList );
 	return sRet;
 }
 


### PR DESCRIPTION
This is basically just resizing the buffer ahead of the vsnprintf, no need for the extra Release/GetBuffer indirection.