### PR TITLE
Make Preference implicit conversion operator return a reference

### DIFF
--- a/src/Preference.h
+++ b/src/Preference.h
@@ -120,7 +120,7 @@ public:
 		return m_defaultValue;
 	}
 
-	operator const T () const
+	operator const T &() const
 	{
 		return Get();
 	}


### PR DESCRIPTION
Instead of copying. We can let the caller decide if they want to copy.

Also helps with #756.