### PR TITLE
don't upload VS2022 Code Analysis indicators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ BuildLog.htm
 *.swp
 *.pc
 *.d
+*.lastcodeanalysissucceeded


### PR DESCRIPTION
Visual Studio filetype; is an empty file.