### PR TITLE
Fix for code scanning alert: Multiplication result converted to larger type

### DIFF
--- a/src/ActorMultiVertex.cpp
+++ b/src/ActorMultiVertex.cpp
@@ -1053,7 +1053,7 @@ public:
 		lua_rawseti(L, -2, 1);
 		lua_pushnumber(L, state.rect.top * height_ratio);
 		lua_rawseti(L, -2, 2);
-		lua_pushnumber(L, (state.rect.right - width_pix) * width_ratio);
+		lua_pushnumber(L, static_cast<lua_Number>(state.rect.right - width_pix) * width_ratio);
 		lua_rawseti(L, -2, 3);
 		lua_pushnumber(L, (state.rect.bottom + height_pix) * height_ratio);
 		lua_rawseti(L, -2, 4);


### PR DESCRIPTION
To fix the issue, we need to ensure that the multiplication is performed in the larger type (`lua_Number`) rather than in `float`. This can be achieved by explicitly casting one of the operands to `lua_Number` before the multiplication. This ensures that the entire operation is performed in the larger type, avoiding any risk of overflow in the smaller type.

The specific change involves casting `(state.rect.right - width_pix)` to `lua_Number` before multiplying it by `width_ratio`. This ensures that the subtraction and multiplication are both performed in the larger type.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._