### PR TITLE
CI - replace Windows installation step with microsoft/setup-msbuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,6 @@ jobs:
           - os: windows-latest
             name: Windows
             arch: x64
-            install: |
-              $vsPath = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
-              &"$vsPath\VC\Auxiliary\Build\vcvarsall.bat" x64
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
             build: cmake --build build --parallel "$env:NUMBER_OF_PROCESSORS"
     name: ${{ matrix.name }}
@@ -59,7 +56,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.arch }}-cmake-build-
       - name: Install dependencies
+        if: matrix.os != 'windows-latest'
         run: ${{ matrix.install }}
+      - name: Add msbuild to PATH
+        if: matrix.os == 'windows-latest'
+        uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x64
       - name: Configure
         run: ${{ matrix.configure }}
       - name: Build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,9 +45,6 @@ jobs:
           - os: windows-latest
             name: Windows
             arch: x64
-            install: |
-              $vsPath = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
-              &"$vsPath\VC\Auxiliary\Build\vcvarsall.bat" x64
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
             release: |
               cmake -B build -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
@@ -68,9 +65,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.arch }}-cmake-build-
       - name: Install dependencies
+        if: matrix.os != 'windows-latest'
         run: ${{ matrix.install }}
-      - name: Configure
-        run: ${{ matrix.configure }}
+      - name: Add msbuild to PATH
+        if: matrix.os == 'windows-latest'
+        uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x64
       - name: Create nightly release
         run: ${{ matrix.release }}
       - name: Upload artifacts


### PR DESCRIPTION
Prior to https://github.com/itgmania/itgmania/commit/398a7062ea427e4bf11c79975d02f0cf3005080b the CI workflow ran both the installation step _and_ the microsoft/setup-msbuild action - https://github.com/itgmania/itgmania/blob/release/.github/workflows/ci.yml#L133-L138 - but I think they do the same thing, right? This PR removes the installation step in favor of microsoft/setup-msbuild, conditionally for Windows builds

Reference https://github.com/microsoft/setup-msbuild