### PR TITLE
Clean up in RageDisplay::SaveScreenshot

### DIFF
--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -767,7 +767,7 @@ void RageDisplay::UpdateCentering()
 		(float) p.m_iTranslateX, (float) p.m_iTranslateY, (float) p.m_iAddWidth, (float) p.m_iAddHeight );
 }
 
-bool RageDisplay::SaveScreenshot( RString sPath, GraphicsFileFormat format )
+bool RageDisplay::SaveScreenshot( const RString &sPath, GraphicsFileFormat format )
 {
 	RageTimer timer;
 	RageSurface *surface = this->CreateScreenshot();

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -773,7 +773,7 @@ bool RageDisplay::SaveScreenshot( const RString &sPath, GraphicsFileFormat forma
 	RageSurface *surface = this->CreateScreenshot();
 //	LOG->Trace( "CreateScreenshot took %f seconds", timer.GetDeltaTime() );
 
-	if (nullptr == surface)
+	if (!surface)
 	{
 		LOG->Trace("CreateScreenshot failed to return a surface");
 		return false;

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -820,7 +820,10 @@ bool RageDisplay::SaveScreenshot( const RString &sPath, GraphicsFileFormat forma
 	case SAVE_LOSSY_HIGH_QUAL:
 		bSuccess = RageSurfaceUtils::SaveJPEG( surface, out, true );
 		break;
-	DEFAULT_FAIL( format );
+	default:
+		LOG->Warn("Unknown graphics file format; expected bmp/png/jpg: %d", format);
+		bSuccess = false;
+		break;
 	}
 //	LOG->Trace( "Saving Screenshot file took %f seconds.", timer.GetDeltaTime() );
 

--- a/src/RageDisplay.h
+++ b/src/RageDisplay.h
@@ -360,7 +360,7 @@ public:
 		SAVE_LOSSY_LOW_QUAL,	// jpg
 		SAVE_LOSSY_HIGH_QUAL	// jpg
 	};
-	bool SaveScreenshot( RString sPath, GraphicsFileFormat format );
+	bool SaveScreenshot( const RString &sPath, GraphicsFileFormat format );
 
 	virtual RString GetTextureDiagnostics( uintptr_t /* id */ ) const { return RString(); }
 	virtual RageSurface* CreateScreenshot() = 0;	// allocates a surface.  Caller must delete it.


### PR DESCRIPTION
When `SaveScreenshot` in StepMania.cpp calls `DISPLAY->SaveScreenshot( Path, fmt )`, this is the function referenced.

It is a little bit of a mess, full of commented out debug logs, an unused timer, and a macro instead of a proper `default` case for the switch.

It also could benefit from passing the parameter `sPath` by reference.