### PR TITLE
Make helper functions for `BitmapText::AddAttribute` to improve its runtime by 1.5-2x

### DIFF
--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -918,14 +918,20 @@ std::pair<size_t, size_t> BitmapText::FixupLengthForNewLines(size_t adjustedPos,
 	for( ; lineIter != m_wTextLines.cend(); ++lineIter )
 	{
 		size_t lineLength = lineIter->length() + 1; // +1 to account for implicit newline at the end
+int BitmapText::FixupLengthForNewLines(size_t adjustedPos, int inputLength) const {
+	std::vector<std::wstring>::const_iterator lineIter = m_wTextLines.cbegin();
+	size_t adjustedEndPos = adjustedPos + static_cast<size_t>(inputLength);
+
+	for (; lineIter != m_wTextLines.cend(); ++lineIter) {
+		size_t lineLength = CalculateLineLength(*lineIter);
 		if (lineLength > adjustedEndPos || lineLength == 0) {
 			break;
 		}
-		adjustedEndPos -= lineLength;
+		adjustedEndPos = AdjustPositionByLineLength(adjustedEndPos, lineLength);
 		inputLength -= 1;
 	}
 
-	return { adjustedEndPos, inputLength };
+	return inputLength;
 }
 
 std::pair<size_t, int> BitmapText::AdjustPositionForNewLines(size_t inputPosition) const {

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -935,20 +935,22 @@ int BitmapText::FixupLengthForNewLines(size_t adjustedPos, int inputLength) cons
 }
 
 std::pair<size_t, int> BitmapText::AdjustPositionForNewLines(size_t inputPosition) const {
-	auto lineIter = m_wTextLines.cbegin();
-	int lineCount = 0;
-	size_t adjustedPosition = inputPosition;
+	std::vector<std::wstring>::const_iterator lineIter = m_wTextLines.cbegin();
+
+	// The first value of the pair is the adjusted position.
+	// The second value of the pair is the line count.
+	std::pair<size_t, int> resultPair = std::make_pair(inputPosition, 0);
 
 	for (; lineIter != m_wTextLines.cend(); ++lineIter) {
-		size_t lineLength = lineIter->length() + 1; // +1 to account for implicit newline at the end
-		if (lineLength > adjustedPosition) {
+		size_t lineLength = CalculateLineLength(*lineIter);
+		if (lineLength > resultPair.first) {
 			break;
 		}
-		adjustedPosition -= lineLength;
-		++lineCount;
+		resultPair.first = AdjustPositionByLineLength(resultPair.first, lineLength);
+		++resultPair.second;
 	}
 
-	return std::make_pair(adjustedPosition, lineCount);
+	return resultPair;
 }
 
 void BitmapText::AddAttribute( size_t iPos, const Attribute &attr )

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -913,7 +913,7 @@ BitmapText::Attribute BitmapText::GetDefaultAttribute() const
 
 static size_t CalculateLineLength(const std::wstring& line)
 {
-	return line.length() + 1; // +1 to account for implicit newline
+	return line.length() + 1ULL; // +1 to account for implicit newline
 }
 
 static size_t AdjustPositionByLineLength(size_t position, size_t lineLength)

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -911,36 +911,50 @@ BitmapText::Attribute BitmapText::GetDefaultAttribute() const
 	return attr;
 }
 
+std::pair<size_t, size_t> BitmapText::FixupLengthForNewLines(size_t adjustedPos, size_t inputLength) const {
+	auto lineIter = m_wTextLines.cbegin();
+	size_t adjustedEndPos = adjustedPos + inputLength;
+
+	for( ; lineIter != m_wTextLines.cend(); ++lineIter )
+	{
+		size_t lineLength = lineIter->length() + 1; // +1 to account for implicit newline at the end
+		if (lineLength > adjustedEndPos || lineLength == 0) {
+			break;
+		}
+		adjustedEndPos -= lineLength;
+		inputLength -= 1;
+	}
+
+	return { adjustedEndPos, inputLength };
+}
+
+std::pair<size_t, int> BitmapText::AdjustPositionForNewLines(size_t inputPosition) const {
+	auto lineIter = m_wTextLines.cbegin();
+	int lineCount = 0;
+	size_t adjustedPosition = inputPosition;
+
+	for (; lineIter != m_wTextLines.cend(); ++lineIter) {
+		size_t lineLength = lineIter->length() + 1; // +1 to account for implicit newline at the end
+		if (lineLength > adjustedPosition) {
+			break;
+		}
+		adjustedPosition -= lineLength;
+		++lineCount;
+	}
+
+	return std::make_pair(adjustedPosition, lineCount);
+}
+
 void BitmapText::AddAttribute( size_t iPos, const Attribute &attr )
 {
 	// Fixup position for new lines.
 	Attribute newAttr = attr;
-	auto lineIter = m_wTextLines.cbegin();
+	const auto [iAdjustedPos, iLines] = AdjustPositionForNewLines(iPos);
 
-	int iLines = 0;
-	size_t iAdjustedPos = iPos;
-
-	for( ; lineIter != m_wTextLines.cend(); ++lineIter )
-	{
-		size_t length = lineIter->length() + 1; // +1 to account for implicit newline at the end
-		if( length > iAdjustedPos )
-			break;
-		iAdjustedPos -= length;
-		++iLines;
-	}
-
-	if( newAttr.length > 0 )
-	{
+	if (newAttr.length > 0)	{
 		// Fixup length for new lines.
-		size_t iAdjustedEndPos = iAdjustedPos + newAttr.length;
-		for( ; lineIter != m_wTextLines.cend(); ++lineIter )
-		{
-			size_t length = lineIter->length() + 1; // +1 to account for implicit newline at the end
-			if( length > iAdjustedEndPos || newAttr.length == 0 )
-				break;
-			iAdjustedEndPos -= length;
-			newAttr.length -= 1;
-		}
+		const auto [iAdjustedEndPos, remainingLength] = FixupLengthForNewLines(iAdjustedPos, newAttr.length);
+		newAttr.length = remainingLength;
 	}
 
 	if( newAttr.length == 0 ) // Attribute doesn't cover any printable characters

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -963,19 +963,19 @@ void BitmapText::AddAttribute( size_t iPos, const Attribute &attr )
 
 	// The first value of the pair is the adjusted position.
 	// The second value of the pair is the line count.
-	std::pair<size_t, int> resultPair = AdjustPositionForNewLines(iPos);
+	std::pair<size_t, int> adjustedPositions = AdjustPositionForNewLines(iPos);
 
 	if (newAttr.length > 0)	{
 		// Fixup length for new lines.
 		const int oldAttrLength = newAttr.length;
-		newAttr.length = FixupLengthForNewLines(resultPair.first, oldAttrLength);
+		newAttr.length = FixupLengthForNewLines(adjustedPositions.first, oldAttrLength);
 	}
 
 	if( newAttr.length == 0 ) // Attribute doesn't cover any printable characters
 		return;
 
 	// Check if there are existing attributes overlapping this one. We might need to remove or fix them up.
-	const size_t iStartPos = iPos - resultPair.second;
+	const size_t iStartPos = iPos - adjustedPositions.second;
 	const size_t iEndPos = iStartPos + newAttr.length;
 
 	// First attribute starting at the same position or further than the new attribute

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -911,9 +911,6 @@ BitmapText::Attribute BitmapText::GetDefaultAttribute() const
 	return attr;
 }
 
-std::pair<size_t, size_t> BitmapText::FixupLengthForNewLines(size_t adjustedPos, size_t inputLength) const {
-	auto lineIter = m_wTextLines.cbegin();
-	size_t adjustedEndPos = adjustedPos + inputLength;
 static size_t CalculateLineLength(const std::wstring& line)
 {
 	return line.length() + 1; // +1 to account for implicit newline
@@ -924,9 +921,6 @@ static size_t AdjustPositionByLineLength(size_t position, size_t lineLength)
 	return position > lineLength ? position - lineLength : 0;
 }
 
-	for( ; lineIter != m_wTextLines.cend(); ++lineIter )
-	{
-		size_t lineLength = lineIter->length() + 1; // +1 to account for implicit newline at the end
 int BitmapText::FixupLengthForNewLines(size_t adjustedPos, int inputLength) const {
 	std::vector<std::wstring>::const_iterator lineIter = m_wTextLines.cbegin();
 	size_t adjustedEndPos = adjustedPos + static_cast<size_t>(inputLength);

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -966,12 +966,14 @@ void BitmapText::AddAttribute( size_t iPos, const Attribute &attr )
 {
 	// Fixup position for new lines.
 	Attribute newAttr = attr;
-	const auto [iAdjustedPos, iLines] = AdjustPositionForNewLines(iPos);
+	std::pair<size_t, int> resultPair = AdjustPositionForNewLines(iPos);
+	size_t iAdjustedEndPos = resultPair.first; // Adjusted position
+	int iLines = resultPair.second; // Number of lines
 
 	if (newAttr.length > 0)	{
 		// Fixup length for new lines.
-		const auto [iAdjustedEndPos, remainingLength] = FixupLengthForNewLines(iAdjustedPos, newAttr.length);
-		newAttr.length = remainingLength;
+		const int oldAttrLength = newAttr.length;
+		newAttr.length = FixupLengthForNewLines(iAdjustedEndPos, oldAttrLength);
 	}
 
 	if( newAttr.length == 0 ) // Attribute doesn't cover any printable characters

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -960,21 +960,22 @@ void BitmapText::AddAttribute( size_t iPos, const Attribute &attr )
 {
 	// Fixup position for new lines.
 	Attribute newAttr = attr;
+
+	// The first value of the pair is the adjusted position.
+	// The second value of the pair is the line count.
 	std::pair<size_t, int> resultPair = AdjustPositionForNewLines(iPos);
-	size_t iAdjustedEndPos = resultPair.first; // Adjusted position
-	int iLines = resultPair.second; // Number of lines
 
 	if (newAttr.length > 0)	{
 		// Fixup length for new lines.
 		const int oldAttrLength = newAttr.length;
-		newAttr.length = FixupLengthForNewLines(iAdjustedEndPos, oldAttrLength);
+		newAttr.length = FixupLengthForNewLines(resultPair.first, oldAttrLength);
 	}
 
 	if( newAttr.length == 0 ) // Attribute doesn't cover any printable characters
 		return;
 
 	// Check if there are existing attributes overlapping this one. We might need to remove or fix them up.
-	const size_t iStartPos = iPos - iLines;
+	const size_t iStartPos = iPos - resultPair.second;
 	const size_t iEndPos = iStartPos + newAttr.length;
 
 	// First attribute starting at the same position or further than the new attribute

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -914,6 +914,15 @@ BitmapText::Attribute BitmapText::GetDefaultAttribute() const
 std::pair<size_t, size_t> BitmapText::FixupLengthForNewLines(size_t adjustedPos, size_t inputLength) const {
 	auto lineIter = m_wTextLines.cbegin();
 	size_t adjustedEndPos = adjustedPos + inputLength;
+static size_t CalculateLineLength(const std::wstring& line)
+{
+	return line.length() + 1; // +1 to account for implicit newline
+}
+
+static size_t AdjustPositionByLineLength(size_t position, size_t lineLength)
+{
+	return position > lineLength ? position - lineLength : 0;
+}
 
 	for( ; lineIter != m_wTextLines.cend(); ++lineIter )
 	{

--- a/src/BitmapText.h
+++ b/src/BitmapText.h
@@ -137,7 +137,7 @@ protected:
 	bool								m_bHasGlowAttribute;
 
 	std::pair<size_t, int> AdjustPositionForNewLines(size_t iPos) const;
-	std::pair<size_t, size_t> FixupLengthForNewLines(size_t iAdjustedPos, size_t length) const;
+	int FixupLengthForNewLines(size_t iAdjustedPos, int length) const;
 
 	TextGlowMode	m_TextGlowMode;
 

--- a/src/BitmapText.h
+++ b/src/BitmapText.h
@@ -136,6 +136,9 @@ protected:
 	std::map<size_t, Attribute>	m_mAttributes;
 	bool								m_bHasGlowAttribute;
 
+	std::pair<size_t, int> AdjustPositionForNewLines(size_t iPos) const;
+	std::pair<size_t, size_t> FixupLengthForNewLines(size_t iAdjustedPos, size_t length) const;
+
 	TextGlowMode	m_TextGlowMode;
 
 	// recalculate the items in SetText()


### PR DESCRIPTION
# Context

PR's "Fix coloring of BitmapText with overlapping attributes #206" and "Fix coloring of multiline BitmapText #183" did a good job of fixing the issue, but the compiler has a hard time optimizing AddAttribute since it has to do so many different jobs, and as a result the function is much slower than it used to be.

# Solution

This very long function is broken down into smaller parts that are more maintainable and can be better optimized by the compiler.

No functionality was changed at all. Just some parts of the function were moved out into helper functions, that's all.

This change decreases function runtime of `AddAttribute()` by 50-70%, making it around 1.5 to 2 times faster, and changes no functionality.

## Alternate visualization

The diff is not super easy to read, since it's mostly rearranged code.
The following links will take you the beginning of the relevant section.

Existing (release 1.0.2): https://github.com/itgmania/itgmania/blob/427484d1007c92c78753e86a39ed6399fed92f10/src/BitmapText.cpp#L914

Proposed: https://github.com/itgmania/itgmania/blob/de3018fbff22cbc916a058304cfc5321f4aa2886/src/BitmapText.cpp#L914


_This is PR is a duplicate of #673 which has been rebased onto the current beta._

