### PR TITLE
Fix for code scanning alert: Multiplication result converted to larger type

### DIFF
--- a/src/ActorMultiVertex.cpp
+++ b/src/ActorMultiVertex.cpp
@@ -1051,7 +1051,7 @@ public:
 		lua_createtable(L, 4, 0);
 		lua_pushnumber(L, state.rect.left * width_ratio);
 		lua_rawseti(L, -2, 1);
-		lua_pushnumber(L, state.rect.top * height_ratio);
+		lua_pushnumber(L, static_cast<lua_Number>(state.rect.top) * height_ratio);
 		lua_rawseti(L, -2, 2);
 		lua_pushnumber(L, (state.rect.right - width_pix) * width_ratio);
 		lua_rawseti(L, -2, 3);


### PR DESCRIPTION
To fix the issue, we need to ensure that the multiplication is performed in the larger type (`lua_Number`) rather than in the smaller type (`float`). This can be achieved by explicitly casting one of the operands to `lua_Number` before performing the multiplication. This ensures that the multiplication is carried out in the larger type, avoiding any risk of overflow in the smaller type.

The specific change involves casting `state.rect.top` or `height_ratio` to `lua_Number` on line 1054. Similar changes should be applied to other multiplications in the same function if they involve the same risk.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._