### PR TITLE
Make RageTimer variables private, & use `std::pair` to encapsulate the two RageTimer variables.

### DIFF
--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -63,32 +63,29 @@ static uint64_t GetTime() noexcept
 	return ArchHooks::GetSystemTimeInMicroseconds();
 }
 
-/* The accuracy of RageTimer::GetTimeSinceStart() is directly tied to the
- * stability of the clock sync. Maintaining precision here is crucial. Too
- * much error here will manifest as a drastic shift in the game's sync, and
- * will feel like the global offset suddenly changed. Incorrect math here will
- * manifest as a _consistent_ sync offset in game. Resolution mismatches or
- * values truncated or rounded when they shouldn't be can cause errors when
- * this is calculated and manifest as a _sudden_ drift of sync. Use caution
- * and do thorough testing if you change anything here. -sukibaby */
-double RageTimer::GetTimeSinceStart()
+// This is not preferred, but sometimes we need time as a floating point.
+// This is represented in seconds.
+double RageTimer::GetTimeSinceStart() noexcept
 {
 	const uint64_t usecs = (GetTime() - g_iStartTime);
 	return static_cast<double>(usecs / kUsecsPerSecDouble);
 }
 
-int RageTimer::GetTimeSinceStartSeconds()
+// This is used where GetTimeSinceStart would be cast to an int without rounding.
+int RageTimer::GetTimeSinceStartSeconds() noexcept
 {
 	const uint64_t usecs = (GetTime() - g_iStartTime);
 	return static_cast<int>(usecs / kUsecsPerSecULL);
 }
 
-uint64_t RageTimer::GetTimeSinceStartMicroseconds()
+// This is the preferred way to handle system time.
+// It has the greatest accuracy and the lowest overhead of all methods.
+uint64_t RageTimer::GetTimeSinceStartMicroseconds() noexcept
 {
 	return (GetTime() - g_iStartTime);
 }
 
-void RageTimer::Touch()
+void RageTimer::Touch() noexcept
 {
 	uint64_t usecs = GetTime();
 
@@ -145,7 +142,7 @@ float RageTimer::GetDeltaTime() noexcept
  * RageTimer AverageTime = tm.Half();	
  * printf( "Something happened approximately %f seconds ago.\n", tm.Ago() ); 
  * Note this has been reverted to the original SM3.95 function. */
-RageTimer RageTimer::Half() const
+RageTimer RageTimer::Half() const noexcept
 {
 	const float fProbableDelay = Ago() / 2;
 	return *this + fProbableDelay;

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -31,9 +31,10 @@
 #include <cstdint>
 
 // Intialize important variables and definitions
-constexpr uint64_t ONE_SECOND_IN_MICROSECONDS_ULL = 1000000ULL;
-constexpr int64_t ONE_SECOND_IN_MICROSECONDS_LL = 1000000LL;
-constexpr double ONE_SECOND_IN_MICROSECONDS_DBL = 1000000.0;
+constexpr uint64_t kUsecsPerSecULL = 1000000ULL;
+constexpr int64_t kUsecsPerSecLL = 1000000LL;
+constexpr double kUsecsPerSecDouble = 1000000.0;
+constexpr double kUsecsToSecRatio = 0.000001;
 const RageTimer RageZeroTimer(0,0);
 static const uint64_t g_iStartTime = ArchHooks::GetSystemTimeInMicroseconds();
 
@@ -53,13 +54,13 @@ static inline uint64_t GetTime() noexcept
 double RageTimer::GetTimeSinceStart()
 {
 	const uint64_t usecs = (GetTime() - g_iStartTime);
-	return static_cast<double>(usecs / ONE_SECOND_IN_MICROSECONDS_DBL);
+	return static_cast<double>(usecs / kUsecsPerSecDouble);
 }
 
 int RageTimer::GetTimeSinceStartSeconds()
 {
 	const uint64_t usecs = (GetTime() - g_iStartTime);
-	return static_cast<int>(usecs / ONE_SECOND_IN_MICROSECONDS_ULL);
+	return static_cast<int>(usecs / kUsecsPerSecULL);
 }
 
 uint64_t RageTimer::GetTimeSinceStartMicroseconds()
@@ -71,8 +72,8 @@ void RageTimer::Touch()
 {
 	uint64_t usecs = GetTime();
 
-	m_time.first = usecs / ONE_SECOND_IN_MICROSECONDS_ULL; // seconds
-	m_time.second = usecs % ONE_SECOND_IN_MICROSECONDS_ULL; // microseconds
+	m_time.first = usecs / kUsecsPerSecULL; // seconds
+	m_time.second = usecs % kUsecsPerSecULL; // microseconds
 }
 
 float RageTimer::Ago() const

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -161,7 +161,7 @@ RageTimer RageTimer::operator+(float tm) const noexcept
 	int64_t newSecs = m_time.first + seconds;
 	int64_t newUs = m_time.second + us;
 
-	// Adjust the seconds and microseconds if microseconds is greater than or equal to one second
+	// Adjust the seconds and microseconds if microseconds exceed or equal one second
 	if (newUs >= kUsecsPerSecLL) {
 		newUs -= kUsecsPerSecLL;
 		++newSecs;
@@ -176,7 +176,7 @@ float RageTimer::operator-(const RageTimer &rhs) const noexcept
 	int64_t secs = m_time.first - rhs.m_time.first;
 	int64_t us = m_time.second - rhs.m_time.second;
 
-	// Adjust the seconds and microseconds if microseconds is greater than or equal to one second
+	// Adjust the seconds and microseconds if microseconds exceed or equal one second
 	if (us < 0) {
 		us += kUsecsPerSecLL;
 		--secs;

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -30,6 +30,32 @@
 #include <cmath>
 #include <cstdint>
 
+///
+/// DO NOT CHANGE THIS FILE WITHOUT DOING EXTENSIVE TESTING!
+/// Very minor changes here can have effects which can cascade
+///  quickly, causing major problems. This code is highly optimized,
+///  and a majority of the engine depends on RageTimer working in
+///  a very specific and predictable way.
+///
+/// Too much error will manifest as a drastic shift in the game's
+///  sync, and will feel like the global offset suddenly changed.
+///
+/// Incorrect math here will manifest as a consistent, or linearly-
+///  compounding change in the global offset.
+///
+/// Resolution mismatches or truncations will manifest as a sudden
+///  change in the global offset, and will feel like an abrupt drift.
+/// 
+/// A RageTimer object is, at its core, a std::pair of two int64_t.
+/// For the sake of optimization, many functions below will directly
+///  access the pair, and the functions below often prefer to construct
+///  compatible pairs of int64_t rather than to create temporary RageTimer
+///  objects. Badly performing/inefficient code manifests as noise/jitter.
+///
+/// m_time.first refers to the seconds part of the std::pair,
+///  and m_time.second refers to the microseconds part.
+/// 
+
 // Intialize important variables and definitions
 constexpr uint64_t kUsecsPerSecULL = 1000000ULL;
 constexpr int64_t kUsecsPerSecLL = 1000000LL;

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -98,18 +98,8 @@ void RageTimer::Touch() noexcept
 // stored time in the RageTimer object. This is useful for tracking elapsed time.
 float RageTimer::Ago() const noexcept
 {
-	RageTimer currentTime;
-	int64_t secs = currentTime.GetSecs() - m_time.first;
-	int64_t us = currentTime.GetUs() - m_time.second;
-
-	// Adjust the seconds and microseconds if microseconds is greater than or equal to one second
-	if (us < 0) {
-		us += kUsecsPerSecLL;
-		--secs;
-	}
-
-	double ret = static_cast<double>(secs) + static_cast<double>(us * kUsecsToSecRatio);
-	return static_cast<float>(ret);
+	const RageTimer currentTime;
+	return currentTime - *this;
 }
 
 // GetDeltaTime() will update the stored time in the RageTimer object as well as
@@ -117,21 +107,9 @@ float RageTimer::Ago() const noexcept
 float RageTimer::GetDeltaTime() noexcept
 {
 	RageTimer currentTime;
-	int64_t secs = currentTime.GetSecs() - m_time.first;
-	int64_t us = currentTime.GetUs() - m_time.second;
-
-	// Adjust the seconds and microseconds if microseconds is greater than or equal to one second
-	if (us < 0) {
-		us += kUsecsPerSecLL;
-		--secs;
-	}
-
-	// Update the stored time
-	m_time.first = secs;
-	m_time.second = us;
-
-	double ret = static_cast<double>(secs) + static_cast<double>(us * kUsecsToSecRatio);
-	return static_cast<float>(ret);
+	float delta = currentTime - *this;
+	*this = currentTime; // Update the stored time
+	return delta;
 }
 
 /* Get a timer representing half of the time ago as this one.  This is	

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -102,10 +102,23 @@ void RageTimer::Touch()
 	m_time.second = usecs % kUsecsPerSecULL; // microseconds
 }
 
-float RageTimer::Ago() const
+// Ago() returns the time since the last call to Touch(), whereas GetDeltaTime()
+// returns the time since the last call to GetDeltaTime() but also updates the
+// stored time in the RageTimer object. This is useful for tracking elapsed time.
+float RageTimer::Ago() const noexcept
 {
-	const RageTimer Now;
-	return Now - *this;
+	RageTimer currentTime;
+	int64_t secs = currentTime.GetSecs() - m_time.first;
+	int64_t us = currentTime.GetUs() - m_time.second;
+
+	// Adjust the seconds and microseconds if microseconds is greater than or equal to one second
+	if (us < 0) {
+		us += kUsecsPerSecLL;
+		--secs;
+	}
+
+	double ret = static_cast<double>(secs) + static_cast<double>(us * kUsecsToSecRatio);
+	return static_cast<float>(ret);
 }
 
 float RageTimer::GetDeltaTime()

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -20,14 +20,8 @@
  */
 
 #include "global.h"
-
 #include "RageTimer.h"
-#include "RageLog.h"
-#include "RageUtil.h"
-
 #include "arch/ArchHooks/ArchHooks.h"
-
-#include <cmath>
 #include <cstdint>
 
 ///

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -121,12 +121,26 @@ float RageTimer::Ago() const noexcept
 	return static_cast<float>(ret);
 }
 
-float RageTimer::GetDeltaTime()
+// GetDeltaTime() will update the stored time in the RageTimer object as well as
+// returning the time since the last call to Touch().
+float RageTimer::GetDeltaTime() noexcept
 {
-	const RageTimer Now;
-	const float diff = Difference( Now, *this );
-	*this = Now;
-	return diff;
+	RageTimer currentTime;
+	int64_t secs = currentTime.GetSecs() - m_time.first;
+	int64_t us = currentTime.GetUs() - m_time.second;
+
+	// Adjust the seconds and microseconds if microseconds is greater than or equal to one second
+	if (us < 0) {
+		us += kUsecsPerSecLL;
+		--secs;
+	}
+
+	// Update the stored time
+	m_time.first = secs;
+	m_time.second = us;
+
+	double ret = static_cast<double>(secs) + static_cast<double>(us * kUsecsToSecRatio);
+	return static_cast<float>(ret);
 }
 
 /* Get a timer representing half of the time ago as this one.  This is	

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -106,7 +106,7 @@ float RageTimer::Ago() const noexcept
 // returning the time since the last call to Touch().
 float RageTimer::GetDeltaTime() noexcept
 {
-	RageTimer currentTime;
+	const RageTimer currentTime;
 	float delta = currentTime - *this;
 	*this = currentTime; // Update the stored time
 	return delta;

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -71,8 +71,8 @@ void RageTimer::Touch()
 {
 	uint64_t usecs = GetTime();
 
-	this->m_secs = uint64_t(usecs / ONE_SECOND_IN_MICROSECONDS_ULL);
-	this->m_us = uint64_t(usecs % ONE_SECOND_IN_MICROSECONDS_ULL);
+	m_time.first = usecs / ONE_SECOND_IN_MICROSECONDS_ULL; // seconds
+	m_time.second = usecs % ONE_SECOND_IN_MICROSECONDS_ULL; // microseconds
 }
 
 float RageTimer::Ago() const
@@ -116,9 +116,8 @@ float RageTimer::operator-(const RageTimer &rhs) const
 
 bool RageTimer::operator<( const RageTimer &rhs ) const
 {
-	if( m_secs != rhs.m_secs ) return m_secs < rhs.m_secs;
-	return m_us < rhs.m_us;
-
+	if (m_time.first != rhs.m_time.first) return m_time.first < rhs.m_time.first;
+	return m_time.second < rhs.m_time.second;
 }
 
 RageTimer RageTimer::Sum(const RageTimer& lhs, float tm)
@@ -133,14 +132,14 @@ RageTimer RageTimer::Sum(const RageTimer& lhs, float tm)
 	RageTimer ret(0, 0);
 
 	// Calculate the sum of the seconds and microseconds
-	ret.m_secs = seconds + lhs.m_secs;
-	ret.m_us = us + lhs.m_us;
+	ret.m_time.first = seconds + lhs.m_time.first;
+	ret.m_time.second = us + lhs.m_time.second;
 
 	// Adjust the seconds and microseconds if microseconds is greater than or equal to TIMESTAMP_RESOLUTION
-	if (ret.m_us >= ONE_SECOND_IN_MICROSECONDS_ULL)
+	if (ret.m_time.second >= ONE_SECOND_IN_MICROSECONDS_LL)
 	{
-		ret.m_us -= ONE_SECOND_IN_MICROSECONDS_ULL;
-		++ret.m_secs;
+		ret.m_time.second -= ONE_SECOND_IN_MICROSECONDS_LL;
+		++ret.m_time.first;
 	}
 
 	return ret;
@@ -149,8 +148,8 @@ RageTimer RageTimer::Sum(const RageTimer& lhs, float tm)
 double RageTimer::Difference(const RageTimer& lhs, const RageTimer& rhs)
 {
 	// Calculate the difference in seconds and microseconds respectively
-	int64_t secs = lhs.m_secs - rhs.m_secs;
-	int64_t us = lhs.m_us - rhs.m_us;
+	int64_t secs = lhs.m_time.first - rhs.m_time.first;
+	int64_t us = lhs.m_time.second - rhs.m_time.second;
 
 	// Adjust seconds and microseconds if microseconds is negative
 	if ( us < 0 )

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -64,7 +64,7 @@ constexpr double kUsecsToSecRatio = 0.000001;
 const RageTimer RageZeroTimer(0,0);
 static const uint64_t g_iStartTime = ArchHooks::GetSystemTimeInMicroseconds();
 
-static inline uint64_t GetTime() noexcept
+static uint64_t GetTime() noexcept
 {
 	return ArchHooks::GetSystemTimeInMicroseconds();
 }

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -151,63 +151,50 @@ RageTimer RageTimer::Half() const
 	return *this + fProbableDelay;
 }
 
-
-RageTimer RageTimer::operator+(float tm) const
+// Calculate the seconds and microseconds from the time:
+// tm == 5.25  -> secs =  5, us = 5.25  - ( 5) = .25
+// tm == -1.25 -> secs = -2, us = -1.25 - (-2) = .75
+RageTimer RageTimer::operator+(float tm) const noexcept
 {
-	return Sum(*this, tm);
-}
+	// Prepare the time in a RageTimer object-compatible format
+	int64_t seconds = static_cast<int64_t>(tm);
+	int64_t us = static_cast<int64_t>((tm - seconds) * kUsecsPerSecLL);
 
-float RageTimer::operator-(const RageTimer &rhs) const
-{
-	return Difference(*this, rhs);
-}
+	// Avoid creating a RageTimer until we have the final result
+	int64_t newSecs = m_time.first + seconds;
+	int64_t newUs = m_time.second + us;
 
-bool RageTimer::operator<( const RageTimer &rhs ) const
-{
-	if (m_time.first != rhs.m_time.first) return m_time.first < rhs.m_time.first;
-	return m_time.second < rhs.m_time.second;
-}
-
-RageTimer RageTimer::Sum(const RageTimer& lhs, float tm)
-{
-	/* Calculate the seconds and microseconds from the time:
-	 * tm == 5.25  -> secs =  5, us = 5.25  - ( 5) = .25
-	 * tm == -1.25 -> secs = -2, us = -1.25 - (-2) = .75 */
-	int64_t seconds = std::floor(tm);
-	int64_t us = static_cast<int64_t>((tm - seconds) * ONE_SECOND_IN_MICROSECONDS_LL);
-
-	// Prevent unnecessarily checking the time
-	RageTimer ret(0, 0);
-
-	// Calculate the sum of the seconds and microseconds
-	ret.m_time.first = seconds + lhs.m_time.first;
-	ret.m_time.second = us + lhs.m_time.second;
-
-	// Adjust the seconds and microseconds if microseconds is greater than or equal to TIMESTAMP_RESOLUTION
-	if (ret.m_time.second >= ONE_SECOND_IN_MICROSECONDS_LL)
-	{
-		ret.m_time.second -= ONE_SECOND_IN_MICROSECONDS_LL;
-		++ret.m_time.first;
+	// Adjust the seconds and microseconds if microseconds is greater than or equal to one second
+	if (newUs >= kUsecsPerSecLL) {
+		newUs -= kUsecsPerSecLL;
+		++newSecs;
 	}
 
-	return ret;
+	return RageTimer(newSecs, newUs);
 }
 
-double RageTimer::Difference(const RageTimer& lhs, const RageTimer& rhs)
+float RageTimer::operator-(const RageTimer &rhs) const noexcept
 {
-	// Calculate the difference in seconds and microseconds respectively
-	int64_t secs = lhs.m_time.first - rhs.m_time.first;
-	int64_t us = lhs.m_time.second - rhs.m_time.second;
+	// Prepare the time in a RageTimer object-compatible format
+	int64_t secs = m_time.first - rhs.m_time.first;
+	int64_t us = m_time.second - rhs.m_time.second;
 
-	// Adjust seconds and microseconds if microseconds is negative
-	if ( us < 0 )
-	{
-		us += ONE_SECOND_IN_MICROSECONDS_LL;
+	// Adjust the seconds and microseconds if microseconds is greater than or equal to one second
+	if (us < 0) {
+		us += kUsecsPerSecLL;
 		--secs;
 	}
 
-	// Return the difference as a double to preserve the fractional part
-	return static_cast<double>(secs) + static_cast<double>(us) / ONE_SECOND_IN_MICROSECONDS_DBL;
+	double ret = static_cast<double>(secs) + static_cast<double>(us * kUsecsToSecRatio);
+	return static_cast<float>(ret);
+}
+
+bool RageTimer::operator<( const RageTimer &rhs ) const noexcept
+{
+	if (m_time.first != rhs.m_time.first) {
+		return m_time.first < rhs.m_time.first;
+	}
+	return m_time.second < rhs.m_time.second;
 }
 
 #include "LuaManager.h"

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -51,9 +51,10 @@
 /// 
 
 // Intialize important variables and definitions
-constexpr uint64_t kUsecsPerSecULL = 1000000ULL;
-constexpr int64_t kUsecsPerSecLL = 1000000LL;
-constexpr double kUsecsPerSecDouble = 1000000.0;
+// TODO: make these kSnakeCase
+constexpr uint64_t ONE_SECOND_IN_MICROSECONDS_ULL = 1000000ULL;
+constexpr int64_t ONE_SECOND_IN_MICROSECONDS_LL = 1000000LL;
+constexpr double ONE_SECOND_IN_MICROSECONDS_DBL = 1000000.0;
 constexpr double kUsecsToSecRatio = 0.000001;
 const RageTimer RageZeroTimer(0,0);
 static const uint64_t g_iStartTime = ArchHooks::GetSystemTimeInMicroseconds();
@@ -68,14 +69,14 @@ static uint64_t GetTime() noexcept
 double RageTimer::GetTimeSinceStart() noexcept
 {
 	const uint64_t usecs = (GetTime() - g_iStartTime);
-	return static_cast<double>(usecs / kUsecsPerSecDouble);
+	return static_cast<double>(usecs / ONE_SECOND_IN_MICROSECONDS_DBL);
 }
 
 // This is used where GetTimeSinceStart would be cast to an int without rounding.
 int RageTimer::GetTimeSinceStartSeconds() noexcept
 {
 	const uint64_t usecs = (GetTime() - g_iStartTime);
-	return static_cast<int>(usecs / kUsecsPerSecULL);
+	return static_cast<int>(usecs / ONE_SECOND_IN_MICROSECONDS_ULL);
 }
 
 // This is the preferred way to handle system time.
@@ -89,8 +90,8 @@ void RageTimer::Touch() noexcept
 {
 	uint64_t usecs = GetTime();
 
-	m_time.first = usecs / kUsecsPerSecULL; // seconds
-	m_time.second = usecs % kUsecsPerSecULL; // microseconds
+	m_time.first = usecs / ONE_SECOND_IN_MICROSECONDS_ULL; // seconds
+	m_time.second = usecs % ONE_SECOND_IN_MICROSECONDS_ULL; // microseconds
 }
 
 // Ago() returns the time since the last call to Touch(), whereas GetDeltaTime()
@@ -133,15 +134,15 @@ RageTimer RageTimer::operator+(float tm) const noexcept
 {
 	// Prepare the time in a RageTimer object-compatible format
 	int64_t seconds = static_cast<int64_t>(tm);
-	int64_t us = static_cast<int64_t>((tm - seconds) * kUsecsPerSecLL);
+	int64_t us = static_cast<int64_t>((tm - seconds) * ONE_SECOND_IN_MICROSECONDS_LL);
 
 	// Avoid creating a RageTimer until we have the final result
 	int64_t newSecs = m_time.first + seconds;
 	int64_t newUs = m_time.second + us;
 
 	// Adjust the seconds and microseconds if microseconds exceed or equal one second
-	if (newUs >= kUsecsPerSecLL) {
-		newUs -= kUsecsPerSecLL;
+	if (newUs >= ONE_SECOND_IN_MICROSECONDS_LL) {
+		newUs -= ONE_SECOND_IN_MICROSECONDS_LL;
 		++newSecs;
 	}
 
@@ -156,7 +157,7 @@ float RageTimer::operator-(const RageTimer &rhs) const noexcept
 
 	// Adjust the seconds and microseconds if microseconds exceed or equal one second
 	if (us < 0) {
-		us += kUsecsPerSecLL;
+		us += ONE_SECOND_IN_MICROSECONDS_LL;
 		--secs;
 	}
 

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -17,6 +17,10 @@ public:
 	RageTimer() {Touch();}
 	RageTimer(int64_t secs, int64_t us) : m_time(secs, us) {}
 
+	/* Getters to protect encapsulation */
+	inline int64_t GetSecs() const { return m_time.first; }
+	inline int64_t GetUs() const { return m_time.second; }
+
 	/* Time ago this RageTimer represents. */
 	float Ago() const;
 	void Touch();

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -4,19 +4,24 @@
 #define RAGE_TIMER_H
 
 #include <cstdint>
+#include <utility>
 
 class RageTimer
 {
 public:
-	/* Initialize the m_secs and m_us values to 0 and then fill them with the current time. */
-	RageTimer(): m_secs(0), m_us(0) { Touch(); }
-	RageTimer( int64_t secs, int64_t us ): m_secs(secs), m_us(us) { }
+	/* We store the seconds and microseconds parts of the time in separate 64-bit integers.
+	 * m_time.first refers to the seconds part, and m_time.second refers to the microseconds part. */
+	using RageTimerPair = std::pair<int64_t, int64_t>;
+
+	/* Default & parameterized constructors */
+	RageTimer() {Touch();}
+	RageTimer(int64_t secs, int64_t us) : m_time(secs, us) {}
 
 	/* Time ago this RageTimer represents. */
 	float Ago() const;
 	void Touch();
-	inline bool IsZero() const { return m_secs == 0 && m_us == 0; }
-	inline void SetZero() { m_secs = m_us = 0; }
+	inline bool IsZero() const { return m_time.first == 0 && m_time.second == 0; }
+	inline void SetZero() { m_time = { 0, 0 }; }
 
 	/* Time between last call to GetDeltaTime() (Ago() + Touch()): */
 	float GetDeltaTime();
@@ -38,14 +43,9 @@ public:
 	float operator-( const RageTimer &rhs ) const;
 
 	bool operator<( const RageTimer &rhs ) const;
-
-	/* The following is a "time since start" RageTimer. Splitting the seconds and
-	 * microseconds values into two integers and combining them later allows for
-	 * better precision. Use caution when changing data types, since resolution
-	 * mismatch errors are easy to cause when changing things in RageTimer. */
-	uint64_t m_secs, m_us;
-
 private:
+	RageTimerPair m_time;
+
 	static RageTimer Sum( const RageTimer &lhs, float tm );
 	static double Difference( const RageTimer &lhs, const RageTimer &rhs );
 };

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -49,9 +49,6 @@ public:
 	bool operator<( const RageTimer &rhs ) const;
 private:
 	RageTimerPair m_time;
-
-	static RageTimer Sum( const RageTimer &lhs, float tm );
-	static double Difference( const RageTimer &lhs, const RageTimer &rhs );
 };
 
 extern const RageTimer RageZeroTimer;

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -22,31 +22,31 @@ public:
 	inline int64_t GetUs() const { return m_time.second; }
 
 	/* Time ago this RageTimer represents. */
-	float Ago() const;
-	void Touch();
+	float Ago() const noexcept;
+	void Touch() noexcept;
 	inline bool IsZero() const { return m_time.first == 0 && m_time.second == 0; }
 	inline void SetZero() { m_time = { 0, 0 }; }
 
 	/* Time between last call to GetDeltaTime() (Ago() + Touch()): */
-	float GetDeltaTime();
+	float GetDeltaTime() noexcept;
 
-	static double GetTimeSinceStart();	// seconds since the program was started
-	static int GetTimeSinceStartSeconds(); 	// This is used where GetTimeSinceStart would be cast to an int without rounding.
-	static uint64_t GetTimeSinceStartMicroseconds();
+	static double GetTimeSinceStart() noexcept;	// seconds since the program was started
+	static int GetTimeSinceStartSeconds() noexcept; 	// This is used where GetTimeSinceStart would be cast to an int without rounding.
+	static uint64_t GetTimeSinceStartMicroseconds() noexcept;
 
 	/* Get a timer representing half of the time ago as this one. */
-	RageTimer Half() const;
+	RageTimer Half() const noexcept;
 
 	/* Add (or subtract) a duration from a timestamp.  The result is another timestamp. */
-	RageTimer operator+( float tm ) const;
+	RageTimer operator+( float tm ) const noexcept;
 	RageTimer operator-( float tm ) const { return *this + -tm; }
 	void operator+=( float tm ) { *this = *this + tm; }
 	void operator-=( float tm ) { *this = *this + -tm; }
 
 	/* Find the amount of time between two timestamps.  The result is a duration. */
-	float operator-( const RageTimer &rhs ) const;
+	float operator-( const RageTimer &rhs ) const noexcept;
 
-	bool operator<( const RageTimer &rhs ) const;
+	bool operator<( const RageTimer &rhs ) const noexcept;
 private:
 	RageTimerPair m_time;
 };

--- a/src/arch/Threads/Threads_Pthreads.cpp
+++ b/src/arch/Threads/Threads_Pthreads.cpp
@@ -356,8 +356,8 @@ bool EventImpl_Pthreads::Wait( RageTimer *pTimeout )
 		/* If we support condattr_setclock, we'll set the condition to use
 		 * the same clock as RageTimer and can use it directly. If the
 		 * clock is CLOCK_REALTIME, that's the default anyway. */
-		abstime.tv_sec = pTimeout->m_secs;
-		abstime.tv_nsec = pTimeout->m_us * 1000;
+		abstime.tv_sec = pTimeout->GetSecs();
+		abstime.tv_nsec = pTimeout->GetUs() * 1000;
 	}
 	else
 	{
@@ -370,8 +370,8 @@ bool EventImpl_Pthreads::Wait( RageTimer *pTimeout )
 		float fSecondsInFuture = -pTimeout->Ago();
 		timeofday += fSecondsInFuture;
 
-		abstime.tv_sec = timeofday.m_secs;
-		abstime.tv_nsec = timeofday.m_us * 1000;
+		abstime.tv_sec = timeofday.GetSecs();
+		abstime.tv_nsec = timeofday.GetUs() * 1000;
 	}
 
 	int iRet = pthread_cond_timedwait( &m_Cond, &m_pParent->mutex, &abstime );


### PR DESCRIPTION
I decided to replace PR #775 with a new one, to demonstrate the full extent of what I wish to do here.

# Introduction

The **main goals of this change** are:
 - to protect RageTimer encapsulation by making time-storage variables (`m_secs` and `m_us`) private.
 - to **modernize** the code by adopting RAII principles and reducing dependence on function calls to manage object state.

We also benefit from adopting `std::pair`: its operators ensure proper automatic memory management/RAII, and guarantees we avoid a memory copy instruction on Windows. It improves semantic clarity by putting the two time variables into a single unit with built-in management and shared state.

# Explanation

This is our most performance-critical and time-critical piece of code, so I think it's reasonable to optimize this code as much as possible.

This makes a very big difference on Windows. Linux and Mac was not tested. But a test case I threw together on godbolt.org implies that by the time the compiler is done with it, the resulting GCC/clang code is identical, which is good IMO.

Testing showed a reduced overhead when calling `Touch()`, `Ago()` or `GetDeltaTime()` with this change (compiled into the game, and determined by calculating the average overhead in wall-clock time taken to measure a 100ms interval 100 times).

The changes in this PR do not affection functionality, but allow us to protect encapsulation while performing the same job. An example is how this PR reduces the reliance on function calls to ensure the state of the variables are managed properly.

# Description of changes

The diff can be hard to view since a lot of stuff has moved around. Here is an explanation of what happens here.

1. Include `utility` in RageTimer.h, move `m_secs` and `m_us` to `private`, encapsulate `m_secs` and `m_us` in a `std::pair`.
   - We define `RageTimerPair` with a `using` because MSVC prefers that.
2. Implement getters for the seconds and microseconds values so that `Threads_Pthreads` can continue to look at those values.
3. Replace references to `m_secs` and `m_us` in RageTimer.cpp with `m_time.first` and `m_time.second`.
4. Rename the constants in RageTimer to be kSnakeCase.
5. Mark functions `noexcept`.
6. Move the functionality of `Sum` and `Difference` directly into the operators.
7. Remove unused includes from RageTimer.
8. Improve commentary all around.

# Notes

None.

Despite being a lot of line changes, it does not change anything functionally and all operations are providing an identical result.