### PR TITLE
Use `ClampToByte` from #805 in RageTypes

### DIFF
--- a/src/RageTypes.cpp
+++ b/src/RageTypes.cpp
@@ -55,12 +55,12 @@ void RageColor::FromStackCompat( lua_State *L, int iPos )
 
 RString RageColor::ToString() const
 {
-	int iR = std::clamp( static_cast<int>(std::lrint(r * 255)), 0, 255 );
-	int iG = std::clamp( static_cast<int>(std::lrint(g * 255)), 0, 255 );
-	int iB = std::clamp( static_cast<int>(std::lrint(b * 255)), 0, 255 );
-	int iA = std::clamp( static_cast<int>(std::lrint(a * 255)), 0, 255 );
+	uint8_t iR = ClampToByte(std::round(r * 255.f));
+	uint8_t iG = ClampToByte(std::round(g * 255.f));
+	uint8_t iB = ClampToByte(std::round(b * 255.f));
+	uint8_t iA = ClampToByte(std::round(a * 255.f));
 
-	if( iA == 255 )
+	if( iA == UINT8_MAX )
 		return ssprintf( "#%02X%02X%02X", iR, iG, iB );
 	else
 		return ssprintf( "#%02X%02X%02X%02X", iR, iG, iB, iA );

--- a/src/RageTypes.h
+++ b/src/RageTypes.h
@@ -265,6 +265,21 @@ public:
 	float r, g, b, a;
 };
 
+inline static uint8_t ClampToByte(float value) {
+	constexpr float lower = 0.0f;
+	constexpr float upper = 255.0f;
+
+	if (value < lower) {
+		return static_cast<uint8_t>(lower);
+	}
+
+	if (value > upper) {
+		return static_cast<uint8_t>(upper);
+	}
+
+	return static_cast<uint8_t>(value);
+}
+
 /* Convert floating-point 0..1 value to integer 0..255 value. *
  *
  * As a test case,
@@ -278,7 +293,7 @@ public:
 inline unsigned char FTOC(float a)
 {
 	int value = static_cast<int>(a * 256.0f);
-	return static_cast<unsigned char>(std::clamp(value, 0, 255));
+	return static_cast<unsigned char>(ClampToByte(value));
 }
 
 /* Color type used only in vertex lists.  OpenGL expects colors in


### PR DESCRIPTION
Prevents a type conversion (float -> long -> int) when handling data that is intended to be clamped to the range of a single byte.

Must be declared in the header, because a clamp between 0 and 255 is called in the header FTOC function.

`.f` suffix is added in RageColor::ToString, because the values it is multiplied with (r/g/b/a) are floats.