### PR TITLE
Remove useless alias `GetTimeSinceStartFast()`

### DIFF
--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -328,7 +328,7 @@ void BitmapText::BuildChars()
 
 	if( m_bUsingDistortion )
 	{
-		int iSeed = std::lrint( RageTimer::GetTimeSinceStartFast()*500000.0f );
+		int iSeed = std::lrint( RageTimer::GetTimeSinceStart()*500000.0f );
 		RandomGen rnd( iSeed );
 		for(unsigned int i= 0; i < m_aVertices.size(); i+=4)
 		{
@@ -731,7 +731,7 @@ void BitmapText::DrawPrimitives() noexcept
 		// render the diffuse pass
 		if( m_bRainbowScroll )
 		{
-			int color_index = int(RageTimer::GetTimeSinceStartFast() / 0.200) % RAINBOW_COLORS.size();
+			int color_index = int(RageTimer::GetTimeSinceStart() / 0.200) % RAINBOW_COLORS.size();
 			for (size_t i = 0; i < m_aVertices.size(); i += 4)
 			{
 				const RageColor color = RAINBOW_COLORS[color_index];
@@ -798,7 +798,7 @@ void BitmapText::DrawPrimitives() noexcept
 		std::vector<RageVector3> vGlyphJitter;
 		if( m_bJitter )
 		{
-			int iSeed = std::lrint( RageTimer::GetTimeSinceStartFast()*8 );
+			int iSeed = std::lrint( RageTimer::GetTimeSinceStart()*8 );
 			RandomGen rnd( iSeed );
 			for (size_t i = 0; i < m_aVertices.size(); i += 4)
 			{

--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -1062,7 +1062,7 @@ void NoteField::DrawPrimitives()
 		*m_FieldRenderArgs.selection_end_marker != -1)
 	{
 		m_FieldRenderArgs.selection_glow= SCALE(
-			std::cos(RageTimer::GetTimeSinceStartFast()*2), -1, 1, 0.1f, 0.3f);
+			std::cos(RageTimer::GetTimeSinceStart()*2), -1, 1, 0.1f, 0.3f);
 	}
 	m_FieldRenderArgs.fade_before_targets= FADE_BEFORE_TARGETS_PERCENT;
 

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -164,7 +164,7 @@ double RageTimer::Difference(const RageTimer& lhs, const RageTimer& rhs)
 }
 
 #include "LuaManager.h"
-LuaFunction(GetTimeSinceStart, RageTimer::GetTimeSinceStartFast())
+LuaFunction(GetTimeSinceStart, RageTimer::GetTimeSinceStart())
 
 /*
  * Copyright (c) 2001-2003 Chris Danford, Glenn Maynard

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -22,7 +22,6 @@ public:
 	float GetDeltaTime();
 
 	static double GetTimeSinceStart();	// seconds since the program was started
-	static double GetTimeSinceStartFast() { return GetTimeSinceStart(); }
 	static int GetTimeSinceStartSeconds(); 	// This is used where GetTimeSinceStart would be cast to an int without rounding.
 	static uint64_t GetTimeSinceStartMicroseconds();
 

--- a/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
+++ b/src/arch/LowLevelWindow/LowLevelWindow_X11.cpp
@@ -627,7 +627,7 @@ void LowLevelWindow_X11::SwapBuffers()
 		 * it's already active.
 		 */
 
-		auto now = RageTimer::GetTimeSinceStartFast();
+		auto now = RageTimer::GetTimeSinceStart();
 		if( (now - m_lastScreensaverInterrupt) > m_screensaverInterruptInterval ) {
 		  m_lastScreensaverInterrupt = now;
 		  XLockDisplay( Dpy );


### PR DESCRIPTION
This used to be a different function than GetTimeSinceStart which returned a lower precision value but we don't do that anymore.

 - I noted the usage of GetTimeSinceStart in `src/arch/LowLevelWindow/LowLevelWindow_X11.cpp` may be appropriate to change to a `GetTimeSinceStartSeconds()` call. not changing it here though, just wanted to mention it