### PR TITLE
Sunset WDMKS audio driver

### DIFF
--- a/src/arch/Sound/RageSoundDriver_WDMKS.cpp
+++ b/src/arch/Sound/RageSoundDriver_WDMKS.cpp
@@ -1256,6 +1256,13 @@ RageSoundDriver_WDMKS::RageSoundDriver_WDMKS()
 	m_bShutdown = false;
 	m_iLastCursorPos = 0;
 	m_hSignal = CreateEvent( nullptr, FALSE, FALSE, nullptr ); /* abort event */
+
+	MessageBox(
+		nullptr,
+		"RageSoundDriver_WDMKS is deprecated and will be removed in a "
+		"future version. "
+		"Please switch to DirectSound-sw or WaveOut instead.",
+		"RageSoundDriver_WDMKS", MB_OK | MB_ICONWARNING);
 }
 
 RString RageSoundDriver_WDMKS::Init()


### PR DESCRIPTION
Adding a dialog box to warn any WDMKS users who may be out there to switch drivers.

![image](https://github.com/user-attachments/assets/1efc592a-9e02-4d8e-8256-e1b452170387)


Proposing eventual removal of this long-unmaintaned driver. [It has not had any meaningful development since its initial commit, and WDMKS has been unsupported since Windows Vista was released.](https://github.com/itgmania/itgmania/commits/beta/src/arch/Sound/RageSoundDriver_WDMKS.cpp)

(This driver still works in Windows 11 thru a compatibility layer, but only with default settings; if you try to define any of the custom audio settings like sample rate, it will crash.)

Only DirectSound or WASAPI are recommended since Vista (so almost 20 years now). I would like to focus my effort on a WASAPI driver.