### PR TITLE
Hash-based `Song::ReloadFromSongDir`

### DIFF
--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -490,6 +490,8 @@ bool Song::ReloadFromSongDir( const RString &sDir )
 	// Clear out all old data to prepare for a reload from disk.
 	// m_vpSteps represent known charts for a given difficulty or mode.
 	// m_UnknownStyleSteps represent things like unfilled difficulty blocks.
+	RemoveAutoGenNotes();
+	
 	for( Steps* step : m_vpSteps )
 	{
 		delete step;

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -489,13 +489,6 @@ bool Song::ReloadFromSongDir( RString sDir )
 		return false;
 	copy.RemoveAutoGenNotes();
 	*this = copy;
-	
-	if (SONGMAN->GetGroup(this) != nullptr) {
-		m_SongTiming.m_fBeat0GroupOffsetInSeconds = SONGMAN->GetGroup(this)->GetSyncOffset();
-	} else {
-		m_SongTiming.m_fBeat0GroupOffsetInSeconds = PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL ? 0 : -0.009;
-		LOG->Warn("Song %s has no group, using default sync offset.", m_sMainTitle.c_str());
-	}
 
 	/* Go through the steps, first setting their Song pointer to this song
 	 * (instead of the copy used above), and constructing a map to let us
@@ -504,24 +497,10 @@ bool Song::ReloadFromSongDir( RString sDir )
 	for( std::vector<Steps*>::const_iterator it = m_vpSteps.begin(); it != m_vpSteps.end(); ++it )
 	{
 		(*it)->m_pSong = this;
+
 		StepsID id;
 		id.FromSteps( *it );
 		mNewSteps[id] = *it;
-
-		// Reapply the Group Offset if the steps have their own timing data.
-		if( mNewSteps[id]->m_Timing.empty() )
-		{
-			continue;
-		}
-		if (SONGMAN->GetGroup(this) != nullptr)
-		{
-			mNewSteps[id]->m_Timing.m_fBeat0GroupOffsetInSeconds = SONGMAN->GetGroup(this)->GetSyncOffset();
-		}
-		else
-		{
-			m_SongTiming.m_fBeat0GroupOffsetInSeconds = PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL ? 0 : -0.009;
-			LOG->Warn("Song %s has no group, using default sync offset.", m_sMainTitle.c_str());
-		}
 	}
 
 	// Now we wipe out the new pointers, which were shallow copied and not deep copied...

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -471,99 +471,71 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
 	return true;	// do load this song
 }
 
-/* This function feels EXTREMELY hacky - copying things on top of pointers so
- * they don't break elsewhere.  Maybe it could be rewritten to politely ask the
- * Song/Steps objects to reload themselves. -- djpohly */
-bool Song::ReloadFromSongDir( RString sDir )
+// Get the hash of the song file. This is primarily used to determine if the simfile
+// has changed since it was last seen. The SHA-1 of the file is also validated against
+// the cached file here. This will potentially clear cached song data and reload from disk!
+bool Song::ReloadFromSongDir( const RString &sDir )
 {
-	// Remove the cache file to force the song to reload from its dir instead
-	// of loading from the cache. -Kyz
+	// Store the hash of the cached file before forcing a reload from disk.
+	RString currentHash = m_sFileHash;
 	FILEMAN->Remove(GetCacheFilePath());
 
-	RemoveAutoGenNotes();
-	std::vector<Steps*> vOldSteps = m_vpSteps;
-
-
-	Song copy;
-	if( !copy.LoadFromSongDir( sDir ) )
-		return false;
-	copy.RemoveAutoGenNotes();
-	*this = copy;
-
-	/* Go through the steps, first setting their Song pointer to this song
-	 * (instead of the copy used above), and constructing a map to let us
-	 * easily find the new steps. */
-	std::map<StepsID, Steps*> mNewSteps;
-	for( std::vector<Steps*>::const_iterator it = m_vpSteps.begin(); it != m_vpSteps.end(); ++it )
+	// Hash comparison. If it's a match, return early without changing anything.
+	m_sFileHash = GetFileHash();
+	if( currentHash == m_sFileHash )
 	{
-		(*it)->m_pSong = this;
-
-		StepsID id;
-		id.FromSteps( *it );
-		mNewSteps[id] = *it;
+		return true;
 	}
 
-	// Now we wipe out the new pointers, which were shallow copied and not deep copied...
+	// Clear out all old data to prepare for a reload from disk.
+	// m_vpSteps represent known charts for a given difficulty or mode.
+	// m_UnknownStyleSteps represent things like unfilled difficulty blocks.
+	for( Steps* step : m_vpSteps )
+	{
+		delete step;
+	}
 	m_vpSteps.clear();
 	FOREACH_ENUM( StepsType, i )
 		m_vpStepsByType[i].clear();
 
-	/* Then we copy as many Steps as possible on top of the old pointers.
-	 * The only pointers that change are pointers to Steps that are not in the
-	 * reverted file, which we delete, and pointers to Steps that are in the
-	 * reverted file but not the original *this, which we create new copies of.
-	 * We have to go through these hoops because many places assume the Steps
-	 * pointers don't change - even though there are other ways they can change,
-	 * such as deleting a Steps via the editor. */
-	for( std::vector<Steps*>::const_iterator itOld = vOldSteps.begin(); itOld != vOldSteps.end(); ++itOld )
+	m_UnknownStyleSteps.clear(); // If we don't clear these out, new difficulties won't be loaded
+	for( Steps* step : m_UnknownStyleSteps )
 	{
-		StepsID id;
-		id.FromSteps( *itOld );
-		std::map<StepsID, Steps*>::iterator itNew = mNewSteps.find( id );
-		if( itNew == mNewSteps.end() )
-		{
-			// This stepchart didn't exist in the file we reverted from
-			delete *itOld;
-		}
-		else
-		{
-			Steps *OldSteps = *itOld;
-			*OldSteps = *(itNew->second);
-			AddSteps( OldSteps );
-			mNewSteps.erase( itNew );
-		}
+		delete step;
 	}
-	// The leftovers in the map are steps that didn't exist before we reverted
-	for( std::map<StepsID, Steps*>::const_iterator it = mNewSteps.begin(); it != mNewSteps.end(); ++it )
-	{
-		Steps *NewSteps = new Steps(this);
-		*NewSteps = *(it->second);
-		AddSteps( NewSteps );
-	}
+	m_UnknownStyleSteps.clear();
 
-	AddAutoGenNotes();
-	// Reload any images associated with the song. -Kyz
-	std::vector<RString> to_reload;
-	to_reload.reserve(7);
-	to_reload.push_back(m_sBannerFile);
-	to_reload.push_back(m_sJacketFile);
-	to_reload.push_back(m_sCDFile);
-	to_reload.push_back(m_sDiscFile);
-	to_reload.push_back(m_sBackgroundFile);
-	to_reload.push_back(m_sCDTitleFile);
-	to_reload.push_back(m_sPreviewVidFile);
-	for(std::vector<RString>::iterator file= to_reload.begin(); file != to_reload.end(); ++file)
+	// Reload into the cache from disk. Group offset will be applied here as well.
+	if( LoadFromSongDir(sDir) )
 	{
-		RageTextureID id(*file);
-		if(TEXTUREMAN->IsTextureRegistered(id))
+		AddAutoGenNotes();
+
+		// Reload associated images.
+		const std::array<RString, 7> toReload =
 		{
-			RageTexture* tex= TEXTUREMAN->LoadTexture(id);
-			if(tex)
+			m_sBannerFile, m_sJacketFile, m_sCDFile, m_sDiscFile,
+			m_sBackgroundFile, m_sCDTitleFile, m_sPreviewVidFile
+		};
+
+		for (const RString& file : toReload)
+		{
+			RageTextureID id(file);
+			if (TEXTUREMAN->IsTextureRegistered(id))
 			{
-				tex->Reload();
+				RageTexture* tex = TEXTUREMAN->LoadTexture(id);
+				if (tex)
+				{
+					tex->Reload();
+				}
 			}
 		}
 	}
+	else
+	{
+		LOG->Trace("Failed to reload song from directory: %s", sDir.c_str());
+		return false;
+	}
+
 	return true;
 }
 

--- a/src/Song.h
+++ b/src/Song.h
@@ -96,7 +96,7 @@ public:
 	bool LoadFromSongDir(RString sDir, bool load_autosave= false,
 		ProfileSlot from_profile= ProfileSlot_Invalid);
 	// This one takes the effort to reuse Steps pointers as best as it can
-	bool ReloadFromSongDir( RString sDir );
+	bool ReloadFromSongDir( const RString &sDir );
 	bool ReloadFromSongDir() { return ReloadFromSongDir(GetSongDir()); }
 	void LoadEditsFromSongDir(RString dir);
 


### PR DESCRIPTION
# Background

A common problem is the failure of a song to load after the file has been changed on disk. This manifests as a chart appearing to have valid data, but when you play the song, no arrows ever appear. Or the chart appears to indicate the chart is completely empty - even though it has valid steps - until the user reloads the songs.

What's more is that reloading from the song wheel (theme based reload, or Ctrl+R) doesn't always resolve this.

# Explanation

The song's chart may fail to load if changes are made on disk while the game is running. Often times when this is the case, a Ctrl-R from the song wheel or a relaunch of the game is needed. In some cases, the cache even needs to be removed.

This happens because `ReloadFromSongDir` ineffectively and incompletely compares the existing cached data against the data on disk.

If it fails then the original pointers remain held even though they have become invalidated (this is why we sometimes get a situation where the song wheel shows valid song data, but playing it gives a blank chart).

_**Ultimately, even if the chart loads successfully, the chart the user is given comes with no guarantee the content matches either what is on disk or in cache!**_ 

# Theory of this PR

This would change the `ReloadFromSongDir` mechanism to automatically notice the file has changed and reload it.

It also provides safer, more consistent state management with regards to the pointers by comparing the hash of the cached data to the hash of the data on disk.

It returns early without touching any pointers if the hashes match.

This PR can also guarantee that the chart the user plays has a verified hash, and corresponds to a known SHA-1.

# Overview of changes

Currently we do this:
1. User selects a song
2. Song is loaded in from disk into a `std::map`
3. This `std::map` is compared to a `std::map` of the cached song
4. If any differences are detected, they are copied on top of the original pointers.
5. You get some mix of the cached song plus the file on disk

This PR would change the behavior to the following.
1. User selects a song
2. The hash is calculated for the cached song and the file on disk
    -  Early return if the hashes match; ached data and all pointers remain untouched.
3. If the file on disk has a different hash than the cached file, we remove the cached data and reload from disk into the cache before the song starts.

The new code is also greatly simplified by the use of range-based for loops instead of traditional for loops. This allows us to remove complex manual iterator handling logic.

I have removed the group offset logic is removed from `ReloadFromSongDir` because it is already handled when necessary by the `LoadFromSongDir(sDir)` call.

# Unintended side effects
- In Edit mode, "Reload from Cache" is now functionally identical to "Reload from Disk", because in either case the hash will be found to differ and the game will reload from disk. The behavior of "Reload from Cache" may want to be evaluated. 
       - I've found no regressions anywhere, but I'm not an Edit Mode power user, and maybe didn't test it in the way some charters may use it.

# Testing

This change has been tested by various members of the community and found to work as expected. In about 2 weeks of testing by various users, no bugs have been noticed.