### PR TITLE
Use std::pair for RageTimers.

### DIFF
--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -116,7 +116,9 @@ float RageTimer::operator-(const RageTimer &rhs) const
 
 bool RageTimer::operator<( const RageTimer &rhs ) const
 {
-	if (m_time.first != rhs.m_time.first) return m_time.first < rhs.m_time.first;
+	if (m_time.first != rhs.m_time.first) {
+		return m_time.first < rhs.m_time.first;
+	}
 	return m_time.second < rhs.m_time.second;
 }
 

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -71,8 +71,8 @@ void RageTimer::Touch()
 {
 	uint64_t usecs = GetTime();
 
-	this->m_secs = uint64_t(usecs / ONE_SECOND_IN_MICROSECONDS_ULL);
-	this->m_us = uint64_t(usecs % ONE_SECOND_IN_MICROSECONDS_ULL);
+	m_time.first = usecs / ONE_SECOND_IN_MICROSECONDS_ULL; // seconds
+	m_time.second = usecs % ONE_SECOND_IN_MICROSECONDS_ULL; // microseconds
 }
 
 float RageTimer::Ago() const
@@ -116,9 +116,8 @@ float RageTimer::operator-(const RageTimer &rhs) const
 
 bool RageTimer::operator<( const RageTimer &rhs ) const
 {
-	if( m_secs != rhs.m_secs ) return m_secs < rhs.m_secs;
-	return m_us < rhs.m_us;
-
+	if (m_time.first != rhs.m_time.first) return m_time.first < rhs.m_time.first;
+	return m_time.second < rhs.m_time.second;
 }
 
 RageTimer RageTimer::Sum(const RageTimer& lhs, float tm)
@@ -133,14 +132,14 @@ RageTimer RageTimer::Sum(const RageTimer& lhs, float tm)
 	RageTimer ret(0, 0);
 
 	// Calculate the sum of the seconds and microseconds
-	ret.m_secs = seconds + lhs.m_secs;
-	ret.m_us = us + lhs.m_us;
+	ret.m_time.first = seconds + lhs.m_time.first;
+	ret.m_time.second = us + lhs.m_time.second;
 
 	// Adjust the seconds and microseconds if microseconds is greater than or equal to TIMESTAMP_RESOLUTION
-	if (ret.m_us >= ONE_SECOND_IN_MICROSECONDS_ULL)
+	if (ret.m_time.second >= ONE_SECOND_IN_MICROSECONDS_LL)
 	{
-		ret.m_us -= ONE_SECOND_IN_MICROSECONDS_ULL;
-		++ret.m_secs;
+		ret.m_time.second -= ONE_SECOND_IN_MICROSECONDS_LL;
+		++ret.m_time.first;
 	}
 
 	return ret;
@@ -149,8 +148,8 @@ RageTimer RageTimer::Sum(const RageTimer& lhs, float tm)
 double RageTimer::Difference(const RageTimer& lhs, const RageTimer& rhs)
 {
 	// Calculate the difference in seconds and microseconds respectively
-	int64_t secs = lhs.m_secs - rhs.m_secs;
-	int64_t us = lhs.m_us - rhs.m_us;
+	int64_t secs = lhs.m_time.first - rhs.m_time.first;
+	int64_t us = lhs.m_time.second - rhs.m_time.second;
 
 	// Adjust seconds and microseconds if microseconds is negative
 	if ( us < 0 )

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -4,19 +4,28 @@
 #define RAGE_TIMER_H
 
 #include <cstdint>
+#include <utility>
 
 class RageTimer
 {
 public:
-	/* Initialize the m_secs and m_us values to 0 and then fill them with the current time. */
-	RageTimer(): m_secs(0), m_us(0) { Touch(); }
-	RageTimer( int64_t secs, int64_t us ): m_secs(secs), m_us(us) { }
+	/* We store the seconds and microseconds parts of the time in separate 64-bit integers.
+	 * m_time.first refers to the seconds part, and m_time.second refers to the microseconds part. */
+	using RageTimerPair = std::pair<int64_t, int64_t>;
+
+	/* Default & parameterized constructors */
+	RageTimer() {Touch();}
+	RageTimer(int64_t secs, int64_t us) : m_time(secs, us) {}
+
+	/* Getters to protect encapsulation */
+	inline int64_t GetSecs() const { return m_time.first; }
+	inline int64_t GetUs() const { return m_time.second; }
 
 	/* Time ago this RageTimer represents. */
 	float Ago() const;
 	void Touch();
-	inline bool IsZero() const { return m_secs == 0 && m_us == 0; }
-	inline void SetZero() { m_secs = m_us = 0; }
+	inline bool IsZero() const { return m_time.first == 0 && m_time.second == 0; }
+	inline void SetZero() { m_time = { 0, 0 }; }
 
 	/* Time between last call to GetDeltaTime() (Ago() + Touch()): */
 	float GetDeltaTime();
@@ -39,14 +48,9 @@ public:
 	float operator-( const RageTimer &rhs ) const;
 
 	bool operator<( const RageTimer &rhs ) const;
-
-	/* The following is a "time since start" RageTimer. Splitting the seconds and
-	 * microseconds values into two integers and combining them later allows for
-	 * better precision. Use caution when changing data types, since resolution
-	 * mismatch errors are easy to cause when changing things in RageTimer. */
-	uint64_t m_secs, m_us;
-
 private:
+	RageTimerPair m_time;
+
 	static RageTimer Sum( const RageTimer &lhs, float tm );
 	static double Difference( const RageTimer &lhs, const RageTimer &rhs );
 };

--- a/src/arch/Threads/Threads_Pthreads.cpp
+++ b/src/arch/Threads/Threads_Pthreads.cpp
@@ -356,8 +356,8 @@ bool EventImpl_Pthreads::Wait( RageTimer *pTimeout )
 		/* If we support condattr_setclock, we'll set the condition to use
 		 * the same clock as RageTimer and can use it directly. If the
 		 * clock is CLOCK_REALTIME, that's the default anyway. */
-		abstime.tv_sec = pTimeout->m_secs;
-		abstime.tv_nsec = pTimeout->m_us * 1000;
+		abstime.tv_sec = pTimeout->GetSecs();
+		abstime.tv_nsec = pTimeout->GetUs() * 1000;
 	}
 	else
 	{
@@ -370,8 +370,8 @@ bool EventImpl_Pthreads::Wait( RageTimer *pTimeout )
 		float fSecondsInFuture = -pTimeout->Ago();
 		timeofday += fSecondsInFuture;
 
-		abstime.tv_sec = timeofday.m_secs;
-		abstime.tv_nsec = timeofday.m_us * 1000;
+		abstime.tv_sec = timeofday.GetSecs();
+		abstime.tv_nsec = timeofday.GetUs() * 1000;
 	}
 
 	int iRet = pthread_cond_timedwait( &m_Cond, &m_pParent->mutex, &abstime );


### PR DESCRIPTION
# Explanation 

The current implementation of RageTimer stores the time as two distinct public member variables. They are usually accessed via `this->m_secs`/`this->m_us`.

### Problems with this implementation:
 -  The member variables have no linkage/association to each other
 - The member variables are public
 - Comparison by pointer is necessary

By comparison, using `std::pair` is preferred for clarity to the reader as well as the compiler. (It also benefits from having pre-defined operators/destructors/comparitors, integration with stdlib methods, etc, the list goes on)

# Summary of the changes in these commits 

   -   The existing code has m_secs and m_us as separate member variables which is less clear and harder to manage than a `std::pair` to keep both variables joined together.
          - We can also avoid many uses of the `this` pointer within RageTimer thanks to this improvement.
   -    In general this only required calls to `this->m_secs`/`this->m_us` to be replaced with `m_time.first`/`m_time.second`.
   -    Making this change revealed a direct dependency on `m_secs` and `m_us` in `Threads_Pthreads.cpp`. 
           - These calls were replaced with getter methods to keep the member variables safe.

# Testing

This has been tested and preferred consistently by testers since making this change.  

With MSVC, defining the `RageTimerPair` with a using statement and defining `m_time` as `RageTimerPair m_time` is significantly faster than `std::pair<int64_t,int64_t> m_time` without the `using`. 