### PR TITLE
New set of RageTimer improvements

### DIFF
--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -69,10 +69,10 @@ uint64_t RageTimer::GetTimeSinceStartMicroseconds()
 
 void RageTimer::Touch()
 {
-	uint64_t usecs = GetTime();
+	const uint64_t usecs = GetTime();
 
-	this->m_secs = uint64_t(usecs / ONE_SECOND_IN_MICROSECONDS_ULL);
-	this->m_us = uint64_t(usecs % ONE_SECOND_IN_MICROSECONDS_ULL);
+	this->m_secs = usecs / ONE_SECOND_IN_MICROSECONDS_ULL;
+	this->m_us = usecs % ONE_SECOND_IN_MICROSECONDS_ULL;
 }
 
 float RageTimer::Ago() const

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -77,16 +77,41 @@ void RageTimer::Touch()
 
 float RageTimer::Ago() const
 {
-	const RageTimer Now;
-	return Now - *this;
+	const uint64_t usecs = GetTime();
+	const uint64_t now_secs = usecs / ONE_SECOND_IN_MICROSECONDS_ULL;
+	const uint64_t now_us = usecs % ONE_SECOND_IN_MICROSECONDS_ULL;
+
+	int64_t secs = now_secs - this->m_secs;
+	int64_t us = now_us - this->m_us;
+
+	if (us < 0)
+	{
+		us += ONE_SECOND_IN_MICROSECONDS_LL;
+		--secs;
+	}
+
+	return static_cast<float>(secs) + static_cast<float>(us) / ONE_SECOND_IN_MICROSECONDS_DBL;
 }
 
 float RageTimer::GetDeltaTime()
 {
-	const RageTimer Now;
-	const float diff = Difference( Now, *this );
-	*this = Now;
-	return diff;
+	const uint64_t usecs = GetTime();
+	const uint64_t now_secs = usecs / ONE_SECOND_IN_MICROSECONDS_ULL;
+	const uint64_t now_us = usecs % ONE_SECOND_IN_MICROSECONDS_ULL;
+
+	int64_t secs = now_secs - this->m_secs;
+	int64_t us = now_us - this->m_us;
+
+	if (us < 0)
+	{
+		us += ONE_SECOND_IN_MICROSECONDS_LL;
+		--secs;
+	}
+
+	this->m_secs = now_secs;
+	this->m_us = now_us;
+
+	return static_cast<float>(secs) + static_cast<float>(us) / ONE_SECOND_IN_MICROSECONDS_DBL;
 }
 
 /* Get a timer representing half of the time ago as this one.  This is	


### PR DESCRIPTION
# Preface

This PR updates the RageTimer methods **Touch()**, **Ago()** and **GetDeltaTime()**. In my testing this is a massive reduction in frame skips (identified via the rendering stats overlay). 

# Why these changes exist

These issues are a primary source of jitter in RageTimer. When you create a new RageTimer object, it has considerable overhead compared to simply defining a pair of uint64_t's. When you make a new RageTimer object, by default it will call Touch() on that RageTimer which incurs a GetTime() call. In many cases, we're wasting a lot of time constructing temporary RageTimers where a simple `this` reference would suffice. Many of these timer measure a very small amount of time (such as the length of an individual button press) so the underlying function calls need to be performant and scalable. 

# Description

The Touch() change is a minor one, but the C-style cast to uint64_t is redundant and unneeded since all data types involved are already type uint64_t. 

The major changes here are to Ago() and GetDeltaTime(). These two functions are almost identical, the only difference being GetDeltaTime() updates the timer to the current time before returning a value whereas Ago() doesn't.

These functions create a temporary RageTimer object for the lifespan of the function, and call a separate function to calculate the difference between the two RageTimer objects. But we can save a lot of time by simply caching the current time locally and splitting that time into the format we need to perform a direct comparison.

The normal float type is plenty acceptable for this, so there's no benefit from calculating as double and casting back to float here.

With these changes, RageTimer::Sum and RageTimer::Difference are only called by the + and - operators, so the logic can be moved directly into the operators.