### PR TITLE
typedef RString as std::string

### DIFF
--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -90,7 +90,6 @@ namespace LuaHelpers
 	template<> void Push<unsigned int>( lua_State *L, const unsigned int &Object ) { lua_pushnumber( L, double(Object) ); }
 	template<> void Push<unsigned long long>( lua_State *L, const unsigned long long &Object ) { lua_pushnumber( L, double(Object) ); }
 	template<> void Push<RString>( lua_State *L, const RString &Object ) { lua_pushlstring( L, Object.data(), Object.size() ); }
-	template<> void Push<std::string>( lua_State *L, std::string const& object ) { lua_pushlstring( L, object.data(), object.size() ); }
 
 	template<> bool FromStack<bool>( Lua *L, bool &Object, int iOffset ) { Object = !!lua_toboolean( L, iOffset ); return true; }
 	template<> bool FromStack<float>( Lua *L, float &Object, int iOffset ) { Object = (float)lua_tonumber( L, iOffset ); return true; }

--- a/src/RageThreads.h
+++ b/src/RageThreads.h
@@ -4,6 +4,8 @@
 #include <cstdint>
 #include <limits>
 
+#include "StdString.h"
+
 struct ThreadSlot;
 class RageTimer;
 /** @brief Thread, mutex, semaphore, and event classes. */

--- a/src/StdString.h
+++ b/src/StdString.h
@@ -560,7 +560,7 @@ struct StdStringEqualsNoCase
 
 }	// namespace StdString
 
-typedef StdString::CStdString RString;
+typedef std::string RString;
 // FIXME: separate these into functions that either modify the argument, or
 // return a new string leaving the original unmodified.
 inline RString MakeLower(RString&& s) {

--- a/src/global.h
+++ b/src/global.h
@@ -38,8 +38,6 @@
 #endif
 
 #include "StdString.h"
-/** @brief Use RStrings throughout the program. */
-typedef StdString::CStdString RString;
 
 
 #include "RageThreads.h"


### PR DESCRIPTION
So we can remove the custom `CStdStr` class in the future.