### PR TITLE
Fix for code scanning alert: Multiplication result converted to larger type

### DIFF
--- a/src/ActorMultiVertex.cpp
+++ b/src/ActorMultiVertex.cpp
@@ -1049,13 +1049,13 @@ public:
 			p->GetStateData(ValidStateIndex(p, L, 1));
 		lua_createtable(L, 2, 0);
 		lua_createtable(L, 4, 0);
-		lua_pushnumber(L, state.rect.left * width_ratio);
+		lua_pushnumber(L, static_cast<lua_Number>(state.rect.left) * width_ratio);
 		lua_rawseti(L, -2, 1);
-		lua_pushnumber(L, state.rect.top * height_ratio);
+		lua_pushnumber(L, static_cast<lua_Number>(state.rect.top) * height_ratio);
 		lua_rawseti(L, -2, 2);
-		lua_pushnumber(L, (state.rect.right - width_pix) * width_ratio);
+		lua_pushnumber(L, (static_cast<lua_Number>(state.rect.right) - width_pix) * width_ratio);
 		lua_rawseti(L, -2, 3);
-		lua_pushnumber(L, (state.rect.bottom + height_pix) * height_ratio);
+		lua_pushnumber(L, (static_cast<lua_Number>(state.rect.bottom) + height_pix) * height_ratio);
 		lua_rawseti(L, -2, 4);
 		lua_rawseti(L, -2, 1);
 		lua_pushnumber(L, state.delay);


### PR DESCRIPTION
To fix the issue, we need to ensure that the multiplication is performed in the larger type (`lua_Number`) rather than in `float`. This can be achieved by explicitly casting one of the operands to `lua_Number` before the multiplication. This forces the multiplication to be performed in the larger type, avoiding overflow or precision loss in the smaller type.

The specific changes are:
1. Cast `state.rect.left` to `lua_Number` before multiplying it with `width_ratio` on line 1052.
2. Similarly, cast the operands in other multiplications (e.g., lines 1054, 1056, and 1058) to ensure consistency and correctness.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
