### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,36 +10,32 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13, windows-latest]
         include:
           - os: ubuntu-latest
             name: Ubuntu x86_64
-            arch: x86_64
             install: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
             build: cmake --build build --parallel "$(nproc)"
           - os: ubuntu-24.04-arm
             name: Ubuntu ARM
-            arch: arm
             install: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)" -DWITH_MINIMAID=OFF
             build: cmake --build build --parallel "$(nproc)"
           - os: macos-latest
             name: macOS (M1)
-            arch: arm64
             install: brew install nasm
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
             build: cmake --build build --parallel "$(sysctl -n hw.logicalcpu)"
           - os: macos-13
             name: macOS (Intel)
-            arch: x86_64
             install: brew install nasm
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
             build: cmake --build build --parallel "$(sysctl -n hw.logicalcpu)"
           - os: windows-latest
             name: Windows
-            arch: x64
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
             build: cmake --build build --parallel "$env:NUMBER_OF_PROCESSORS"
     name: ${{ matrix.name }}
@@ -52,9 +48,9 @@ jobs:
         with:
           path: |
             build
-          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-ci-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-cmake-build-
+            ${{ runner.os }}-${{ runner.arch }}-cmake-build-ci-
       - name: Install dependencies
         if: matrix.os != 'windows-latest'
         run: ${{ matrix.install }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,12 +12,12 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest] # TODO: macos-13
         include:
           - os: ubuntu-latest
             name: Ubuntu x86_64
-            arch: x86_64
             install: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
             release: |
@@ -26,16 +26,14 @@ jobs:
             path: build/ITGmania-*-NIGHTLY-git-*-Linux-no-songs.tar.gz
           - os: ubuntu-24.04-arm
             name: Ubuntu ARM
-            arch: arm
             install: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
-            configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)" -DWITH_MINIMAID=OFF
+            configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
             release: |
-              cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
+              cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off -DWITH_MINIMAID=Off
               cmake --build build --target package
             path: build/ITGmania-*-NIGHTLY-git-*-Linux-no-songs.tar.gz
           - os: macos-latest
             name: macOS (M1)
-            arch: arm64
             install: brew install nasm
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
             release: |
@@ -44,7 +42,6 @@ jobs:
             path: build/ITGmania-*-NIGHTLY-git-*-macOS-M1-no-songs.dmg
           - os: windows-latest
             name: Windows
-            arch: x64
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
             release: |
               cmake -B build -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
@@ -61,9 +58,9 @@ jobs:
           path: |
             build/*
             !${{ matrix.path }}
-          key: ${{ runner.os }}-${{ matrix.arch }}-cmake-build-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-nightly-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-cmake-build-
+            ${{ runner.os }}-${{ runner.arch }}-cmake-build-nightly-
       - name: Install dependencies
         if: matrix.os != 'windows-latest'
         run: ${{ matrix.install }}


### PR DESCRIPTION
1. _Don't_ cancel all in-progress and queued jobs in the matrix if any job in the matrix fails, reference https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#handling-failures
2. Rework caching to utilize https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#runner-context for architecture context in caching, removing value from matrix as unused, and name the caches per-workflow as they're different
3. Relocate `WITH_MINIMAID` build flag for Ubuntu ARM to skip https://github.com/itgmania/itgmania/blob/beta/src/CMakeLists.txt#L328 which was causing build failures