### PR TITLE
Pass a const char* instead of RString to RageException::Throw

### DIFF
--- a/src/RageDisplay_D3D.cpp
+++ b/src/RageDisplay_D3D.cpp
@@ -583,8 +583,9 @@ bool RageDisplay_D3D::BeginFrame()
 		{
 			bool bIgnore = false;
 			RString sError = SetD3DParams( bIgnore );
-			if( sError != "" )
-				RageException::Throw( sError );
+			if( !sError.empty() ) {
+				RageException::Throw(sError.c_str());
+			}
 
 			break;
 		}


### PR DESCRIPTION
For #781

This should resolve the failing Windows CI on the RString removal PR's, I saw they always die here due to lack of a suitable operator.  But really it appears to be a mistake by the author of this code, because RageException::Throw asks for a const char* but we were giving it a RString. So now it uses `.c_str()` to provide the expected format.

Since we're here,  also correctly use `.empty` instead of comparing against `""`, and also add braces.