### PR TITLE
Add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+BasedOnStyle: Google
+AlignAfterOpenBracket: AlwaysBreak
+DerivePointerAlignment: false
+PointerAlignment: Left
+QualifierAlignment: Left
+ReferenceAlignment: Left
+InsertBraces: true


### PR DESCRIPTION
This tells clang-format what kind of style we want to format as, see https://clang.llvm.org/docs/ClangFormatStyleOptions.html.

Set it based on Google style. We can iterate on details in the future.