### PR TITLE
Fix for code scanning alert: Multiplication result converted to larger type

### DIFF
--- a/src/RageSurfaceUtils.cpp
+++ b/src/RageSurfaceUtils.cpp
@@ -767,7 +767,7 @@ bool RageSurfaceUtils::SaveSurface( const RageSurface *img, RString file )
 		f.Write( img->format->palette->colors, img->format->palette->ncolors * sizeof(RageSurfaceColor) );
 	}
 
-	f.Write( img->pixels, img->h * img->pitch );
+	f.Write( img->pixels, static_cast<size_t>(img->h) * img->pitch );
 
 	return true;
 }
@@ -808,7 +808,7 @@ RageSurface *RageSurfaceUtils::LoadSurface( RString file )
 		return nullptr;
 	}
 
-	if( f.Read( img->pixels, h.height * h.pitch ) != h.height * h.pitch )
+	if( f.Read( img->pixels, static_cast<size_t>(h.height) * h.pitch ) != static_cast<size_t>(h.height) * h.pitch )
 	{
 		delete img;
 		return nullptr;


### PR DESCRIPTION
To fix the issue, we need to ensure that the multiplication is performed using a larger integer type (e.g., `size_t`) to prevent overflow. This can be achieved by explicitly casting one of the operands to `size_t` before the multiplication. This ensures that the multiplication is performed in the larger type, avoiding overflow.

The specific change involves modifying the expression `img->h * img->pitch` on line 770 to cast one of the operands (e.g., `img->h`) to `size_t`. This change is localized and does not affect the rest of the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._