### PR TITLE
Update Windows build flags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -150,7 +150,7 @@ endif()
 
 if(MSVC)
   # TODO: Find a way to do this cleanly for non MSVC users.
-  set(SM_COMPILE_FLAGS "${SM_COMPILE_FLAGS} /MP2 /utf-8")
+  set(SM_COMPILE_FLAGS "${SM_COMPILE_FLAGS} /MP /permissive- /utf-8")
 endif()
 
 set_target_properties("${SM_EXE_NAME}"


### PR DESCRIPTION
Looked into this after wondering why compile times were not notably improved after switching to a much better PC. These changes brought my compile time down from 5m 30s to 3m 55s on Windows.

`/MP2` limits the build processes to a maximum of 2. Many CPU's nowadays have more than two cores, so the integer specifier is removed so that the build is not artificially constrained to two cores.

`/FS` allows multiple compiler processes to write to the `.pdb` file; it should be used in conjunction with `/MP` to speed up the build. 

`/permissive-` disables certain MSVC-specific extensions to ensure standard C++ compliance.

Note, `/utf-8` does NOT build the program with Unicode support. It merely indicates to the compiler that the source files are using UTF-8 encoding. I think the intention was to use `/DUNICODE`, which can happen in a different PR IMO since things like CreateZip break if you try to do that.