### PR TITLE
Replace outdated method of determining system locale (Windows only)

### DIFF
--- a/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
@@ -108,109 +108,28 @@ void ArchHooks::MountUserFilesystems(const RString& sDirOfExecutable) {
 	MountDirectories(sAppDataDir);
 }
 
-static RString LangIdToString( LANGID l )
-{
-	switch( PRIMARYLANGID(l) )
-	{
-	case LANG_ARABIC: return "ar";
-	case LANG_BULGARIAN: return "bg";
-	case LANG_CATALAN: return "ca";
-	case LANG_CHINESE:
-	{
-		switch (SUBLANGID(l))
-		{
-		case SUBLANG_CHINESE_TRADITIONAL:
-		case SUBLANG_CHINESE_HONGKONG:
-		case SUBLANG_CHINESE_MACAU:
-			return "zh-Hant";
-		case SUBLANG_CHINESE_SIMPLIFIED:
-		case SUBLANG_CHINESE_SINGAPORE:
-			return "zh-Hans";
-		}
-	}
-	case LANG_CZECH: return "cs";
-	case LANG_DANISH: return "da";
-	case LANG_GERMAN: return "de";
-	case LANG_GREEK: return "el";
-	case LANG_SPANISH: return "es";
-	case LANG_FINNISH: return "fi";
-	case LANG_FRENCH: return "fr";
-	case LANG_HEBREW: return "iw";
-	case LANG_HUNGARIAN: return "hu";
-	case LANG_ICELANDIC: return "is";
-	case LANG_ITALIAN: return "it";
-	case LANG_JAPANESE: return "ja";
-	case LANG_KOREAN: return "ko";
-	case LANG_DUTCH: return "nl";
-	case LANG_NORWEGIAN: return "no";
-	case LANG_POLISH: return "pl";
-	case LANG_PORTUGUESE: return "pt";
-	case LANG_ROMANIAN: return "ro";
-	case LANG_RUSSIAN: return "ru";
-	case LANG_CROATIAN: return "hr";
-	// case LANG_SERBIAN: return "sr"; // same as LANG_CROATIAN?
-	case LANG_SLOVAK: return "sk";
-	case LANG_ALBANIAN: return "sq";
-	case LANG_SWEDISH: return "sv";
-	case LANG_THAI: return "th";
-	case LANG_TURKISH: return "tr";
-	case LANG_URDU: return "ur";
-	case LANG_INDONESIAN: return "in";
-	case LANG_UKRAINIAN: return "uk";
-	case LANG_SLOVENIAN: return "sl";
-	case LANG_ESTONIAN: return "et";
-	case LANG_LATVIAN: return "lv";
-	case LANG_LITHUANIAN: return "lt";
-	case LANG_VIETNAMESE: return "vi";
-	case LANG_ARMENIAN: return "hy";
-	case LANG_BASQUE: return "eu";
-	case LANG_MACEDONIAN: return "mk";
-	case LANG_AFRIKAANS: return "af";
-	case LANG_GEORGIAN: return "ka";
-	case LANG_FAEROESE: return "fo";
-	case LANG_HINDI: return "hi";
-	case LANG_MALAY: return "ms";
-	case LANG_KAZAK: return "kk";
-	case LANG_SWAHILI: return "sw";
-	case LANG_UZBEK: return "uz";
-	case LANG_TATAR: return "tt";
-	case LANG_PUNJABI: return "pa";
-	case LANG_GUJARATI: return "gu";
-	case LANG_TAMIL: return "ta";
-	case LANG_KANNADA: return "kn";
-	case LANG_MARATHI: return "mr";
-	case LANG_SANSKRIT: return "sa";
-	// These aren't present in the VC6 headers. We'll never have translations to these languages anyway. -C
-	//case LANG_MONGOLIAN: return "mn";
-	//case LANG_GALICIAN: return "gl";
-	default: LOG->Warn("Unable to determine system language. Using English.");
-	case LANG_ENGLISH: return "en";
-	}
-}
+static RString GetSystemLocale() {
+	wchar_t locale_name[LOCALE_NAME_MAX_LENGTH] = {0};
 
-static LANGID GetLanguageID()
-{
-	HINSTANCE hDLL = LoadLibrary( "kernel32.dll" );
-	if( hDLL )
-	{
-		typedef LANGID(GET_USER_DEFAULT_UI_LANGUAGE)(void);
+	// Retrieve the system's default locale name
+	if (GetUserDefaultLocaleName(locale_name, LOCALE_NAME_MAX_LENGTH) > 0) {
+		char locale_name_utf8[LOCALE_NAME_MAX_LENGTH] = {0};
+		WideCharToMultiByte(
+			CP_UTF8, 0, locale_name, -1, locale_name_utf8, LOCALE_NAME_MAX_LENGTH,
+			nullptr, nullptr);
 
-		GET_USER_DEFAULT_UI_LANGUAGE *pGetUserDefaultUILanguage = (GET_USER_DEFAULT_UI_LANGUAGE*) GetProcAddress( hDLL, "GetUserDefaultUILanguage" );
-		if( pGetUserDefaultUILanguage )
-		{
-			LANGID ret = pGetUserDefaultUILanguage();
-			FreeLibrary( hDLL );
-			return ret;
-		}
-		FreeLibrary( hDLL );
+		// Truncate to the first two characters (language code)
+		return RString(locale_name_utf8).substr(0, 2);
 	}
 
-	return GetUserDefaultLangID();
+	// Fallback to English if the locale cannot be determined.
+	LOG->Warn("Unable to determine system locale. Using English.");
+	return "en";
 }
 
 RString ArchHooks::GetPreferredLanguage()
 {
-	return LangIdToString( GetLanguageID() );
+	return GetSystemLocale();
 }
 
 /*


### PR DESCRIPTION
The existing LANGID based method is deprecated in `winnt.h`, and is only recommended for use when compatibility with Win9x is needed. This uses the system locale instead.

A very minor change, as the function is called extremely rarely if ever, but allows us to do the same thing with greater accuracy, without needing to load a DLL.