### PR TITLE
Fix for Code scanning alert #40 "Unsigned difference expression compared to zero"

### DIFF
--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -755,7 +755,7 @@ void do_split( const S &Source, const C Delimitor, std::vector<S> &AddIt, const 
 		if( pos == Source.npos )
 			pos = Source.size();
 
-		if( pos-startpos > 0 || !bIgnoreEmpty )
+		if( pos > startpos || !bIgnoreEmpty )
 		{
 			/* Optimization: if we're copying the whole string, avoid substr; this
 			 * allows this copy to be refcounted, which is much faster. */


### PR DESCRIPTION
Has been flagged as critical due to [CWE-191](https://cwe.mitre.org/data/definitions/191.html). I tested this, and all functions that depend on `do_split` still seem to work as expected.