### PR TITLE
Fix for code scanning alert: Multiplication result converted to larger type

### DIFF
--- a/src/RageSurfaceUtils.cpp
+++ b/src/RageSurfaceUtils.cpp
@@ -808,7 +808,7 @@ RageSurface *RageSurfaceUtils::LoadSurface( RString file )
 		return nullptr;
 	}
 
-	if( f.Read( img->pixels, h.height * h.pitch ) != h.height * h.pitch )
+	if( f.Read( img->pixels, static_cast<size_t>(h.height) * h.pitch ) != static_cast<size_t>(h.height) * h.pitch )
 	{
 		delete img;
 		return nullptr;


### PR DESCRIPTION
To fix the issue, we need to ensure that the multiplication is performed using a larger type (`size_t`) to prevent overflow. This can be achieved by casting one of the operands (`h.height` or `h.pitch`) to `size_t` before the multiplication. This ensures that the multiplication is performed in the larger type, avoiding overflow.

The specific change will be made on line 811, where `h.height * h.pitch` is used. We will cast `h.height` to `size_t` before the multiplication. This change does not alter the functionality but ensures that the multiplication is safe.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._