### PR TITLE
BitmapText: replace some `std::lrint`'s with `GetTimeSinceStartSeconds()`

### DIFF
--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -328,7 +328,7 @@ void BitmapText::BuildChars()
 
 	if( m_bUsingDistortion )
 	{
-		int iSeed = std::lrint( RageTimer::GetTimeSinceStart()*500000.0f );
+		int iSeed = RageTimer::GetTimeSinceStartSeconds() * 500000;
 		RandomGen rnd( iSeed );
 		for(unsigned int i= 0; i < m_aVertices.size(); i+=4)
 		{
@@ -798,7 +798,7 @@ void BitmapText::DrawPrimitives() noexcept
 		std::vector<RageVector3> vGlyphJitter;
 		if( m_bJitter )
 		{
-			int iSeed = std::lrint( RageTimer::GetTimeSinceStart()*8 );
+			int iSeed = RageTimer::GetTimeSinceStartSeconds() * 8;
 			RandomGen rnd( iSeed );
 			for (size_t i = 0; i < m_aVertices.size(); i += 4)
 			{


### PR DESCRIPTION
Optimization to avoid several stages of integer-to-float and float-to-integer by making use of `GetTimeSinceStartSeconds()`.

see below:
https://github.com/itgmania/itgmania/blob/427484d1007c92c78753e86a39ed6399fed92f10/src/RageTimer.cpp#L53-L63