### PR TITLE
Resolve critical CWE-134 warning (malformed `fprintf` statement)

### DIFF
--- a/src/archutils/Unix/CrashHandlerChild.cpp
+++ b/src/archutils/Unix/CrashHandlerChild.cpp
@@ -197,7 +197,7 @@ static void child_process()
 	FILE *CrashDump = fopen( sCrashInfoPath, "w+" );
 	if(CrashDump == nullptr)
 	{
-		fprintf( stderr, "Couldn't open " + sCrashInfoPath + ": %s\n", strerror(errno) );
+		fprintf( stderr, "Couldn't open %s: %s\n", sCrashInfoPath.c_str(), strerror(errno) );
 		exit(1);
 	}
 


### PR DESCRIPTION
Resolves CWE-134: Use of Externally-Controlled Format String by using `c_str` on the path variable and removing an invalid string concatenation.