### PR TITLE
SaveScreenshot: Use const & in function header

### DIFF
--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -767,7 +767,7 @@ void RageDisplay::UpdateCentering()
 		(float) p.m_iTranslateX, (float) p.m_iTranslateY, (float) p.m_iAddWidth, (float) p.m_iAddHeight );
 }
 
-bool RageDisplay::SaveScreenshot( RString sPath, GraphicsFileFormat format )
+bool RageDisplay::SaveScreenshot( const RString &sPath, GraphicsFileFormat format )
 {
 	RageTimer timer;
 	RageSurface *surface = this->CreateScreenshot();

--- a/src/RageDisplay.h
+++ b/src/RageDisplay.h
@@ -360,7 +360,7 @@ public:
 		SAVE_LOSSY_LOW_QUAL,	// jpg
 		SAVE_LOSSY_HIGH_QUAL	// jpg
 	};
-	bool SaveScreenshot( RString sPath, GraphicsFileFormat format );
+	bool SaveScreenshot( const RString &sPath, GraphicsFileFormat format );
 
 	virtual RString GetTextureDiagnostics( uintptr_t /* id */ ) const { return RString(); }
 	virtual RageSurface* CreateScreenshot() = 0;	// allocates a surface.  Caller must delete it.


### PR DESCRIPTION
Pass sPath by reference to avoid unnecessary copies.

Remake of PR #789 which I accidentally force-pushed while closed, so had to re-open a new one.