### PR TITLE
Remove implicit conversion operator from RString to const char*

### DIFF
--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -1943,7 +1943,7 @@ public:
 	static int GetHAlign( T* p, lua_State *L )	{ lua_pushnumber( L, p->GetHorizAlign() ); return 1; }
 	static int GetVAlign( T* p, lua_State *L )	{ lua_pushnumber( L, p->GetVertAlign() ); return 1; }
 
-	static int GetName( T* p, lua_State *L )		{ lua_pushstring( L, p->GetName() ); return 1; }
+	static int GetName( T* p, lua_State *L )		{ lua_pushstring( L, p->GetName().c_str() ); return 1; }
 	static int GetParent( T* p, lua_State *L )
 	{
 		Actor *pParent = p->GetParent();

--- a/src/AdjustSync.cpp
+++ b/src/AdjustSync.cpp
@@ -321,7 +321,7 @@ void AdjustSync::GetSyncChangeTextGlobal( std::vector<RString> &vsAddTo )
 		if( std::abs(fDelta) > 0.0001f )
 		{
 			vsAddTo.push_back( ssprintf(
-				GLOBAL_OFFSET_FROM.GetValue(),
+				GLOBAL_OFFSET_FROM.GetValue().c_str(),
 				fOld, fNew,
 				(fDelta > 0 ? EARLIER:LATER).GetValue().c_str() ));
 		}
@@ -351,7 +351,7 @@ void AdjustSync::GetSyncChangeTextSong( std::vector<RString> &vsAddTo )
 			if( std::abs(fDelta) > 0.0001f )
 			{
 				vsAddTo.push_back( ssprintf(
-					SONG_OFFSET_FROM.GetValue(),
+					SONG_OFFSET_FROM.GetValue().c_str(),
 					fOld,
 					fNew,
 					(fDelta > 0 ? EARLIER:LATER).GetValue().c_str() ) );
@@ -375,7 +375,7 @@ void AdjustSync::GetSyncChangeTextSong( std::vector<RString> &vsAddTo )
 				break;
 			}
 
-			RString s = ssprintf( TEMPO_SEGMENT_FROM.GetValue(),
+			RString s = ssprintf( TEMPO_SEGMENT_FROM.GetValue().c_str(),
 					FormatNumberAndSuffix(i+1).c_str(), fOld, fNew );
 
 			vsAddTo.push_back( s );
@@ -400,7 +400,7 @@ void AdjustSync::GetSyncChangeTextSong( std::vector<RString> &vsAddTo )
 				break;
 			}
 
-			RString s = ssprintf( CHANGED_STOP.GetValue(), i+1, fOld, fNew, fDelta );
+			RString s = ssprintf( CHANGED_STOP.GetValue().c_str(), i+1, fOld, fNew, fDelta );
 			vsAddTo.push_back( s );
 		}
 
@@ -426,18 +426,18 @@ void AdjustSync::GetSyncChangeTextSong( std::vector<RString> &vsAddTo )
 				break;
 			}
 
-			RString s = ssprintf( CHANGED_STOP.GetValue(),
+			RString s = ssprintf( CHANGED_STOP.GetValue().c_str(),
 				i+1, fOld, fNew, fDelta );
 			vsAddTo.push_back( s );
 		}
 
 		if( vsAddTo.size() > iOriginalSize && s_fAverageError > 0.0f )
 		{
-			vsAddTo.push_back( ssprintf(ERROR.GetValue(), s_fAverageError) );
+			vsAddTo.push_back( ssprintf(ERROR.GetValue().c_str(), s_fAverageError) );
 		}
 		if( vsAddTo.size() > iOriginalSize && s_iStepsFiltered > 0 )
 		{
-			vsAddTo.push_back( ssprintf(TAPS_IGNORED.GetValue(), s_iStepsFiltered) );
+			vsAddTo.push_back( ssprintf(TAPS_IGNORED.GetValue().c_str(), s_iStepsFiltered) );
 		}
 #undef SEGMENTS_MISMATCH_MESSAGE
 	}

--- a/src/AnnouncerManager.cpp
+++ b/src/AnnouncerManager.cpp
@@ -41,7 +41,7 @@ void AnnouncerManager::GetAnnouncerNames( std::vector<RString>& AddTo )
 
 	// strip out the empty announcer folder
 	for( int i=AddTo.size()-1; i>=0; i-- )
-		if( !strcasecmp( AddTo[i], EMPTY_ANNOUNCER_NAME ) )
+		if( !strcasecmp( AddTo[i].c_str(), EMPTY_ANNOUNCER_NAME.c_str() ) )
 			AddTo.erase(AddTo.begin()+i, AddTo.begin()+i+1 );
 }
 
@@ -53,7 +53,7 @@ bool AnnouncerManager::DoesAnnouncerExist( RString sAnnouncerName )
 	std::vector<RString> asAnnouncerNames;
 	GetAnnouncerNames( asAnnouncerNames );
 	for( unsigned i=0; i<asAnnouncerNames.size(); i++ )
-		if( 0==strcasecmp(sAnnouncerName, asAnnouncerNames[i]) )
+		if( 0==strcasecmp(sAnnouncerName.c_str(), asAnnouncerNames[i].c_str()) )
 			return true;
 	return false;
 }
@@ -203,7 +203,7 @@ public:
 		}
 		else
 		{
-			lua_pushstring(L, s );
+			lua_pushstring(L, s.c_str() );
 		}
 		return 1;
 	}

--- a/src/BGAnimation.cpp
+++ b/src/BGAnimation.cpp
@@ -27,9 +27,9 @@ static bool CompareLayerNames( const RString& s1, const RString& s2 )
 	int i1, i2;
 	int ret;
 
-	ret = sscanf( s1, "Layer%d", &i1 );
+	ret = sscanf( s1.c_str(), "Layer%d", &i1 );
 	ASSERT( ret == 1 );
-	ret = sscanf( s2, "Layer%d", &i2 );
+	ret = sscanf( s2.c_str(), "Layer%d", &i2 );
 	ASSERT( ret == 1 );
 	return i1 < i2;
 }
@@ -42,7 +42,7 @@ void BGAnimation::AddLayersFromAniDir( const RString &_sAniDir, const XNode *pNo
 		std::vector<RString> vsLayerNames;
 		FOREACH_CONST_Child( pNode, pLayer )
 		{
-			if( strncmp(pLayer->GetName(), "Layer", 5) == 0 )
+			if( strncmp(pLayer->GetName().c_str(), "Layer", 5) == 0 )
 				vsLayerNames.push_back( pLayer->GetName() );
 		}
 

--- a/src/BPMDisplay.cpp
+++ b/src/BPMDisplay.cpp
@@ -82,9 +82,9 @@ void BPMDisplay::Update( float fDeltaTime )
 		{
 			m_fBPMFrom = -1;
 			if( (bool)SHOW_QMARKS )
-				SetText( (RandomFloat(0,1)>0.90f) ? (RString)QUESTIONMARKS_TEXT : ssprintf((RString)BPM_FORMAT_STRING,RandomFloat(0,999)) );
+				SetText( (RandomFloat(0,1)>0.90f) ? (RString)QUESTIONMARKS_TEXT : ssprintf(((RString)BPM_FORMAT_STRING).c_str(),RandomFloat(0,999)) );
 			else
-				SetText( ssprintf((RString)BPM_FORMAT_STRING, RandomFloat(0,999)) );
+				SetText( ssprintf(((RString)BPM_FORMAT_STRING).c_str(), RandomFloat(0,999)) );
 		}
 		else if(m_fBPMFrom == -1)
 		{
@@ -95,7 +95,7 @@ void BPMDisplay::Update( float fDeltaTime )
 	if( m_fBPMTo != -1)
 	{
 		const float fActualBPM = GetActiveBPM();
-		SetText( ssprintf((RString)BPM_FORMAT_STRING, fActualBPM) );
+		SetText( ssprintf(((RString)BPM_FORMAT_STRING).c_str(), fActualBPM) );
 	}
 }
 
@@ -341,7 +341,7 @@ public:
 		}
 		COMMON_RETURN_SELF;
 	}
-	static int GetText( T* p, lua_State *L )		{ lua_pushstring( L, p->GetText() ); return 1; }
+	static int GetText( T* p, lua_State *L )		{ lua_pushstring( L, p->GetText().c_str() ); return 1; }
 
 	LunaBPMDisplay()
 	{

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -1087,7 +1087,7 @@ public:
 	static int distort( T* p, lua_State *L) { p->SetDistortion( FArg(1) ); COMMON_RETURN_SELF; }
 	static int undistort( T* p, lua_State *L) { p->UnSetDistortion(); COMMON_RETURN_SELF; }
 	GETTER_SETTER_BOOL_METHOD(mult_attrs_with_diffuse);
-	static int GetText( T* p, lua_State *L )		{ lua_pushstring( L, p->GetText() ); return 1; }
+	static int GetText( T* p, lua_State *L )		{ lua_pushstring( L, p->GetText().c_str() ); return 1; }
 	static int AddAttribute( T* p, lua_State *L )
 	{
 		size_t iPos = IArg(1);

--- a/src/Character.cpp
+++ b/src/Character.cpp
@@ -213,17 +213,17 @@ void Character::UndemandGraphics()
 class LunaCharacter: public Luna<Character>
 {
 public:
-	static int GetCardPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetCardPath() ); return 1; }
-	static int GetIconPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetIconPath() ); return 1; }
-	static int GetSongSelectIconPath( T* p, lua_State *L )	{ lua_pushstring(L, p->GetSongSelectIconPath() ); return 1; }
-	static int GetStageIconPath( T* p, lua_State *L )		{ lua_pushstring(L, p->GetStageIconPath() ); return 1; }
-	static int GetModelPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetModelPath() ); return 1; }
-	static int GetRestAnimationPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetRestAnimationPath() ); return 1; }
-	static int GetWarmUpAnimationPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetWarmUpAnimationPath() ); return 1; }
-	static int GetDanceAnimationPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetDanceAnimationPath() ); return 1; }
-	static int GetCharacterDir( T* p, lua_State *L )			{ lua_pushstring(L, p->m_sCharDir ); return 1; }
-	static int GetCharacterID( T* p, lua_State *L )			{ lua_pushstring(L, p->m_sCharacterID ); return 1; }
-	static int GetDisplayName( T* p, lua_State *L )			{ lua_pushstring(L, p->GetDisplayName() ); return 1; }
+	static int GetCardPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetCardPath().c_str() ); return 1; }
+	static int GetIconPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetIconPath().c_str() ); return 1; }
+	static int GetSongSelectIconPath( T* p, lua_State *L )	{ lua_pushstring(L, p->GetSongSelectIconPath().c_str() ); return 1; }
+	static int GetStageIconPath( T* p, lua_State *L )		{ lua_pushstring(L, p->GetStageIconPath().c_str() ); return 1; }
+	static int GetModelPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetModelPath().c_str() ); return 1; }
+	static int GetRestAnimationPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetRestAnimationPath().c_str() ); return 1; }
+	static int GetWarmUpAnimationPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetWarmUpAnimationPath().c_str() ); return 1; }
+	static int GetDanceAnimationPath( T* p, lua_State *L )			{ lua_pushstring(L, p->GetDanceAnimationPath().c_str() ); return 1; }
+	static int GetCharacterDir( T* p, lua_State *L )			{ lua_pushstring(L, p->m_sCharDir.c_str() ); return 1; }
+	static int GetCharacterID( T* p, lua_State *L )			{ lua_pushstring(L, p->m_sCharacterID.c_str() ); return 1; }
+	static int GetDisplayName( T* p, lua_State *L )			{ lua_pushstring(L, p->GetDisplayName().c_str() ); return 1; }
 
 	LunaCharacter()
 	{

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -1310,8 +1310,8 @@ class LunaCourse: public Luna<Course>
 {
 public:
 	DEFINE_METHOD( GetPlayMode, GetPlayMode() )
-	static int GetDisplayFullTitle( T* p, lua_State *L )	{ lua_pushstring(L, p->GetDisplayFullTitle() ); return 1; }
-	static int GetTranslitFullTitle( T* p, lua_State *L )	{ lua_pushstring(L, p->GetTranslitFullTitle() ); return 1; }
+	static int GetDisplayFullTitle( T* p, lua_State *L )	{ lua_pushstring(L, p->GetDisplayFullTitle().c_str() ); return 1; }
+	static int GetTranslitFullTitle( T* p, lua_State *L )	{ lua_pushstring(L, p->GetTranslitFullTitle().c_str() ); return 1; }
 	static int HasMods( T* p, lua_State *L )		{ lua_pushboolean(L, p->HasMods() ); return 1; }
 	static int HasTimedMods( T* p, lua_State *L )		{ lua_pushboolean( L, p->HasTimedMods() ); return 1; }
 	DEFINE_METHOD( GetCourseType, GetCourseType() )
@@ -1352,12 +1352,12 @@ public:
 	}
 	static int GetBannerPath( T* p, lua_State *L )		{ RString s = p->GetBannerPath(); if( s.empty() ) return 0; LuaHelpers::Push(L, s); return 1; }
 	static int GetBackgroundPath( T* p, lua_State *L )		{ RString s = p->GetBackgroundPath(); if( s.empty() ) return 0; LuaHelpers::Push(L, s); return 1; }
-	static int GetCourseDir( T* p, lua_State *L )			{ lua_pushstring(L, p->m_sPath ); return 1; }
-	static int GetGroupName( T* p, lua_State *L )		{ lua_pushstring(L, p->m_sGroupName ); return 1; }
+	static int GetCourseDir( T* p, lua_State *L )			{ lua_pushstring(L, p->m_sPath.c_str() ); return 1; }
+	static int GetGroupName( T* p, lua_State *L )		{ lua_pushstring(L, p->m_sGroupName.c_str() ); return 1; }
 	static int IsAutogen( T* p, lua_State *L )		{ lua_pushboolean(L, p->m_bIsAutogen ); return 1; }
 	static int GetEstimatedNumStages( T* p, lua_State *L )	{ lua_pushnumber(L, p->GetEstimatedNumStages() ); return 1; }
-	static int GetScripter( T* p, lua_State *L )		{ lua_pushstring(L, p->m_sScripter ); return 1; }
-	static int GetDescription( T* p, lua_State *L )		{ lua_pushstring(L, p->m_sDescription ); return 1; }
+	static int GetScripter( T* p, lua_State *L )		{ lua_pushstring(L, p->m_sScripter.c_str() ); return 1; }
+	static int GetDescription( T* p, lua_State *L )		{ lua_pushstring(L, p->m_sDescription.c_str() ); return 1; }
 	static int GetTotalSeconds( T* p, lua_State *L )
 	{
 		StepsType st = Enum::Check<StepsType>(L, 1);

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -503,7 +503,7 @@ bool CourseLoaderCRS::ParseCourseSong( const MsdFile::value_t &sParams, CourseEn
 
 	if( new_entry.stepsCriteria.m_difficulty == Difficulty_Invalid )
 	{
-		int retval = sscanf( sParams[2], "%d..%d", &new_entry.stepsCriteria.m_iLowMeter, &new_entry.stepsCriteria.m_iHighMeter );
+		int retval = sscanf( sParams[2].c_str(), "%d..%d", &new_entry.stepsCriteria.m_iLowMeter, &new_entry.stepsCriteria.m_iHighMeter );
 		if( retval == 1 )
 			new_entry.stepsCriteria.m_iHighMeter = new_entry.stepsCriteria.m_iLowMeter;
 		else if( retval != 2 )

--- a/src/CourseUtil.cpp
+++ b/src/CourseUtil.cpp
@@ -425,9 +425,9 @@ bool EditCourseUtil::ValidateEditCourseName( const RString &sAnswer, RString &sE
 	}
 
 	static const RString sInvalidChars = "\\/:*?\"<>|";
-	if( strpbrk(sAnswer, sInvalidChars) != nullptr )
+	if( strpbrk(sAnswer.c_str(), sInvalidChars.c_str()) != nullptr )
 	{
-		sErrorOut = ssprintf( EDIT_NAME_CANNOT_CONTAIN.GetValue(), sInvalidChars.c_str() );
+		sErrorOut = ssprintf( EDIT_NAME_CANNOT_CONTAIN.GetValue().c_str(), sInvalidChars.c_str() );
 		return false;
 	}
 

--- a/src/CreateZip.cpp
+++ b/src/CreateZip.cpp
@@ -1009,12 +1009,12 @@ RString MakeDestZipFileName( RString fn )
 }
 bool CreateZip::AddFile(RString fn)
 {
-	lasterrorZ = hz->Add(MakeDestZipFileName(fn),fn,ZIP_FILENAME);
+	lasterrorZ = hz->Add(MakeDestZipFileName(fn).c_str(),fn.c_str(),ZIP_FILENAME);
 	return lasterrorZ == ZR_OK;
 }
 bool CreateZip::AddDir(RString fn)
 {
-	lasterrorZ = hz->Add(MakeDestZipFileName(fn),nullptr,ZIP_FOLDER);
+	lasterrorZ = hz->Add(MakeDestZipFileName(fn).c_str(),nullptr,ZIP_FOLDER);
 	return lasterrorZ == ZR_OK;
 }
 bool CreateZip::Finish()

--- a/src/CryptManager.cpp
+++ b/src/CryptManager.cpp
@@ -493,49 +493,49 @@ public:
 	{
 		RString md5out;
 		md5out = p->GetMD5ForString(SArg(1));
-		lua_pushlstring(L, md5out, md5out.size());
+		lua_pushlstring(L, md5out.c_str(), md5out.size());
 		return 1;
 	}
 	static int MD5File( T* p, lua_State *L )
 	{
 		RString md5fout;
 		md5fout = p->GetMD5ForFile(SArg(1));
-		lua_pushlstring(L, md5fout, md5fout.size());
+		lua_pushlstring(L, md5fout.c_str(), md5fout.size());
 		return 1;
 	}
 	static int SHA1String( T* p, lua_State *L )
 	{
 		RString sha1out;
 		sha1out = p->GetSHA1ForString(SArg(1));
-		lua_pushlstring(L, sha1out, sha1out.size());
+		lua_pushlstring(L, sha1out.c_str(), sha1out.size());
 		return 1;
 	}
 	static int SHA1File( T* p, lua_State *L )
 	{
 		RString sha1fout;
 		sha1fout = p->GetSHA1ForFile(SArg(1));
-		lua_pushlstring(L, sha1fout, sha1fout.size());
+		lua_pushlstring(L, sha1fout.c_str(), sha1fout.size());
 		return 1;
 	}
 	static int SHA256String( T* p, lua_State *L )
 	{
 		RString sha256out;
 		sha256out = p->GetSHA256ForString(SArg(1));
-		lua_pushlstring(L, sha256out, sha256out.size());
+		lua_pushlstring(L, sha256out.c_str(), sha256out.size());
 		return 1;
 	}
 	static int SHA256File( T* p, lua_State *L )
 	{
 		RString sha256fout;
 		sha256fout = p->GetSHA256ForFile(SArg(1));
-		lua_pushlstring(L, sha256fout, sha256fout.size());
+		lua_pushlstring(L, sha256fout.c_str(), sha256fout.size());
 		return 1;
 	}
 	static int GenerateRandomUUID( T* p, lua_State *L )
 	{
 		RString uuidOut;
 		uuidOut = p->GenerateRandomUUID();
-		lua_pushlstring(L, uuidOut, uuidOut.size());
+		lua_pushlstring(L, uuidOut.c_str(), uuidOut.size());
 		return 1;
 	}
 

--- a/src/DateTime.cpp
+++ b/src/DateTime.cpp
@@ -114,7 +114,7 @@ bool DateTime::FromString( const RString sDateTime )
 
 	int ret;
 
-	ret = sscanf( sDateTime, "%d-%d-%d %d:%d:%d", 
+	ret = sscanf( sDateTime.c_str(), "%d-%d-%d %d:%d:%d", 
 		&tm_year,
 		&tm_mon,
 		&tm_mday,
@@ -123,7 +123,7 @@ bool DateTime::FromString( const RString sDateTime )
 		&tm_sec );
 	if( ret != 6 )
 	{
-		ret = sscanf( sDateTime, "%d-%d-%d", 
+		ret = sscanf( sDateTime.c_str(), "%d-%d-%d", 
 			&tm_year,
 			&tm_mon,
 			&tm_mday );
@@ -148,7 +148,7 @@ RString DayInYearToString( int iDayInYear )
 int StringToDayInYear( RString sDayInYear )
 {
 	int iDayInYear;
-	if( sscanf( sDayInYear, "DayInYear%d", &iDayInYear ) != 1 )
+	if( sscanf( sDayInYear.c_str(), "DayInYear%d", &iDayInYear ) != 1 )
 		return -1;
 	return iDayInYear;
 }

--- a/src/EnumHelper.h
+++ b/src/EnumHelper.h
@@ -133,7 +133,7 @@ static void Lua##X(lua_State* L) \
 	FOREACH_ENUM( X, i ) \
 	{ \
 		RString s = X##ToString( i ); \
-		lua_pushstring( L, (#X "_")+s ); \
+		lua_pushstring( L, ((#X "_")+s).c_str() ); \
 		lua_rawseti( L, -2, i+1 ); /* 1-based */ \
 	} \
 	EnumTraits<X>::EnumToString.SetFromStack( L ); \
@@ -144,12 +144,12 @@ static void Lua##X(lua_State* L) \
 	FOREACH_ENUM( X, i ) \
 	{ \
 		RString s = X##ToString( i ); \
-		lua_pushstring( L, (#X "_")+s ); \
+		lua_pushstring( L, ((#X "_")+s).c_str() ); \
 		lua_pushnumber( L, i ); /* 0-based */ \
 		lua_rawset( L, -3 ); \
 		/* Compatibility with old, case-insensitive values */ \
 		s.MakeLower(); \
-		lua_pushstring( L, s ); \
+		lua_pushstring( L, s.c_str() ); \
 		lua_pushnumber( L, i ); /* 0-based */ \
 		lua_rawset( L, -3 ); \
 		/* Compatibility with old, raw values */ \

--- a/src/GameCommand.cpp
+++ b/src/GameCommand.cpp
@@ -467,8 +467,8 @@ void GameCommand::LoadOne( const Command& cmd )
 		if( cmd.m_vsArgs.size() == 3 )
 		{
 			m_bFadeMusic = true;
-			m_fMusicFadeOutVolume = static_cast<float>(atof( cmd.m_vsArgs[1] ));
-			m_fMusicFadeOutSeconds = static_cast<float>(atof( cmd.m_vsArgs[2] ));
+			m_fMusicFadeOutVolume = static_cast<float>(atof( cmd.m_vsArgs[1].c_str() ));
+			m_fMusicFadeOutSeconds = static_cast<float>(atof( cmd.m_vsArgs[2].c_str() ));
 		}
 		else
 		{
@@ -797,8 +797,8 @@ void GameCommand::ApplySelf( const std::vector<PlayerNumber> &vpns ) const
 	{
 		Lua *L = LUA->Get();
 		GAMESTATE->m_Environment->PushSelf(L);
-		lua_pushstring( L, i->first );
-		lua_pushstring( L, i->second );
+		lua_pushstring( L, i->first.c_str() );
+		lua_pushstring( L, i->second.c_str() );
 		lua_settable( L, -3 );
 		lua_pop( L, 1 );
 		LUA->Release(L);
@@ -912,27 +912,27 @@ bool GameCommand::IsZero() const
 class LunaGameCommand: public Luna<GameCommand>
 {
 public:
-	static int GetName( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sName ); return 1; }
-	static int GetText( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sText ); return 1; }
+	static int GetName( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sName.c_str() ); return 1; }
+	static int GetText( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sText.c_str() ); return 1; }
 	static int GetIndex( T* p, lua_State *L )	{ lua_pushnumber(L, p->m_iIndex ); return 1; }
 	static int GetMultiPlayer( T* p, lua_State *L )	{ lua_pushnumber(L, p->m_MultiPlayer); return 1; }
 	static int GetStyle( T* p, lua_State *L )	{ if(p->m_pStyle== nullptr) lua_pushnil(L); else {Style *pStyle = (Style*)p->m_pStyle; pStyle->PushSelf(L);} return 1; }
-	static int GetScreen( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sScreen ); return 1; }
-	static int GetProfileID( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sProfileID ); return 1; }
+	static int GetScreen( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sScreen.c_str() ); return 1; }
+	static int GetProfileID( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sProfileID.c_str() ); return 1; }
 	static int GetSong( T* p, lua_State *L )	{ if(p->m_pSong== nullptr) lua_pushnil(L); else p->m_pSong->PushSelf(L); return 1; }
 	static int GetSteps( T* p, lua_State *L )	{ if(p->m_pSteps== nullptr) lua_pushnil(L); else p->m_pSteps->PushSelf(L); return 1; }
 	static int GetCourse( T* p, lua_State *L )	{ if(p->m_pCourse== nullptr) lua_pushnil(L); else p->m_pCourse->PushSelf(L); return 1; }
 	static int GetTrail( T* p, lua_State *L )	{ if(p->m_pTrail== nullptr) lua_pushnil(L); else p->m_pTrail->PushSelf(L); return 1; }
 	static int GetCharacter( T* p, lua_State *L )	{ if(p->m_pCharacter== nullptr) lua_pushnil(L); else p->m_pCharacter->PushSelf(L); return 1; }
-	static int GetSongGroup( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sSongGroup ); return 1; }
+	static int GetSongGroup( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sSongGroup.c_str() ); return 1; }
 	static int GetUrl(T* p, lua_State* L)
 	{
 		LOG->Warn("GetUrl usage has been deprecated.");
 		return 1;
 	}
-	static int GetAnnouncer( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sAnnouncer ); return 1; }
-	static int GetPreferredModifiers( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sPreferredModifiers ); return 1; }
-	static int GetStageModifiers( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sStageModifiers ); return 1; }
+	static int GetAnnouncer( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sAnnouncer.c_str() ); return 1; }
+	static int GetPreferredModifiers( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sPreferredModifiers.c_str() ); return 1; }
+	static int GetStageModifiers( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sStageModifiers.c_str() ); return 1; }
 
 	DEFINE_METHOD( GetCourseDifficulty,	m_CourseDifficulty )
 	DEFINE_METHOD( GetDifficulty,	m_dc )

--- a/src/GameInput.cpp
+++ b/src/GameInput.cpp
@@ -46,7 +46,7 @@ bool GameInput::FromString( const InputScheme* pInputs, const RString &s )
 	char szController[32] = "";
 	char szButton[32] = "";
 
-	if( 2 != sscanf( s, "%31[^_]_%31[^_]", szController, szButton ) )
+	if( 2 != sscanf( s.c_str(), "%31[^_]_%31[^_]", szController, szButton ) )
 	{
 		controller = GameController_Invalid;
 		return false;

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -3499,7 +3499,7 @@ const Style* GameManager::GameAndStringToStyle( const Game *game, RString sStyle
 class LunaGameManager: public Luna<GameManager>
 {
 public:
-	static int StepsTypeToLocalizedString( T* p, lua_State *L )	{ lua_pushstring(L, p->GetStepsTypeInfo(Enum::Check<StepsType>(L, 1)).GetLocalizedString() ); return 1; }
+	static int StepsTypeToLocalizedString( T* p, lua_State *L )	{ lua_pushstring(L, p->GetStepsTypeInfo(Enum::Check<StepsType>(L, 1)).GetLocalizedString().c_str() ); return 1; }
 	static int GetFirstStepsTypeForGame( T* p, lua_State *L )
 	{
 		Game *pGame = Luna<Game>::check( L, 1 );

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -2948,7 +2948,7 @@ public:
 	{
 		SongOptions so;
 		p->GetDefaultSongOptions( so );
-		lua_pushstring(L, so.GetString());
+		lua_pushstring(L, so.GetString().c_str());
 		return 1;
 	}
 	static int ApplyPreferredSongOptionsToOtherLevels(T* p, lua_State* L)
@@ -3033,8 +3033,8 @@ public:
 			const Steps* pSteps = vpStepsToShow[i];
 			RString sDifficulty = CustomDifficultyToLocalizedString( GetCustomDifficulty( pSteps->m_StepsType, pSteps->GetDifficulty(), CourseType_Invalid ) );
 
-			lua_pushstring( L, sDifficulty );
-			lua_pushstring( L, pSteps->GetDescription() );
+			lua_pushstring( L, sDifficulty.c_str() );
+			lua_pushstring( L, pSteps->GetDescription().c_str() );
 		}
 
 		return vpStepsToShow.size()*2;
@@ -3114,7 +3114,7 @@ public:
 			p->m_pCurCharacters[Enum::Check<PlayerNumber>(L, 1)] = c;
 		COMMON_RETURN_SELF;
 	}
-	static int GetExpandedSectionName( T* p, lua_State *L )				{ lua_pushstring(L, p->sExpandedSectionName); return 1; }
+	static int GetExpandedSectionName( T* p, lua_State *L )				{ lua_pushstring(L, p->sExpandedSectionName.c_str()); return 1; }
 	static int AddStageToPlayer( T* p, lua_State *L )				{ p->AddStageToPlayer(Enum::Check<PlayerNumber>(L, 1)); COMMON_RETURN_SELF; }
 	static int InsertCoin( T* p, lua_State *L )
 	{

--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -148,30 +148,30 @@ class LunaGroup: public Luna<Group>
 public:
 	static int GetGroupName(T* p, lua_State *L)
 	{
-		lua_pushstring(L, p->GetGroupName());
+		lua_pushstring(L, p->GetGroupName().c_str());
 		return 1;
 	}
 	static int GetSortTitle(T* p, lua_State *L)
 	{
-		lua_pushstring(L, p->GetSortTitle());
+		lua_pushstring(L, p->GetSortTitle().c_str());
         return 1;
     }
 
     static int GetDisplayTitle(T* p, lua_State *L)
     {
-        lua_pushstring(L, p->GetDisplayTitle());
+        lua_pushstring(L, p->GetDisplayTitle().c_str());
         return 1;
     }
 
     static int GetTranslitTitle(T* p, lua_State *L)
     {
-        lua_pushstring(L, p->GetTranslitTitle());
+        lua_pushstring(L, p->GetTranslitTitle().c_str());
         return 1;
     }
 
     static int GetSeries(T* p, lua_State *L)
     {
-        lua_pushstring(L, p->GetSeries());
+        lua_pushstring(L, p->GetSeries().c_str());
         return 1;
     }
 
@@ -189,7 +189,7 @@ public:
 
     static int GetBannerPath(T* p, lua_State *L)
     {
-        lua_pushstring(L, p->GetBannerPath());
+        lua_pushstring(L, p->GetBannerPath().c_str());
         return 1;
     }
 

--- a/src/HighScore.cpp
+++ b/src/HighScore.cpp
@@ -480,10 +480,10 @@ void Screenshot::LoadFromNode( const XNode* pNode )
 class LunaHighScore: public Luna<HighScore>
 {
 public:
-	static int GetName( T* p, lua_State *L )			{ lua_pushstring(L, p->GetName() ); return 1; }
+	static int GetName( T* p, lua_State *L )			{ lua_pushstring(L, p->GetName().c_str() ); return 1; }
 	static int GetScore( T* p, lua_State *L )			{ lua_pushnumber(L, p->GetScore() ); return 1; }
 	static int GetPercentDP( T* p, lua_State *L )			{ lua_pushnumber(L, p->GetPercentDP() ); return 1; }
-	static int GetDate( T* p, lua_State *L )			{ lua_pushstring(L, p->GetDateTime().GetString() ); return 1; }
+	static int GetDate( T* p, lua_State *L )			{ lua_pushstring(L, p->GetDateTime().GetString().c_str() ); return 1; }
 	static int GetSurvivalSeconds( T* p, lua_State *L )			{ lua_pushnumber(L, p->GetSurvivalSeconds() ); return 1; }
 	static int IsFillInMarker( T* p, lua_State *L )
 	{
@@ -494,7 +494,7 @@ public:
 		return 1;
 	}
 	static int GetMaxCombo( T* p, lua_State *L )			{ lua_pushnumber(L, p->GetMaxCombo() ); return 1; }
-	static int GetModifiers( T* p, lua_State *L )			{ lua_pushstring(L, p->GetModifiers() ); return 1; }
+	static int GetModifiers( T* p, lua_State *L )			{ lua_pushstring(L, p->GetModifiers().c_str() ); return 1; }
 	static int GetTapNoteScore( T* p, lua_State *L )			{ lua_pushnumber(L, p->GetTapNoteScore( Enum::Check<TapNoteScore>(L, 1) ) ); return 1; }
 	static int GetHoldNoteScore( T* p, lua_State *L )			{ lua_pushnumber(L, p->GetHoldNoteScore( Enum::Check<HoldNoteScore>(L, 1) ) ); return 1; }
 	static int GetRadarValues( T* p, lua_State *L )

--- a/src/InputMapper.cpp
+++ b/src/InputMapper.cpp
@@ -1145,7 +1145,7 @@ MultiPlayer InputMapper::InputDeviceToMultiPlayer( InputDevice id )
 GameButton InputScheme::ButtonNameToIndex( const RString &sButtonName ) const
 {
 	for( GameButton gb=(GameButton) 0; gb<m_iButtonsPerController; gb=(GameButton)(gb+1) )
-		if( strcasecmp(GetGameButtonName(gb), sButtonName) == 0 )
+		if( strcasecmp(GetGameButtonName(gb), sButtonName.c_str()) == 0 )
 			return gb;
 
 	return GameButton_Invalid;

--- a/src/LifeMeterBattery.cpp
+++ b/src/LifeMeterBattery.cpp
@@ -248,7 +248,7 @@ int LifeMeterBattery::GetRemainingLives() const
 }
 void LifeMeterBattery::Refresh()
 {
-	m_textNumLives.SetText( ssprintf(LIVES_FORMAT.GetValue(), m_iLivesLeft) );
+	m_textNumLives.SetText( ssprintf(LIVES_FORMAT.GetValue().c_str(), m_iLivesLeft) );
 	if( m_iLivesLeft < 0 )
 	{
 		// hide text to avoid showing -1

--- a/src/LuaBinding.cpp
+++ b/src/LuaBinding.cpp
@@ -75,7 +75,7 @@ void LuaBinding::Register( lua_State *L )
 	int methods = lua_gettop( L );
 
 	/* Create a metatable for the userdata objects. */
-	luaL_newmetatable( L, GetClassName() );
+	luaL_newmetatable( L, GetClassName().c_str() );
 	int metatable = lua_gettop( L );
 
 	// We use the metatable to determine the type of the table, so don't
@@ -101,17 +101,17 @@ void LuaBinding::Register( lua_State *L )
 	// to the base class.
 	if( IsDerivedClass() )
 	{
-		lua_getfield( L, LUA_GLOBALSINDEX, GetBaseClassName() );
+		lua_getfield( L, LUA_GLOBALSINDEX, GetBaseClassName().c_str() );
 		lua_setfield( L, methods_metatable, "__index" );
 
-		lua_pushstring( L, GetBaseClassName() );
+		lua_pushstring( L, GetBaseClassName().c_str() );
 		lua_setfield( L, metatable, "base" );
 	}
 
-	lua_pushstring( L, GetClassName() );
+	lua_pushstring( L, GetClassName().c_str() );
 	lua_setfield( L, methods_metatable, "class" );
 
-	lua_pushstring( L, GetClassName() );
+	lua_pushstring( L, GetClassName().c_str() );
 	LuaHelpers::PushValueFunc( L, 1 );
 	lua_setfield( L, metatable, "__type" ); // for luaL_pushtype
 
@@ -123,12 +123,12 @@ void LuaBinding::Register( lua_State *L )
 		int iIndex = 0;
 		while( !sClass.empty() )
 		{
-			lua_pushstring( L, sClass );
+			lua_pushstring( L, sClass.c_str() );
 			lua_pushinteger( L, iIndex );
 			lua_rawset( L, iHeirarchyTable );
 			++iIndex;
 
-			luaL_getmetatable( L, sClass );
+			luaL_getmetatable( L, sClass.c_str() );
 			ASSERT( !lua_isnil(L, -1) );
 			lua_getfield( L, -1, "base" );
 
@@ -159,7 +159,7 @@ void LuaBinding::CreateMethodsTable( lua_State *L, const RString &sName )
 {
 	lua_newtable( L );
 	lua_pushvalue( L, -1 );
-	lua_setfield( L, LUA_GLOBALSINDEX, sName );
+	lua_setfield( L, LUA_GLOBALSINDEX, sName.c_str() );
 }
 
 int LuaBinding::PushEqual( lua_State *L )
@@ -290,7 +290,7 @@ void LuaBinding::ApplyDerivedType( Lua *L, const RString &sClassName, void *pSel
 		lua_settop( L, iTable );
 	}
 
-	luaL_getmetatable( L, sClassName );
+	luaL_getmetatable( L, sClassName.c_str() );
 	lua_setmetatable( L, iTable );
 }
 

--- a/src/LuaBinding.h
+++ b/src/LuaBinding.h
@@ -74,12 +74,12 @@ public:
 	// Get userdata from the Lua stack and return a pointer to T object.
 	static T *check( lua_State *L, int narg, bool bIsSelf = false )
 	{
-		if( !LuaBinding::CheckLuaObjectType(L, narg, m_sClassName) )
+		if( !LuaBinding::CheckLuaObjectType(L, narg, m_sClassName.c_str()) )
 		{
 			if( bIsSelf )
-				luaL_typerror( L, narg, m_sClassName );
+				luaL_typerror( L, narg, m_sClassName.c_str() );
 			else
-				LuaHelpers::TypeError( L, narg, m_sClassName );
+				LuaHelpers::TypeError( L, narg, m_sClassName.c_str() );
 		}
 
 		return get( L, narg );

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -60,7 +60,7 @@ void LuaManager::SetGlobal( const RString &sName, int val )
 {
 	Lua *L = Get();
 	LuaHelpers::Push( L, val );
-	lua_setglobal( L, sName );
+	lua_setglobal( L, sName.c_str() );
 	Release( L );
 }
 
@@ -68,7 +68,7 @@ void LuaManager::SetGlobal( const RString &sName, const RString &val )
 {
 	Lua *L = Get();
 	LuaHelpers::Push( L, val );
-	lua_setglobal( L, sName );
+	lua_setglobal( L, sName.c_str() );
 	Release( L );
 }
 
@@ -76,7 +76,7 @@ void LuaManager::UnsetGlobal( const RString &sName )
 {
 	Lua *L = Get();
 	lua_pushnil( L );
-	lua_setglobal( L, sName );
+	lua_setglobal( L, sName.c_str() );
 	Release( L );
 }
 
@@ -143,7 +143,7 @@ namespace
 
 		FOREACH_CONST_Attr( pNode, pAttr )
 		{
-			lua_pushstring( L, pAttr->first );			// push key
+			lua_pushstring( L, pAttr->first.c_str() );			// push key
 			pNode->PushAttrValue( L, pAttr->first );	// push value
 
 			//add key-value pair to our table
@@ -153,7 +153,7 @@ namespace
 		FOREACH_CONST_Child( pNode, c )
 		{
 			const XNode *pChild = c;
-			lua_pushstring( L, pChild->m_sName ); // push key
+			lua_pushstring( L, pChild->m_sName.c_str() ); // push key
 
 			// push value (more correctly, build this child's table and leave it there)
 			CreateTableFromXNodeRecursive( L, pChild );
@@ -784,7 +784,7 @@ bool LuaHelpers::RunScriptFile( const RString &sFile )
 bool LuaHelpers::LoadScript( Lua *L, const RString &sScript, const RString &sName, RString &sError )
 {
 	// load string
-	int ret = luaL_loadbuffer( L, sScript.data(), sScript.size(), sName );
+	int ret = luaL_loadbuffer( L, sScript.data(), sScript.size(), sName.c_str() );
 	if( ret )
 	{
 		LuaHelpers::Pop( L, sError );
@@ -1080,7 +1080,7 @@ namespace
 	static int CheckType( lua_State *L )
 	{
 		RString sType = SArg(1);
-		bool bRet = LuaBinding::CheckLuaObjectType( L, 2, sType );
+		bool bRet = LuaBinding::CheckLuaObjectType( L, 2, sType.c_str() );
 		LuaHelpers::Push( L, bRet );
 		return 1;
 	}

--- a/src/LuaReference.cpp
+++ b/src/LuaReference.cpp
@@ -190,14 +190,14 @@ void LuaTable::Set( Lua *L, const RString &sKey )
 	int iTop = lua_gettop( L );
 	this->PushSelf( L );
 	lua_pushvalue( L, iTop ); // push the value
-	lua_setfield( L, -2, sKey );
+	lua_setfield( L, -2, sKey.c_str() );
 	lua_settop( L, iTop-1 ); // remove all of the above
 }
 
 void LuaTable::Get( Lua *L, const RString &sKey )
 {
 	this->PushSelf( L );
-	lua_getfield( L, -1, sKey );
+	lua_getfield( L, -1, sKey.c_str() );
 	lua_remove( L, -2 ); // remove self
 }
 

--- a/src/MemoryCardManager.cpp
+++ b/src/MemoryCardManager.cpp
@@ -731,7 +731,7 @@ public:
 	static int GetName( T* p, lua_State *L )
 	{
 		PlayerNumber pn = Enum::Check<PlayerNumber>(L, 1);
-		lua_pushstring(L, p->GetName(pn) );
+		lua_pushstring(L, p->GetName(pn).c_str() );
 		return 1;
 	}
 

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -146,16 +146,16 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 	{
 		iLineNum++;
 
-		if( !strncmp (sLine, "//", 2) )
+		if( !strncmp (sLine.c_str(), "//", 2) )
 			continue;
 
 		int nFrame;
-		if( sscanf(sLine, "Frames: %d", &nFrame) == 1 )
+		if( sscanf(sLine.c_str(), "Frames: %d", &nFrame) == 1 )
 		{
 			// ignore
 			// m_pModel->nTotalFrames = nFrame;
 		}
-		if( sscanf(sLine, "Frame: %d", &nFrame) == 1 )
+		if( sscanf(sLine.c_str(), "Frame: %d", &nFrame) == 1 )
 		{
 			// ignore
 			// m_pModel->nFrame = nFrame;
@@ -163,7 +163,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 
 		// materials
 		int nNumMaterials = 0;
-		if( sscanf(sLine, "Materials: %d", &nNumMaterials) == 1 )
+		if( sscanf(sLine.c_str(), "Materials: %d", &nNumMaterials) == 1 )
 		{
 			m_Materials.resize( nNumMaterials );
 
@@ -176,7 +176,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				// name
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
-				if( sscanf(sLine, "\"%255[^\"]\"", szName) != 1 )
+				if( sscanf(sLine.c_str(), "\"%255[^\"]\"", szName) != 1 )
 					THROW;
 				Material.sName = szName;
 
@@ -184,7 +184,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
 				RageVector4 Ambient;
-				if( sscanf(sLine, "%f %f %f %f", &Ambient[0], &Ambient[1], &Ambient[2], &Ambient[3]) != 4 )
+				if( sscanf(sLine.c_str(), "%f %f %f %f", &Ambient[0], &Ambient[1], &Ambient[2], &Ambient[3]) != 4 )
 					THROW;
 				Material.Ambient = Ambient;
 
@@ -192,7 +192,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
 				RageVector4 Diffuse;
-				if( sscanf(sLine, "%f %f %f %f", &Diffuse[0], &Diffuse[1], &Diffuse[2], &Diffuse[3]) != 4 )
+				if( sscanf(sLine.c_str(), "%f %f %f %f", &Diffuse[0], &Diffuse[1], &Diffuse[2], &Diffuse[3]) != 4 )
 					THROW;
 				Material.Diffuse = Diffuse;
 
@@ -200,7 +200,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
 				RageVector4 Specular;
-				if( sscanf(sLine, "%f %f %f %f", &Specular[0], &Specular[1], &Specular[2], &Specular[3]) != 4 )
+				if( sscanf(sLine.c_str(), "%f %f %f %f", &Specular[0], &Specular[1], &Specular[2], &Specular[3]) != 4 )
 					THROW;
 				Material.Specular = Specular;
 
@@ -208,7 +208,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
 				RageVector4 Emissive;
-				if( sscanf (sLine, "%f %f %f %f", &Emissive[0], &Emissive[1], &Emissive[2], &Emissive[3]) != 4 )
+				if( sscanf (sLine.c_str(), "%f %f %f %f", &Emissive[0], &Emissive[1], &Emissive[2], &Emissive[3]) != 4 )
 					THROW;
 				Material.Emissive = Emissive;
 
@@ -232,7 +232,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
 				strcpy( szName, "" );
-				sscanf( sLine, "\"%255[^\"]\"", szName );
+				sscanf( sLine.c_str(), "\"%255[^\"]\"", szName );
 				RString sDiffuseTexture = szName;
 
 				if( sDiffuseTexture == "" )
@@ -254,7 +254,7 @@ void Model::LoadMaterialsFromMilkshapeAscii( const RString &_sPath )
 				if( f.GetLine( sLine ) <= 0 )
 					THROW;
 				strcpy( szName, "" );
-				sscanf( sLine, "\"%255[^\"]\"", szName );
+				sscanf( sLine.c_str(), "\"%255[^\"]\"", szName );
 				RString sAlphaTexture = szName;
 
 				if( sAlphaTexture == "" )
@@ -783,7 +783,7 @@ public:
 	static int position( T* p, lua_State *L )	{ p->SetPosition( FArg(1) ); COMMON_RETURN_SELF; }
 	static int playanimation( T* p, lua_State *L )	{ p->PlayAnimation(SArg(1),FArg(2)); COMMON_RETURN_SELF; }
 	static int SetDefaultAnimation( T* p, lua_State *L )	{ p->SetDefaultAnimation(SArg(1),FArg(2)); COMMON_RETURN_SELF; }
-	static int GetDefaultAnimation( T* p, lua_State *L )	{ lua_pushstring( L, p->GetDefaultAnimation() ); return 1; }
+	static int GetDefaultAnimation( T* p, lua_State *L )	{ lua_pushstring( L, p->GetDefaultAnimation().c_str() ); return 1; }
 	static int loop( T* p, lua_State *L )		{ p->SetLoop(BArg(1)); COMMON_RETURN_SELF; }
 	static int rate( T* p, lua_State *L )		{ p->SetRate(FArg(1)); COMMON_RETURN_SELF; }
 	static int GetNumStates( T* p, lua_State *L )		{ lua_pushnumber( L, p->GetNumStates() ); return 1; }

--- a/src/ModelTypes.cpp
+++ b/src/ModelTypes.cpp
@@ -241,12 +241,12 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 	{
 		iLineNum++;
 
-		if (!strncmp (sLine, "//", 2))
+		if (!strncmp (sLine.c_str(), "//", 2))
 			continue;
 
 		// bones
 		int nNumBones = 0;
-		if( sscanf (sLine, "Bones: %d", &nNumBones) != 1 )
+		if( sscanf (sLine.c_str(), "Bones: %d", &nNumBones) != 1 )
 			continue;
 
 		char szName[MS_MAX_NAME];
@@ -260,7 +260,7 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 			// name
 			if( f.GetLine( sLine ) <= 0 )
 				THROW;
-			if (sscanf(sLine, "\"%31[^\"]\"", szName) != 1)
+			if (sscanf(sLine.c_str(), "\"%31[^\"]\"", szName) != 1)
 				THROW;
 			Bone.sName = szName;
 
@@ -268,7 +268,7 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 			if( f.GetLine( sLine ) <= 0 )
 				THROW;
 			strcpy(szName, "");
-			sscanf(sLine, "\"%31[^\"]\"", szName);
+			sscanf(sLine.c_str(), "\"%31[^\"]\"", szName);
 
 			Bone.sParentName = szName;
 
@@ -278,7 +278,7 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 				THROW;
 
 			int nFlags;
-			if (sscanf (sLine, "%d %f %f %f %f %f %f",
+			if (sscanf (sLine.c_str(), "%d %f %f %f %f %f %f",
 				&nFlags,
 				&Position[0], &Position[1], &Position[2],
 				&Rotation[0], &Rotation[1], &Rotation[2]) != 7)
@@ -295,7 +295,7 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 			if( f.GetLine( sLine ) <= 0 )
 				THROW;
 			int nNumPositionKeys = 0;
-			if (sscanf (sLine, "%d", &nNumPositionKeys) != 1)
+			if (sscanf (sLine.c_str(), "%d", &nNumPositionKeys) != 1)
 				THROW;
 
 			Bone.PositionKeys.resize( nNumPositionKeys );
@@ -306,7 +306,7 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 					THROW;
 
 				float fTime;
-				if (sscanf (sLine, "%f %f %f %f", &fTime, &Position[0], &Position[1], &Position[2]) != 4)
+				if (sscanf (sLine.c_str(), "%f %f %f %f", &fTime, &Position[0], &Position[1], &Position[2]) != 4)
 					THROW;
 
 				msPositionKey key = {};
@@ -319,7 +319,7 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 			if( f.GetLine( sLine ) <= 0 )
 				THROW;
 			int nNumRotationKeys = 0;
-			if (sscanf (sLine, "%d", &nNumRotationKeys) != 1)
+			if (sscanf (sLine.c_str(), "%d", &nNumRotationKeys) != 1)
 				THROW;
 
 			Bone.RotationKeys.resize( nNumRotationKeys );
@@ -330,7 +330,7 @@ bool msAnimation::LoadMilkshapeAsciiBones( RString sAniName, RString sPath )
 					THROW;
 
 				float fTime;
-				if (sscanf (sLine, "%f %f %f %f", &fTime, &Rotation[0], &Rotation[1], &Rotation[2]) != 4)
+				if (sscanf (sLine.c_str(), "%f %f %f %f", &fTime, &Rotation[0], &Rotation[1], &Rotation[2]) != 4)
 					THROW;
 				Rotation = RadianToDegree(Rotation);
 

--- a/src/NoteDisplay.cpp
+++ b/src/NoteDisplay.cpp
@@ -146,7 +146,7 @@ struct NoteSkinAndPath
 	GameController gc;
 	bool operator<( const NoteSkinAndPath &other ) const
 	{
-		int cmp = strcmp(sNoteSkin, other.sNoteSkin);
+		int cmp = strcmp(sNoteSkin.c_str(), other.sNoteSkin.c_str());
 
 		if( cmp < 0 )
 		{

--- a/src/NoteSkinManager.cpp
+++ b/src/NoteSkinManager.cpp
@@ -215,7 +215,7 @@ bool NoteSkinManager::NoteSkinNameInList(const RString name, std::vector<RString
 {
 	for(size_t i= 0; i < name_list.size(); ++i)
 	{
-		if(0 == strcasecmp(name, name_list[i]))
+		if(0 == strcasecmp(name.c_str(), name_list[i].c_str()))
 		{
 			return true;
 		}

--- a/src/NotesLoaderBMS.cpp
+++ b/src/NotesLoaderBMS.cpp
@@ -1332,7 +1332,7 @@ bool BMSChartReader::ReadNoteData()
 		if( channel == 3 ) // bpm change
 		{
 			unsigned int bpm;
-			if( sscanf(obj.value, "%x", &bpm) == 1 )
+			if( sscanf(obj.value.c_str(), "%x", &bpm) == 1 )
 			{
 				if( bpm > 0 ) td.SetBPMAtRow( row, measureAdjust * (currentBPM = bpm) );
 			}

--- a/src/NotesLoaderDWI.cpp
+++ b/src/NotesLoaderDWI.cpp
@@ -620,13 +620,13 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 			/* We can't parse this as a float with sscanf, since '.' is a valid
 			 * character in a float.  (We could do it with a regex, but it's not
 			 * worth bothering with since we don't display fractional BPM anyway.) */
-		    if( sscanf( sParams[1], "%i..%i", &iMin, &iMax ) == 2 )
+		    if( sscanf( sParams[1].c_str(), "%i..%i", &iMin, &iMax ) == 2 )
 			{
 				out.m_DisplayBPMType = DISPLAY_BPM_SPECIFIED;
 				out.m_fSpecifiedBPMMin = (float) iMin;
 				out.m_fSpecifiedBPMMax = (float) iMax;
 			}
-			else if( sscanf( sParams[1], "%i", &iMin ) == 1 )
+			else if( sscanf( sParams[1].c_str(), "%i", &iMin ) == 1 )
 			{
 				out.m_DisplayBPMType = DISPLAY_BPM_SPECIFIED;
 				out.m_fSpecifiedBPMMin = out.m_fSpecifiedBPMMax = (float) iMin;

--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -350,7 +350,7 @@ void SMLoader::LoadFromTokens(
 void SMLoader::ProcessBGChanges( Song &out, const RString &sValueName, const RString &sPath, const RString &sParam )
 {
 	BackgroundLayer iLayer = BACKGROUND_LAYER_1;
-	if( sscanf(sValueName, "BGCHANGES%d", &*ConvertValue<int>(&iLayer)) == 1 )
+	if( sscanf(sValueName.c_str(), "BGCHANGES%d", &*ConvertValue<int>(&iLayer)) == 1 )
 		enum_add(iLayer, -1);	// #BGCHANGES2 = BACKGROUND_LAYER_2
 
 	bool bValid = iLayer>=0 && iLayer<NUM_BackgroundLayer;
@@ -400,11 +400,11 @@ void SMLoader::ProcessAttacks( AttackArray &attacks, MsdFile::value_t params )
 		Trim( sBits[0] );
 
 		if( !sBits[0].CompareNoCase("TIME") )
-			attack.fStartSecond = strtof( sBits[1], nullptr );
+			attack.fStartSecond = strtof( sBits[1].c_str(), nullptr );
 		else if( !sBits[0].CompareNoCase("LEN") )
-			attack.fSecsRemaining = strtof( sBits[1], nullptr );
+			attack.fSecsRemaining = strtof( sBits[1].c_str(), nullptr );
 		else if( !sBits[0].CompareNoCase("END") )
-			end = strtof( sBits[1], nullptr );
+			end = strtof( sBits[1].c_str(), nullptr );
 		else if( !sBits[0].CompareNoCase("MODS") )
 		{
 			Trim(sBits[1]);
@@ -872,7 +872,7 @@ void SMLoader::ProcessTickcounts( TimingData &out, const RString line, const int
 		}
 
 		const float fTickcountBeat = RowToBeat( arrayTickcountValues[0], rowsPerBeat );
-		int iTicks = std::clamp(atoi( arrayTickcountValues[1] ), 0, ROWS_PER_BEAT);
+		int iTicks = std::clamp(atoi( arrayTickcountValues[1].c_str() ), 0, ROWS_PER_BEAT);
 
 		out.AddSegment( TickcountSegment(BeatToNoteRow(fTickcountBeat), iTicks) );
 	}

--- a/src/NotesWriterSM.cpp
+++ b/src/NotesWriterSM.cpp
@@ -330,14 +330,14 @@ bool NotesWriterSM::WriteEditFileToMachine( const Song *pSong, Steps *pSteps, RS
 			pSteps->GetFilename() != sPath;
 	if( bFileNameChanging  &&  DoesFileExist(sPath) )
 	{
-		sErrorOut = ssprintf( DESTINATION_ALREADY_EXISTS.GetValue(), sPath.c_str() );
+		sErrorOut = ssprintf( DESTINATION_ALREADY_EXISTS.GetValue().c_str(), sPath.c_str() );
 		return false;
 	}
 
 	RageFile f;
 	if( !f.Open(sPath, RageFile::WRITE | RageFile::SLOW_FLUSH) )
 	{
-		sErrorOut = ssprintf( ERROR_WRITING_FILE.GetValue(), sPath.c_str() );
+		sErrorOut = ssprintf( ERROR_WRITING_FILE.GetValue().c_str(), sPath.c_str() );
 		return false;
 	}
 
@@ -345,7 +345,7 @@ bool NotesWriterSM::WriteEditFileToMachine( const Song *pSong, Steps *pSteps, RS
 	GetEditFileContents( pSong, pSteps, sTag );
 	if( f.PutLine(sTag) == -1 || f.Flush() == -1 )
 	{
-		sErrorOut = ssprintf( ERROR_WRITING_FILE.GetValue(), sPath.c_str() );
+		sErrorOut = ssprintf( ERROR_WRITING_FILE.GetValue().c_str(), sPath.c_str() );
 		return false;
 	}
 

--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -50,12 +50,12 @@ struct TimingTagWriter {
 		m_sNext = ",";
 	}
 
-	void Write( const int row, const float value )        { Write( row, ssprintf( "%.6f",  value ) ); }
-	void Write( const int row, const int value )          { Write( row, ssprintf( "%d",    value ) ); }
-	void Write( const int row, const int a, const int b ) { Write( row, ssprintf( "%d=%d", a, b ) );  }
-	void Write( const int row, const float a, const float b ) { Write( row, ssprintf( "%.6f=%.6f", a, b) ); }
+	void Write( const int row, const float value )        { Write( row, ssprintf( "%.6f",  value ).c_str() ); }
+	void Write( const int row, const int value )          { Write( row, ssprintf( "%d",    value ).c_str() ); }
+	void Write( const int row, const int a, const int b ) { Write( row, ssprintf( "%d=%d", a, b ).c_str() );  }
+	void Write( const int row, const float a, const float b ) { Write( row, ssprintf( "%.6f=%.6f", a, b).c_str() ); }
 	void Write( const int row, const float a, const float b, const unsigned short c )
-		{ Write( row, ssprintf( "%.6f=%.6f=%hd", a, b, c) ); }
+		{ Write( row, ssprintf( "%.6f=%.6f=%hd", a, b, c).c_str() ); }
 
 	void Init( const RString sTag ) { m_sNext = "#" + sTag + ":"; }
 	void Finish( ) { m_pvsLines->push_back( ( m_sNext != "," ? m_sNext : RString("") ) + ";" ); }
@@ -585,14 +585,14 @@ bool NotesWriterSSC::WriteEditFileToMachine( const Song *pSong, Steps *pSteps, R
 		pSteps->GetFilename() != sPath;
 	if( bFileNameChanging  &&  DoesFileExist(sPath) )
 	{
-		sErrorOut = ssprintf( DESTINATION_ALREADY_EXISTS.GetValue(), sPath.c_str() );
+		sErrorOut = ssprintf( DESTINATION_ALREADY_EXISTS.GetValue().c_str(), sPath.c_str() );
 		return false;
 	}
 
 	RageFile f;
 	if( !f.Open(sPath, RageFile::WRITE | RageFile::SLOW_FLUSH) )
 	{
-		sErrorOut = ssprintf( ERROR_WRITING_FILE.GetValue(), sPath.c_str() );
+		sErrorOut = ssprintf( ERROR_WRITING_FILE.GetValue().c_str(), sPath.c_str() );
 		return false;
 	}
 
@@ -600,7 +600,7 @@ bool NotesWriterSSC::WriteEditFileToMachine( const Song *pSong, Steps *pSteps, R
 	GetEditFileContents( pSong, pSteps, sTag );
 	if( f.PutLine(sTag) == -1 || f.Flush() == -1 )
 	{
-		sErrorOut = ssprintf( ERROR_WRITING_FILE.GetValue(), sPath.c_str() );
+		sErrorOut = ssprintf( ERROR_WRITING_FILE.GetValue().c_str(), sPath.c_str() );
 		return false;
 	}
 

--- a/src/OptionRow.cpp
+++ b/src/OptionRow.cpp
@@ -979,7 +979,7 @@ public:
 	DEFINE_METHOD( FirstItemGoesDown, GetFirstItemGoesDown() )
 	static int GetChoiceInRowWithFocus( T* p, lua_State *L ) { lua_pushnumber( L, p->GetChoiceInRowWithFocus(Enum::Check<PlayerNumber>(L, 1)) ); return 1; }
 	DEFINE_METHOD( GetLayoutType, GetHandler()->m_Def.m_layoutType )
-	static int GetName( T* p, lua_State *L ) { lua_pushstring( L, p->GetHandler()->m_Def.m_sName ); return 1; }
+	static int GetName( T* p, lua_State *L ) { lua_pushstring( L, p->GetHandler()->m_Def.m_sName.c_str() ); return 1; }
 	static int GetNumChoices( T* p, lua_State *L ) { lua_pushnumber( L, p->GetHandler()->m_Def.m_vsChoices.size() ); return 1; }
 	DEFINE_METHOD( GetSelectType, GetHandler()->m_Def.m_selectType )
 	DEFINE_METHOD( GetRowTitle, GetRowTitle() )

--- a/src/PaneDisplay.cpp
+++ b/src/PaneDisplay.cpp
@@ -295,7 +295,7 @@ void PaneDisplay::GetPaneTextAndLevel( PaneCategory c, RString & sTextOut, float
 				case PaneCategory_Hands:
 				case PaneCategory_Lifts:
 				case PaneCategory_Fakes:
-					sTextOut = ssprintf( COUNT_FORMAT.GetValue(), fLevelOut );
+					sTextOut = ssprintf( COUNT_FORMAT.GetValue().c_str(), fLevelOut );
 					break;
 				default: break;
 			}

--- a/src/PercentageDisplay.cpp
+++ b/src/PercentageDisplay.cpp
@@ -167,8 +167,8 @@ void PercentageDisplay::Refresh()
 		{
 			int iPercentWhole = int(fPercentDancePoints*100);
 			int iPercentRemainder = int( (fPercentDancePoints*100 - int(fPercentDancePoints*100)) * 10 );
-			sNumToDisplay = ssprintf( m_sPercentFormat, iPercentWhole );
-			m_textPercentRemainder.SetText( ssprintf(m_sRemainderFormat, iPercentRemainder) );
+			sNumToDisplay = ssprintf( m_sPercentFormat.c_str(), iPercentWhole );
+			m_textPercentRemainder.SetText( ssprintf(m_sRemainderFormat.c_str(), iPercentRemainder) );
 		}
 		else
 		{

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -691,7 +691,7 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 		}
 		else if( s[0]=='*' )
 		{
-			sscanf( s, "*%f", &speed );
+			sscanf( s.c_str(), "*%f", &speed );
 			if( !std::isfinite(speed) )
 				speed = 1.0f;
 		}
@@ -713,7 +713,7 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 		m_fTimeSpacing = 0;
 		m_fMaxScrollBPM = 0;
 	}
-	else if( sscanf( sBit, "c%f", &level ) == 1 )
+	else if( sscanf( sBit.c_str(), "c%f", &level ) == 1 )
 	{
 		if( !std::isfinite(level) || level <= 0.0f )
 			level = CMOD_DEFAULT;
@@ -723,7 +723,7 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 		m_fMaxScrollBPM = 0;
 	}
 	// oITG's m-mods
-	else if( sscanf( sBit, "m%f", &level ) == 1 )
+	else if( sscanf( sBit.c_str(), "m%f", &level ) == 1 )
 	{
 		// OpenITG doesn't have this block:
 		/*
@@ -1481,7 +1481,7 @@ bool PlayerOptions::operator==( const PlayerOptions &other ) const
 	// manager forces lowercase, but some obscure part of PlayerOptions
 	// uppercases the first letter.  The previous code that used != probably
 	// relied on RString::operator!= misbehaving. -Kyz
-	if(strcasecmp(m_sNoteSkin, other.m_sNoteSkin) != 0)
+	if(strcasecmp(m_sNoteSkin.c_str(), other.m_sNoteSkin.c_str()) != 0)
 	{
 		return false;
 	}
@@ -2133,11 +2133,11 @@ public:
 		int original_top= lua_gettop(L);
 		if( p->m_sNoteSkin.empty()  )
 		{
-			lua_pushstring( L, CommonMetrics::DEFAULT_NOTESKIN_NAME.GetValue() );
+			lua_pushstring( L, CommonMetrics::DEFAULT_NOTESKIN_NAME.GetValue().c_str() );
 		}
 		else
 		{
-			lua_pushstring( L, p->m_sNoteSkin );
+			lua_pushstring( L, p->m_sNoteSkin.c_str() );
 		}
 		if(original_top >= 1 && lua_isstring(L, 1))
 		{

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -2581,13 +2581,13 @@ public:
 	DEFINE_METHOD(GetType, m_Type);
 	DEFINE_METHOD(GetPriority, m_ListPriority);
 
-	static int GetDisplayName( T* p, lua_State *L )			{ lua_pushstring(L, p->m_sDisplayName ); return 1; }
+	static int GetDisplayName( T* p, lua_State *L )			{ lua_pushstring(L, p->m_sDisplayName.c_str() ); return 1; }
 	static int SetDisplayName( T* p, lua_State *L )
 	{
 		p->m_sDisplayName= SArg(1);
 		COMMON_RETURN_SELF;
 	}
-	static int GetLastUsedHighScoreName( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sLastUsedHighScoreName ); return 1; }
+	static int GetLastUsedHighScoreName( T* p, lua_State *L )	{ lua_pushstring(L, p->m_sLastUsedHighScoreName.c_str() ); return 1; }
 	static int SetLastUsedHighScoreName( T* p, lua_State *L )
 	{
 		p->m_sLastUsedHighScoreName= SArg(1);
@@ -2737,7 +2737,7 @@ public:
 	static int GetTotalGameplaySeconds( T* p, lua_State *L )		{ lua_pushnumber(L, p->m_iTotalGameplaySeconds ); return 1; }
 	static int GetSongsAndCoursesPercentCompleteAllDifficulties( T* p, lua_State *L )		{ lua_pushnumber(L, p->GetSongsAndCoursesPercentCompleteAllDifficulties(Enum::Check<StepsType>(L, 1)) ); return 1; }
 	static int GetTotalCaloriesBurned( T* p, lua_State *L )		{ lua_pushnumber(L, p->m_fTotalCaloriesBurned ); return 1; }
-	static int GetDisplayTotalCaloriesBurned( T* p, lua_State *L )	{ lua_pushstring(L, p->GetDisplayTotalCaloriesBurned() ); return 1; }
+	static int GetDisplayTotalCaloriesBurned( T* p, lua_State *L )	{ lua_pushstring(L, p->GetDisplayTotalCaloriesBurned().c_str() ); return 1; }
 	static int GetMostPopularSong( T* p, lua_State *L )
 	{
 		Song *p2 = p->GetMostPopularSong();

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -1348,21 +1348,21 @@ public:
 		{
 			luaL_error(L, "Profile index %d out of range.", index);
 		}
-		lua_pushstring(L, p->GetLocalProfileIDFromIndex(index) );
+		lua_pushstring(L, p->GetLocalProfileIDFromIndex(index).c_str() );
 		return 1;
 	}
 	static int GetLocalProfileIndexFromID( T* p, lua_State *L )	{ lua_pushnumber(L, p->GetLocalProfileIndexFromID(SArg(1)) ); return 1; }
 	static int GetNumLocalProfiles( T* p, lua_State *L )	{ lua_pushnumber(L, p->GetNumLocalProfiles() ); return 1; }
-	static int GetProfileDir( T* p, lua_State *L ) { lua_pushstring(L, p->GetProfileDir(Enum::Check<ProfileSlot>(L, 1)) ); return 1; }
+	static int GetProfileDir( T* p, lua_State *L ) { lua_pushstring(L, p->GetProfileDir(Enum::Check<ProfileSlot>(L, 1)).c_str() ); return 1; }
 	static int IsSongNew( T* p, lua_State *L )	{ lua_pushboolean(L, p->IsSongNew(Luna<Song>::check(L,1)) ); return 1; }
 	static int ProfileWasLoadedFromMemoryCard( T* p, lua_State *L )	{ lua_pushboolean(L, p->ProfileWasLoadedFromMemoryCard(Enum::Check<PlayerNumber>(L, 1)) ); return 1; }
 	static int LastLoadWasTamperedOrCorrupt( T* p, lua_State *L ) { lua_pushboolean(L, p->LastLoadWasTamperedOrCorrupt(Enum::Check<PlayerNumber>(L, 1)) ); return 1; }
-	static int GetPlayerName( T* p, lua_State *L )				{ PlayerNumber pn = Enum::Check<PlayerNumber>(L, 1); lua_pushstring(L, p->GetPlayerName(pn)); return 1; }
+	static int GetPlayerName( T* p, lua_State *L )				{ PlayerNumber pn = Enum::Check<PlayerNumber>(L, 1); lua_pushstring(L, p->GetPlayerName(pn).c_str()); return 1; }
 
 	static int LocalProfileIDToDir( T* , lua_State *L )
 	{
 		RString dir = USER_PROFILES_DIR + SArg(1) + "/";
-		lua_pushstring( L, dir );
+		lua_pushstring( L, dir.c_str() );
 		return 1;
 	}
 	static int SaveProfile( T* p, lua_State *L ) { lua_pushboolean( L, p->SaveProfile(Enum::Check<PlayerNumber>(L, 1)) ); return 1; }

--- a/src/RageException.cpp
+++ b/src/RageException.cpp
@@ -46,7 +46,7 @@ void RageException::Throw( const char *sFmt, ... )
 	}
 	else
 	{
-		puts( msg );
+		puts( msg.c_str() );
 		fflush( stdout );
 	}
 

--- a/src/RageFile.cpp
+++ b/src/RageFile.cpp
@@ -393,7 +393,7 @@ public:
 		can_safely_read(p, L);
 		RString string;
 		p->Read(string);
-		lua_pushstring( L, string );
+		lua_pushstring( L, string.c_str() );
 		return 1;
 	}
 
@@ -402,7 +402,7 @@ public:
 		can_safely_read(p, L);
 		RString string;
 		p->Read( string, IArg(1) );
-		lua_pushstring( L, string );
+		lua_pushstring( L, string.c_str() );
 		return 1;
 	}
 
@@ -425,7 +425,7 @@ public:
 		can_safely_read(p, L);
 		RString string;
 		p->GetLine(string);
-		lua_pushstring( L, string );
+		lua_pushstring( L, string.c_str() );
 		return 1;
 	}
 
@@ -440,7 +440,7 @@ public:
 	{
 		RString error;
 		error = p->GetError();
-		lua_pushstring( L, error );
+		lua_pushstring( L, error.c_str() );
 		return 1;
 	}
 

--- a/src/RageFileDriverDirect.cpp
+++ b/src/RageFileDriverDirect.cpp
@@ -60,7 +60,7 @@ static RageFileObjDirect *MakeFileObjDirect( RString sPath, int iMode, int &iErr
 	int iFD;
 	if( iMode & RageFile::READ )
 	{
-		iFD = DoOpen( sPath, O_BINARY|O_RDONLY, 0666 );
+		iFD = DoOpen( sPath.c_str(), O_BINARY|O_RDONLY, 0666 );
 
 		/* XXX: Windows returns EACCES if we try to open a file on a CDROM that isn't
 		 * ready, instead of something like ENODEV.  We want to return that case as
@@ -75,7 +75,7 @@ static RageFileObjDirect *MakeFileObjDirect( RString sPath, int iMode, int &iErr
 			sOut = MakeTempFilename(sPath);
 
 		/* Open a temporary file for writing. */
-		iFD = DoOpen( sOut, O_BINARY|O_WRONLY|O_CREAT|O_TRUNC, 0666 );
+		iFD = DoOpen( sOut.c_str(), O_BINARY|O_WRONLY|O_CREAT|O_TRUNC, 0666 );
 	}
 
 	if( iFD == -1 )
@@ -145,7 +145,7 @@ bool RageFileDriverDirect::Move( const RString &sOldPath_, const RString &sNewPa
 	int size = FDB->GetFileSize( sOldPath );
 	int hash = FDB->GetFileHash( sOldPath );
 	TRACE( ssprintf("rename \"%s\" -> \"%s\"", (m_sRoot + sOldPath).c_str(), (m_sRoot + sNewPath).c_str()) );
-	if( DoRename(m_sRoot + sOldPath, m_sRoot + sNewPath) == -1 )
+	if( DoRename((m_sRoot + sOldPath).c_str(), (m_sRoot + sNewPath).c_str()) == -1 )
 	{
 		WARN( ssprintf("rename(%s,%s) failed: %s", (m_sRoot + sOldPath).c_str(), (m_sRoot + sNewPath).c_str(), strerror(errno)) );
 		return false;
@@ -170,7 +170,7 @@ bool RageFileDriverDirect::Remove( const RString &sPath_ )
 	switch( type )
 	{
 	case RageFileManager::TYPE_FILE:
-		if( DoRemove(m_sRoot + sPath) == -1 )
+		if( DoRemove((m_sRoot + sPath).c_str()) == -1 )
 		{
 			WARN("remove failed: " + sPath);
 			return false;
@@ -179,7 +179,7 @@ bool RageFileDriverDirect::Remove( const RString &sPath_ )
 		return true;
 
 	case RageFileManager::TYPE_DIR:
-		if( DoRmdir(m_sRoot + sPath) == -1 )
+		if( DoRmdir((m_sRoot + sPath).c_str()) == -1 )
 		{
 			WARN("rmdir failed: " + sPath);
 			return false;
@@ -258,7 +258,7 @@ namespace
 	bool FlushDir( RString sPath, RString &sError )
 	{
 		/* Wait for the directory to be flushed. */
-		int dirfd = open( sPath, O_RDONLY );
+		int dirfd = open( sPath.c_str(), O_RDONLY );
 		if( dirfd == -1 )
 		{
 			sError = strerror(errno);
@@ -361,7 +361,7 @@ RageFileObjDirect::~RageFileObjDirect()
 		SetError( error );
 		break;
 #else
-		if( rename( sOldPath, sNewPath ) == -1 )
+		if( rename( sOldPath.c_str(), sNewPath.c_str() ) == -1 )
 		{
 			WARN( ssprintf("Error renaming \"%s\" to \"%s\": %s",
 					sOldPath.c_str(), sNewPath.c_str(), strerror(errno)) );
@@ -386,7 +386,7 @@ RageFileObjDirect::~RageFileObjDirect()
 	} while(0);
 
 	// The write or the rename failed. Delete the incomplete temporary file.
-	DoRemove( MakeTempFilename(m_sPath) );
+	DoRemove( MakeTempFilename(m_sPath).c_str() );
 }
 
 int RageFileObjDirect::ReadInternal( void *pBuf, size_t iBytes )

--- a/src/RageFileDriverDirectHelpers.cpp
+++ b/src/RageFileDriverDirectHelpers.cpp
@@ -28,7 +28,7 @@ RString DoPathReplace(const RString &sPath)
 #if defined(_WIN32)
 static bool WinMoveFileInternal( const RString &sOldPath, const RString &sNewPath )
 {
-	if( MoveFileEx( sOldPath, sNewPath, MOVEFILE_REPLACE_EXISTING ) )
+	if( MoveFileEx( sOldPath.c_str(), sNewPath.c_str(), MOVEFILE_REPLACE_EXISTING ) )
 		return true;
 
 	DWORD err = GetLastError();
@@ -62,10 +62,10 @@ static bool WinMoveFileInternal( const RString &sOldPath, const RString &sNewPat
 		}
 	}
 
-	if( !DeleteFile( sNewPath ) )
+	if( !DeleteFile( sNewPath.c_str() ) )
 		return false;
 
-	return !!MoveFile( sOldPath, sNewPath );
+	return !!MoveFile( sOldPath.c_str(), sNewPath.c_str() );
 }
 
 bool WinMoveFile( RString sOldPath, RString sNewPath )
@@ -75,7 +75,7 @@ bool WinMoveFile( RString sOldPath, RString sNewPath )
 	if( GetLastError() != ERROR_ACCESS_DENIED )
 		return false;
 	/* Try turning off the read-only bit on the file we're overwriting. */
-	SetFileAttributes( DoPathReplace(sNewPath), FILE_ATTRIBUTE_NORMAL );
+	SetFileAttributes( DoPathReplace(sNewPath).c_str(), FILE_ATTRIBUTE_NORMAL );
 
 	return WinMoveFileInternal( DoPathReplace(sOldPath), DoPathReplace(sNewPath) );
 }
@@ -109,7 +109,7 @@ bool CreateDirectories( RString Path )
 		}
 #endif
 
-		if( DoMkdir(curpath, 0777) == 0 )
+		if( DoMkdir(curpath.c_str(), 0777) == 0 )
 			continue;
 
 #if defined(_WIN32)
@@ -128,7 +128,7 @@ bool CreateDirectories( RString Path )
 		{
 			/* Make sure it's a directory. */
 			struct stat st;
-			if( DoStat(curpath, &st) != -1 && !(st.st_mode & S_IFDIR) )
+			if( DoStat(curpath.c_str(), &st) != -1 && !(st.st_mode & S_IFDIR) )
 			{
 				WARN( ssprintf("Couldn't create %s: path exists and is not a directory", curpath.c_str()) );
 				return false;
@@ -181,7 +181,7 @@ void DirectFilenameDB::CacheFile( const RString &sPath )
 
 #if defined(_WIN32)
 	WIN32_FIND_DATA fd;
-	HANDLE hFind = DoFindFirstFile( root+sPath, &fd );
+	HANDLE hFind = DoFindFirstFile( (root+sPath).c_str(), &fd );
 	if( hFind == INVALID_HANDLE_VALUE )
 	{
 		m_Mutex.Unlock(); // Locked by GetFileSet()
@@ -198,7 +198,7 @@ void DirectFilenameDB::CacheFile( const RString &sPath )
 	File f( Basename(sPath) );
 
 	struct stat st;
-	if( DoStat(root+sPath, &st) == -1 )
+	if( DoStat((root+sPath).c_str(), &st) == -1 )
 	{
 		WARN(ssprintf("File '%s' is gone! (%s)", sPath.c_str(), strerror(errno)));
 	}
@@ -230,7 +230,7 @@ void DirectFilenameDB::PopulateFileSet( FileSet &fs, const RString &path )
 	if ( sPath.size() > 0  && sPath.Right(1) == "/" )
 		sPath.erase( sPath.size() - 1 );
 
-	HANDLE hFind = DoFindFirstFile( root+sPath+"/*", &fd );
+	HANDLE hFind = DoFindFirstFile( (root+sPath+"/*").c_str(), &fd );
 	CHECKPOINT_M( root+sPath+"/*" );
 
 	if( hFind == INVALID_HANDLE_VALUE )
@@ -257,7 +257,7 @@ void DirectFilenameDB::PopulateFileSet( FileSet &fs, const RString &path )
 	 * for each file.  This isn't a major issue, since most large directory
 	 * scans are I/O-bound. */
 
-	DIR *pDir = opendir(root+sPath);
+	DIR *pDir = opendir((root+sPath).c_str());
 	if( pDir == nullptr )
 		return;
 
@@ -271,11 +271,11 @@ void DirectFilenameDB::PopulateFileSet( FileSet &fs, const RString &path )
 		File f( pEnt->d_name );
 
 		struct stat st;
-		if( DoStat(root+sPath + "/" + pEnt->d_name, &st) == -1 )
+		if( DoStat((root+sPath + "/" + pEnt->d_name).c_str(), &st) == -1 )
 		{
 			int iError = errno;
 			/* If it's a broken symlink, ignore it.  Otherwise, warn. */
-			if( lstat(root+sPath + "/" + pEnt->d_name, &st) == 0 )
+			if( lstat((root+sPath + "/" + pEnt->d_name).c_str(), &st) == 0 )
 				continue;
 
 			/* Huh? */

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -319,7 +319,7 @@ static RString ReadlinkRecursive( RString sPath )
 	{
 		sPath = dereferenced;
 		char derefPath[512];
-		ssize_t linkSize = readlink(sPath, derefPath, sizeof(derefPath));
+		ssize_t linkSize = readlink(sPath.c_str(), derefPath, sizeof(derefPath));
 		if ( linkSize != -1 && linkSize != sizeof(derefPath) )
 		{
 			dereferenced = RString( derefPath, linkSize );
@@ -376,7 +376,7 @@ static RString GetDirOfExecutable( RString argv0 )
 			split( path, ":", vPath );
 			for (RString &i : vPath)
 			{
-				if( access(i + "/" + argv0, X_OK|R_OK) )
+				if( access((i + "/" + argv0).c_str(), X_OK|R_OK) )
 					continue;
 				sPath = ExtractDirectory(ReadlinkRecursive(i + "/" + argv0));
 				break;
@@ -406,9 +406,9 @@ static void ChangeToDirOfExecutable( const RString &argv0 )
 	/* Set the CWD.  Any effects of this is platform-specific; most files are read and
 	 * written through RageFile.  See also RageFileManager::RageFileManager. */
 #if defined(_WINDOWS)
-	if( _chdir( RageFileManagerUtil::sDirOfExecutable + "/.." ) )
+	if( _chdir( (RageFileManagerUtil::sDirOfExecutable + "/..").c_str() ) )
 #elif defined(UNIX)
-	if( chdir( RageFileManagerUtil::sDirOfExecutable + "/" ) )
+	if( chdir( (RageFileManagerUtil::sDirOfExecutable + "/").c_str() ) )
 #elif defined(MACOSX)
 	/* If the basename is not MacOS, then we've likely been launched via the command line
 	 * through a symlink. Assume this is the case and change to the dir of the symlink. */
@@ -706,7 +706,7 @@ bool RageFileManager::Mount( const RString &sType, const RString &sRoot_, const 
 	const RString &sPaths = ssprintf( "\"%s\", \"%s\", \"%s\"", sType.c_str(), sRoot.c_str(), sMountPoint.c_str() );
 	CHECKPOINT_M( sPaths );
 #if defined(DEBUG)
-	puts( sPaths );
+	puts( sPaths.c_str() );
 #endif
 
 	// Unmount anything that was previously mounted here.
@@ -984,7 +984,7 @@ static bool PathUsesSlowFlush( const RString &sPath )
 	};
 
 	for( unsigned i = 0; i < ARRAYLEN(FlushPaths); ++i )
-		if( !strncmp( sPath, FlushPaths[i], strlen(FlushPaths[i]) ) )
+		if( !strncmp( sPath.c_str(), FlushPaths[i], strlen(FlushPaths[i]) ) )
 			return true;
 	return false;
 }

--- a/src/RageInputDevice.cpp
+++ b/src/RageInputDevice.cpp
@@ -176,16 +176,16 @@ DeviceButton StringToDeviceButton( const RString& s )
 		return (DeviceButton) s[0];
 
 	int i;
-	if( sscanf(s, "unk %i", &i) == 1 )
+	if( sscanf(s.c_str(), "unk %i", &i) == 1 )
 		return enum_add2( KEY_OTHER_0, i );
 
-	if( sscanf(s, "B%i", &i) == 1 )
+	if( sscanf(s.c_str(), "B%i", &i) == 1 )
 		return enum_add2( JOY_BUTTON_1, i-1 );
 
-	if( sscanf(s, "Midi %i", &i) == 1 )
+	if( sscanf(s.c_str(), "Midi %i", &i) == 1 )
 		return enum_add2( MIDI_FIRST, i );
 
-	if( sscanf(s, "Mouse %i", &i) == 1 )
+	if( sscanf(s.c_str(), "Mouse %i", &i) == 1 )
 		return enum_add2( MOUSE_LEFT, i );
 
 	std::map<RString, DeviceButton>::const_iterator it = g_mapStringToNames.find( s );
@@ -255,7 +255,7 @@ bool DeviceInput::FromString( const RString &s )
 	char szDevice[32] = "";
 	char szButton[32] = "";
 
-	if( 2 != sscanf( s, "%31[^_]_%31[^_]", szDevice, szButton ) )
+	if( 2 != sscanf( s.c_str(), "%31[^_]_%31[^_]", szDevice, szButton ) )
 	{
 		device = InputDevice_Invalid;
 		return false;

--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -282,7 +282,7 @@ void RageLog::Write( int where, const RString &sLine )
 			sStr.insert( 0, sWarning );
 
 		if( m_bShowLogOutput || (where&WRITE_TO_INFO) )
-			puts(sStr); //fputws( (const wchar_t *)sStr.c_str(), stdout );
+			puts(sStr.c_str()); //fputws( (const wchar_t *)sStr.c_str(), stdout );
 		if( where & WRITE_TO_INFO )
 			AddToInfo( sStr );
 		if( m_bLogToDisk && (where&WRITE_TO_INFO) && g_fileInfo->IsOpen() )
@@ -365,7 +365,7 @@ void RageLog::AddToRecentLogs( const RString &str )
 	if( len > sizeof(backlog[backlog_start])-1 )
 		len = sizeof(backlog[backlog_start])-1;
 
-	strncpy( backlog[backlog_start], str, len );
+	strncpy( backlog[backlog_start], str.c_str(), len );
 	backlog[backlog_start] [ len ] = 0;
 
 	backlog_start++;
@@ -429,6 +429,11 @@ void RageLog::UnmapLog( const RString &key )
 {
 	LogMaps.erase( key );
 	UpdateMappedLog();
+}
+
+void ShowWarningOrTrace( const char *file, int line, const RString& message, bool bWarning )
+{
+	ShowWarningOrTrace(file, line, message.c_str(), bWarning);
 }
 
 void ShowWarningOrTrace( const char *file, int line, const char *message, bool bWarning )

--- a/src/RageModelGeometry.cpp
+++ b/src/RageModelGeometry.cpp
@@ -114,23 +114,23 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 	{
 		iLineNum++;
 
-		if( !strncmp(sLine, "//", 2) )
+		if( !strncmp(sLine.c_str(), "//", 2) )
 			continue;
 
 		int nFrame;
-		if( sscanf(sLine, "Frames: %d", &nFrame) == 1 )
+		if( sscanf(sLine.c_str(), "Frames: %d", &nFrame) == 1 )
 		{
 			// ignore
 			// m_pRageModelGeometry->nTotalFrames = nFrame;
 		}
-		if( sscanf(sLine, "Frame: %d", &nFrame) == 1 )
+		if( sscanf(sLine.c_str(), "Frame: %d", &nFrame) == 1 )
 		{
 			// ignore
 			// m_pRageModelGeometry->nFrame = nFrame;
 		}
 
 		int nNumMeshes = 0;
-		if( sscanf(sLine, "Meshes: %d", &nNumMeshes) == 1 )
+		if( sscanf(sLine.c_str(), "Meshes: %d", &nNumMeshes) == 1 )
 		{
 			ASSERT( m_Meshes.empty() );
 			m_Meshes.resize( nNumMeshes );
@@ -145,7 +145,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 					THROW;
 
 				// mesh: name, flags, material index
-				if( sscanf (sLine, "\"%31[^\"]\" %d %d",szName, &nFlags, &nIndex) != 3 )
+				if( sscanf (sLine.c_str(), "\"%31[^\"]\" %d %d",szName, &nFlags, &nIndex) != 3 )
 					THROW;
 
 				mesh.sName = szName;
@@ -161,7 +161,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 					THROW;
 
 				int nNumVertices = 0;
-				if( sscanf (sLine, "%d", &nNumVertices) != 1 )
+				if( sscanf (sLine.c_str(), "%d", &nNumVertices) != 1 )
 					THROW;
 
 				Vertices.resize( nNumVertices );
@@ -173,7 +173,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 					if( f.GetLine( sLine ) <= 0 )
 						THROW;
 
-					if( sscanf(sLine, "%d %f %f %f %f %f %d",
+					if( sscanf(sLine.c_str(), "%d %f %f %f %f %f %d",
 								&nFlags,
 								&v.p[0], &v.p[1], &v.p[2],
 								&v.t[0], &v.t[1],
@@ -205,7 +205,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 					THROW;
 
 				int nNumNormals = 0;
-				if( sscanf(sLine, "%d", &nNumNormals) != 1 )
+				if( sscanf(sLine.c_str(), "%d", &nNumNormals) != 1 )
 					THROW;
 
 				std::vector<RageVector3> Normals;
@@ -216,7 +216,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 						THROW;
 
 					RageVector3 Normal;
-					if( sscanf(sLine, "%f %f %f", &Normal[0], &Normal[1], &Normal[2]) != 3 )
+					if( sscanf(sLine.c_str(), "%f %f %f", &Normal[0], &Normal[1], &Normal[2]) != 3 )
 						THROW;
 
 					RageVec3Normalize( (RageVector3*)&Normal, (RageVector3*)&Normal );
@@ -230,7 +230,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 					THROW;
 
 				int nNumTriangles = 0;
-				if( sscanf (sLine, "%d", &nNumTriangles) != 1 )
+				if( sscanf (sLine.c_str(), "%d", &nNumTriangles) != 1 )
 					THROW;
 
 				Triangles.resize( nNumTriangles );
@@ -242,7 +242,7 @@ void RageModelGeometry::LoadMilkshapeAscii( const RString& _sPath, bool bNeedsNo
 
 					uint16_t nIndices[3];
 					uint16_t nNormalIndices[3];
-					if( sscanf (sLine, "%d %hu %hu %hu %hu %hu %hu %d",
+					if( sscanf (sLine.c_str(), "%d %hu %hu %hu %hu %hu %hu %d",
 								&nFlags,
 								&nIndices[0], &nIndices[1], &nIndices[2],
 								&nNormalIndices[0], &nNormalIndices[1], &nNormalIndices[2],

--- a/src/RageSurface_Load_JPEG.cpp
+++ b/src/RageSurface_Load_JPEG.cpp
@@ -206,7 +206,7 @@ RageSurfaceUtils::OpenResult RageSurface_Load_JPEG( const RString &sPath, RageSu
 	}
 
 	char errorbuf[1024];
-	ret = RageSurface_Load_JPEG( &f, sPath, errorbuf );
+	ret = RageSurface_Load_JPEG( &f, sPath.c_str(), errorbuf );
 	if( ret == nullptr )
 	{
 		error = errorbuf;

--- a/src/RageSurface_Load_PNG.cpp
+++ b/src/RageSurface_Load_PNG.cpp
@@ -31,7 +31,7 @@ void RageFile_png_read( png_struct *png, png_byte *p, png_size_t size )
 		 * GetError().c_str() to it, a temporary may be created; since control
 		 * never returns here, it may never be destructed and we could leak. */
 		static char error[256];
-		strncpy( error, f->GetError(), sizeof(error) );
+		strncpy( error, f->GetError().c_str(), sizeof(error) );
 		error[sizeof(error)-1] = 0;
 		png_error( png, error );
 	}
@@ -271,7 +271,7 @@ RageSurfaceUtils::OpenResult RageSurface_Load_PNG( const RString &sPath, RageSur
 	}
 
 	char errorbuf[1024];
-	ret = RageSurface_Load_PNG( &f, sPath, errorbuf, bHeaderOnly );
+	ret = RageSurface_Load_PNG( &f, sPath.c_str(), errorbuf, bHeaderOnly );
 	if( ret == nullptr )
 	{
 		error = errorbuf;

--- a/src/RageSurface_Load_XPM.cpp
+++ b/src/RageSurface_Load_XPM.cpp
@@ -57,7 +57,7 @@ RageSurface *RageSurface_Load_XPM( char * const *xpm, RString &error )
 
 		RString clr = color.substr( color_length+4 );
 		unsigned int r, g, b;
-		if( sscanf( clr, "%2x%2x%2x", &r, &g, &b ) != 3 )
+		if( sscanf( clr.c_str(), "%2x%2x%2x", &r, &g, &b ) != 3 )
 			continue;
 		RageSurfaceColor colorval;
 		colorval.r = (uint8_t) r;

--- a/src/RageSurface_Save_PNG.cpp
+++ b/src/RageSurface_Save_PNG.cpp
@@ -22,7 +22,7 @@ static void SafePngError( png_struct *pPng, const RString &sStr )
 	 * GetError().c_str() to it, a temporary may be created; since control
 	 * never returns, it may never be destructed and leak. */
 	static char error[256];
-	strncpy( error, sStr, sizeof(error) );
+	strncpy( error, sStr.c_str(), sizeof(error) );
 	error[sizeof(error)-1] = 0;
 	png_error( pPng, error );
 }

--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -264,7 +264,7 @@ RageThreadRegister::RageThreadRegister( const RString &sName )
 
 	m_pSlot = &g_ThreadSlots[iSlot];
 
-	strcpy( m_pSlot->m_szName, sName );
+	strcpy( m_pSlot->m_szName, sName.c_str() );
 	sprintf( m_pSlot->m_szThreadFormattedOutput, "Thread: %s", sName.c_str() );
 
 	m_pSlot->m_iID = GetThisThreadId();
@@ -378,6 +378,11 @@ static bool g_LogCheckpoints = false;
 void Checkpoints::LogCheckpoints( bool on )
 {
 	g_LogCheckpoints = on;
+}
+
+void Checkpoints::SetCheckpoint( const char *file, int line, const RString& message )
+{
+	SetCheckpoint(file, line, message.c_str());
 }
 
 void Checkpoints::SetCheckpoint( const char *file, int line, const char *message )

--- a/src/RageTypes.h
+++ b/src/RageTypes.h
@@ -230,7 +230,7 @@ public:
 
 	bool FromString( const RString &str )
 	{
-		int result = sscanf( str, "%f,%f,%f,%f", &r, &g, &b, &a );
+		int result = sscanf( str.c_str(), "%f,%f,%f,%f", &r, &g, &b, &a );
 		if( result == 3 )
 		{
 			a = 1;
@@ -240,7 +240,7 @@ public:
 			return true;
 
 		unsigned int ir=255, ib=255, ig=255, ia=255;
-		result = sscanf( str, "#%2x%2x%2x%2x", &ir, &ig, &ib, &ia );
+		result = sscanf( str.c_str(), "#%2x%2x%2x%2x", &ir, &ig, &ib, &ia );
 		if( result >= 3 )
 		{
 			r = ir / 255.0f; g = ig / 255.0f; b = ib / 255.0f;

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -195,7 +195,7 @@ bool HexToBinary( const RString &s, unsigned char *stringOut )
 		RString sByte = s.substr( i*2, 2 );
 
 		uint8_t val = 0;
-		if( sscanf( sByte, "%hhx", &val ) != 1 )
+		if( sscanf( sByte.c_str(), "%hhx", &val ) != 1 )
 			return false;
 		stringOut[i] = val;
 	}
@@ -633,7 +633,7 @@ RString serialize(const std::vector<float> & sSource, const RString &sDelimitor,
 	RString precisionStr = ssprintf("%%.%df", precision);
 	for(float s : sSource)
 	{
-		values.push_back(ssprintf(precisionStr, s));
+		values.push_back(ssprintf(precisionStr.c_str(), s));
 	}
 	return join(sDelimitor, values);
 }
@@ -1813,7 +1813,7 @@ void MakeLower( wchar_t *p, size_t iLen )
 
 float StringToFloat( const RString &sString )
 {
-	float fOut = std::strtof(sString, nullptr);
+	float fOut = std::strtof(sString.c_str(), nullptr);
 	if (!std::isfinite(fOut))
 	{
 		fOut = 0.0f;
@@ -1825,7 +1825,7 @@ bool StringToFloat( const RString &sString, float &fOut )
 {
 	char *endPtr = nullptr;
 
-	fOut = std::strtof(sString, &endPtr);
+	fOut = std::strtof(sString.c_str(), &endPtr);
 	return sString.size() && *endPtr == '\0' && std::isfinite(fOut);
 }
 
@@ -2290,7 +2290,7 @@ namespace StringConversion
 	template<> bool FromString<float>( const RString &sValue, float &out )
 	{
 		const char *endptr = sValue.data() + sValue.size();
-		out = strtof( sValue, (char **) &endptr );
+		out = strtof( sValue.c_str(), (char **) &endptr );
 		if( endptr != sValue.data() && std::isfinite( out ) )
 			return true;
 		out = 0;

--- a/src/RollingNumbers.cpp
+++ b/src/RollingNumbers.cpp
@@ -127,7 +127,7 @@ void RollingNumbers::UpdateText()
 	{
 		return;
 	}
-	RString s = ssprintf( TEXT_FORMAT.GetValue(), m_fCurrentNumber );
+	RString s = ssprintf( TEXT_FORMAT.GetValue().c_str(), m_fCurrentNumber );
 	if(COMMIFY)
 	{
 		s = Commify( s );

--- a/src/Screen.cpp
+++ b/src/Screen.cpp
@@ -422,9 +422,9 @@ void Screen::InternalRemoveCallback(callback_key_t key)
 class LunaScreen: public Luna<Screen>
 {
 public:
-	static int GetNextScreenName( T* p, lua_State *L ) { lua_pushstring(L, p->GetNextScreenName() ); return 1; }
+	static int GetNextScreenName( T* p, lua_State *L ) { lua_pushstring(L, p->GetNextScreenName().c_str() ); return 1; }
 	static int SetNextScreenName( T* p, lua_State *L ) { p->SetNextScreenName(SArg(1)); COMMON_RETURN_SELF; }
-	static int GetPrevScreenName( T* p, lua_State *L ) { lua_pushstring(L, p->GetPrevScreen() ); return 1; }
+	static int GetPrevScreenName( T* p, lua_State *L ) { lua_pushstring(L, p->GetPrevScreen().c_str() ); return 1; }
 	static int SetPrevScreenName( T* p, lua_State *L ) { p->SetPrevScreenName(SArg(1)); COMMON_RETURN_SELF; }
 	static int lockinput( T* p, lua_State *L ) { p->SetLockInputSecs(FArg(1)); COMMON_RETURN_SELF; }
 	DEFINE_METHOD( GetScreenType,	GetScreenType() )

--- a/src/ScreenBookkeeping.cpp
+++ b/src/ScreenBookkeeping.cpp
@@ -155,7 +155,7 @@ void ScreenBookkeeping::UpdateView()
 				iCount += pProfile->GetSongNumTimesPlayed( pSong );
 				vpSongs.push_back( pSong );
 			}
-			m_textTitle.SetText( ssprintf(SONG_PLAYS.GetValue(), iCount) );
+			m_textTitle.SetText( ssprintf(SONG_PLAYS.GetValue().c_str(), iCount) );
 			SongUtil::SortSongPointerArrayByNumPlays( vpSongs, pProfile, true );
 
 			const int iSongPerCol = 15;
@@ -184,7 +184,7 @@ void ScreenBookkeeping::UpdateView()
 		break;
 	case BookkeepingView_LastDays:
 		{
-			m_textTitle.SetText( ssprintf(LAST_DAYS.GetValue(), NUM_LAST_DAYS) );
+			m_textTitle.SetText( ssprintf(LAST_DAYS.GetValue().c_str(), NUM_LAST_DAYS) );
 
 			int coins[NUM_LAST_DAYS];
 			BOOKKEEPER->GetCoinsLastDays( coins );
@@ -211,7 +211,7 @@ void ScreenBookkeeping::UpdateView()
 		break;
 	case BookkeepingView_LastWeeks:
 		{
-			m_textTitle.SetText( ssprintf(LAST_WEEKS.GetValue(), NUM_LAST_WEEKS) );
+			m_textTitle.SetText( ssprintf(LAST_WEEKS.GetValue().c_str(), NUM_LAST_WEEKS) );
 
 			int coins[NUM_LAST_WEEKS];
 			BOOKKEEPER->GetCoinsLastWeeks( coins );

--- a/src/ScreenDebugOverlay.cpp
+++ b/src/ScreenDebugOverlay.cpp
@@ -159,7 +159,7 @@ static RString GetDebugButtonName( const IDebugLine *pLine )
 	case IDebugLine::all_screens:
 		return s;
 	case IDebugLine::gameplay_only:
-		return ssprintf( IN_GAMEPLAY.GetValue(), s.c_str() );
+		return ssprintf( IN_GAMEPLAY.GetValue().c_str(), s.c_str() );
 	default:
 		FAIL_M(ssprintf("Invalid debug line type: %i", type));
 	}

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -1906,12 +1906,12 @@ void ScreenEdit::UpdateTextInfo()
 
 	m_bTextInfoNeedsUpdate = false;
 
-	RString sNoteType = ssprintf( NOTES.GetValue(), NoteTypeToLocalizedString(m_SnapDisplay.GetNoteType()).c_str() );
+	RString sNoteType = ssprintf( NOTES.GetValue().c_str(), NoteTypeToLocalizedString(m_SnapDisplay.GetNoteType()).c_str() );
 
 	RString sText;
-	sText += ssprintf( CURRENT_BEAT_FORMAT.GetValue(), CURRENT_BEAT.GetValue().c_str(), GetBeat() );
+	sText += ssprintf( CURRENT_BEAT_FORMAT.GetValue().c_str(), CURRENT_BEAT.GetValue().c_str(), GetBeat() );
 	float second= GetAppropriateTiming().GetElapsedTimeFromBeatNoOffset(GetBeat());
-	sText += ssprintf( CURRENT_SECOND_FORMAT.GetValue(), CURRENT_SECOND.GetValue().c_str(), second );
+	sText += ssprintf( CURRENT_SECOND_FORMAT.GetValue().c_str(), CURRENT_SECOND.GetValue().c_str(), second );
 	switch( EDIT_MODE.GetValue() )
 	{
 	DEFAULT_FAIL( EDIT_MODE.GetValue() );
@@ -1920,35 +1920,35 @@ void ScreenEdit::UpdateTextInfo()
 	case EditMode_CourseMods:
 	case EditMode_Home:
 	case EditMode_Full:
-		sText += ssprintf( SNAP_TO_FORMAT.GetValue(), SNAP_TO.GetValue().c_str(), sNoteType.c_str() );
+		sText += ssprintf( SNAP_TO_FORMAT.GetValue().c_str(), SNAP_TO.GetValue().c_str(), sNoteType.c_str() );
 		break;
 	}
 
 	if( m_NoteFieldEdit.m_iBeginMarker != -1 )
 	{
-		sText += ssprintf( SELECTION_BEAT_BEGIN_FORMAT.GetValue(), SELECTION_BEAT.GetValue().c_str(), NoteRowToBeat(m_NoteFieldEdit.m_iBeginMarker) );
+		sText += ssprintf( SELECTION_BEAT_BEGIN_FORMAT.GetValue().c_str(), SELECTION_BEAT.GetValue().c_str(), NoteRowToBeat(m_NoteFieldEdit.m_iBeginMarker) );
 
 		if( m_NoteFieldEdit.m_iEndMarker != -1 )
-			sText += ssprintf( SELECTION_BEAT_END_FORMAT.GetValue(), NoteRowToBeat(m_NoteFieldEdit.m_iEndMarker) );
+			sText += ssprintf( SELECTION_BEAT_END_FORMAT.GetValue().c_str(), NoteRowToBeat(m_NoteFieldEdit.m_iEndMarker) );
 		else
 			sText += SELECTION_BEAT_UNFINISHED_FORMAT;
 	}
 
 	if (EDIT_MODE.GetValue() == EditMode_Full)
 	{
-		sText += ssprintf( DIFFICULTY_FORMAT.GetValue(), DIFFICULTY.GetValue().c_str(), DifficultyToString( m_pSteps->GetDifficulty() ).c_str() );
+		sText += ssprintf( DIFFICULTY_FORMAT.GetValue().c_str(), DIFFICULTY.GetValue().c_str(), DifficultyToString( m_pSteps->GetDifficulty() ).c_str() );
 		if ( m_InputPlayerNumber != PLAYER_INVALID )
-			sText += ssprintf( ROUTINE_PLAYER_FORMAT.GetValue(), ROUTINE_PLAYER.GetValue().c_str(), m_InputPlayerNumber + 1 );
+			sText += ssprintf( ROUTINE_PLAYER_FORMAT.GetValue().c_str(), ROUTINE_PLAYER.GetValue().c_str(), m_InputPlayerNumber + 1 );
 		//sText += ssprintf( DESCRIPTION_FORMAT.GetValue(), DESCRIPTION.GetValue().c_str(), m_pSteps->GetDescription().c_str() );
-		sText += ssprintf( CHART_NAME_FORMAT.GetValue(), CHART_NAME.GetValue().c_str(), m_pSteps->GetChartName().c_str() );
-		sText += ssprintf( STEP_AUTHOR_FORMAT.GetValue(), STEP_AUTHOR.GetValue().c_str(), m_pSteps->GetCredit().c_str() );
+		sText += ssprintf( CHART_NAME_FORMAT.GetValue().c_str(), CHART_NAME.GetValue().c_str(), m_pSteps->GetChartName().c_str() );
+		sText += ssprintf( STEP_AUTHOR_FORMAT.GetValue().c_str(), STEP_AUTHOR.GetValue().c_str(), m_pSteps->GetCredit().c_str() );
 		//sText += ssprintf( CHART_STYLE_FORMAT.GetValue(), CHART_STYLE.GetValue().c_str(), m_pSteps->GetChartStyle().c_str() );
-		sText += ssprintf( MAIN_TITLE_FORMAT.GetValue(), MAIN_TITLE.GetValue().c_str(), m_pSong->m_sMainTitle.c_str() );
+		sText += ssprintf( MAIN_TITLE_FORMAT.GetValue().c_str(), MAIN_TITLE.GetValue().c_str(), m_pSong->m_sMainTitle.c_str() );
 		if( m_pSong->m_sSubTitle.size() )
-			sText += ssprintf( SUBTITLE_FORMAT.GetValue(), SUBTITLE.GetValue().c_str(), m_pSong->m_sSubTitle.c_str() );
-		sText += ssprintf( SEGMENT_TYPE_FORMAT.GetValue(), SEGMENT_TYPE.GetValue().c_str(), TimingSegmentTypeToString(currentCycleSegment).c_str() );
+			sText += ssprintf( SUBTITLE_FORMAT.GetValue().c_str(), SUBTITLE.GetValue().c_str(), m_pSong->m_sSubTitle.c_str() );
+		sText += ssprintf( SEGMENT_TYPE_FORMAT.GetValue().c_str(), SEGMENT_TYPE.GetValue().c_str(), TimingSegmentTypeToString(currentCycleSegment).c_str() );
         const RString tapnoteType = TapNoteTypeToString( m_selectedTap.type );
-		sText += ssprintf( TAP_NOTE_TYPE_FORMAT.GetValue(), TAP_NOTE_TYPE.GetValue().c_str(), tapnoteType.c_str() );
+		sText += ssprintf( TAP_NOTE_TYPE_FORMAT.GetValue().c_str(), TAP_NOTE_TYPE.GetValue().c_str(), tapnoteType.c_str() );
 
 		AttackArray &attacks =
 			(GAMESTATE->m_bIsUsingStepTiming ? m_pSteps->m_Attacks : m_pSong->m_Attacks);
@@ -1961,48 +1961,48 @@ void ScreenEdit::UpdateTextInfo()
 	if (cat == StepsTypeCategory_Couple || cat == StepsTypeCategory_Routine)
 	{
 		std::pair<int, int> tmp = m_NoteDataEdit.GetNumTapNotesTwoPlayer();
-		sText += ssprintf(NUM_STEPS_FORMAT_TWO_PLAYER.GetValue(),
+		sText += ssprintf(NUM_STEPS_FORMAT_TWO_PLAYER.GetValue().c_str(),
 						  TAP_STEPS.GetValue().c_str(),
 						  tmp.first, tmp.second);
 		tmp = m_NoteDataEdit.GetNumJumpsTwoPlayer();
-		sText += ssprintf(NUM_JUMPS_FORMAT_TWO_PLAYER.GetValue(),
+		sText += ssprintf(NUM_JUMPS_FORMAT_TWO_PLAYER.GetValue().c_str(),
 						  JUMPS.GetValue().c_str(),
 						  tmp.first, tmp.second);
 		tmp = m_NoteDataEdit.GetNumHandsTwoPlayer();
-		sText += ssprintf(NUM_HANDS_FORMAT_TWO_PLAYER.GetValue(),
+		sText += ssprintf(NUM_HANDS_FORMAT_TWO_PLAYER.GetValue().c_str(),
 						  HANDS.GetValue().c_str(),
 						  tmp.first, tmp.second);
 		tmp = m_NoteDataEdit.GetNumHoldNotesTwoPlayer();
-		sText += ssprintf(NUM_HOLDS_FORMAT_TWO_PLAYER.GetValue(),
+		sText += ssprintf(NUM_HOLDS_FORMAT_TWO_PLAYER.GetValue().c_str(),
 						  HOLDS.GetValue().c_str(),
 						  tmp.first, tmp.second);
 		tmp = m_NoteDataEdit.GetNumMinesTwoPlayer();
-		sText += ssprintf(NUM_MINES_FORMAT_TWO_PLAYER.GetValue(),
+		sText += ssprintf(NUM_MINES_FORMAT_TWO_PLAYER.GetValue().c_str(),
 						  MINES.GetValue().c_str(),
 						  tmp.first, tmp.second);
 		tmp = m_NoteDataEdit.GetNumRollsTwoPlayer();
-		sText += ssprintf(NUM_ROLLS_FORMAT_TWO_PLAYER.GetValue(),
+		sText += ssprintf(NUM_ROLLS_FORMAT_TWO_PLAYER.GetValue().c_str(),
 						  ROLLS.GetValue().c_str(),
 						  tmp.first, tmp.second);
 		tmp = m_NoteDataEdit.GetNumLiftsTwoPlayer();
-		sText += ssprintf(NUM_LIFTS_FORMAT_TWO_PLAYER.GetValue(),
+		sText += ssprintf(NUM_LIFTS_FORMAT_TWO_PLAYER.GetValue().c_str(),
 						  LIFTS.GetValue().c_str(),
 						  tmp.first, tmp.second);
 		tmp = m_NoteDataEdit.GetNumFakesTwoPlayer();
-		sText += ssprintf(NUM_FAKES_FORMAT_TWO_PLAYER.GetValue(),
+		sText += ssprintf(NUM_FAKES_FORMAT_TWO_PLAYER.GetValue().c_str(),
 						  FAKES.GetValue().c_str(),
 						  tmp.first, tmp.second);
 	}
 	else
 	{
-		sText += ssprintf( NUM_STEPS_FORMAT.GetValue(), TAP_STEPS.GetValue().c_str(), m_NoteDataEdit.GetNumTapNotes() );
-		sText += ssprintf( NUM_JUMPS_FORMAT.GetValue(), JUMPS.GetValue().c_str(), m_NoteDataEdit.GetNumJumps() );
-		sText += ssprintf( NUM_HANDS_FORMAT.GetValue(), HANDS.GetValue().c_str(), m_NoteDataEdit.GetNumHands() );
-		sText += ssprintf( NUM_HOLDS_FORMAT.GetValue(), HOLDS.GetValue().c_str(), m_NoteDataEdit.GetNumHoldNotes() );
-		sText += ssprintf( NUM_MINES_FORMAT.GetValue(), MINES.GetValue().c_str(), m_NoteDataEdit.GetNumMines() );
-		sText += ssprintf( NUM_ROLLS_FORMAT.GetValue(), ROLLS.GetValue().c_str(), m_NoteDataEdit.GetNumRolls() );
-		sText += ssprintf( NUM_LIFTS_FORMAT.GetValue(), LIFTS.GetValue().c_str(), m_NoteDataEdit.GetNumLifts() );
-		sText += ssprintf( NUM_FAKES_FORMAT.GetValue(), FAKES.GetValue().c_str(), m_NoteDataEdit.GetNumFakes() );
+		sText += ssprintf( NUM_STEPS_FORMAT.GetValue().c_str(), TAP_STEPS.GetValue().c_str(), m_NoteDataEdit.GetNumTapNotes() );
+		sText += ssprintf( NUM_JUMPS_FORMAT.GetValue().c_str(), JUMPS.GetValue().c_str(), m_NoteDataEdit.GetNumJumps() );
+		sText += ssprintf( NUM_HANDS_FORMAT.GetValue().c_str(), HANDS.GetValue().c_str(), m_NoteDataEdit.GetNumHands() );
+		sText += ssprintf( NUM_HOLDS_FORMAT.GetValue().c_str(), HOLDS.GetValue().c_str(), m_NoteDataEdit.GetNumHoldNotes() );
+		sText += ssprintf( NUM_MINES_FORMAT.GetValue().c_str(), MINES.GetValue().c_str(), m_NoteDataEdit.GetNumMines() );
+		sText += ssprintf( NUM_ROLLS_FORMAT.GetValue().c_str(), ROLLS.GetValue().c_str(), m_NoteDataEdit.GetNumRolls() );
+		sText += ssprintf( NUM_LIFTS_FORMAT.GetValue().c_str(), LIFTS.GetValue().c_str(), m_NoteDataEdit.GetNumLifts() );
+		sText += ssprintf( NUM_FAKES_FORMAT.GetValue().c_str(), FAKES.GetValue().c_str(), m_NoteDataEdit.GetNumFakes() );
 	}
 	switch( EDIT_MODE.GetValue() )
 	{
@@ -2012,20 +2012,20 @@ void ScreenEdit::UpdateTextInfo()
 	case EditMode_Home:
 		break;
 	case EditMode_Full:
-		sText += ssprintf( TIMING_MODE_FORMAT.GetValue(),
+		sText += ssprintf( TIMING_MODE_FORMAT.GetValue().c_str(),
 				  TIMING_MODE.GetValue().c_str(),
 				  ( GAMESTATE->m_bIsUsingStepTiming ?
 				   STEP_TIMING.GetValue().c_str() :
 				   SONG_TIMING.GetValue().c_str() ) );
-		sText += ssprintf( BEAT_0_OFFSET_FORMAT.GetValue(),
+		sText += ssprintf( BEAT_0_OFFSET_FORMAT.GetValue().c_str(),
 				  BEAT_0_OFFSET.GetValue().c_str(),
 				  GetAppropriateTiming().m_fBeat0OffsetInSeconds );
-		sText += ssprintf( PREVIEW_START_FORMAT.GetValue(), PREVIEW_START.GetValue().c_str(), m_pSong->m_fMusicSampleStartSeconds );
-		sText += ssprintf( PREVIEW_LENGTH_FORMAT.GetValue(), PREVIEW_LENGTH.GetValue().c_str(), m_pSong->m_fMusicSampleLengthSeconds );
+		sText += ssprintf( PREVIEW_START_FORMAT.GetValue().c_str(), PREVIEW_START.GetValue().c_str(), m_pSong->m_fMusicSampleStartSeconds );
+		sText += ssprintf( PREVIEW_LENGTH_FORMAT.GetValue().c_str(), PREVIEW_LENGTH.GetValue().c_str(), m_pSong->m_fMusicSampleLengthSeconds );
 		if(record_hold_seconds < record_hold_default - .001f ||
 			record_hold_seconds > record_hold_default + .001f)
 		{
-			sText += ssprintf(RECORD_HOLD_TIME_FORMAT.GetValue(), RECORD_HOLD_TIME.GetValue().c_str(), record_hold_seconds);
+			sText += ssprintf(RECORD_HOLD_TIME_FORMAT.GetValue().c_str(), RECORD_HOLD_TIME.GetValue().c_str(), record_hold_seconds);
 		}
 		break;
 	}
@@ -2511,7 +2511,7 @@ bool ScreenEdit::InputEdit( const InputEventPlus &input, EditButton EditB )
 			pSteps->GetNoteData( m_NoteDataEdit );
 
 			RString s = ssprintf(
-				SWITCHED_TO.GetValue() + " %s %s '%s' (%d of %d)",
+				(SWITCHED_TO.GetValue() + " %s %s '%s' (%d of %d)").c_str(),
 				GAMEMAN->GetStepsTypeInfo( st ).szName,
 				DifficultyToString( pSteps->GetDifficulty() ).c_str(),
 				pSteps->GetChartName().c_str(),
@@ -5039,12 +5039,12 @@ static bool ConvertMappingInputToMapping(RString const& mapstr, int* mapping, RS
 		}
 		else if(!(mapping_input[track] >> mapping[track]))
 		{
-			error= ssprintf(NOT_A_TRACK.GetValue(), mapping_input[track].c_str());
+			error= ssprintf(NOT_A_TRACK.GetValue().c_str(), mapping_input[track].c_str());
 			return false;
 		}
 		if(mapping[track] < 1 || mapping[track] > static_cast<int>(tracks_for_type))
 		{
-			error= ssprintf(OUT_OF_RANGE_ID.GetValue(), track+1, mapping[track], tracks_for_type);
+			error= ssprintf(OUT_OF_RANGE_ID.GetValue().c_str(), track+1, mapping[track], tracks_for_type);
 			return false;
 		}
 		// Simpler for the user if they input track ids starting at 1.
@@ -5130,7 +5130,7 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const std::vector<int>
 				m_NoteFieldEdit.m_iBeginMarker, m_NoteFieldEdit.m_iEndMarker);
 			if(note_count >= PREFSMAN->m_EditClearPromptThreshold && prompt_clear)
 			{
-				ScreenPrompt::Prompt(SM_ConfirmClearArea, ssprintf(CONFIRM_CLEAR.GetValue(), note_count), PROMPT_YES_NO);
+				ScreenPrompt::Prompt(SM_ConfirmClearArea, ssprintf(CONFIRM_CLEAR.GetValue().c_str(), note_count), PROMPT_YES_NO);
 			}
 			else
 			{
@@ -6513,7 +6513,7 @@ void ScreenEdit::DoKeyboardTrackMenu()
 			++foundKeysounds;
 		}
 
-		g_KeysoundTrack.rows.push_back(MenuRowDef(i, ssprintf(TRACK_NUM.GetValue(), i + 1),
+		g_KeysoundTrack.rows.push_back(MenuRowDef(i, ssprintf(TRACK_NUM.GetValue().c_str(), i + 1),
 												  true, EditMode_Full, false, false, keyIndex, choices));
 	}
 	g_KeysoundTrack.rows.push_back(MenuRowDef(m_NoteDataEdit.GetNumTracks(), "Remove Keysound",
@@ -6542,7 +6542,7 @@ void ScreenEdit::DoHelp()
 			continue;
 		}
 
-		g_EditHelp.rows.push_back( MenuRowDef( -1, sDescription, false, EditMode_Practice, false, false, 0, sButtons ) );
+		g_EditHelp.rows.push_back( MenuRowDef( -1, sDescription, false, EditMode_Practice, false, false, 0, sButtons.c_str() ) );
 	}
 
 	EditMiniMenu( &g_EditHelp );

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -590,7 +590,7 @@ void ScreenEvaluation::Init()
 
 				// todo: check if format string is valid
 				// (two integer values in DETAILLINE_FORMAT) -aj
-				m_textDetailText[l][p].SetText( ssprintf(DETAILLINE_FORMAT,iActual,iPossible) );
+				m_textDetailText[l][p].SetText( ssprintf(DETAILLINE_FORMAT.c_str(),iActual,iPossible) );
 			}
 		}
 	}

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1115,7 +1115,7 @@ void ScreenGameplay::LoadNextSong()
 	{
 		pi->GetPlayerStageStats()->m_iSongsPlayed++;
 		if( pi->m_ptextCourseSongNumber )
-			pi->m_ptextCourseSongNumber->SetText( ssprintf(SONG_NUMBER_FORMAT.GetValue(), pi->GetPlayerStageStats()->m_iSongsPassed+1) );
+			pi->m_ptextCourseSongNumber->SetText( ssprintf(SONG_NUMBER_FORMAT.GetValue().c_str(), pi->GetPlayerStageStats()->m_iSongsPassed+1) );
 	}
 
 	if( GAMESTATE->m_bMultiplayer )
@@ -2924,7 +2924,7 @@ void ScreenGameplay::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if( SM >= SM_BattleTrickLevel1 && SM <= SM_BattleTrickLevel3 )
 	{
-		int iTrickLevel = SM-SM_BattleTrickLevel1+1;
+		int iTrickLevel = SM.c_str()-SM_BattleTrickLevel1.c_str()+1;
 		PlayAnnouncer( ssprintf("gameplay battle trick level%d",iTrickLevel), 3 );
 		if( SM == SM_BattleTrickLevel1 ) m_soundBattleTrickLevel1.Play(false);
 		else if( SM == SM_BattleTrickLevel2 ) m_soundBattleTrickLevel2.Play(false);
@@ -2932,7 +2932,7 @@ void ScreenGameplay::HandleScreenMessage( const ScreenMessage SM )
 	}
 	else if( SM >= SM_BattleDamageLevel1 && SM <= SM_BattleDamageLevel3 )
 	{
-		int iDamageLevel = SM-SM_BattleDamageLevel1+1;
+		int iDamageLevel = SM.c_str()-SM_BattleDamageLevel1.c_str()+1;
 		PlayAnnouncer( ssprintf("gameplay battle damage level%d",iDamageLevel), 3 );
 	}
 	else if( SM == SM_DoPrevScreen )

--- a/src/ScreenHighScores.cpp
+++ b/src/ScreenHighScores.cpp
@@ -153,7 +153,7 @@ void ScoreScroller::ConfigureActor( Actor *pActor, int iItem )
 		}
 		// Because pSteps or pTrail can be nullptr, what we're creating in Lua is not an array.
 		// It must be iterated using pairs(), not ipairs().
-		lua_setfield( L, -2, ssprintf("%d",i+1) );
+		lua_setfield( L, -2, ssprintf("%d",i+1).c_str() );
 	}
 	lua_pop( L, 1 );
 	LUA->Release( L );

--- a/src/ScreenMapControllers.cpp
+++ b/src/ScreenMapControllers.cpp
@@ -95,7 +95,7 @@ void ScreenMapControllers::Init()
 			text.LoadFromFont( THEME->GetPathF(m_sName,"title") );
 			PlayerNumber pn = (PlayerNumber)c;
 			text.SetName( "Label"+PlayerNumberToString(pn) );
-			RString sText = ssprintf(PLAYER_SLOTS.GetValue(), PlayerNumberToLocalizedString(pn).c_str());
+			RString sText = ssprintf(PLAYER_SLOTS.GetValue().c_str(), PlayerNumberToLocalizedString(pn).c_str());
 			text.SetText( sText );
 			ActorUtil::LoadAllCommands( text, m_sName );
 			m_Line.back()->AddChild( &m_textLabel[c] );

--- a/src/ScreenOptionsCourseOverview.cpp
+++ b/src/ScreenOptionsCourseOverview.cpp
@@ -168,7 +168,7 @@ void ScreenOptionsCourseOverview::HandleScreenMessage( const ScreenMessage SM )
 		{
 			if( !EditCourseUtil::RemoveAndDeleteFile(GAMESTATE->m_pCurCourse) )
 			{
-				ScreenPrompt::Prompt( SM_None, ssprintf(ERROR_DELETING_FILE.GetValue(), GAMESTATE->m_pCurCourse->m_sPath.c_str()) );
+				ScreenPrompt::Prompt( SM_None, ssprintf(ERROR_DELETING_FILE.GetValue().c_str(), GAMESTATE->m_pCurCourse->m_sPath.c_str()) );
 				return;
 			}
 

--- a/src/ScreenOptionsEditCourse.cpp
+++ b/src/ScreenOptionsEditCourse.cpp
@@ -203,10 +203,10 @@ void ScreenOptionsEditCourse::BeginScreen()
 	for( int i=0; i<NUM_SONG_ROWS; i++ )
 	{
 		{
-			MenuRowDef mrd = MenuRowDef( -1, "---", true, EditMode_Practice, true, false, 0, EMPTY.GetValue() );
+			MenuRowDef mrd = MenuRowDef( -1, "---", true, EditMode_Practice, true, false, 0, EMPTY.GetValue().c_str() );
 			for (Song const *s : m_vpSongs)
 				mrd.choices.push_back( s->GetDisplayFullTitle() );
-			mrd.sName = ssprintf(SONG.GetValue() + " %d",i+1);
+			mrd.sName = ssprintf((SONG.GetValue() + " %d").c_str(),i+1);
 			OptionRowHandler *pHand = OptionRowHandlerUtil::MakeSimple( mrd );
 			pHand->m_Def.m_bAllowThemeTitle = false;	// already themed
 			pHand->m_Def.m_sExplanationName = "Choose Song";
@@ -219,7 +219,7 @@ void ScreenOptionsEditCourse::BeginScreen()
 			EditCourseOptionRowHandlerSteps *pHand = new EditCourseOptionRowHandlerSteps;
 			pHand->Load( i );
 			pHand->m_Def.m_vsChoices.push_back( "n/a" );
-			pHand->m_Def.m_sName = ssprintf(STEPS.GetValue() + " %d",i+1);
+			pHand->m_Def.m_sName = ssprintf((STEPS.GetValue() + " %d").c_str(),i+1);
 			pHand->m_Def.m_bAllowThemeTitle = false;	// already themed
 			pHand->m_Def.m_bAllowThemeItems = false;	// already themed
 			pHand->m_Def.m_sExplanationName = "Choose Steps";
@@ -313,7 +313,7 @@ void ScreenOptionsEditCourse::ExportOptions( int iRow, const std::vector<PlayerN
 		case EditCourseRow_Minutes:
 			GAMESTATE->m_pCurCourse->m_fGoalSeconds = 0;
 			int mins;
-			if( sscanf( sValue, "%d", &mins ) == 1 )
+			if( sscanf( sValue.c_str(), "%d", &mins ) == 1 )
 				GAMESTATE->m_pCurCourse->m_fGoalSeconds = float(mins * 60);
 			break;
 		}
@@ -497,7 +497,7 @@ void ScreenOptionsEditCourse::ProcessMenuStart( const InputEventPlus &input )
 
 	if( m_pRows[iRow]->GetRowType() == OptionRow::RowType_Exit  &&  iSongCount < unsigned(MIN_ENABLED_SONGS) )
 	{
-		ScreenPrompt::Prompt( SM_None, ssprintf(MUST_ENABLE_AT_LEAST.GetValue(),MIN_ENABLED_SONGS) );
+		ScreenPrompt::Prompt( SM_None, ssprintf(MUST_ENABLE_AT_LEAST.GetValue().c_str(),MIN_ENABLED_SONGS) );
 		return;
 	}
 

--- a/src/ScreenOptionsManageCourses.cpp
+++ b/src/ScreenOptionsManageCourses.cpp
@@ -240,7 +240,7 @@ void ScreenOptionsManageCourses::ProcessMenuStart( const InputEventPlus & )
 		EditCourseUtil::GetAllEditCourses( vpCourses );
 		if( vpCourses.size() >= (size_t)EditCourseUtil::MAX_PER_PROFILE )
 		{
-			RString s = ssprintf( YOU_HAVE_MAX.GetValue()+"\n\n"+YOU_MUST_DELETE.GetValue(), EditCourseUtil::MAX_PER_PROFILE );
+			RString s = ssprintf( (YOU_HAVE_MAX.GetValue()+"\n\n"+YOU_MUST_DELETE.GetValue()).c_str(), EditCourseUtil::MAX_PER_PROFILE );
 			ScreenPrompt::Prompt( SM_None, s );
 			return;
 		}

--- a/src/ScreenOptionsManageEditSteps.cpp
+++ b/src/ScreenOptionsManageEditSteps.cpp
@@ -257,7 +257,7 @@ void ScreenOptionsManageEditSteps::ProcessMenuStart( const InputEventPlus & )
 		SONGMAN->GetStepsLoadedFromProfile( v, ProfileSlot_Machine );
 		if( v.size() >= size_t(MAX_EDIT_STEPS_PER_PROFILE) )
 		{
-			RString s = ssprintf( YOU_HAVE_MAX_STEP_EDITS.GetValue()+"\n\n"+YOU_MUST_DELETE.GetValue(), MAX_EDIT_STEPS_PER_PROFILE );
+			RString s = ssprintf( (YOU_HAVE_MAX_STEP_EDITS.GetValue()+"\n\n"+YOU_MUST_DELETE.GetValue()).c_str(), MAX_EDIT_STEPS_PER_PROFILE );
 			ScreenPrompt::Prompt( SM_None, s );
 			return;
 		}

--- a/src/ScreenOptionsManageProfiles.cpp
+++ b/src/ScreenOptionsManageProfiles.cpp
@@ -326,14 +326,14 @@ void ScreenOptionsManageProfiles::HandleScreenMessage( const ScreenMessage SM )
 			case ProfileAction_Delete:
 				{
 					RString sTitle = pProfile->m_sDisplayName;
-					RString sMessage = ssprintf( CONFIRM_DELETE_PROFILE.GetValue(), sTitle.c_str() );
+					RString sMessage = ssprintf( CONFIRM_DELETE_PROFILE.GetValue().c_str(), sTitle.c_str() );
 					ScreenPrompt::Prompt( SM_BackFromDeleteConfirm, sMessage, PROMPT_YES_NO );
 				}
 				break;
 			case ProfileAction_Clear:
 				{
 					RString sTitle = pProfile->m_sDisplayName;
-					RString sMessage = ssprintf( CONFIRM_CLEAR_PROFILE.GetValue(), sTitle.c_str() );
+					RString sMessage = ssprintf( CONFIRM_CLEAR_PROFILE.GetValue().c_str(), sTitle.c_str() );
 					ScreenPrompt::Prompt( SM_BackFromClearConfirm, sMessage, PROMPT_YES_NO );
 				}
 				break;

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -192,7 +192,7 @@ static void GameSel( int &sel, bool ToSel, const ConfOption *pConfOption )
 
 		sel = 0;
 		for(unsigned i = 0; i < choices.size(); ++i)
-			if( !strcasecmp(choices[i], sCurGameName) )
+			if( !strcasecmp(choices[i].c_str(), sCurGameName.c_str()) )
 				sel = i;
 	} else {
 		std::vector<const Game*> aGames;
@@ -227,12 +227,12 @@ static void Language( int &sel, bool ToSel, const ConfOption *pConfOption )
 	{
 		sel = -1;
 		for( unsigned i=0; sel == -1 && i < vs.size(); ++i )
-			if( !strcasecmp(vs[i], THEME->GetCurLanguage()) )
+			if( !strcasecmp(vs[i].c_str(), THEME->GetCurLanguage().c_str()) )
 				sel = i;
 
 		// If the current language doesn't exist, we'll show BASE_LANGUAGE, so select that.
 		for( unsigned i=0; sel == -1 && i < vs.size(); ++i )
-			if( !strcasecmp(vs[i], SpecialFiles::BASE_LANGUAGE) )
+			if( !strcasecmp(vs[i].c_str(), SpecialFiles::BASE_LANGUAGE.c_str()) )
 				sel = i;
 
 		if( sel == -1 )
@@ -291,7 +291,7 @@ static void RequestedTheme( int &sel, bool ToSel, const ConfOption *pConfOption 
 	{
 		sel = 0;
 		for( unsigned i=1; i<vsThemeNames.size(); i++ )
-			if( !strcasecmp(vsThemeNames[i], PREFSMAN->m_sTheme.Get()) )
+			if( !strcasecmp(vsThemeNames[i].c_str(), PREFSMAN->m_sTheme.Get().c_str()) )
 				sel = i;
 	}
 	else
@@ -317,7 +317,7 @@ static void Announcer( int &sel, bool ToSel, const ConfOption *pConfOption )
 	{
 		sel = 0;
 		for( unsigned i=1; i<choices.size(); i++ )
-			if( !strcasecmp(choices[i], ANNOUNCER->GetCurAnnouncerName()) )
+			if( !strcasecmp(choices[i].c_str(), ANNOUNCER->GetCurAnnouncerName().c_str()) )
 				sel = i;
 	}
 	else
@@ -344,7 +344,7 @@ static void DefaultNoteSkin( int &sel, bool ToSel, const ConfOption *pConfOption
 		po.FromString( PREFSMAN->m_sDefaultModifiers );
 		sel = 0;
 		for( unsigned i=0; i < choices.size(); i++ )
-			if( !strcasecmp(choices[i], po.m_sNoteSkin) )
+			if( !strcasecmp(choices[i].c_str(), po.m_sNoteSkin.c_str()) )
 				sel = i;
 	}
 	else

--- a/src/ScreenOptionsMasterPrefs.h
+++ b/src/ScreenOptionsMasterPrefs.h
@@ -64,7 +64,7 @@ struct ConfOption
 #define PUSH( c )	if(c) names.push_back(c);
 		PUSH(c0);PUSH(c1);PUSH(c2);PUSH(c3);PUSH(c4);PUSH(c5);PUSH(c6);PUSH(c7);PUSH(c8);PUSH(c9);PUSH(c10);PUSH(c11);PUSH(c12);PUSH(c13);PUSH(c14);PUSH(c15);PUSH(c16);PUSH(c17);PUSH(c18);PUSH(c19);
 	}
-	void AddOption( const RString &sName ) { PUSH(sName); }
+	void AddOption( const RString &sName ) { PUSH(sName.c_str()); }
 #undef PUSH
 
 	ConfOption( const char *n, MoveData_t m,

--- a/src/ScreenOptionsMemoryCard.cpp
+++ b/src/ScreenOptionsMemoryCard.cpp
@@ -215,7 +215,7 @@ void ScreenOptionsMemoryCard::ProcessMenuStart( const InputEventPlus & )
 		}
 		else
 		{
-			RString s = ssprintf(ERROR_MOUNTING_CARD.GetValue(), MEMCARDMAN->GetCardError(PLAYER_1).c_str() );
+			RString s = ssprintf(ERROR_MOUNTING_CARD.GetValue().c_str(), MEMCARDMAN->GetCardError(PLAYER_1).c_str() );
 			ScreenPrompt::Prompt( SM_None, s );
 		}
 	}

--- a/src/ScreenSaveSync.cpp
+++ b/src/ScreenSaveSync.cpp
@@ -29,9 +29,9 @@ static RString GetPromptText()
 		if( !vs.empty() )
 		{
 			s += ssprintf(
-				CHANGED_TIMING_OF.GetValue()+"\n"
+				(CHANGED_TIMING_OF.GetValue()+"\n"
 				"%s:\n"
-				"\n",
+				"\n").c_str(),
 				GAMESTATE->m_pCurSong->GetDisplayFullTitle().c_str() );
 
 			s += join( "\n", vs ) + "\n\n";

--- a/src/ScreenSelect.cpp
+++ b/src/ScreenSelect.cpp
@@ -54,7 +54,7 @@ void ScreenSelect::Init()
 					lua_rawgeti(L, 1, i);
 					if(!lua_isstring(L, -1))
 					{
-						LuaHelpers::ReportScriptErrorFmt(m_sName + "::ChoiceNames element %zu is not a string.", i);
+						LuaHelpers::ReportScriptErrorFmt((m_sName + "::ChoiceNames element %zu is not a string.").c_str(), i);
 					}
 					else
 					{

--- a/src/ScreenSelectMaster.cpp
+++ b/src/ScreenSelectMaster.cpp
@@ -276,7 +276,7 @@ void ScreenSelectMaster::Init()
 		for( unsigned part = 0; part < parts.size(); ++part )
 		{
 			int from, to;
-			if( sscanf( parts[part], "%d:%d", &from, &to ) != 2 )
+			if( sscanf( parts[part].c_str(), "%d:%d", &from, &to ) != 2 )
 			{
 				LuaHelpers::ReportScriptErrorFmt( "%s::OptionOrder%s parse error", m_sName.c_str(), MenuDirToString(dir).c_str() );
 				continue;

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -495,7 +495,7 @@ bool ScreenSelectMusic::Input( const InputEventPlus &input )
 			if ( songToDelete && PREFSMAN->m_bAllowSongDeletion.Get() )
 			{
 				m_pSongAwaitingDeletionConfirmation = songToDelete;
-				ScreenPrompt::Prompt(SM_ConfirmDeleteSong, ssprintf(PERMANENTLY_DELETE.GetValue(), songToDelete->m_sMainTitle.c_str(), songToDelete->GetSongDir().c_str()), PROMPT_YES_NO);
+				ScreenPrompt::Prompt(SM_ConfirmDeleteSong, ssprintf(PERMANENTLY_DELETE.GetValue().c_str(), songToDelete->m_sMainTitle.c_str(), songToDelete->GetSongDir().c_str()), PROMPT_YES_NO);
 				return true;
 			}
 		}

--- a/src/ScreenServiceAction.cpp
+++ b/src/ScreenServiceAction.cpp
@@ -52,7 +52,7 @@ static RString ClearMachineEdits()
 	PROFILEMAN->LoadMachineProfile();
 
 	int errorCount = editCount - removedCount;
-	return ssprintf(MACHINE_EDITS_CLEARED.GetValue(), editCount, errorCount);
+	return ssprintf(MACHINE_EDITS_CLEARED.GetValue().c_str(), editCount, errorCount);
 }
 
 static PlayerNumber GetFirstReadyMemoryCard()
@@ -90,7 +90,7 @@ static RString ClearMemoryCardEdits()
 
 	MEMCARDMAN->UnmountCard(pn);
 
-	return ssprintf(EDITS_CLEARED.GetValue(), editCount, editCount - removedCount);
+	return ssprintf(EDITS_CLEARED.GetValue().c_str(), editCount, editCount - removedCount);
 }
 
 
@@ -114,9 +114,9 @@ static RString TransferStatsMachineToMemoryCard()
 	MEMCARDMAN->UnmountCard(pn);
 
 	if( bSaved )
-		return ssprintf(MACHINE_STATS_SAVED.GetValue(),pn+1);
+		return ssprintf(MACHINE_STATS_SAVED.GetValue().c_str(),pn+1);
 	else
-		return ssprintf(ERROR_SAVING_MACHINE_STATS.GetValue(),pn+1);
+		return ssprintf(ERROR_SAVING_MACHINE_STATS.GetValue().c_str(),pn+1);
 }
 
 static LocalizedString STATS_NOT_LOADED		( "ScreenServiceAction", "Stats not loaded - No memory cards ready." );
@@ -142,15 +142,15 @@ static RString TransferStatsMemoryCardToMachine()
 	switch( lr )
 	{
 	case ProfileLoadResult_Success:
-		s = ssprintf(MACHINE_STATS_LOADED.GetValue(),pn+1);
+		s = ssprintf(MACHINE_STATS_LOADED.GetValue().c_str(),pn+1);
 		break;
 	case ProfileLoadResult_FailedNoProfile:
 		*PROFILEMAN->GetMachineProfile() = backup;
-		s = ssprintf(THERE_IS_NO_PROFILE.GetValue(),pn+1);
+		s = ssprintf(THERE_IS_NO_PROFILE.GetValue().c_str(),pn+1);
 		break;
 	case ProfileLoadResult_FailedTampered:
 		*PROFILEMAN->GetMachineProfile() = backup;
-		s = ssprintf(PROFILE_CORRUPT.GetValue(),pn+1);
+		s = ssprintf(PROFILE_CORRUPT.GetValue().c_str(),pn+1);
 		break;
 	default:
 		FAIL_M(ssprintf("Invalid profile load result: %i", lr));
@@ -235,11 +235,11 @@ static RString CopyEdits( const RString &sFromProfileDir, const RString &sToProf
 
 	std::vector<RString> vs;
 	vs.push_back( sDisplayDir );
-	vs.push_back( ssprintf( COPIED.GetValue(), iNumSucceeded ) + ", " + ssprintf( OVERWRITTEN.GetValue(), iNumOverwritten ) );
+	vs.push_back( ssprintf( COPIED.GetValue().c_str(), iNumSucceeded ) + ", " + ssprintf( OVERWRITTEN.GetValue().c_str(), iNumOverwritten ) );
 	if( iNumIgnored )
-		vs.push_back( ssprintf( IGNORED.GetValue(), iNumIgnored ) );
+		vs.push_back( ssprintf( IGNORED.GetValue().c_str(), iNumIgnored ) );
 	if( iNumErrored )
-		vs.push_back( ssprintf( FAILED.GetValue(), iNumErrored ) );
+		vs.push_back( ssprintf( FAILED.GetValue().c_str(), iNumErrored ) );
 	return join( "\n", vs );
 }
 
@@ -309,7 +309,7 @@ static RString CopyEditsMachineToMemoryCard()
 	RString sToDir = MEM_CARD_MOUNT_POINT[pn] + (RString)PREFSMAN->m_sMemoryCardProfileSubdir + "/";
 
 	std::vector<RString> vs;
-	vs.push_back( ssprintf( COPIED_TO_CARD.GetValue(), pn+1 ) );
+	vs.push_back( ssprintf( COPIED_TO_CARD.GetValue().c_str(), pn+1 ) );
 	RString s = CopyEdits( sFromDir, sToDir, PREFSMAN->m_sMemoryCardProfileSubdir );
 	vs.push_back( s );
 
@@ -338,12 +338,12 @@ static RString SyncEditsMachineToMemoryCard()
 
 	MEMCARDMAN->UnmountCard(pn);
 
-	RString sRet = ssprintf( COPIED_TO_CARD.GetValue(), pn+1 ) + " ";
-	sRet += ssprintf( ADDED.GetValue(), iNumAdded ) + ", " + ssprintf( OVERWRITTEN.GetValue(), iNumOverwritten );
+	RString sRet = ssprintf( COPIED_TO_CARD.GetValue().c_str(), pn+1 ) + " ";
+	sRet += ssprintf( ADDED.GetValue().c_str(), iNumAdded ) + ", " + ssprintf( OVERWRITTEN.GetValue().c_str(), iNumOverwritten );
 	if( iNumDeleted )
-		sRet += RString(" ") + ssprintf( DELETED.GetValue(), iNumDeleted );
+		sRet += RString(" ") + ssprintf( DELETED.GetValue().c_str(), iNumDeleted );
 	if( iNumFailed )
-		sRet += RString("; ") + ssprintf( FAILED.GetValue(), iNumFailed );
+		sRet += RString("; ") + ssprintf( FAILED.GetValue().c_str(), iNumFailed );
 	return sRet;
 }
 
@@ -361,7 +361,7 @@ static RString CopyEditsMemoryCardToMachine()
 	ProfileManager::GetMemoryCardProfileDirectoriesToTry( vsSubDirs );
 
 	std::vector<RString> vs;
-	vs.push_back( ssprintf( COPIED_FROM_CARD.GetValue(), pn+1 ) );
+	vs.push_back( ssprintf( COPIED_FROM_CARD.GetValue().c_str(), pn+1 ) );
 
 	for (RString const &sSubDir : vsSubDirs)
 	{

--- a/src/ScreenTextEntry.cpp
+++ b/src/ScreenTextEntry.cpp
@@ -106,7 +106,7 @@ bool ScreenTextEntry::FloatValidate( const RString &sAnswer, RString &sErrorOut 
 	float f;
 	if( StringToFloat(sAnswer, f) )
 		return true;
-	sErrorOut = ssprintf( INVALID_FLOAT.GetValue(), sAnswer.c_str() );
+	sErrorOut = ssprintf( INVALID_FLOAT.GetValue().c_str(), sAnswer.c_str() );
 	return false;
 }
 
@@ -116,7 +116,7 @@ bool ScreenTextEntry::IntValidate( const RString &sAnswer, RString &sErrorOut )
 	int f;
 	if(sAnswer >> f)
 		return true;
-	sErrorOut = ssprintf( INVALID_INT.GetValue(), sAnswer.c_str() );
+	sErrorOut = ssprintf( INVALID_INT.GetValue().c_str(), sAnswer.c_str() );
 	return false;
 }
 
@@ -453,10 +453,10 @@ static bool ValidateFromLua( const RString &sAnswer, RString &sErrorOut )
 	g_ValidateFunc.PushSelf( L );
 
 	// Argument 1 (answer):
-	lua_pushstring( L, sAnswer );
+	lua_pushstring( L, sAnswer.c_str() );
 
 	// Argument 2 (error out):
-	lua_pushstring( L, sErrorOut );
+	lua_pushstring( L, sErrorOut.c_str() );
 
 	bool valid= false;
 
@@ -493,7 +493,7 @@ static void OnOKFromLua( const RString &sAnswer )
 
 	g_OnOKFunc.PushSelf( L );
 	// Argument 1 (answer):
-	lua_pushstring( L, sAnswer );
+	lua_pushstring( L, sAnswer.c_str() );
 	RString error= "Lua error in ScreenTextEntry OnOK: ";
 	LuaHelpers::RunScriptOnStack(L, error, 1, 0, true);
 
@@ -526,10 +526,10 @@ static bool ValidateAppendFromLua( const RString &sAnswerBeforeChar, RString &sA
 	g_ValidateAppendFunc.PushSelf( L );
 
 	// Argument 1 (AnswerBeforeChar):
-	lua_pushstring( L, sAnswerBeforeChar );
+	lua_pushstring( L, sAnswerBeforeChar.c_str() );
 
 	// Argument 2 (Append):
-	lua_pushstring( L, sAppend );
+	lua_pushstring( L, sAppend.c_str() );
 
 	bool append= false;
 
@@ -560,7 +560,7 @@ static RString FormatAnswerForDisplayFromLua( const RString &sAnswer )
 
 	g_FormatAnswerForDisplayFunc.PushSelf( L );
 	// Argument 1 (Answer):
-	lua_pushstring( L, sAnswer );
+	lua_pushstring( L, sAnswer.c_str() );
 
 	RString answer;
 	RString error= "Lua error in ScreenTextEntry FormatAnswerForDisplay: ";

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -1711,7 +1711,7 @@ RString Song::GetCacheFile(RString sType)
 	PreDefs["Disc"] = GetDiscPath();
 
 	// Check if Predefined images exist, And return function if they do.
-	if(PreDefs[sType.c_str()])
+	if(PreDefs[sType.c_str()].c_str())
 		return PreDefs[sType.c_str()];
 
 	// Get all image files and put them into a vector.
@@ -2142,47 +2142,47 @@ class LunaSong: public Luna<Song>
 public:
 	static int GetDisplayFullTitle( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetDisplayFullTitle() ); return 1;
+		lua_pushstring(L, p->GetDisplayFullTitle().c_str() ); return 1;
 	}
 	static int GetTranslitFullTitle( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetTranslitFullTitle() ); return 1;
+		lua_pushstring(L, p->GetTranslitFullTitle().c_str() ); return 1;
 	}
 	static int GetDisplayMainTitle( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetDisplayMainTitle() ); return 1;
+		lua_pushstring(L, p->GetDisplayMainTitle().c_str() ); return 1;
 	}
 	static int GetMainTitle(T* p, lua_State* L)
 	{
-		lua_pushstring(L, p->GetMainTitle()); return 1;
+		lua_pushstring(L, p->GetMainTitle().c_str()); return 1;
 	}
 	static int GetTranslitMainTitle( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetTranslitMainTitle() ); return 1;
+		lua_pushstring(L, p->GetTranslitMainTitle().c_str() ); return 1;
 	}
 	static int GetDisplaySubTitle( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetDisplaySubTitle() ); return 1;
+		lua_pushstring(L, p->GetDisplaySubTitle().c_str() ); return 1;
 	}
 	static int GetTranslitSubTitle( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetTranslitSubTitle() ); return 1;
+		lua_pushstring(L, p->GetTranslitSubTitle().c_str() ); return 1;
 	}
 	static int GetDisplayArtist( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetDisplayArtist() ); return 1;
+		lua_pushstring(L, p->GetDisplayArtist().c_str() ); return 1;
 	}
 	static int GetTranslitArtist( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetTranslitArtist() ); return 1;
+		lua_pushstring(L, p->GetTranslitArtist().c_str() ); return 1;
 	}
 	static int GetGenre( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->m_sGenre ); return 1;
+		lua_pushstring(L, p->m_sGenre.c_str() ); return 1;
 	}
 	static int GetOrigin( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->m_sOrigin ); return 1;
+		lua_pushstring(L, p->m_sOrigin.c_str() ); return 1;
 	}
 	static int GetAllSteps( T* p, lua_State *L )
 	{
@@ -2199,14 +2199,14 @@ public:
 	}
 	static int GetSongDir( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetSongDir() );
+		lua_pushstring(L, p->GetSongDir().c_str() );
 		return 1;
 	}
 	static int GetMusicPath( T* p, lua_State *L )
 	{
 		RString s = p->GetMusicPath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
@@ -2215,7 +2215,7 @@ public:
 	{
 		RString s = p->GetBannerPath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
@@ -2224,7 +2224,7 @@ public:
 	{
 		RString s = p->GetBackgroundPath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
@@ -2233,7 +2233,7 @@ public:
 	{
 		RString s = p->GetPreviewVidPath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
@@ -2241,14 +2241,14 @@ public:
 	static int GetPreviewMusicPath(T* p, lua_State* L)
 	{
 		RString s= p->GetPreviewMusicPath();
-		lua_pushstring(L, s);
+		lua_pushstring(L, s.c_str());
 		return 1;
 	}
 	static int GetJacketPath( T* p, lua_State *L )
 	{
 		RString s = p->GetJacketPath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
@@ -2257,7 +2257,7 @@ public:
 	{
 		RString s = p->GetCDImagePath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
@@ -2266,7 +2266,7 @@ public:
 	{
 		RString s = p->GetDiscPath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
@@ -2275,7 +2275,7 @@ public:
 	{
 		RString s = p->GetCDTitlePath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
@@ -2284,14 +2284,14 @@ public:
 	{
 		RString s = p->GetLyricsPath();
 		if( !s.empty() )
-			lua_pushstring(L, s);
+			lua_pushstring(L, s.c_str());
 		else
 			lua_pushnil(L);
 		return 1;
 	}
 	static int GetSongFilePath(  T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->GetSongFilePath() );
+		lua_pushstring(L, p->GetSongFilePath().c_str() );
 		return 1;
 	}
 	static int IsTutorial( T* p, lua_State *L )
@@ -2311,7 +2311,7 @@ public:
 	}
 	static int GetGroupName( T* p, lua_State *L )
 	{
-		lua_pushstring(L, p->m_sGroupName);
+		lua_pushstring(L, p->m_sGroupName.c_str());
 		return 1;
 	}
 

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -262,7 +262,7 @@ bool SongManager::SanityCheckGroupDir( RString sDir ) const
 		{
 			if(ext == aud)
 			{
-				LOG->Warn(FOLDER_CONTAINS_MUSIC_FILES.GetValue(), sDir.c_str());
+				LOG->Warn(FOLDER_CONTAINS_MUSIC_FILES.GetValue().c_str(), sDir.c_str());
 				return false;
 			}
 		}
@@ -2395,7 +2395,7 @@ public:
 	static int SongToPreferredSortSectionName( T* p, lua_State *L )
 	{
 		const Song* pSong = Luna<Song>::check(L,1);
-		lua_pushstring(L, p->SongToPreferredSortSectionName(pSong));
+		lua_pushstring(L, p->SongToPreferredSortSectionName(pSong).c_str());
 		return 1;
 	}
 	static int GetPreferredSortSongsBySectionName( T* p, lua_State *L )

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -435,7 +435,7 @@ static bool CompareSongPointersByTitle( const Song *pSong1, const Song *pSong2 )
 	s1 = SongUtil::MakeSortString(s1);
 	s2 = SongUtil::MakeSortString(s2);
 
-	int ret = strcmp( s1, s2 );
+	int ret = strcmp( s1.c_str(), s2.c_str() );
 	if(ret < 0) return true;
 	if(ret > 0) return false;
 
@@ -622,7 +622,7 @@ int SongUtil::CompareSongPointersByGroup(const Song *pSong1, const Song *pSong2)
 	s1 = SongUtil::MakeSortString(s1);
 	s2 = SongUtil::MakeSortString(s2);
 
-	int ret = strcmp( s1, s2 );
+	int ret = strcmp( s1.c_str(), s2.c_str() );
 	return ret < 0;
 }
 
@@ -654,7 +654,7 @@ static int CompareSongPointersByGroupAndTitle( const Song *pSong1, const Song *p
 	s1 = SongUtil::MakeSortString(s1);
 	s2 = SongUtil::MakeSortString(s2);
 
-	int ret = strcmp( s1, s2 );
+	int ret = strcmp( s1.c_str(), s2.c_str() );
 	return ret < 0;
 }
 
@@ -970,9 +970,9 @@ bool SongUtil::ValidateCurrentEditStepsDescription( const RString &sAnswer, RStr
 	}
 
 	static const RString sInvalidChars = "\\/:*?\"<>|";
-	if( strpbrk(sAnswer, sInvalidChars) != nullptr )
+	if( strpbrk(sAnswer.c_str(), sInvalidChars.c_str()) != nullptr )
 	{
-		sErrorOut = ssprintf( EDIT_NAME_CANNOT_CONTAIN.GetValue(), sInvalidChars.c_str() );
+		sErrorOut = ssprintf( EDIT_NAME_CANNOT_CONTAIN.GetValue().c_str(), sInvalidChars.c_str() );
 		return false;
 	}
 
@@ -1020,9 +1020,9 @@ bool SongUtil::ValidateCurrentStepsChartName(const RString &answer, RString &err
 	if (answer.empty()) return true;
 
 	static const RString sInvalidChars = "\\/:*?\"<>|";
-	if( strpbrk(answer, sInvalidChars) != nullptr )
+	if( strpbrk(answer.c_str(), sInvalidChars.c_str()) != nullptr )
 	{
-		error = ssprintf( CHART_NAME_CANNOT_CONTAIN.GetValue(), sInvalidChars.c_str() );
+		error = ssprintf( CHART_NAME_CANNOT_CONTAIN.GetValue().c_str(), sInvalidChars.c_str() );
 		return false;
 	}
 
@@ -1054,9 +1054,9 @@ bool SongUtil::ValidateCurrentStepsCredit( const RString &sAnswer, RString &sErr
 
 	// Borrow from EditDescription testing. Perhaps this should be abstracted? -Wolfman2000
 	static const RString sInvalidChars = "\\/:*?\"<>|";
-	if( strpbrk(sAnswer, sInvalidChars) != nullptr )
+	if( strpbrk(sAnswer.c_str(), sInvalidChars.c_str()) != nullptr )
 	{
-		sErrorOut = ssprintf( AUTHOR_NAME_CANNOT_CONTAIN.GetValue(), sInvalidChars.c_str() );
+		sErrorOut = ssprintf( AUTHOR_NAME_CANNOT_CONTAIN.GetValue().c_str(), sInvalidChars.c_str() );
 		return false;
 	}
 
@@ -1076,7 +1076,7 @@ bool SongUtil::ValidateCurrentSongPreview(const RString& answer, RString& error)
 	song->m_PreviewFile= real_file;
 	if(!valid)
 	{
-		error= ssprintf(PREVIEW_DOES_NOT_EXIST.GetValue(), answer.c_str());
+		error= ssprintf(PREVIEW_DOES_NOT_EXIST.GetValue().c_str(), answer.c_str());
 	}
 	return valid;
 }
@@ -1094,7 +1094,7 @@ bool SongUtil::ValidateCurrentStepsMusic(const RString &answer, RString &error)
 	pSteps->SetMusicFile(real_file);
 	if(!valid)
 	{
-		error= ssprintf(MUSIC_DOES_NOT_EXIST.GetValue(), answer.c_str());
+		error= ssprintf(MUSIC_DOES_NOT_EXIST.GetValue().c_str(), answer.c_str());
 	}
 	return valid;
 }

--- a/src/Sprite.cpp
+++ b/src/Sprite.cpp
@@ -380,7 +380,7 @@ void Sprite::LoadFromCached( const RString &sDir, const RString &sPath )
 {
 	if( sPath.empty() )
 	{
-		Load( THEME->GetPathG("Common","fallback %s", sDir) );
+		Load( THEME->GetPathG("Common","fallback %s", sDir.c_str()) );
 		return;
 	}
 
@@ -394,7 +394,7 @@ void Sprite::LoadFromCached( const RString &sDir, const RString &sPath )
 	else if( IsAFile(sPath) )
 		Load( sPath );
 	else
-		Load( THEME->GetPathG("Common","fallback %s", sDir) );
+		Load( THEME->GetPathG("Common","fallback %s", sDir.c_str()) );
 }
 
 void Sprite::LoadStatesFromTexture()

--- a/src/StdString.h
+++ b/src/StdString.h
@@ -499,10 +499,18 @@ public:
 	{
 		return ssicmp(this->c_str(), szThat);
 	}
+	int CompareNoCase(const MYTYPE& other)	const
+	{
+		return ssicmp(this->c_str(), other.c_str());
+	}
 
 	bool EqualsNoCase(PCMYSTR szThat)	const
 	{
 		return CompareNoCase(szThat) == 0;
+	}
+	bool EqualsNoCase(const MYTYPE& other)	const
+	{
+		return CompareNoCase(other.c_str()) == 0;
 	}
 
 	MYTYPE Left(int nCount) const
@@ -546,6 +554,11 @@ public:
 			nIdx += nNewLen;
 		}
 		return nReplaced;
+	}
+
+	int Replace(const MYTYPE& szOld, const MYTYPE& szNew)
+	{
+		return Replace(szOld.c_str(), szNew.c_str());
 	}
 
 	MYTYPE Right(int nCount) const

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -127,7 +127,7 @@ static RString GetActualGraphicOptionsString()
 {
 	const VideoModeParams &params = DISPLAY->GetActualVideoModeParams();
 	RString sFormat = "%s %s %dx%d %d "+COLOR.GetValue()+" %d "+TEXTURE.GetValue()+" %dHz %s %s";
-	RString sLog = ssprintf( sFormat,
+	RString sLog = ssprintf( sFormat.c_str(),
 		DISPLAY->GetApiDescription().c_str(),
 		(params.windowed? WINDOWED : FULLSCREEN).GetValue().c_str(),
 		(int)params.width,
@@ -576,7 +576,7 @@ RageDisplay *CreateDisplay()
 	RString error = ERROR_INITIALIZING_CARD.GetValue()+"\n\n"+
 		ERROR_DONT_FILE_BUG.GetValue()+"\n\n"
 		VIDEO_TROUBLESHOOTING_URL "\n\n"+
-		ssprintf(ERROR_VIDEO_DRIVER.GetValue(), GetVideoDriverName().c_str())+"\n\n";
+		ssprintf(ERROR_VIDEO_DRIVER.GetValue().c_str(), GetVideoDriverName().c_str())+"\n\n";
 
 	std::vector<RString> asRenderers;
 	split( PREFSMAN->m_sVideoRenderers, ",", asRenderers, true );
@@ -614,7 +614,7 @@ RageDisplay *CreateDisplay()
 		}
 		else
 		{
-			RageException::Throw( ERROR_UNKNOWN_VIDEO_RENDERER.GetValue(), sRenderer.c_str() );
+			RageException::Throw( ERROR_UNKNOWN_VIDEO_RENDERER.GetValue().c_str(), sRenderer.c_str() );
 		}
 
 		if( pRet == nullptr )
@@ -623,7 +623,7 @@ RageDisplay *CreateDisplay()
 		RString sError = pRet->Init( params, PREFSMAN->m_bAllowUnacceleratedRenderer );
 		if( !sError.empty() )
 		{
-			error += ssprintf(ERROR_INITIALIZING.GetValue(), sRenderer.c_str())+"\n" + sError;
+			error += ssprintf(ERROR_INITIALIZING.GetValue().c_str(), sRenderer.c_str())+"\n" + sError;
 			RageUtil::SafeDelete( pRet );
 			error += "\n\n\n";
 			continue;
@@ -1433,7 +1433,7 @@ int LuaFunc_SaveScreenshot(lua_State *L)
 	}
 	RString path= dir + filename;
 	lua_pushboolean(L, !filename.empty());
-	lua_pushstring(L, path);
+	lua_pushstring(L, path.c_str());
 	return 2;
 }
 void LuaFunc_Register_SaveScreenshot(lua_State *L);

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -1183,7 +1183,7 @@ public:
 
 	static int GetGrooveStatsHash(T *p, lua_State *L)
 	{
-		lua_pushstring(L, p->GetGrooveStatsHash());
+		lua_pushstring(L, p->GetGrooveStatsHash().c_str());
 		return 1;
 	}
 	
@@ -1195,7 +1195,7 @@ public:
 	
 	static int GetChartName(T *p, lua_State *L)
 	{
-		lua_pushstring(L, p->GetChartName());
+		lua_pushstring(L, p->GetChartName().c_str());
 		return 1;
 	}
 	static int GetDisplayBpms( T* p, lua_State *L )

--- a/src/Style.cpp
+++ b/src/Style.cpp
@@ -180,7 +180,7 @@ public:
 		ret.Set( L, "Track" );
 		lua_pushnumber( L, p->m_ColumnInfo[pn][iCol].fXOffset );
 		ret.Set( L,  "XOffset" );
-		lua_pushstring( L, p->ColToButtonName(iCol) );
+		lua_pushstring( L, p->ColToButtonName(iCol).c_str() );
 		ret.Set( L, "Name" );
 
 		ret.PushSelf(L);

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -1351,16 +1351,16 @@ public:
 		{
 			luaL_error(L, "Cannot fetch string with empty group name or empty value name.");
 		}
-		lua_pushstring(L, p->GetString(group, name));
+		lua_pushstring(L, p->GetString(group, name).c_str());
 		return 1;
 	}
 	static int GetPathInfoB( T* p, lua_State *L )
 	{
 		ThemeManager::PathInfo pi;
 		p->GetPathInfo( pi, EC_BGANIMATIONS, SArg(1), SArg(2) );
-		lua_pushstring(L, pi.sResolvedPath);
-		lua_pushstring(L, pi.sMatchingMetricsGroup);
-		lua_pushstring(L, pi.sMatchingElement);
+		lua_pushstring(L, pi.sResolvedPath.c_str());
+		lua_pushstring(L, pi.sMatchingMetricsGroup.c_str());
+		lua_pushstring(L, pi.sMatchingElement.c_str());
 		return 3;
 	}
 	// GENERAL_GET_PATH uses lua_toboolean instead of BArg because that makes
@@ -1369,7 +1369,7 @@ public:
 	static int get_path_name(T* p, lua_State* L) \
 	{ \
 		lua_pushstring(L, p->get_path_name( \
-				SArg(1), SArg(2), lua_toboolean(L, 3))); \
+				SArg(1), SArg(2), lua_toboolean(L, 3)).c_str()); \
 		return 1; \
 	}
 	GENERAL_GET_PATH(GetPathF);
@@ -1395,8 +1395,8 @@ public:
 
 	DEFINE_METHOD( GetCurrentThemeDirectory, GetCurThemeDir() );
 	DEFINE_METHOD( GetCurLanguage, GetCurLanguage() );
-	static int GetThemeDisplayName( T* p, lua_State *L )			{  lua_pushstring(L, p->GetThemeDisplayName(p->GetCurThemeName())); return 1; }
-	static int GetThemeAuthor( T* p, lua_State *L )			{  lua_pushstring(L, p->GetThemeAuthor(p->GetCurThemeName())); return 1; }
+	static int GetThemeDisplayName( T* p, lua_State *L )			{  lua_pushstring(L, p->GetThemeDisplayName(p->GetCurThemeName()).c_str()); return 1; }
+	static int GetThemeAuthor( T* p, lua_State *L )			{  lua_pushstring(L, p->GetThemeAuthor(p->GetCurThemeName()).c_str()); return 1; }
 	DEFINE_METHOD( DoesThemeExist, DoesThemeExist(SArg(1)) );
 	DEFINE_METHOD( IsThemeSelectable, IsThemeSelectable(SArg(1)) );
 	DEFINE_METHOD( DoesLanguageExist, DoesLanguageExist(SArg(1)) );

--- a/src/UnlockManager.cpp
+++ b/src/UnlockManager.cpp
@@ -796,7 +796,7 @@ class LunaUnlockEntry: public Luna<UnlockEntry>
 {
 public:
 	static int IsLocked( T* p, lua_State *L )		{ lua_pushboolean(L, p->IsLocked() ); return 1; }
-	static int GetDescription( T* p, lua_State *L )		{ lua_pushstring(L, p->GetDescription() ); return 1; }
+	static int GetDescription( T* p, lua_State *L )		{ lua_pushstring(L, p->GetDescription().c_str() ); return 1; }
 	static int GetUnlockRewardType( T* p, lua_State *L )	{ lua_pushnumber(L, p->m_Type ); return 1; }
 	static int GetRequirement( T* p, lua_State *L )		{ UnlockRequirement i = Enum::Check<UnlockRequirement>( L, 1 ); lua_pushnumber(L, p->m_fRequirement[i] ); return 1; }
 	static int GetRequirePassHardSteps( T* p, lua_State *L ){ lua_pushboolean(L, p->m_bRequirePassHardSteps); return 1; }
@@ -858,7 +858,7 @@ public:
 	}
 	static int GetCode( T* p, lua_State *L )
 	{
-		lua_pushstring( L, p->m_sEntryID );
+		lua_pushstring( L, p->m_sEntryID.c_str() );
 		return 1;
 	}
 
@@ -927,7 +927,7 @@ public:
 		lua_pushnumber( L, p->PointsUntilNextUnlock(ut) );
 		return 1;
 	}
-	static int FindEntryID( T* p, lua_State *L )			{ RString sName = SArg(1); RString s = p->FindEntryID(sName); if( s.empty() ) lua_pushnil(L); else lua_pushstring(L, s); return 1; }
+	static int FindEntryID( T* p, lua_State *L )			{ RString sName = SArg(1); RString s = p->FindEntryID(sName); if( s.empty() ) lua_pushnil(L); else lua_pushstring(L, s.c_str()); return 1; }
 	static int UnlockEntryID( T* p, lua_State *L )			{ RString sUnlockEntryID = SArg(1); p->UnlockEntryID(sUnlockEntryID); COMMON_RETURN_SELF; }
 	static int UnlockEntryIndex( T* p, lua_State *L )		{ int iUnlockEntryID = IArg(1); p->UnlockEntryIndex(iUnlockEntryID); COMMON_RETURN_SELF; }
 	static int LockEntryID( T * p, lua_State * L)

--- a/src/XmlFile.cpp
+++ b/src/XmlFile.cpp
@@ -53,7 +53,7 @@ void XNodeStringValue::GetValue( RString &out ) const		{ out = m_sValue; }
 void XNodeStringValue::GetValue( int &out ) const		{ out = StringToInt(m_sValue); }
 void XNodeStringValue::GetValue( float &out ) const		{ out = StringToFloat(m_sValue); }
 void XNodeStringValue::GetValue( bool &out ) const		{ out = StringToInt(m_sValue) != 0; }
-void XNodeStringValue::GetValue( unsigned &out ) const		{ out = strtoul(m_sValue,nullptr,0); }
+void XNodeStringValue::GetValue( unsigned &out ) const		{ out = strtoul(m_sValue.c_str(),nullptr,0); }
 void XNodeStringValue::PushValue( lua_State *L ) const
 {
 	LuaHelpers::Push( L, m_sValue );

--- a/src/XmlToLua.cpp
+++ b/src/XmlToLua.cpp
@@ -250,7 +250,7 @@ void convert_lua_chunk(RString& chunk_text)
 	for(std::map<RString, RString>::iterator chunk= chunks_to_replace.begin();
 			chunk != chunks_to_replace.end(); ++chunk)
 	{
-		chunk_text.Replace(chunk->first, chunk->second);
+		chunk_text.Replace(chunk->first.c_str(), chunk->second.c_str());
 	}
 }
 

--- a/src/arch/ArchHooks/ArchHooks_MacOSX.mm
+++ b/src/arch/ArchHooks/ArchHooks_MacOSX.mm
@@ -298,7 +298,7 @@ void ArchHooks::MountInitialFilesystems( const RString &sDirOfExecutable )
 		CFStringRef dataPath = CFURLCopyFileSystemPath( dataUrl, kCFURLPOSIXPathStyle );
 		CFStringGetCString( dataPath, dir, PATH_MAX, kCFStringEncodingUTF8 );
 
-		if( strncmp(sDirOfExecutable, dir, sDirOfExecutable.length()) == 0 )
+		if( strncmp(sDirOfExecutable.c_str(), dir, sDirOfExecutable.length()) == 0 )
 			FILEMAN->Mount( "zip", dir + sDirOfExecutable.length(), "/" );
 		CFRelease( dataPath );
 		CFRelease( dataUrl );

--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -271,7 +271,7 @@ void ArchHooks_Unix::SetTime( tm newtime )
 		newtime.tm_sec );
 
 	LOG->Trace( "executing '%s'", sCommand.c_str() );
-	int ret = system( sCommand );
+	int ret = system( sCommand.c_str() );
 	if( ret == -1 || ret == 127 || !WIFEXITED(ret) || WEXITSTATUS(ret) )
 		LOG->Trace( "'%s' failed", sCommand.c_str() );
 

--- a/src/arch/Dialog/DialogDriver.cpp
+++ b/src/arch/Dialog/DialogDriver.cpp
@@ -27,7 +27,7 @@ DialogDriver *DialogDriver::Create()
 
 	for (RString const &Driver : asDriversToTry)
 	{
-		std::map<istring, CreateDialogDriverFn>::const_iterator iter = RegisterDialogDriver::g_pRegistrees->find( istring(Driver) );
+		std::map<istring, CreateDialogDriverFn>::const_iterator iter = RegisterDialogDriver::g_pRegistrees->find( istring(Driver.c_str()) );
 
 		if( iter == RegisterDialogDriver::g_pRegistrees->end() )
 			continue;

--- a/src/arch/Dialog/DialogDriver_MacOSX.cpp
+++ b/src/arch/Dialog/DialogDriver_MacOSX.cpp
@@ -16,7 +16,7 @@ static CFOptionFlags ShowAlert( CFOptionFlags flags, const RString& sMessage, CF
 				CFStringRef alt = nullptr, CFStringRef other = nullptr)
 {
 	CFOptionFlags result;
-	CFStringRef text = CFStringCreateWithCString( nullptr, sMessage, kCFStringEncodingUTF8 );
+	CFStringRef text = CFStringCreateWithCString( nullptr, sMessage.c_str(), kCFStringEncodingUTF8 );
 
 	if( text == nullptr )
 	{

--- a/src/arch/InputHandler/InputHandler_Linux_Event.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Event.cpp
@@ -87,7 +87,7 @@ bool EventDevice::Open( RString sFile, InputDevice dev )
 {
 	m_sPath = sFile;
 	m_Dev = dev;
-	m_iFD = open( sFile, O_RDWR );
+	m_iFD = open( sFile.c_str(), O_RDWR );
 	if( m_iFD == -1 )
 	{
 		// HACK: Let the caller handle errno.

--- a/src/arch/InputHandler/InputHandler_Linux_Joystick.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Joystick.cpp
@@ -65,7 +65,7 @@ void InputHandler_Linux_Joystick::StopThread()
 bool InputHandler_Linux_Joystick::TryDevice(RString dev)
 {
 	struct stat st;
-	if( stat( dev, &st ) == -1 )
+	if( stat( dev.c_str(), &st ) == -1 )
 		{ LOG->Warn( "LinuxJoystick: Couldn't stat %s: %s", dev.c_str(), strerror(errno) ); return false; }
 
 	if( !S_ISCHR( st.st_mode ) )
@@ -77,7 +77,7 @@ bool InputHandler_Linux_Joystick::TryDevice(RString dev)
 	/* Thread is stopped! DO NOT RETURN */
 	{
 		FileDescriptor f;
-		f.fd = open( dev, O_RDONLY );
+		f.fd = open( dev.c_str(), O_RDONLY );
 		if(f.fd != -1)
 		{
 			char szName[1024];

--- a/src/arch/LoadingWindow/LoadingWindow_Gtk.cpp
+++ b/src/arch/LoadingWindow/LoadingWindow_Gtk.cpp
@@ -70,7 +70,7 @@ LoadingWindow_Gtk::~LoadingWindow_Gtk()
 
 void LoadingWindow_Gtk::SetText( RString s )
 {
-	gtk_label_set_text(GTK_LABEL(label), s);
+	gtk_label_set_text(GTK_LABEL(label), s.c_str());
 	gtk_widget_show(label);
 	gtk_main_iteration_do(FALSE);
 }

--- a/src/arch/LoadingWindow/LoadingWindow_MacOSX.mm
+++ b/src/arch/LoadingWindow/LoadingWindow_MacOSX.mm
@@ -128,7 +128,7 @@ void LoadingWindow_MacOSX::SetText( RString str )
 {
 	if( !g_Helper )
 		return;
-	NSString *s = [[NSString alloc] initWithUTF8String:str];
+	NSString *s = [[NSString alloc] initWithUTF8String:(str.c_str())];
 	[g_Helper->m_Text performSelectorOnMainThread:@selector(setString:) withObject:(s ? s : @"") waitUntilDone:NO];
 	[s release];
 }

--- a/src/arch/LowLevelWindow/LowLevelWindow_MacOSX.mm
+++ b/src/arch/LowLevelWindow/LowLevelWindow_MacOSX.mm
@@ -331,7 +331,7 @@ void *LowLevelWindow_MacOSX::GetProcAddress( RString s )
 	const uint32_t options = NSLOOKUPSYMBOLINIMAGE_OPTION_RETURN_ON_ERROR;
 
 	for( uint32_t i = 0; i < count && !symbol; ++i )
-		symbol = NSLookupSymbolInImage( _dyld_get_image_header(i), symbolName, options );
+		symbol = NSLookupSymbolInImage( _dyld_get_image_header(i), symbolName.c_str(), options );
 	return symbol ? NSAddressOfSymbol( symbol ) : nil;
 }
 

--- a/src/arch/RageDriver.cpp
+++ b/src/arch/RageDriver.cpp
@@ -15,7 +15,7 @@ RageDriver *DriverList::Create( const RString &sDriverName )
 	if( m_pRegistrees == nullptr )
 		return nullptr;
 
-	std::map<istring, CreateRageDriverFn>::const_iterator iter = m_pRegistrees->find( istring(sDriverName) );
+	std::map<istring, CreateRageDriverFn>::const_iterator iter = m_pRegistrees->find( istring(sDriverName.c_str()) );
 	if( iter == m_pRegistrees->end() )
 		return nullptr;
 	return (iter->second)();

--- a/src/arch/Sound/ALSA9Dynamic.cpp
+++ b/src/arch/Sound/ALSA9Dynamic.cpp
@@ -35,7 +35,7 @@ RString LoadALSA()
 
 	ASSERT( Handle == nullptr );
 
-	Handle = dlopen( lib, RTLD_NOW );
+	Handle = dlopen( lib.c_str(), RTLD_NOW );
 	if( Handle == nullptr )
 		return ssprintf("dlopen(%s): %s", lib.c_str(), dlerror());
 

--- a/src/arch/Sound/ALSA9Helpers.cpp
+++ b/src/arch/Sound/ALSA9Helpers.cpp
@@ -160,7 +160,7 @@ void Alsa9Buf::GetSoundCardDebugInfo()
 		const RString id = ssprintf( "hw:%d", card );
 		snd_ctl_t *handle;
 		int err;
-		err = dsnd_ctl_open( &handle, id, 0 );
+		err = dsnd_ctl_open( &handle, id.c_str(), 0 );
 		if ( err < 0 )
 		{
 			LOG->Info( "Couldn't open card #%i (\"%s\") to probe: %s", card, id.c_str(), dsnd_strerror(err) );
@@ -239,7 +239,7 @@ RString Alsa9Buf::Init( int channels_,
 
 	/* Open the device. */
 	int err;
-	err = dsnd_pcm_open( &pcm, DeviceName(), SND_PCM_STREAM_PLAYBACK, SND_PCM_NONBLOCK );
+	err = dsnd_pcm_open( &pcm, DeviceName().c_str(), SND_PCM_STREAM_PLAYBACK, SND_PCM_NONBLOCK );
 	if( err < 0 )
 		return ssprintf( "dsnd_pcm_open(%s): %s", DeviceName().c_str(), dsnd_strerror(err) );
 
@@ -424,7 +424,7 @@ RString Alsa9Buf::GetHardwareID( RString name )
 
 	snd_ctl_t *handle;
 	int err;
-	err = dsnd_ctl_open( &handle, name, 0 );
+	err = dsnd_ctl_open( &handle, name.c_str(), 0 );
 	if ( err < 0 )
 	{
 		LOG->Info( "Couldn't open card \"%s\" to get ID: %s", name.c_str(), dsnd_strerror(err) );

--- a/src/arch/Sound/RageSoundDriver_JACK.cpp
+++ b/src/arch/Sound/RageSoundDriver_JACK.cpp
@@ -149,7 +149,7 @@ RString RageSoundDriver_JACK::ConnectPorts()
 		// "aliases" in the docs.)
 		for ( RString const &portName : portNames )
 		{
-			jack_port_t *out = jack_port_by_name( client, portName );
+			jack_port_t *out = jack_port_by_name( client, portName.c_str() );
 			// Make sure the port is a sink.
 			if( ! ( jack_port_flags( out ) & JackPortIsInput ) )
 				continue;

--- a/src/archutils/Unix/CrashHandler.cpp
+++ b/src/archutils/Unix/CrashHandler.cpp
@@ -375,7 +375,7 @@ void CrashHandler::ForceDeadlock( RString reason, uint64_t iID )
 
 	strncpy( crash.m_ThreadName[0], RageThread::GetCurrentThreadName(), sizeof(crash.m_ThreadName[0])-1 );
 
-	strncpy( crash.reason, reason, std::min(sizeof(crash.reason) - 1, reason.length()) );
+	strncpy( crash.reason, reason.c_str(), std::min(sizeof(crash.reason) - 1, reason.length()) );
 	crash.reason[ sizeof(crash.reason)-1 ] = 0;
 
 	RunCrashHandler( &crash );

--- a/src/archutils/Unix/CrashHandlerChild.cpp
+++ b/src/archutils/Unix/CrashHandlerChild.cpp
@@ -194,10 +194,10 @@ static void child_process()
 #endif
 	sCrashInfoPath += "/crashinfo.txt";
 
-	FILE *CrashDump = fopen( sCrashInfoPath, "w+" );
+	FILE *CrashDump = fopen( sCrashInfoPath.c_str(), "w+" );
 	if(CrashDump == nullptr)
 	{
-		fprintf( stderr, "Couldn't open " + sCrashInfoPath + ": %s\n", strerror(errno) );
+		fprintf( stderr, "Couldn't open %s: %s\n", sCrashInfoPath.c_str(), strerror(errno) );
 		exit(1);
 	}
 
@@ -245,7 +245,7 @@ static void child_process()
 
 	fprintf(CrashDump, "Checkpoints:\n");
 	for( unsigned i=0; i<Checkpoints.size(); ++i )
-		fputs( Checkpoints[i], CrashDump );
+		fputs( Checkpoints[i].c_str(), CrashDump );
 	fprintf( CrashDump, "\n" );
 
 	for( int i = 0; i < CrashData::MAX_BACKTRACE_THREADS; ++i )
@@ -276,7 +276,7 @@ static void child_process()
 	if( tty == nullptr )
 		tty = stderr;
 
-	fputs( 	"\n"
+	fputs(( 	"\n"
 		 PRODUCT_ID " has crashed.  Debug information has been output to\n"
 		 "\n"
 		 "    " + sCrashInfoPath + "\n"
@@ -284,7 +284,7 @@ static void child_process()
 		 "Please report a bug at:\n"
 		 "\n"
 		 "    " REPORT_BUG_URL "\n"
-		 "\n", tty );
+		 "\n").c_str(), tty );
 #endif
 }
 

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -25,6 +25,11 @@
     #include "archutils/Unix/CrashHandler.h"
 #endif
 
+void sm_crash(const RString& s)
+{
+    sm_crash(s.c_str());
+}
+
 void sm_crash( const char *reason )
 {
 #if ( defined(_WIN32) && defined(CRASH_HANDLER) ) || defined(MACOSX) || defined(_XDBG)

--- a/src/global.h
+++ b/src/global.h
@@ -37,10 +37,15 @@
 #undef ASSERT
 #endif
 
+#include "StdString.h"
+/** @brief Use RStrings throughout the program. */
+typedef StdString::CStdString RString;
+
 /** @brief RageThreads defines (don't pull in all of RageThreads.h here) */
 namespace Checkpoints
 {
 	void SetCheckpoint( const char *file, int line, const char *message );
+	void SetCheckpoint( const char *file, int line, const RString& message );
 }
 /** @brief Set a checkpoint with no message. */
 #define CHECKPOINT (Checkpoints::SetCheckpoint(__FILE__, __LINE__, nullptr))
@@ -57,6 +62,8 @@ namespace Checkpoints
  * @param reason the crash reason as determined by prior function calls.
  * @return nothing: there is no escape without quitting the program.
  */
+[[noreturn]]
+void sm_crash(const RString& reason);
 [[noreturn]]
 void sm_crash( const char *reason = "Internal error" );
 
@@ -78,6 +85,7 @@ void sm_crash( const char *reason = "Internal error" );
 /** @brief Use this to catch switching on invalid values */
 #define DEFAULT_FAIL(i) 	default: FAIL_M( ssprintf("%s = %i", #i, (i)) )
 
+void ShowWarningOrTrace( const char *file, int line, const RString& message, bool bWarning );
 void ShowWarningOrTrace( const char *file, int line, const char *message, bool bWarning ); // don't pull in LOG here
 #define WARN(MESSAGE) (ShowWarningOrTrace(__FILE__, __LINE__, MESSAGE, true))
 #if !defined(CO_EXIST_WITH_MFC)
@@ -101,10 +109,6 @@ void ShowWarningOrTrace( const char *file, int line, const char *message, bool b
 #define SM_UNIQUE_NAME3(x,line) x##line
 #define SM_UNIQUE_NAME2(x,line) SM_UNIQUE_NAME3(x, line)
 #define SM_UNIQUE_NAME(x) SM_UNIQUE_NAME2(x, __LINE__)
-
-#include "StdString.h"
-/** @brief Use RStrings throughout the program. */
-typedef StdString::CStdString RString;
 
 #include "RageException.h"
 


### PR DESCRIPTION
This is required for the RString to std::string migration.

Mostly automated from https://github.com/aeubanks/rewriter/blob/main/c_str.cc, with some manual intervention required for fixing up `a + b.c_str()` to `(a + b).c_str()`.

Added some overloads for some common global functions like sm_crash and some RString methods to reduce the number of changes required here.

This isn't complete due to me only being able to automate the Linux build, there are too many Windows breakages. You can test the removal of the implicit conversion operator [here](https://github.com/itgmania/itgmania/blob/607b407007426afbbc308c8bed863a4875f92785/src/StdString.h#L596).