### PR TITLE
Fix for code scanning: Multiplication result converted to larger type

### DIFF
--- a/src/RageSurface_Load_XPM.cpp
+++ b/src/RageSurface_Load_XPM.cpp
@@ -96,7 +96,7 @@ RageSurface *RageSurface_Load_XPM( char * const *xpm, RString &error )
 		int32_t *p32 = (int32_t *) p;
 		for( int x = 0; x < width; ++x )
 		{
-			RString color_name = row.substr( x*color_length, color_length );
+			RString color_name = row.substr( static_cast<size_t>(x) * color_length, color_length );
 			std::map<RString, int>::const_iterator it;
 			it = name_to_color.find( color_name );
 			if( it == name_to_color.end() )


### PR DESCRIPTION
Potential fix for [https://github.com/itgmania/itgmania/security/code-scanning/60](https://github.com/itgmania/itgmania/security/code-scanning/60)

To fix the issue, we need to ensure that the multiplication `x * color_length` is performed in a larger integer type (e.g., `size_t`) to prevent overflow. This can be achieved by explicitly casting one of the operands (`x` or `color_length`) to `size_t` before the multiplication. This ensures that the multiplication is performed in the larger type, avoiding overflow.

The specific change will be made on line 99, where the multiplication occurs. We will cast `x` to `size_t` before multiplying it with `color_length`. This change does not alter the functionality of the code but ensures that the operation is safe from overflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
