### PR TITLE
Improve CMake caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           path: |
             build
-          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ github.sha }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-cmake-build-
       - name: Install dependencies
@@ -54,7 +54,7 @@ jobs:
         with:
           path: |
             build
-          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ github.sha }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-cmake-build-
       - name: Install dependencies
@@ -89,7 +89,7 @@ jobs:
         with:
           path: |
             build
-          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ github.sha }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-cmake-build-
       - name: Install dependencies
@@ -112,7 +112,7 @@ jobs:
         with:
           path: |
             build
-          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ github.sha }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-cmake-build-
       - name: Install dependencies


### PR DESCRIPTION
The current cache key is based on`github.sha`, this means the cache will be invalidated for every new commit (`github.sha` changes with every commit)

Proposing modifying to invalidate the cache only when `CMakeLists.txt` or `.cmake` files change, improving cache efficiency.

Reference https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#hashfiles