### PR TITLE
Remove antiquated uses of `std::lrint` for rounding, replace with `std::round`.

### DIFF
--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -798,7 +798,7 @@ void BitmapText::DrawPrimitives() noexcept
 		std::vector<RageVector3> vGlyphJitter;
 		if( m_bJitter )
 		{
-			int iSeed = std::lrint( RageTimer::GetTimeSinceStart()*8 );
+			int iSeed = std::round( RageTimer::GetTimeSinceStart()*8 );
 			RandomGen rnd( iSeed );
 			for (size_t i = 0; i < m_aVertices.size(); i += 4)
 			{

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -798,7 +798,7 @@ void BitmapText::DrawPrimitives() noexcept
 		std::vector<RageVector3> vGlyphJitter;
 		if( m_bJitter )
 		{
-			int iSeed = std::round( RageTimer::GetTimeSinceStart()*8 );
+			int iSeed = RageTimer::GetTimeSinceStartSeconds() * 8;
 			RandomGen rnd( iSeed );
 			for (size_t i = 0; i < m_aVertices.size(); i += 4)
 			{

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -106,7 +106,7 @@ void FontPage::Load( const FontPageSettings &cfg )
 	if( cfg.m_fScaleAllWidthsBy != 1 )
 	{
 		for( int i=0; i<m_FontPageTextures.m_pTextureMain->GetNumFrames(); i++ )
-			aiFrameWidths[i] = std::lrint( aiFrameWidths[i] * cfg.m_fScaleAllWidthsBy );
+			aiFrameWidths[i] = std::round( aiFrameWidths[i] * cfg.m_fScaleAllWidthsBy );
 	}
 
 	m_iCharToGlyphNo = cfg.CharToGlyphNo;

--- a/src/NoteDataUtil.cpp
+++ b/src/NoteDataUtil.cpp
@@ -35,7 +35,7 @@ NoteType NoteDataUtil::GetSmallestNoteTypeInRange( const NoteData &n, int iStart
 	FOREACH_ENUM(NoteType, nt)
 	{
 		float fBeatSpacing = NoteTypeToBeat( nt );
-		int iRowSpacing = std::lrint( fBeatSpacing * ROWS_PER_BEAT );
+		int iRowSpacing = std::round( fBeatSpacing * ROWS_PER_BEAT );
 
 		bool bFoundSmallerNote = false;
 		// for each index in this measure
@@ -381,7 +381,7 @@ void NoteDataUtil::GetSMNoteDataString( const NoteData &in, RString &sRet )
 			if( nt == NoteType_Invalid )
 				iRowSpacing = 1;
 			else
-				iRowSpacing = std::lrint( NoteTypeToBeat(nt) * ROWS_PER_BEAT );
+				iRowSpacing = std::round( NoteTypeToBeat(nt) * ROWS_PER_BEAT );
 			// (verify first)
 			// iRowSpacing = BeatToNoteRow( NoteTypeToBeat(nt) );
 
@@ -2329,7 +2329,7 @@ void NoteDataUtil::Wide( NoteData &inout, int iStartIndex, int iEndIndex )
 			continue;	// skip
 
 		// add a note determinitsitcally
-		int iBeat = std::lrint( NoteRowToBeat(i) );
+		int iBeat = std::round( NoteRowToBeat(i) );
 		int iTrackOfNote = inout.GetFirstTrackWithTap(i);
 		int iTrackToAdd = iTrackOfNote + (iBeat%5)-2;	// won't be more than 2 tracks away from the existing note
 		CLAMP( iTrackToAdd, 0, inout.GetNumTracks()-1 );
@@ -3124,8 +3124,8 @@ void NoteDataUtil::Scale( NoteData &nd, float fScale )
 		for( NoteData::const_iterator iter = nd.begin(t); iter != nd.end(t); ++iter )
 		{
 			TapNote tn = iter->second;
-			int iNewRow      = std::lrint( fScale * iter->first );
-			int iNewDuration = std::lrint( fScale * (iter->first + tn.iDuration) );
+			int iNewRow      = std::round( fScale * iter->first );
+			int iNewDuration = std::round( fScale * (iter->first + tn.iDuration) );
 			tn.iDuration = iNewDuration;
 			ndOut.SetTapNote( t, iNewRow, tn );
 		}
@@ -3141,9 +3141,9 @@ static inline int GetScaledRow( float fScale, int iStartIndex, int iEndIndex, in
 	if( iRow < iStartIndex )
 		return iRow;
 	else if( iRow > iEndIndex )
-		return iRow + std::lrint( (iEndIndex - iStartIndex) * (fScale - 1) );
+		return iRow + std::round( (iEndIndex - iStartIndex) * (fScale - 1) );
 	else
-		return std::lrint( (iRow - iStartIndex) * fScale ) + iStartIndex;
+		return std::round( (iRow - iStartIndex) * fScale ) + iStartIndex;
 }
 
 void NoteDataUtil::ScaleRegion( NoteData &nd, float fScale, int iStartIndex, int iEndIndex )

--- a/src/NoteTypes.h
+++ b/src/NoteTypes.h
@@ -299,7 +299,7 @@ inline int   BeatToNoteRow( float fBeatNum )
  * @brief Convert the beat into a note row.
  * @param fBeatNum the beat to convert.
  * @return the note row. */
-inline int   BeatToNoteRow( float fBeatNum )		{ return std::lrint( fBeatNum * ROWS_PER_BEAT ); }	// round
+inline int   BeatToNoteRow( float fBeatNum )		{ return std::round( fBeatNum * ROWS_PER_BEAT ); }	// round
 /**
  * @brief Convert the beat into a note row without rounding.
  * @param fBeatNum the beat to convert.

--- a/src/OptionRow.cpp
+++ b/src/OptionRow.cpp
@@ -686,9 +686,9 @@ void OptionRow::GetWidthXY( PlayerNumber pn, int iChoiceOnRow, int &iWidthOut, i
 {
 	const BitmapText &text = GetTextItemForRow( pn, iChoiceOnRow );
 
-	iWidthOut = std::lrint( text.GetZoomedWidth() );
-	iXOut = std::lrint( text.GetDestX() );
-	iYOut = std::lrint( m_Frame.GetDestY() );
+	iWidthOut = std::round( text.GetZoomedWidth() );
+	iXOut = std::round( text.GetDestX() );
+	iYOut = std::round( m_Frame.GetDestY() );
 }
 
 int OptionRow::GetOneSelection( PlayerNumber pn, bool bAllowFail ) const

--- a/src/PlayerStageStats.cpp
+++ b/src/PlayerStageStats.cpp
@@ -340,7 +340,7 @@ int PlayerStageStats::GetLessonScoreNeeded() const
 {
 	float fScore = std::accumulate(m_vpPossibleSteps.begin(), m_vpPossibleSteps.end(), 0.f,
 		[](float total, Steps const *steps) { return total + steps->GetRadarValues(PLAYER_1)[RadarCategory_TapsAndHolds]; });
-	return std::lrint( fScore * LESSON_PASS_THRESHOLD );
+	return std::round( fScore * LESSON_PASS_THRESHOLD );
 }
 
 void PlayerStageStats::ResetScoreForLesson()

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -139,9 +139,9 @@ void RageDisplay::ProcessStatsOnFlip()
 	{
 		float fActualTime = g_LastCheckTimer.GetDeltaTime();
 		g_iNumChecksSinceLastReset++;
-		g_iFPS = std::lrint( g_iFramesRenderedSinceLastCheck / fActualTime );
+		g_iFPS = std::round( g_iFramesRenderedSinceLastCheck / fActualTime );
 		g_iCFPS = g_iFramesRenderedSinceLastReset / g_iNumChecksSinceLastReset;
-		g_iCFPS = std::lrint( g_iCFPS / fActualTime );
+		g_iCFPS = std::round( g_iCFPS / fActualTime );
 		g_iVPF = g_iVertsRenderedSinceLastCheck / g_iFramesRenderedSinceLastCheck;
 		g_iFramesRenderedSinceLastCheck = g_iVertsRenderedSinceLastCheck = 0;
 		if( LOG_FPS )

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -689,10 +689,10 @@ static void CheckReversePackedPixels()
 void SetupExtensions()
 {
 	const float fGLVersion = StringToFloat( (const char *) glGetString(GL_VERSION) );
-	g_glVersion = std::lrint( fGLVersion * 10 );
+	g_glVersion = std::round( fGLVersion * 10 );
 
 	const float fGLUVersion = StringToFloat( (const char *) gluGetString(GLU_VERSION) );
-	g_gluVersion = std::lrint( fGLUVersion * 10 );
+	g_gluVersion = std::round( fGLUVersion * 10 );
 
 #ifndef HAVE_X11 // LLW_X11 needs to init GLEW early for GLX exts
 	glewInit();

--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -64,7 +64,7 @@ void RageSoundReader_Chain::AddSound( int iIndex, float fOffsetSecs, float fPan 
 
 	Sound s;
 	s.iIndex = iIndex;
-	s.iOffsetMS = static_cast<int>((fOffsetSecs * 1000) + 0.5 );
+	s.iOffsetMS = std::round( fOffsetSecs * 1000 );
 	s.fPan = fPan;
 	s.pSound = nullptr;
 	m_aSounds.push_back( s );

--- a/src/RageSoundReader_Extend.cpp
+++ b/src/RageSoundReader_Extend.cpp
@@ -155,7 +155,7 @@ bool RageSoundReader_Extend::SetProperty( const RString &sProperty, float fValue
 {
 	if( sProperty == "StartSecond" )
 	{
-		m_iStartFrames = static_cast<int>((fValue * this->GetSampleRate()) + 0.5);
+		m_iStartFrames = std::round( fValue * this->GetSampleRate() );
 		return true;
 	}
 
@@ -164,7 +164,7 @@ bool RageSoundReader_Extend::SetProperty( const RString &sProperty, float fValue
 		if( fValue == -1 )
 			m_iLengthFrames = -1;
 		else
-			m_iLengthFrames = static_cast<int>((fValue * this->GetSampleRate()) + 0.5);
+			m_iLengthFrames = std::round( fValue * this->GetSampleRate() );
 		return true;
 	}
 
@@ -188,13 +188,13 @@ bool RageSoundReader_Extend::SetProperty( const RString &sProperty, float fValue
 
 	if( sProperty == "FadeInSeconds" )
 	{
-		m_iFadeInFrames = static_cast<int>((fValue * this->GetSampleRate()) + 0.5);
+		m_iFadeInFrames = std::round( fValue * this->GetSampleRate() );
 		return true;
 	}
 
 	if( sProperty == "FadeSeconds" || sProperty == "FadeOutSeconds" )
 	{
-		m_iFadeOutFrames = static_cast<int>((fValue * this->GetSampleRate()) + 0.5);
+		m_iFadeOutFrames = std::round( fValue * this->GetSampleRate() );
 		return true;
 	}
 

--- a/src/RageSoundReader_Merge.cpp
+++ b/src/RageSoundReader_Merge.cpp
@@ -213,7 +213,7 @@ int RageSoundReader_Merge::Read( float *pBuffer, int iFrames )
 			/* A sound is being delayed to resync it; clamp the number of frames we
 			 * read now, so we don't advance past it. */
 			int iMaxSourceFramesToRead = aNextSourceFrames[i] - iMinPosition;
-			int iMaxStreamFramesToRead = static_cast<int>((iMaxSourceFramesToRead / m_fCurrentStreamToSourceRatio) + 0.5 );
+			int iMaxStreamFramesToRead = std::round( iMaxSourceFramesToRead / m_fCurrentStreamToSourceRatio );
 			iFrames = std::min( iFrames, iMaxStreamFramesToRead );
 //			LOG->Warn( "RageSoundReader_Merge: sound positions moving at different rates" );
 		}
@@ -226,7 +226,7 @@ int RageSoundReader_Merge::Read( float *pBuffer, int iFrames )
 		iFrames = pSound->Read( pBuffer, iFrames );
 		if( iFrames > 0 )
 		{
-			m_iNextSourceFrame += static_cast<int>((iFrames * m_fCurrentStreamToSourceRatio) + 0.5 );
+			m_iNextSourceFrame += std::round( iFrames * m_fCurrentStreamToSourceRatio );
 		}
 		return iFrames;
 	}

--- a/src/RageSoundReader_Preload.cpp
+++ b/src/RageSoundReader_Preload.cpp
@@ -63,7 +63,7 @@ bool RageSoundReader_Preload::Open( RageSoundReader *pSource )
 	{
 		float fSecs = iLen / 1000.f;
 
-		int iFrames = static_cast<int>((fSecs * m_iSampleRate) + 0.5 ); /* seconds -> frames */
+		int iFrames = std::round( fSecs * m_iSampleRate ); /* seconds -> frames */
 		int iSamples = unsigned( iFrames * m_iChannels ); /* frames -> samples */
 		if( iSamples > iMaxSamples )
 			return false; /* Don't bother trying to preload it. */
@@ -126,7 +126,7 @@ int RageSoundReader_Preload::GetLength_Fast() const
 int RageSoundReader_Preload::SetPosition( int iFrame )
 {
 	m_iPosition = iFrame;
-	m_iPosition = static_cast<int>((m_iPosition / m_fRate) + 0.5);
+	m_iPosition = std::round(m_iPosition / m_fRate);
 
 	if( m_iPosition >= int(m_Buffer->size() / framesize) )
 	{
@@ -139,7 +139,7 @@ int RageSoundReader_Preload::SetPosition( int iFrame )
 
 int RageSoundReader_Preload::GetNextSourceFrame() const
 {
-	return static_cast<int>((m_iPosition * m_fRate) + 0.5);
+	return std::round(m_iPosition * m_fRate);
 }
 
 int RageSoundReader_Preload::Read( float *pBuffer, int iFrames )

--- a/src/RageSoundReader_Resample_Good.cpp
+++ b/src/RageSoundReader_Resample_Good.cpp
@@ -632,7 +632,7 @@ void RageSoundReader_Resample_Good::ReopenResampler()
 	}
 
 	if( m_fRate != -1 )
-		iDownFactor = static_cast<int>((m_fRate * iDownFactor) + 0.5 );
+		iDownFactor = std::round( m_fRate * iDownFactor );
 
 	for( size_t iChannel = 0; iChannel < m_apResamplers.size(); ++iChannel )
 		m_apResamplers[iChannel]->SetDownFactor( iDownFactor );
@@ -708,7 +708,7 @@ void RageSoundReader_Resample_Good::SetRate( float fRatio )
 	int iDownFactor, iUpFactor;
 	GetFactors( iDownFactor, iUpFactor );
 	if( m_fRate != -1 )
-		iDownFactor = static_cast<int>((m_fRate * iDownFactor) + 0.5 );
+		iDownFactor = std::round( m_fRate * iDownFactor );
 
 	/* Set m_fRate to the actual rate, after quantization by iUpFactor. */
 	m_fRate = float(iDownFactor) / iUpFactor;

--- a/src/RageSoundReader_SpeedChange.cpp
+++ b/src/RageSoundReader_SpeedChange.cpp
@@ -166,7 +166,7 @@ int RageSoundReader_SpeedChange::Step()
 		 * by 2.0 frames, and advance by 0.3 more the next time around. */
 		float fAdvanceFrames = GetWindowSizeFrames() * m_fTrailingSpeedRatio;
 		fAdvanceFrames += m_fErrorFrames;
-		int iTrailingDeltaFrames = static_cast<int>( (fAdvanceFrames) + 0.5 );
+		int iTrailingDeltaFrames = std::round( fAdvanceFrames );
 		m_fErrorFrames = fAdvanceFrames - iTrailingDeltaFrames;
 		m_iUncorrelatedPos += iTrailingDeltaFrames;
 
@@ -315,7 +315,7 @@ int RageSoundReader_SpeedChange::GetNextSourceFrame() const
 	float fRatio = m_fTrailingSpeedRatio;
 
 	int iSourceFrame = RageSoundReader_Filter::GetNextSourceFrame();
-	int iPos = static_cast<int>((m_iPos * fRatio) + 0.5);
+	int iPos = std::round(m_iPos * fRatio);
 
 	iSourceFrame -= m_iDataBufferAvailFrames;
 	iSourceFrame += m_iUncorrelatedPos + iPos;

--- a/src/RageSoundReader_ThreadedBuffer.cpp
+++ b/src/RageSoundReader_ThreadedBuffer.cpp
@@ -237,7 +237,7 @@ void RageSoundReader_ThreadedBuffer::BufferingThread()
 		else
 		{
 			m_Event.Unlock();
-			usleep( static_cast<int>((fTimeToSleep * 1000000) + 0.5) );
+			usleep( std::round(fTimeToSleep * 1000000) );
 			m_Event.Lock();
 		}
 	}

--- a/src/RageSoundUtil.cpp
+++ b/src/RageSoundUtil.cpp
@@ -94,7 +94,7 @@ void RageSoundUtil::ConvertFloatToNativeInt16( const float *pFrom, int16_t *pTo,
 {
 	for( int i = 0; i < iSamples; ++i )
 	{
-		int iOut = static_cast<int>((pFrom[i] * 32768.0f) + 0.5);
+		int iOut = std::round( pFrom[i] * 32768.0f );
 		pTo[i] = std::clamp( iOut, -32768, 32767 );
 	}
 }

--- a/src/RageSurfaceUtils.cpp
+++ b/src/RageSurfaceUtils.cpp
@@ -456,7 +456,7 @@ void RageSurfaceUtils::BlitTransform( const RageSurface *src, RageSurface *dst,
 				sum += v[1][i] * (1-weight_x) * (weight_y);
 				sum += v[2][i] * (weight_x)   * (1-weight_y);
 				sum += v[3][i] * (weight_x)   * (weight_y);
-				out[i] = (uint8_t) std::clamp( std::lrint(sum), 0L, 255L );
+				out[i] = static_cast<uint8_t>(std::min(std::max(static_cast<long>(std::round(sum)), 0L), 255L));
 			}
 
 			// If the source has no alpha, set the destination to opaque.

--- a/src/RageSurfaceUtils.cpp
+++ b/src/RageSurfaceUtils.cpp
@@ -269,6 +269,22 @@ static void SetAlphaRGB(const RageSurface *pImg, uint8_t r, uint8_t g, uint8_t b
 	}
 }
 
+// Local helper for PalletizeToGrayscale and BlitTransform.
+static uint8_t ClampToByte(float value) {
+	constexpr float lower = 0.0f;
+	constexpr float upper = 255.0f;
+
+	if (value < lower) {
+		return static_cast<uint8_t>(lower);
+	}
+
+	if (value > upper) {
+		return static_cast<uint8_t>(upper);
+	}
+
+	return static_cast<uint8_t>(value);
+}
+
 /* When we scale up images (which we always do in high res), pixels
  * that are completely transparent can be blended with opaque pixels,
  * causing their RGB elements to show. This is visible in many textures
@@ -456,7 +472,7 @@ void RageSurfaceUtils::BlitTransform( const RageSurface *src, RageSurface *dst,
 				sum += v[1][i] * (1-weight_x) * (weight_y);
 				sum += v[2][i] * (weight_x)   * (1-weight_y);
 				sum += v[3][i] * (weight_x)   * (weight_y);
-				out[i] = static_cast<uint8_t>(std::min(std::max(static_cast<long>(std::round(sum)), 0L), 255L));
+				out[i] = ClampToByte(sum);
 			}
 
 			// If the source has no alpha, set the destination to opaque.
@@ -819,21 +835,6 @@ RageSurface *RageSurfaceUtils::LoadSurface( RString file )
 		*img->fmt.palette = palette;
 
 	return img;
-}
-
-static uint8_t ClampToByte(float value) {
-	constexpr float lower = 0.0f;
-	constexpr float upper = 255.0f;
-
-	if (value < lower) {
-		return static_cast<uint8_t>(lower);
-	}
-
-	if (value > upper) {
-		return static_cast<uint8_t>(upper);
-	}
-
-	return static_cast<uint8_t>(value);
 }
 
 /* This converts an image to a special 8-bit paletted format. The palette is set up

--- a/src/RageSurfaceUtils.cpp
+++ b/src/RageSurfaceUtils.cpp
@@ -821,6 +821,21 @@ RageSurface *RageSurfaceUtils::LoadSurface( RString file )
 	return img;
 }
 
+static uint8_t ClampToByte(float value) {
+	constexpr float lower = 0.0f;
+	constexpr float upper = 255.0f;
+
+	if (value < lower) {
+		return static_cast<uint8_t>(lower);
+	}
+
+	if (value > upper) {
+		return static_cast<uint8_t>(upper);
+	}
+
+	return static_cast<uint8_t>(value);
+}
+
 /* This converts an image to a special 8-bit paletted format. The palette is set up
  * so that palette indexes look like regular, packed components.
  *
@@ -865,10 +880,10 @@ RageSurface *RageSurfaceUtils::PalettizeToGrayscale( const RageSurface *src_surf
 		const unsigned int A = (index & Amask) >> Ashift;
 
 		// if only one intensity value, always fullbright
-		const uint8_t ScaledI = Ivalues == 1 ? 255 : std::clamp( std::lrint(I * (255.0f / (Ivalues-1))), 0L, 255L );
+		const uint8_t ScaledI = (Ivalues == 1U) ? 255U : ClampToByte(std::round(I * (255.0f / (Ivalues - 1U))));
 
 		// if only one alpha value, always opaque
-		const uint8_t ScaledA = Avalues == 1 ? 255 : std::clamp( std::lrint(A * (255.0f / (Avalues-1))), 0L, 255L );
+		const uint8_t ScaledA = (Avalues == 1U) ? 255U : ClampToByte(std::round(A * (255.0f / (Avalues - 1U))));
 
 		RageSurfaceColor c;
 		c.r = ScaledI;

--- a/src/RageTypes.cpp
+++ b/src/RageTypes.cpp
@@ -55,10 +55,10 @@ void RageColor::FromStackCompat( lua_State *L, int iPos )
 
 RString RageColor::ToString() const
 {
-	int iR = std::clamp( static_cast<int>(std::lrint(r * 255)), 0, 255 );
-	int iG = std::clamp( static_cast<int>(std::lrint(g * 255)), 0, 255 );
-	int iB = std::clamp( static_cast<int>(std::lrint(b * 255)), 0, 255 );
-	int iA = std::clamp( static_cast<int>(std::lrint(a * 255)), 0, 255 );
+	int iR = std::clamp( static_cast<int>(std::round(r * 255)), 0, 255 );
+	int iG = std::clamp( static_cast<int>(std::round(g * 255)), 0, 255 );
+	int iB = std::clamp( static_cast<int>(std::round(b * 255)), 0, 255 );
+	int iA = std::clamp( static_cast<int>(std::round(a * 255)), 0, 255 );
 
 	if( iA == 255 )
 		return ssprintf( "#%02X%02X%02X", iR, iG, iB );

--- a/src/SampleHistory.cpp
+++ b/src/SampleHistory.cpp
@@ -18,7 +18,7 @@ SampleHistory::SampleHistory()
 	m_fHistorySeconds = 0.0f;
 	m_fToSample = sample_step_size(m_iHistorySamplesPerSecond);
 	m_fHistorySeconds = 10.0f;
-	int iSamples = std::lrint( m_iHistorySamplesPerSecond * m_fHistorySeconds );
+	int iSamples = std::round( m_iHistorySamplesPerSecond * m_fHistorySeconds );
 	m_afHistory.resize( iSamples );
 }
 
@@ -33,7 +33,7 @@ float SampleHistory::GetSampleNum( float fSamplesAgo ) const
 	float fSample = m_iLastHistory - fSamplesAgo - 1;
 
 	float f = std::floor( fSample );
-	int iSample = std::lrint(f);
+	int iSample = std::round(f);
 	int iNextSample = iSample + 1;
 	wrap( iSample, m_afHistory.size() );
 	wrap( iNextSample, m_afHistory.size() );

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -5269,7 +5269,7 @@ void ScreenEdit::HandleAlterMenuChoice(AlterMenuChoice c, const std::vector<int>
 
 			int iStartIndex  = m_NoteFieldEdit.m_iBeginMarker;
 			int iEndIndex    = m_NoteFieldEdit.m_iEndMarker;
-			int iNewEndIndex = iEndIndex + std::lrint( (iEndIndex - iStartIndex) * (fScale - 1) );
+			int iNewEndIndex = iEndIndex + std::round( (iEndIndex - iStartIndex) * (fScale - 1) );
 
 			// scale currently editing notes
 			NoteDataUtil::ScaleRegion( m_NoteDataEdit, fScale, iStartIndex, iEndIndex );

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -585,8 +585,8 @@ void ScreenEvaluation::Init()
 					RadarCategory_Hands, RadarCategory_Rolls, RadarCategory_Lifts, RadarCategory_Fakes
 				};
 				const int ind = indices[l];
-				const int iActual = std::lrint(m_pStageStats->m_player[p].m_radarActual[ind]);
-				const int iPossible = std::lrint(m_pStageStats->m_player[p].m_radarPossible[ind]);
+				const int iActual = std::round(m_pStageStats->m_player[p].m_radarActual[ind]);
+				const int iPossible = std::round(m_pStageStats->m_player[p].m_radarPossible[ind]);
 
 				// todo: check if format string is valid
 				// (two integer values in DETAILLINE_FORMAT) -aj

--- a/src/ScreenNameEntry.cpp
+++ b/src/ScreenNameEntry.cpp
@@ -66,7 +66,7 @@ void ScreenNameEntry::ScrollingText::Init( const RString &sName, const std::vect
 void ScreenNameEntry::ScrollingText::DrawPrimitives()
 {
 	const float fFakeBeat = GAMESTATE->m_Position.m_fSongBeat;
-	const size_t iClosestIndex = std::lrint( fFakeBeat ) % CHARS_CHOICES.size();
+	const size_t iClosestIndex = static_cast<size_t>(std::round( fFakeBeat )) % CHARS_CHOICES.size();
 	const float fClosestYOffset = GetClosestCharYOffset( fFakeBeat );
 
 	size_t iCharIndex = ( iClosestIndex - NUM_CHARS_TO_DRAW_BEHIND + CHARS_CHOICES.size() ) % CHARS_CHOICES.size();
@@ -102,7 +102,7 @@ void ScreenNameEntry::ScrollingText::DrawPrimitives()
 char ScreenNameEntry::ScrollingText::GetClosestChar( float fFakeBeat ) const
 {
 	ASSERT( fFakeBeat >= 0.f );
-	return CHARS_CHOICES[std::lrint(fFakeBeat) % CHARS_CHOICES.size()];
+	return CHARS_CHOICES[static_cast<size_t>(std::round(fFakeBeat)) % CHARS_CHOICES.size()];
 }
 
 // return value is relative to gray arrows

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -898,7 +898,7 @@ void Song::TidyUpData( bool from_cache, bool /* duringCache */ )
 				if(m_fMusicSampleStartSeconds+m_fMusicSampleLengthSeconds > this->m_fMusicLengthSeconds)
 				{
 					// Attempt to get a reasonable default.
-					int iBeat = std::lrint(this->m_SongTiming.GetBeatFromElapsedTime(this->GetLastSecond())/2);
+					int iBeat = std::round(this->m_SongTiming.GetBeatFromElapsedTime(this->GetLastSecond())/2);
 					iBeat -= iBeat%4;
 					m_fMusicSampleStartSeconds = timing.GetElapsedTimeFromBeat((float)iBeat);
 				}

--- a/src/TimingData.cpp
+++ b/src/TimingData.cpp
@@ -1035,7 +1035,7 @@ void TimingData::ScaleRegion( float fScale, int iStartIndex, int iEndIndex, bool
 	ASSERT( iStartIndex < iEndIndex );
 
 	int length = iEndIndex - iStartIndex;
-	int newLength = std::lrint( fScale * length );
+	int newLength = std::round( fScale * length );
 
 	FOREACH_TimingSegmentType( tst )
 		for (unsigned j = 0; j < m_avpTimingSegments[tst].size(); j++)

--- a/src/Trail.cpp
+++ b/src/Trail.cpp
@@ -158,7 +158,7 @@ int Trail::GetMeter() const
 
 	float fMeter = GetTotalMeter() / (float)m_vEntries.size();
 
-	return std::lrint( fMeter );
+	return std::round( fMeter );
 }
 
 int Trail::GetTotalMeter() const

--- a/src/arch/LoadingWindow/LoadingWindow_Win32.cpp
+++ b/src/arch/LoadingWindow/LoadingWindow_Win32.cpp
@@ -39,7 +39,7 @@ static HBITMAP LoadWin32Surface( const RageSurface *pSplash, HWND hWnd )
 
 		int iWidth = r.right;
 		float fRatio = (float) iWidth / s->w;
-		int iHeight = std::lrint( s->h * fRatio );
+		int iHeight = std::round( s->h * fRatio );
 
 		RageSurfaceUtils::Zoom( s, iWidth, iHeight );
 	}

--- a/src/arch/MovieTexture/MovieTexture_Generic.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Generic.cpp
@@ -187,9 +187,9 @@ void MovieTexture_Generic::CreateTexture()
 	/* Adjust m_iSourceWidth to support different source aspect ratios. */
 	float fSourceAspectRatio = decoder_->GetSourceAspectRatio();
 	if (fSourceAspectRatio < 1)
-		m_iSourceHeight = std::lrint(m_iSourceHeight / fSourceAspectRatio);
+		m_iSourceHeight = std::round(m_iSourceHeight / fSourceAspectRatio);
 	else if (fSourceAspectRatio > 1)
-		m_iSourceWidth = std::lrint(m_iSourceWidth * fSourceAspectRatio);
+		m_iSourceWidth = std::round(m_iSourceWidth * fSourceAspectRatio);
 
 	/* HACK: Don't cap movie textures to the max texture size, since we
 	 * render them onto the texture at the source dimensions.  If we find a


### PR DESCRIPTION
I realized most uses of `std::lrint` in the code base predate the existence of `std::round`. In most cases, it makes more sense to use `std::round` and this is usually faster as well, as evidenced by godbolt.org tests linked in the commit descriptions. This is also more accurate to use `std::round(x)` rather than `static_cast<int>(x+0.5)`.