### PR TITLE
Fix for Code scanning alert #487 "Multiplication result converted to larger type"

### DIFF
--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -341,11 +341,14 @@ int RageSoundReader_Chain::Read( float *pBuffer, int iFrames )
 		return iFrames;
 	}
 
+	// Note: this is only safe because we know pBuffer is not nullptr
+	// and iFrames and m_iChannels are reasonable sizes.
 	if( m_apActiveSounds.empty() )
 	{
 		/* If we have more sounds ahead of us, pretend we read the entire block, since
 		 * there's silence in between.  Otherwise, we're at EOF. */
-		memset( pBuffer, 0, iFrames * m_iChannels * sizeof(float) );
+		size_t pBufferSize = static_cast<size_t>(iFrames) * m_iChannels * sizeof(float);
+		memset( pBuffer, 0, pBufferSize );
 		m_iCurrentFrame += iFrames;
 		return iFrames;
 	}


### PR DESCRIPTION
My own fix, not auto-generated.
m_iChannels is implicitly promoted to size_t.

![Screenshot 2025-05-06 061104](https://github.com/user-attachments/assets/9f4e5006-af6a-46fa-b89f-94f859369a9c)
