### PR TITLE
Replace custom RageUtil `vssprintf` with `std::vsnprintf`.

### DIFF
--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -21,6 +21,7 @@
 #include <map>
 #include <sstream> // conversion for lua functions.
 #include <vector>
+#include <cstdio>
 
 LuaManager *LUA = nullptr;
 struct Impl
@@ -825,8 +826,10 @@ void LuaHelpers::ReportScriptErrorFmt(const char *fmt, ...)
 {
 	va_list	va;
 	va_start( va, fmt );
-	RString Buff = vssprintf( fmt, va );
+	char buffer[1024];
+	std::vsnprintf( buffer, sizeof(buffer), fmt, va );
 	va_end( va );
+	RString Buff = buffer;
 	ReportScriptError(Buff);
 }
 

--- a/src/RageException.cpp
+++ b/src/RageException.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdarg>
 #include <cstdint>
+#include <cstdio>
 
 #if defined(_WIN32) && defined(DEBUG)
 #define WIN32_LEAN_AND_MEAN
@@ -30,9 +31,11 @@ void RageException::Throw( const char *sFmt, ... )
 {
 	va_list	va;
 	va_start( va, sFmt );
-	RString error = vssprintf( sFmt, va );
+	char buffer[1024];
+	std::vsnprintf( buffer, sizeof(buffer), sFmt, va );
 	va_end( va );
 
+	RString error = buffer;
 	RString msg = ssprintf(
 		"\n"
 		"//////////////////////////////////////////////////////\n"

--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -9,6 +9,7 @@
 #include <cstdarg>
 #include <map>
 #include <vector>
+#include <cstdio>
 
 #if defined(_WIN32)
 #include <windows.h>
@@ -202,11 +203,13 @@ void RageLog::SetShowLogOutput( bool show )
 
 void RageLog::Trace( const char *fmt, ... )
 {
+	char buffer[1024];
 	va_list	va;
 	va_start( va, fmt );
-	RString sBuff = vssprintf( fmt, va );
+	std::vsnprintf( buffer, sizeof(buffer), fmt, va );
 	va_end( va );
 
+	RString sBuff = buffer;
 	Write( 0, sBuff );
 }
 
@@ -214,41 +217,49 @@ void RageLog::Trace( const char *fmt, ... )
  * in crash dumps. */
 void RageLog::Info( const char *fmt, ... )
 {
+	char buffer[1024];
 	va_list	va;
 	va_start( va, fmt );
-	RString sBuff = vssprintf( fmt, va );
+	std::vsnprintf( buffer, sizeof(buffer), fmt, va );
 	va_end( va );
 
+	RString sBuff = buffer;
 	Write( WRITE_TO_INFO, sBuff );
 }
 
 void RageLog::Warn( const char *fmt, ... )
 {
+	char buffer[1024];
 	va_list	va;
 	va_start( va, fmt );
-	RString sBuff = vssprintf( fmt, va );
+	std::vsnprintf( buffer, sizeof(buffer), fmt, va );
 	va_end( va );
 
+	RString sBuff = buffer;
 	Write( WRITE_TO_INFO | WRITE_LOUD, sBuff );
 }
 
 void RageLog::Time(const char *fmt, ...)
 {
+	char buffer[1024];
 	va_list	va;
 	va_start(va, fmt);
-	RString sBuff = vssprintf(fmt, va);
+	std::vsnprintf( buffer, sizeof(buffer), fmt, va );
 	va_end(va);
 
+	RString sBuff = buffer;
 	Write(WRITE_TO_TIME, sBuff);
 }
 
 void RageLog::UserLog( const RString &sType, const RString &sElement, const char *fmt, ... )
 {
+	char buffer[1024];
 	va_list va;
 	va_start( va, fmt );
-	RString sBuf = vssprintf( fmt, va );
+	std::vsnprintf( buffer, sizeof(buffer), fmt, va );
 	va_end( va );
 
+	RString sBuf = buffer;
 	if( !sType.empty() )
 		sBuf = ssprintf( "%s \"%s\" %s", sType.c_str(), sElement.c_str(), sBuf.c_str() );
 
@@ -414,13 +425,13 @@ const char *RageLog::GetAdditionalLog()
 
 void RageLog::MapLog( const RString &key, const char *fmt, ... )
 {
-	RString s;
-
+	char buffer[1024];
 	va_list	va;
 	va_start( va, fmt );
-	s += vssprintf( fmt, va );
+	std::vsnprintf( buffer, sizeof(buffer), fmt, va );
 	va_end( va );
 
+	RString s = buffer;
 	LogMaps[key] = s;
 	UpdateMappedLog();
 }

--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -17,6 +17,13 @@
 
 RageLog* LOG;		// global and accessible from anywhere in the program
 
+// For the calls to vsnprintf, one must define a maximum possible size for the buffer.
+// This is the maximum size of a single log line, not the total size of the log.
+// e.g. if the value is 10240, and then you use 2500 chars for a single log line,
+// the resulting string will be not be truncated and will not have extra spaces added to it.
+// vsnprintf only guarantees null termination as long as we don't overflow the buffer.
+constexpr int MAX_LOG_SIZE = 10240;
+
 /*
  * We have a couple log types and a couple logs.
  *
@@ -203,7 +210,7 @@ void RageLog::SetShowLogOutput( bool show )
 
 void RageLog::Trace( const char *fmt, ... )
 {
-	char buffer[1024];
+	char buffer[MAX_LOG_SIZE];
 	va_list	va;
 	va_start( va, fmt );
 	std::vsnprintf( buffer, sizeof(buffer), fmt, va );
@@ -217,7 +224,7 @@ void RageLog::Trace( const char *fmt, ... )
  * in crash dumps. */
 void RageLog::Info( const char *fmt, ... )
 {
-	char buffer[1024];
+	char buffer[MAX_LOG_SIZE];
 	va_list	va;
 	va_start( va, fmt );
 	std::vsnprintf( buffer, sizeof(buffer), fmt, va );
@@ -229,7 +236,7 @@ void RageLog::Info( const char *fmt, ... )
 
 void RageLog::Warn( const char *fmt, ... )
 {
-	char buffer[1024];
+	char buffer[MAX_LOG_SIZE];
 	va_list	va;
 	va_start( va, fmt );
 	std::vsnprintf( buffer, sizeof(buffer), fmt, va );
@@ -241,7 +248,7 @@ void RageLog::Warn( const char *fmt, ... )
 
 void RageLog::Time(const char *fmt, ...)
 {
-	char buffer[1024];
+	char buffer[MAX_LOG_SIZE];
 	va_list	va;
 	va_start(va, fmt);
 	std::vsnprintf( buffer, sizeof(buffer), fmt, va );
@@ -253,7 +260,7 @@ void RageLog::Time(const char *fmt, ...)
 
 void RageLog::UserLog( const RString &sType, const RString &sElement, const char *fmt, ... )
 {
-	char buffer[1024];
+	char buffer[MAX_LOG_SIZE];
 	va_list va;
 	va_start( va, fmt );
 	std::vsnprintf( buffer, sizeof(buffer), fmt, va );
@@ -402,7 +409,7 @@ const char *RageLog::GetRecentLog( int n )
 }
 
 
-static char g_AdditionalLogStr[10240] = "";
+static char g_AdditionalLogStr[MAX_LOG_SIZE] = "";
 static int g_AdditionalLogSize = 0;
 
 void RageLog::UpdateMappedLog()
@@ -425,7 +432,7 @@ const char *RageLog::GetAdditionalLog()
 
 void RageLog::MapLog( const RString &key, const char *fmt, ... )
 {
-	char buffer[1024];
+	char buffer[MAX_LOG_SIZE];
 	va_list	va;
 	va_start( va, fmt );
 	std::vsnprintf( buffer, sizeof(buffer), fmt, va );

--- a/src/RageSoundReader_Vorbisfile.cpp
+++ b/src/RageSoundReader_Vorbisfile.cpp
@@ -16,6 +16,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <cstdio>
 
 static size_t OggRageFile_read_func( void *ptr, size_t size, size_t nmemb, void *datasource )
 {
@@ -44,7 +45,8 @@ static RString ov_ssprintf( int err, const char *fmt, ...)
 {
 	va_list	va;
 	va_start( va, fmt );
-	RString s = vssprintf( fmt, va );
+	char formatted[1024];
+	std::vsnprintf( formatted, sizeof(formatted), fmt, va );
 	va_end( va );
 
 	RString errstr;
@@ -70,7 +72,7 @@ static RString ov_ssprintf( int err, const char *fmt, ...)
 		default:		errstr = ssprintf( "unknown error %i", err ); break;
 	}
 
-	return s + ssprintf( " (%s)", errstr.c_str() );
+	return RString(formatted) + ssprintf( " (%s)", errstr.c_str() );
 }
 
 RageSoundReader_FileReader::OpenResult RageSoundReader_Vorbisfile::Open( RageFileBasic *pFile )

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -394,21 +394,16 @@ RString ssprintf( const char *fmt, ...)
 {
 	va_list	va;
 	va_start(va, fmt);
-	RString sRet = vssprintf(fmt, va);
-	va_end(va);
-	return sRet;
-}
 
-RString vssprintf( const char *szFormat, va_list argList )
-{
-	va_list tmp;
-	va_copy( tmp, argList );
-	int iNeeded = std::vsnprintf( nullptr, 0, szFormat, tmp );
-	va_end(tmp);
+	va_list va_copy;
+	va_copy(va_copy, va);
+	int sizeNeeded = std::vsnprintf(nullptr, 0, fmt, va_copy);
+	va_end(va_copy);
 
 	RString sRet;
-	sRet.resize(iNeeded);
-	std::vsnprintf( &sRet.front(), iNeeded+1, szFormat, argList );
+	sRet.resize(sizeNeeded);
+	std::vsnprintf(&sRet.front(), sizeNeeded + 1, fmt, va);
+	va_end(va);
 	return sRet;
 }
 

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -355,7 +355,6 @@ RString NormalizeDecimal(float num);
 struct tm GetLocalTime();
 
 RString ssprintf( const char *fmt, ...) PRINTF(1,2);
-RString vssprintf( const char *fmt, va_list argList );
 
 /*
  * Splits a Path into 4 parts (Directory, Drive, Filename, Extention).  Supports UNC path names.

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <thread>
+#include <cstdio>
 
 static void FixLilEndian()
 {
@@ -481,9 +482,10 @@ static RString averr_ssprintf(int err, const char* fmt, ...)
 {
 	ASSERT(err < 0);
 
+	char formatted[1024];
 	va_list     va;
 	va_start(va, fmt);
-	RString s = vssprintf(fmt, va);
+	std::vsnprintf(formatted, sizeof(formatted), fmt, va);
 	va_end(va);
 
 	size_t errbuf_size = 512;
@@ -492,7 +494,7 @@ static RString averr_ssprintf(int err, const char* fmt, ...)
 	RString Error = ssprintf("%i: %s", err, errbuf);
 	delete[] errbuf;
 
-	return s + " (" + Error + ")";
+	return RString(formatted) + " (" + Error + ")";
 }
 
 static int AVIORageFile_ReadPacket(void* opaque, uint8_t* buf, int buf_size)

--- a/src/arch/Sound/ALSA9Helpers.cpp
+++ b/src/arch/Sound/ALSA9Helpers.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <fstream>
 #include <string>
+#include <cstdio>
 
 /* int err; must be defined before using this macro */
 #define ALSA_CHECK(x) \
@@ -111,18 +112,25 @@ bool Alsa9Buf::SetSWParams()
 
 void Alsa9Buf::ErrorHandler(const char *file, int line, const char *function, int err, const char *fmt, ...)
 {
+	char formatted[1024];
 	va_list va;
 	va_start( va, fmt );
-	RString str = vssprintf(fmt, va);
+	std::vsnprintf(formatted, sizeof(formatted), fmt, va);
 	va_end( va );
 
+	// strncat is used to avoid buffer overflow, but it will not null-terminate if it's completely filled.
 	if( err )
-		str += ssprintf( " (%s)", dsnd_strerror(err) );
+	{
+		size_t remaining = sizeof(formatted) - strlen(formatted) - 1;
+		strncat(formatted, " (", remaining);
+		strncat(formatted, dsnd_strerror(err), remaining);
+		strncat(formatted, ")", remaining);
+	}
 
 	/* Annoying: these happen both normally (eg. "out of memory" when allocating too many PCM
 	 * slots) and abnormally, and there's no way to tell which is which.  I don't want to
 	 * pollute the warning output. */
-	LOG->Trace( "ALSA error: %s:%i %s: %s", file, line, function, str.c_str() );
+	LOG->Trace( "ALSA error: %s:%i %s: %s", file, line, function, formatted );
 }
 
 void Alsa9Buf::InitializeErrorHandler()

--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -15,7 +15,7 @@
 
 #include <cstdint>
 #include <vector>
-
+#include <cstdio>
 
 REGISTER_SOUND_DRIVER_CLASS( WaveOut );
 
@@ -34,12 +34,13 @@ static RString wo_ssprintf( MMRESULT err, const char *szFmt, ...)
 	char szBuf[MAXERRORLENGTH];
 	waveOutGetErrorText( err, szBuf, MAXERRORLENGTH );
 
+	char formatted[1024];
 	va_list va;
 	va_start( va, szFmt );
-	RString s = vssprintf( szFmt, va );
+	std::vsnprintf(formatted, sizeof(formatted), szFmt, va);
 	va_end( va );
 
-	return s += ssprintf( "(%s)", szBuf );
+	return RString(formatted) += ssprintf( "(%s)", szBuf );
 }
 
 int RageSoundDriver_WaveOut::MixerThread_start( void *p )

--- a/src/archutils/Win32/DebugInfoHunt.cpp
+++ b/src/archutils/Win32/DebugInfoHunt.cpp
@@ -7,6 +7,7 @@
 #include "ErrorStrings.h"
 
 #include <vector>
+#include <cstring>
 
 #include <windows.h>
 #include <mmsystem.h>
@@ -82,12 +83,13 @@ static RString wo_ssprintf( MMRESULT err, const char *fmt, ...)
 	char buf[MAXERRORLENGTH];
 	waveOutGetErrorText(err, buf, MAXERRORLENGTH);
 
-	va_list	va;
+	char formatted[1024];
+	va_list va;
 	va_start(va, fmt);
-	RString s = vssprintf( fmt, va );
+	std::vsnprintf(formatted, sizeof(formatted), fmt, va);
 	va_end(va);
 
-	return s += ssprintf( "(%s)", buf );
+	return RString(formatted) + ssprintf(" (%s)", buf);
 }
 
 static void GetDriveDebugInfo()

--- a/src/archutils/Win32/DirectXHelpers.cpp
+++ b/src/archutils/Win32/DirectXHelpers.cpp
@@ -7,18 +7,23 @@
 #include <mmsystem.h> // dsound.h needs this
 #include <dsound.h>
 #include <stdexcept>
+#include <cstdio>
 
 RString GetErrorString(HRESULT hr);
 
 RString hr_ssprintf( int hr, const char *fmt, ... )
 {
 	va_list	va;
+	char formattedMessage[1024];
 	va_start(va, fmt);
-	RString s = vssprintf( fmt, va );
+	std::vsnprintf( formattedMessage, sizeof(formattedMessage), fmt, va );
 	va_end(va);
 
 	RString szError = GetErrorString(hr);
-	return s + ssprintf(" (%s)", szError.c_str());
+
+	char result[1024];
+	std::snprintf( result, sizeof(result), "%s (%s)", formattedMessage, szError.c_str() );
+	return RString(result);
 }
 
 #define DXERRMSG(hrcode, dummy) case hrcode: return #hrcode;

--- a/src/archutils/Win32/ErrorStrings.cpp
+++ b/src/archutils/Win32/ErrorStrings.cpp
@@ -3,6 +3,7 @@
 #include "RageUtil.h"
 
 #include <windows.h>
+#include <cstdio>
 
 RString werr_ssprintf( int err, const char *fmt, ... )
 {
@@ -19,8 +20,11 @@ RString werr_ssprintf( int err, const char *fmt, ... )
 
 	va_list	va;
 	va_start(va, fmt);
-	RString s = vssprintf( fmt, va );
+	char formatted[1024];
+	std::vsnprintf(formatted, sizeof(formatted), fmt, va);
 	va_end(va);
+
+	RString s = formatted;
 
 	return s += ssprintf( " (%s)", text.c_str() );
 }


### PR DESCRIPTION
`vssprintf` is a function in RageUtil which returns an RString. It mostly performs the same job as `std::vsnprintf`, but determines the size of the buffer to prevent truncation.

![image](https://github.com/user-attachments/assets/807ef20f-8512-42bf-8282-f663f9fc47e3)

But, the places we call this from are very low level to the point where this RageUtil dependency seems to add unwanted complexity.

I was able to replace every direct `vssprintf` call with a simple declaration of a character array and `std::vsnprintf` call. This does introduce the risk of truncation, but I don't think we're having this print any one line that is thousands of characters.

In the end no functionality is changed, provided we have some idea of how long the strings generally will be, and then we can remove the function from RageUtil.

_If accepted, can then put thru a follow up PR that removes the RageUtil.h dependency completely from RageException.cpp by replacing its ssprintf calls_