### PR TITLE
Implement `fast_lrint` in RageUtil

### DIFF
--- a/src/RageSoundMixBuffer.cpp
+++ b/src/RageSoundMixBuffer.cpp
@@ -53,8 +53,10 @@ void RageSoundMixBuffer::read( int16_t *pBuf )
 		float iOut = m_pMixbuf[iPos];
 		// ensure volume is within expected levels to prevent clipping
 		iOut = std::clamp( iOut, -1.0f, +1.0f );
-		// round rather than truncate to minimize distortion
-		pBuf[iPos] = static_cast<int16_t>(std::round(iOut * INT16_MAX));
+		// round rather than truncate to minimize distortion.
+		// this is heavily optimized, but will be off by one if the value
+		//  is exactly 0.5. this is unlikely to be audible though.
+		pBuf[iPos] = static_cast<int16_t>(iOut + (iOut >= 0 ? 0.5 : -0.5));
 	}
 	m_pMixbuf.clear();
 }

--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -64,7 +64,7 @@ void RageSoundReader_Chain::AddSound( int iIndex, float fOffsetSecs, float fPan 
 
 	Sound s;
 	s.iIndex = iIndex;
-	s.iOffsetMS = static_cast<int>((fOffsetSecs * 1000) + 0.5 );
+	s.iOffsetMS = fast_lrint( fOffsetSecs * 1000 );
 	s.fPan = fPan;
 	s.pSound = nullptr;
 	m_aSounds.push_back( s );

--- a/src/RageSoundReader_Extend.cpp
+++ b/src/RageSoundReader_Extend.cpp
@@ -155,7 +155,7 @@ bool RageSoundReader_Extend::SetProperty( const RString &sProperty, float fValue
 {
 	if( sProperty == "StartSecond" )
 	{
-		m_iStartFrames = static_cast<int>((fValue * this->GetSampleRate()) + 0.5);
+		m_iStartFrames = fast_lrint( fValue * this->GetSampleRate() );
 		return true;
 	}
 
@@ -164,7 +164,7 @@ bool RageSoundReader_Extend::SetProperty( const RString &sProperty, float fValue
 		if( fValue == -1 )
 			m_iLengthFrames = -1;
 		else
-			m_iLengthFrames = static_cast<int>((fValue * this->GetSampleRate()) + 0.5);
+			m_iLengthFrames = fast_lrint( fValue * this->GetSampleRate() );
 		return true;
 	}
 
@@ -188,13 +188,13 @@ bool RageSoundReader_Extend::SetProperty( const RString &sProperty, float fValue
 
 	if( sProperty == "FadeInSeconds" )
 	{
-		m_iFadeInFrames = static_cast<int>((fValue * this->GetSampleRate()) + 0.5);
+		m_iFadeInFrames = fast_lrint( fValue * this->GetSampleRate() );
 		return true;
 	}
 
 	if( sProperty == "FadeSeconds" || sProperty == "FadeOutSeconds" )
 	{
-		m_iFadeOutFrames = static_cast<int>((fValue * this->GetSampleRate()) + 0.5);
+		m_iFadeOutFrames = fast_lrint( fValue * this->GetSampleRate() );
 		return true;
 	}
 

--- a/src/RageSoundReader_Merge.cpp
+++ b/src/RageSoundReader_Merge.cpp
@@ -213,7 +213,7 @@ int RageSoundReader_Merge::Read( float *pBuffer, int iFrames )
 			/* A sound is being delayed to resync it; clamp the number of frames we
 			 * read now, so we don't advance past it. */
 			int iMaxSourceFramesToRead = aNextSourceFrames[i] - iMinPosition;
-			int iMaxStreamFramesToRead = static_cast<int>((iMaxSourceFramesToRead / m_fCurrentStreamToSourceRatio) + 0.5 );
+			int iMaxStreamFramesToRead = fast_lrint( iMaxSourceFramesToRead / m_fCurrentStreamToSourceRatio );
 			iFrames = std::min( iFrames, iMaxStreamFramesToRead );
 //			LOG->Warn( "RageSoundReader_Merge: sound positions moving at different rates" );
 		}
@@ -226,8 +226,10 @@ int RageSoundReader_Merge::Read( float *pBuffer, int iFrames )
 		iFrames = pSound->Read( pBuffer, iFrames );
 		if( iFrames > 0 )
 		{
-			m_iNextSourceFrame += static_cast<int>((iFrames * m_fCurrentStreamToSourceRatio) + 0.5 );
+			m_iNextSourceFrame += fast_lrint( iFrames * m_fCurrentStreamToSourceRatio );
 		}
+		aNextSourceFrames.front() = pSound->GetNextSourceFrame();
+		aRatios.front() = pSound->GetStreamToSourceRatio();
 		return iFrames;
 	}
 

--- a/src/RageSoundReader_Preload.cpp
+++ b/src/RageSoundReader_Preload.cpp
@@ -63,7 +63,7 @@ bool RageSoundReader_Preload::Open( RageSoundReader *pSource )
 	{
 		float fSecs = iLen / 1000.f;
 
-		int iFrames = static_cast<int>((fSecs * m_iSampleRate) + 0.5 ); /* seconds -> frames */
+		int iFrames = fast_lrint( fSecs * m_iSampleRate ); /* seconds -> frames */
 		int iSamples = unsigned( iFrames * m_iChannels ); /* frames -> samples */
 		if( iSamples > iMaxSamples )
 			return false; /* Don't bother trying to preload it. */
@@ -126,7 +126,7 @@ int RageSoundReader_Preload::GetLength_Fast() const
 int RageSoundReader_Preload::SetPosition( int iFrame )
 {
 	m_iPosition = iFrame;
-	m_iPosition = static_cast<int>((m_iPosition / m_fRate) + 0.5);
+	m_iPosition = fast_lrint(m_iPosition / m_fRate);
 
 	if( m_iPosition >= int(m_Buffer->size() / framesize) )
 	{
@@ -139,7 +139,7 @@ int RageSoundReader_Preload::SetPosition( int iFrame )
 
 int RageSoundReader_Preload::GetNextSourceFrame() const
 {
-	return static_cast<int>((m_iPosition * m_fRate) + 0.5);
+	return fast_lrint(m_iPosition * m_fRate);
 }
 
 int RageSoundReader_Preload::Read( float *pBuffer, int iFrames )

--- a/src/RageSoundReader_Resample_Good.cpp
+++ b/src/RageSoundReader_Resample_Good.cpp
@@ -632,7 +632,7 @@ void RageSoundReader_Resample_Good::ReopenResampler()
 	}
 
 	if( m_fRate != -1 )
-		iDownFactor = static_cast<int>((m_fRate * iDownFactor) + 0.5 );
+		iDownFactor = fast_lrint( m_fRate * iDownFactor );
 
 	for( size_t iChannel = 0; iChannel < m_apResamplers.size(); ++iChannel )
 		m_apResamplers[iChannel]->SetDownFactor( iDownFactor );
@@ -708,7 +708,7 @@ void RageSoundReader_Resample_Good::SetRate( float fRatio )
 	int iDownFactor, iUpFactor;
 	GetFactors( iDownFactor, iUpFactor );
 	if( m_fRate != -1 )
-		iDownFactor = static_cast<int>((m_fRate * iDownFactor) + 0.5 );
+		iDownFactor = fast_lrint( m_fRate * iDownFactor );
 
 	/* Set m_fRate to the actual rate, after quantization by iUpFactor. */
 	m_fRate = float(iDownFactor) / iUpFactor;

--- a/src/RageSoundReader_SpeedChange.cpp
+++ b/src/RageSoundReader_SpeedChange.cpp
@@ -166,7 +166,7 @@ int RageSoundReader_SpeedChange::Step()
 		 * by 2.0 frames, and advance by 0.3 more the next time around. */
 		float fAdvanceFrames = GetWindowSizeFrames() * m_fTrailingSpeedRatio;
 		fAdvanceFrames += m_fErrorFrames;
-		int iTrailingDeltaFrames = static_cast<int>( (fAdvanceFrames) + 0.5 );
+		int iTrailingDeltaFrames = fast_lrint( fAdvanceFrames );
 		m_fErrorFrames = fAdvanceFrames - iTrailingDeltaFrames;
 		m_iUncorrelatedPos += iTrailingDeltaFrames;
 
@@ -315,7 +315,7 @@ int RageSoundReader_SpeedChange::GetNextSourceFrame() const
 	float fRatio = m_fTrailingSpeedRatio;
 
 	int iSourceFrame = RageSoundReader_Filter::GetNextSourceFrame();
-	int iPos = static_cast<int>((m_iPos * fRatio) + 0.5);
+	int iPos = fast_lrint(m_iPos * fRatio);
 
 	iSourceFrame -= m_iDataBufferAvailFrames;
 	iSourceFrame += m_iUncorrelatedPos + iPos;

--- a/src/RageSoundReader_ThreadedBuffer.cpp
+++ b/src/RageSoundReader_ThreadedBuffer.cpp
@@ -237,7 +237,7 @@ void RageSoundReader_ThreadedBuffer::BufferingThread()
 		else
 		{
 			m_Event.Unlock();
-			usleep( static_cast<int>((fTimeToSleep * 1000000) + 0.5) );
+			usleep( fast_lrint(fTimeToSleep * 1000000) );
 			m_Event.Lock();
 		}
 	}

--- a/src/RageSoundUtil.cpp
+++ b/src/RageSoundUtil.cpp
@@ -94,7 +94,7 @@ void RageSoundUtil::ConvertFloatToNativeInt16( const float *pFrom, int16_t *pTo,
 {
 	for( int i = 0; i < iSamples; ++i )
 	{
-		int iOut = static_cast<int>((pFrom[i] * 32768.0f) + 0.5);
+		int iOut = fast_lrint( pFrom[i] * 32768.0f );
 		pTo[i] = std::clamp( iOut, -32768, 32767 );
 	}
 }

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -332,7 +332,7 @@ float fmodfp( float x, float y );
 // This is super fast, but it doesn't handle overflow.
 // If you need to handle overflow, use std::lrint() instead.
 inline int fast_lrint(volatile double x) {
-	return static_cast<int>(x + (x >= 0 ? 0.5 : -0.5));
+	return static_cast<int>(x + (x >= 0.0 ? 0.5 : -0.5));
 }
 
 int power_of_two( int v );

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -328,6 +328,13 @@ void fapproach( float& val, float other_val, float to_move );
 /* Return a positive x mod y. */
 float fmodfp( float x, float y );
 
+// lrint is notoriously slow in some implementations, so we provide our own.
+// This is super fast, but it doesn't handle overflow.
+// If you need to handle overflow, use std::lrint() instead.
+inline int fast_lrint(volatile double x) {
+	return static_cast<int>(x + (x >= 0 ? 0.5 : -0.5));
+}
+
 int power_of_two( int v );
 bool IsAnInt( const RString &s );
 bool IsHexVal( const RString &s );


### PR DESCRIPTION
A long time ago when I was talking with OutFox devs, they suggested we replace `std::lrint` calls with something faster. This did help performance, especially on Windows, but the implementation we chose for ITGm 0.9.0 didn't actually match `lrint` behavior.

Now it does.

Also is easier to track down instances where this is called this way.