### PR TITLE
#797 followup: `ArchHooks_Win32Static` housekeeping

### DIFF
--- a/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
@@ -8,34 +8,124 @@
 
 #include <cstdint>
 #include <vector>
-#include <mutex> // for call_once
+#include <mutex>
 
-// for QueryPerformanceCounter
 #include <windows.h>
 #include <mmsystem.h>
 #if defined(_MSC_VER)
 #pragma comment(lib, "winmm.lib")
 #endif
 
-static std::once_flag g_timerInitFlag;
-
-/* QueryPerformanceCounter variables below.
- * QueryPerformanceCounter and QueryPerformanceFrequency expect
- * a LARGE_INTEGER, which is a union. These functions store data
- * in the QuadPart of the LARGE_INTEGER, which is a 64-bit integer. */
 namespace {
-    LARGE_INTEGER g_liFrequency;
-    LARGE_INTEGER g_liCurrentTime;
-}  // namespace
+	std::once_flag g_timerInitFlag;
 
-static void InitTimer()
-{
-	// Set the thread scheduler to let us update every 1ms.
-	timeBeginPeriod(1);
-	
-	// Retrieve the number of ticks per second.
-	QueryPerformanceFrequency(&g_liFrequency);
-}
+	// QueryPerformanceCounter and QueryPerformanceFrequency expect
+	// a LARGE_INTEGER, which is a union. These functions store data
+	// in the QuadPart of the LARGE_INTEGER, which is a 64-bit integer.
+	LARGE_INTEGER g_liFrequency;  // constant after InitTimer() is called
+	LARGE_INTEGER g_liCurrentTime;  // TODO: move within GetSystemTimeInMicroseconds()
+
+	void InitTimer()
+	{
+		// Set the thread scheduler to let us update every 1ms.
+		timeBeginPeriod(1);
+
+		// Retrieve the number of ticks per second.
+		QueryPerformanceFrequency(&g_liFrequency);
+	}
+
+	RString GetMountDir(const RString &dir_of_executable)
+	{
+		// All Windows data goes in the directory one level above the executable.
+		CHECKPOINT_M(ssprintf("DOE \"%s\"", dir_of_executable.c_str()));
+		std::vector<RString> parts;
+		split(dir_of_executable, "/", parts);
+		CHECKPOINT_M(ssprintf("... %i parts", parts.size()));
+		ASSERT_M(parts.size() > 1, ssprintf("Strange dir_of_executable: %s", dir_of_executable.c_str()));
+		RString dir = join("/", parts.begin(), parts.end() - 1);
+		return dir;
+	}
+
+	RString LangIdToString()
+	{
+		LANGID lang_id = GetUserDefaultLangID();
+		switch (PRIMARYLANGID(lang_id))
+		{
+		case LANG_ARABIC: return "ar";
+		case LANG_BULGARIAN: return "bg";
+		case LANG_CATALAN: return "ca";
+		case LANG_CHINESE:
+			switch (SUBLANGID(lang_id))
+			{
+			case SUBLANG_CHINESE_TRADITIONAL:
+			case SUBLANG_CHINESE_HONGKONG:
+			case SUBLANG_CHINESE_MACAU:
+				return "zh-Hant";
+			case SUBLANG_CHINESE_SIMPLIFIED:
+			case SUBLANG_CHINESE_SINGAPORE:
+				return "zh-Hans";
+			default:
+				LOG->Warn("Unknown Chinese sublanguage. Using zh-Hans.");
+				return "zh-Hans";
+			}
+		case LANG_CZECH: return "cs";
+		case LANG_DANISH: return "da";
+		case LANG_GERMAN: return "de";
+		case LANG_GREEK: return "el";
+		case LANG_SPANISH: return "es";
+		case LANG_FINNISH: return "fi";
+		case LANG_FRENCH: return "fr";
+		case LANG_HEBREW: return "iw";
+		case LANG_HUNGARIAN: return "hu";
+		case LANG_ICELANDIC: return "is";
+		case LANG_ITALIAN: return "it";
+		case LANG_JAPANESE: return "ja";
+		case LANG_KOREAN: return "ko";
+		case LANG_DUTCH: return "nl";
+		case LANG_NORWEGIAN: return "no";
+		case LANG_POLISH: return "pl";
+		case LANG_PORTUGUESE: return "pt";
+		case LANG_ROMANIAN: return "ro";
+		case LANG_RUSSIAN: return "ru";
+		case LANG_CROATIAN: return "hr";
+		case LANG_SLOVAK: return "sk";
+		case LANG_ALBANIAN: return "sq";
+		case LANG_SWEDISH: return "sv";
+		case LANG_THAI: return "th";
+		case LANG_TURKISH: return "tr";
+		case LANG_URDU: return "ur";
+		case LANG_INDONESIAN: return "in";
+		case LANG_UKRAINIAN: return "uk";
+		case LANG_SLOVENIAN: return "sl";
+		case LANG_ESTONIAN: return "et";
+		case LANG_LATVIAN: return "lv";
+		case LANG_LITHUANIAN: return "lt";
+		case LANG_VIETNAMESE: return "vi";
+		case LANG_ARMENIAN: return "hy";
+		case LANG_BASQUE: return "eu";
+		case LANG_MACEDONIAN: return "mk";
+		case LANG_AFRIKAANS: return "af";
+		case LANG_GEORGIAN: return "ka";
+		case LANG_FAEROESE: return "fo";
+		case LANG_HINDI: return "hi";
+		case LANG_MALAY: return "ms";
+		case LANG_KAZAK: return "kk";
+		case LANG_SWAHILI: return "sw";
+		case LANG_UZBEK: return "uz";
+		case LANG_TATAR: return "tt";
+		case LANG_PUNJABI: return "pa";
+		case LANG_GUJARATI: return "gu";
+		case LANG_TAMIL: return "ta";
+		case LANG_KANNADA: return "kn";
+		case LANG_MARATHI: return "mr";
+		case LANG_SANSKRIT: return "sa";
+		default:
+			LOG->Warn("Unable to determine system language. Using English.");
+			[[fallthrough]];
+		case LANG_ENGLISH: return "en";
+		}
+	}
+}  // namespace
 
 int64_t ArchHooks::GetSystemTimeInMicroseconds()
 {
@@ -46,19 +136,7 @@ int64_t ArchHooks::GetSystemTimeInMicroseconds()
 	QueryPerformanceCounter(&g_liCurrentTime);
 
 	// Calculate the elapsed time in microseconds.
-	return (g_liCurrentTime.QuadPart * 1000000) / g_liFrequency.QuadPart;
-}
-
-static RString GetMountDir( const RString &sDirOfExecutable )
-{
-	/* All Windows data goes in the directory one level above the executable. */
-	CHECKPOINT_M( ssprintf( "DOE \"%s\"", sDirOfExecutable.c_str()) );
-	std::vector<RString> asParts;
-	split( sDirOfExecutable, "/", asParts );
-	CHECKPOINT_M( ssprintf( "... %i asParts", asParts.size()) );
-	ASSERT_M( asParts.size() > 1, ssprintf("Strange sDirOfExecutable: %s", sDirOfExecutable.c_str()) );
-	RString sDir = join( "/", asParts.begin(), asParts.end()-1 );
-	return sDir;
+	return (g_liCurrentTime.QuadPart * 1000000LL) / g_liFrequency.QuadPart;
 }
 
 void MountDirectories(const RString& baseDir) {
@@ -79,131 +157,33 @@ void MountDirectories(const RString& baseDir) {
 		"/Screenshots",
 		"/Songs",
 		"/RandomMovies",
-		"/Themes"
-	};
+		"/Themes"};
 
 	for (const RString& dir : winDirectoryStructureITGm) {
 		FILEMAN->Mount("dir", baseDir + dir, dir);
 	}
 }
 
-void ArchHooks::MountInitialFilesystems(const RString& sDirOfExecutable) {
-	RString sDir = GetMountDir(sDirOfExecutable);
-	FILEMAN->Mount("dirro", sDir, "/");
-
-	if (DoesFileExist("/Portable.ini")) {
-		MountDirectories(sDir);
-	}
-}
-
-void ArchHooks::MountUserFilesystems(const RString& sDirOfExecutable) {
-	RString sAppDataDir = SpecialDirs::GetAppDataDir() + PRODUCT_ID;
-	MountDirectories(sAppDataDir);
-}
-
-static RString LangIdToString( LANGID l )
+void ArchHooks::MountInitialFilesystems(const RString &dir_of_executable)
 {
-	switch( PRIMARYLANGID(l) )
+	RString dir = GetMountDir(dir_of_executable);
+	FILEMAN->Mount("dirro", dir, "/");
+
+	if (DoesFileExist("/Portable.ini"))
 	{
-	case LANG_ARABIC: return "ar";
-	case LANG_BULGARIAN: return "bg";
-	case LANG_CATALAN: return "ca";
-	case LANG_CHINESE:
-	{
-		switch (SUBLANGID(l))
-		{
-		case SUBLANG_CHINESE_TRADITIONAL:
-		case SUBLANG_CHINESE_HONGKONG:
-		case SUBLANG_CHINESE_MACAU:
-			return "zh-Hant";
-		case SUBLANG_CHINESE_SIMPLIFIED:
-		case SUBLANG_CHINESE_SINGAPORE:
-			return "zh-Hans";
-		}
-	}
-	case LANG_CZECH: return "cs";
-	case LANG_DANISH: return "da";
-	case LANG_GERMAN: return "de";
-	case LANG_GREEK: return "el";
-	case LANG_SPANISH: return "es";
-	case LANG_FINNISH: return "fi";
-	case LANG_FRENCH: return "fr";
-	case LANG_HEBREW: return "iw";
-	case LANG_HUNGARIAN: return "hu";
-	case LANG_ICELANDIC: return "is";
-	case LANG_ITALIAN: return "it";
-	case LANG_JAPANESE: return "ja";
-	case LANG_KOREAN: return "ko";
-	case LANG_DUTCH: return "nl";
-	case LANG_NORWEGIAN: return "no";
-	case LANG_POLISH: return "pl";
-	case LANG_PORTUGUESE: return "pt";
-	case LANG_ROMANIAN: return "ro";
-	case LANG_RUSSIAN: return "ru";
-	case LANG_CROATIAN: return "hr";
-	// case LANG_SERBIAN: return "sr"; // same as LANG_CROATIAN?
-	case LANG_SLOVAK: return "sk";
-	case LANG_ALBANIAN: return "sq";
-	case LANG_SWEDISH: return "sv";
-	case LANG_THAI: return "th";
-	case LANG_TURKISH: return "tr";
-	case LANG_URDU: return "ur";
-	case LANG_INDONESIAN: return "in";
-	case LANG_UKRAINIAN: return "uk";
-	case LANG_SLOVENIAN: return "sl";
-	case LANG_ESTONIAN: return "et";
-	case LANG_LATVIAN: return "lv";
-	case LANG_LITHUANIAN: return "lt";
-	case LANG_VIETNAMESE: return "vi";
-	case LANG_ARMENIAN: return "hy";
-	case LANG_BASQUE: return "eu";
-	case LANG_MACEDONIAN: return "mk";
-	case LANG_AFRIKAANS: return "af";
-	case LANG_GEORGIAN: return "ka";
-	case LANG_FAEROESE: return "fo";
-	case LANG_HINDI: return "hi";
-	case LANG_MALAY: return "ms";
-	case LANG_KAZAK: return "kk";
-	case LANG_SWAHILI: return "sw";
-	case LANG_UZBEK: return "uz";
-	case LANG_TATAR: return "tt";
-	case LANG_PUNJABI: return "pa";
-	case LANG_GUJARATI: return "gu";
-	case LANG_TAMIL: return "ta";
-	case LANG_KANNADA: return "kn";
-	case LANG_MARATHI: return "mr";
-	case LANG_SANSKRIT: return "sa";
-	// These aren't present in the VC6 headers. We'll never have translations to these languages anyway. -C
-	//case LANG_MONGOLIAN: return "mn";
-	//case LANG_GALICIAN: return "gl";
-	default: LOG->Warn("Unable to determine system language. Using English.");
-	case LANG_ENGLISH: return "en";
+		MountDirectories(dir);
 	}
 }
 
-static LANGID GetLanguageID()
+void ArchHooks::MountUserFilesystems(const RString &dir_of_executable)
 {
-	HINSTANCE hDLL = LoadLibrary( "kernel32.dll" );
-	if( hDLL )
-	{
-		typedef LANGID(GET_USER_DEFAULT_UI_LANGUAGE)(void);
-
-		GET_USER_DEFAULT_UI_LANGUAGE *pGetUserDefaultUILanguage = (GET_USER_DEFAULT_UI_LANGUAGE*) GetProcAddress( hDLL, "GetUserDefaultUILanguage" );
-		if( pGetUserDefaultUILanguage )
-		{
-			LANGID ret = pGetUserDefaultUILanguage();
-			FreeLibrary( hDLL );
-			return ret;
-		}
-		FreeLibrary( hDLL );
-	}
-
-	return GetUserDefaultLangID();
+	RString appdata_dir = SpecialDirs::GetAppDataDir() + PRODUCT_ID;
+	MountDirectories(appdata_dir);
 }
 
 RString ArchHooks::GetPreferredLanguage()
 {
-	return LangIdToString( GetLanguageID() );
+	return LangIdToString();
 }
 
 /*


### PR DESCRIPTION
re: https://github.com/itgmania/itgmania/pull/797#issuecomment-2848655576

### List of changes:

- File reorginization 
- `LangIdToString(LANGID lang_id)` no longer  requires `GetLanguageID()`, since we don't need to load `kernel32.dll` to call `GetUserDefaultLangID()` since Windows Vista, so the entire function `GetLanguageID()` is removed
- Added missing `LL` specifier to QueryPerformanceCounter math to avoid an unwanted type conversion
- Remove extraneous comments