### PR TITLE
Handle return of freopen to prevent MSVC warning C6031

### DIFF
--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -190,8 +190,12 @@ void RageLog::SetShowLogOutput( bool show )
 		// create a new console window and attach standard handles
 		AllocConsole();
 		SetConsoleOutputCP(CP_UTF8);
-		freopen( "CONOUT$","wb", stdout );
-		freopen( "CONOUT$","wb", stderr );
+		if (freopen("CONOUT$", "wb", stdout) == nullptr) {
+			FAIL_M( "Failed to redirect standard output to the console." );
+		}
+		if (freopen("CONOUT$", "wb", stderr) == nullptr) {
+			FAIL_M( "Failed to redirect standard error to the console." );
+		}
 	}
 	else
 	{


### PR DESCRIPTION
Warning C6031 for ignored function return value can be prevented here. A failure here would be unexpected; bad enough it's worth calling a fail here.

**Note that the affected code is inside _WIN32 ifdefs (the default view of the diff doesn't reveal this).**