### PR TITLE
Potential fix for code scanning alert no. 93: Unsigned difference expression compared to zero

### DIFF
--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -1432,7 +1432,7 @@ void SMLoader::ParseBGChangesString(const RString& _sChanges, std::vector<std::v
 		if (RString::npos == pos)
 			pos = _sChanges.size();
 
-		if (pos - start > 0) {
+		if (pos != start) {
 			if ((start == 0) && (pos == _sChanges.size()))
 				sChanges = _sChanges;
 			else


### PR DESCRIPTION
Potential fix for [https://github.com/itgmania/itgmania/security/code-scanning/93](https://github.com/itgmania/itgmania/security/code-scanning/93)*

To fix the issue, we need to replace the comparison `pos - start > 0` with a clearer and more appropriate expression. Since the intention appears to be checking whether `pos` and `start` are not equal, we can replace `pos - start > 0` with `pos != start`. This avoids the use of subtraction and makes the code more readable and less error-prone.

The changes will be made in the `do-while` loop starting at line 1430 in the file `src/NotesLoaderSM.cpp`. No additional imports, methods, or definitions are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

*this is a code scanning alert on my fork, not sure if it translates here, screenshot below
![image](https://github.com/user-attachments/assets/338c8365-9c55-49ec-9eae-f5b3fa4f3d41)

