### PR TITLE
SaveScreenshot: return the status boolean directly

### DIFF
--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -829,10 +829,9 @@ bool RageDisplay::SaveScreenshot( RString sPath, GraphicsFileFormat format )
 	if( !bSuccess )
 	{
 		LOG->Trace("Couldn't write %s: %s", sPath.c_str(), out.GetError().c_str() );
-		return false;
 	}
 
-	return true;
+	return bSuccess;
 }
 
 void RageDisplay::DrawQuads( const RageSpriteVertex v[], int iNumVerts )

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -828,7 +828,7 @@ bool RageDisplay::SaveScreenshot( RString sPath, GraphicsFileFormat format )
 
 	if( !bSuccess )
 	{
-		LOG->Trace("Couldn't write %s: %s", sPath.c_str(), out.GetError().c_str() );
+		LOG->Warn("SaveScreenshot: Failed to save screenshot to %s: %s", sPath.c_str(), out.GetError().c_str() );
 	}
 
 	return bSuccess;


### PR DESCRIPTION
The code uses `bSuccess` to determine whether or not the save was successful, but then returns a hardcoded true or false, so this changes it to simply return `bSuccess`.