### PR TITLE
Fix for code scanning alert: Multiplication result converted to larger type

### DIFF
--- a/src/ActorMultiVertex.cpp
+++ b/src/ActorMultiVertex.cpp
@@ -1055,7 +1055,7 @@ public:
 		lua_rawseti(L, -2, 2);
 		lua_pushnumber(L, (state.rect.right - width_pix) * width_ratio);
 		lua_rawseti(L, -2, 3);
-		lua_pushnumber(L, (state.rect.bottom + height_pix) * height_ratio);
+		lua_pushnumber(L, (static_cast<lua_Number>(state.rect.bottom) + height_pix) * height_ratio);
 		lua_rawseti(L, -2, 4);
 		lua_rawseti(L, -2, 1);
 		lua_pushnumber(L, state.delay);


### PR DESCRIPTION
To fix the issue, we need to ensure that the multiplication is performed in the larger type (`lua_Number`) rather than the smaller type (`float`). This can be achieved by explicitly casting one of the operands to `lua_Number` before the multiplication. This ensures that the entire operation is performed in the larger type, avoiding any risk of overflow or precision loss in the intermediate result.

The specific change involves casting `state.rect.bottom` or `height_pix` to `lua_Number` before the addition and multiplication. This change will be applied to line 1058.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._