### PR TITLE
Remove architecture from artifact name

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,6 +73,6 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ITGmania-${{ github.sha }}-${{ matrix.name }}-${{ matrix.arch }}
+          name: ITGmania-${{ github.sha }}-${{ matrix.name }}
           path: ${{ matrix.path }}
           compression-level: 0


### PR DESCRIPTION
Missed when removing 'matrix.arch' in https://github.com/itgmania/itgmania/commit/b77a6af416a646e195ff4a72e80f9c2d77eaf1b1, now the artifact names end with a `-` - https://github.com/itgmania/itgmania/actions/runs/15194371500#artifacts

But 'matrix.name' includes the architecture where applicable, so we can just remove this here