### PR TITLE
Run nightly builds only for the beta branch

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,5 @@
 on:
   push:
-  pull_request:
     branches:
       - beta
     paths-ignore:


### PR DESCRIPTION
I don't think we want to run nightly releases for every merge request or for every push into any branch.

Probably, we want to have nightly builds for the beta branch.