### PR TITLE
Remove a useless alias from RageTimer

### DIFF
--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -135,7 +135,7 @@ void RageDisplay::ProcessStatsOnFlip()
 	g_iFramesRenderedSinceLastCheck++;
 	g_iFramesRenderedSinceLastReset++;
 
-	if( g_LastCheckTimer.PeekDeltaTime() >= 1.0f )	// update stats every 1 sec.
+	if( g_LastCheckTimer.Ago() >= 1.0f )	// update stats every 1 sec.
 	{
 		float fActualTime = g_LastCheckTimer.GetDeltaTime();
 		g_iNumChecksSinceLastReset++;

--- a/src/RageSoundPosMap.cpp
+++ b/src/RageSoundPosMap.cpp
@@ -158,7 +158,7 @@ int64_t pos_map_queue::Search( int64_t iSourceFrame ) const
 	 * 3. Underflow; we'll be given a larger frame number than we know about.
 	 */
 	static RageTimer last;
-	if( last.PeekDeltaTime() >= 1.0f )
+	if( last.Ago() >= 1.0f )
 	{
 		last.Touch();
 		LOG->Trace("Audio frame (%" PRId64 ") was out of range of the data sent - possible buffer underflow? This is not always an error, however if you see it frequently there could be sound buffer problems.", iSourceFrame);

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -20,8 +20,6 @@ public:
 
 	/* Time between last call to GetDeltaTime() (Ago() + Touch()): */
 	float GetDeltaTime();
-	/* (alias) */
-	float PeekDeltaTime() const { return Ago(); }
 
 	static double GetTimeSinceStart();	// seconds since the program was started
 	static double GetTimeSinceStartFast() { return GetTimeSinceStart(); }

--- a/src/RageUtil_FileDB.cpp
+++ b/src/RageUtil_FileDB.cpp
@@ -317,7 +317,7 @@ FileSet *FilenameDB::GetFileSet( const RString &sDir_, bool bCreate )
 			continue;
 		}
 
-		if( ExpireSeconds == -1 || pFileSet->age.PeekDeltaTime() < ExpireSeconds )
+		if( ExpireSeconds == -1 || pFileSet->age.Ago() < ExpireSeconds )
 		{
 			/* Found it, and it hasn't expired. */
 			return pFileSet;

--- a/src/ScreenMapControllers.cpp
+++ b/src/ScreenMapControllers.cpp
@@ -285,7 +285,7 @@ void ScreenMapControllers::Update( float fDeltaTime )
 
 	if( !m_WaitingForPress.IsZero() && m_DeviceIToMap.IsValid() ) // we're going to map an input
 	{
-		if( m_WaitingForPress.PeekDeltaTime() < g_fSecondsToWaitForInput )
+		if( m_WaitingForPress.Ago() < g_fSecondsToWaitForInput )
 			return; /* keep waiting */
 		m_WaitingForPress.SetZero();
 

--- a/src/ScreenReloadSongs.cpp
+++ b/src/ScreenReloadSongs.cpp
@@ -31,7 +31,7 @@ public:
 	{
 		/* We load songs much faster than we draw frames. Cap the draw rate,
 		 * so we don't slow down the reload. */
-		if( m_LastDraw.PeekDeltaTime() < 1.0f/DrawFrameRate )
+		if( m_LastDraw.Ago() < 1.0f/DrawFrameRate )
 			return;
 		m_LastDraw.GetDeltaTime();
 

--- a/src/ScreenSelect.cpp
+++ b/src/ScreenSelect.cpp
@@ -121,13 +121,13 @@ void ScreenSelect::Update( float fDelta )
 {
 	if( !IsTransitioning() )
 	{
-		if( IDLE_COMMENT_SECONDS > 0  &&  m_timerIdleComment.PeekDeltaTime() >= IDLE_COMMENT_SECONDS )
+		if( IDLE_COMMENT_SECONDS > 0  &&  m_timerIdleComment.Ago() >= IDLE_COMMENT_SECONDS )
 		{
 			SOUND->PlayOnceFromAnnouncer( m_sName+" IdleComment" );
 			m_timerIdleComment.GetDeltaTime();
 		}
 
-		if( IDLE_TIMEOUT_SECONDS > 0  &&  m_timerIdleTimeout.PeekDeltaTime() >= IDLE_TIMEOUT_SECONDS )
+		if( IDLE_TIMEOUT_SECONDS > 0  &&  m_timerIdleTimeout.Ago() >= IDLE_TIMEOUT_SECONDS )
 		{
 			SCREENMAN->SetNewScreen( IDLE_TIMEOUT_SCREEN );
 			m_timerIdleTimeout.GetDeltaTime();

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -395,7 +395,7 @@ void ScreenSelectMusic::Update( float fDeltaTime )
 {
 	if( !IsTransitioning() )
 	{
-		if( IDLE_COMMENT_SECONDS > 0  &&  m_timerIdleComment.PeekDeltaTime() >= IDLE_COMMENT_SECONDS )
+		if( IDLE_COMMENT_SECONDS > 0  &&  m_timerIdleComment.Ago() >= IDLE_COMMENT_SECONDS )
 		{
 			SOUND->PlayOnceFromAnnouncer( m_sName+" IdleComment" );
 			m_timerIdleComment.GetDeltaTime();

--- a/src/ScreenTextEntry.cpp
+++ b/src/ScreenTextEntry.cpp
@@ -196,7 +196,7 @@ void ScreenTextEntry::Update( float fDelta )
 {
 	ScreenWithMenuElements::Update( fDelta );
 
-	if( m_timerToggleCursor.PeekDeltaTime() > 0.25f )
+	if( m_timerToggleCursor.Ago() > 0.25f )
 	{
 		m_timerToggleCursor.Touch();
 		m_bShowAnswerCaret = !m_bShowAnswerCaret;

--- a/src/WheelBase.cpp
+++ b/src/WheelBase.cpp
@@ -231,7 +231,7 @@ void WheelBase::Update( float fDeltaTime )
 		}
 
 		if( PREFSMAN->m_iMusicWheelSwitchSpeed >= MAX_WHEEL_SOUND_SPEED &&
-			m_MovingSoundTimer.PeekDeltaTime() >= 1.0f / MAX_WHEEL_SOUND_SPEED )
+			m_MovingSoundTimer.Ago() >= 1.0f / MAX_WHEEL_SOUND_SPEED )
 		{
 			m_MovingSoundTimer.GetDeltaTime();
 			m_soundChangeMusic.Play(true);


### PR DESCRIPTION
No need for this to exist. It just adds ambiguity (and an avoidable function call).