### PR TITLE
Resolve unintended shared state of DecodeMovie `status` variable. (Fixes edge case where a canceled video can be stuck in a loop; also fixes a crash that can occur if focus is lost and regained while a video is looping).

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -270,6 +270,9 @@ void MovieDecoder_FFMpeg::HandleReset() {
 
 int MovieDecoder_FFMpeg::DecodeMovie()
 {
+	// Should be thread local so that each thread has its own status variable.
+	thread_local int status;
+
 	// Never exit when the movie is looping. Otherwise exit when the last frame
 	// is added to the FrameBuffer.
 	while (looping_ || (!looping_ && display_frame_num_ < total_frames_)) {
@@ -277,7 +280,7 @@ int MovieDecoder_FFMpeg::DecodeMovie()
 			HandleReset();
 		}
 
-		int status = DecodeFrame();
+		status = DecodeFrame();
 
 		// If cancelled (quitting a song, scrolling the banner), or fatal error,
 		// stop decoding.


### PR DESCRIPTION
# Background

This resolves an issue where a video decoding thread could possibly get stuck in a loop if it fails to respond to a cancel (`-2`) status.

This rare edge case is **only possible** when multiple video threads are concurrently looping their own video. See below for an explanation of how to set up this edge case.

It also separately fixes an issue where [looping video banners can cause the game to lock up if you switch in and out of focus](https://github.com/itgmania/itgmania/pull/860#issuecomment-2917838396).

# Summary

This seems is a thread contention issue because it does not present itself reliably, and when it does, it only presents itself when there are multiple video threads which are concurrently active.

I was able to occasionally set up a situation where videos would not get properly marked as cancelled and would stay in the loop despite being marked `-2`. Lots of CPU time and memory would be wasted in this situation.

This PR is an incredibly simple, minimal change. We simply make the `status` variable `thread_local` to guarantee that it has relevance to **its own thread**.

# Why `if (status < 0)` doesn't help

If multiple video threads are concurrently looping, and one **but not all of them** change status, there's a chance the other threads erroneously get their own `status` variable modified.

Note again this is definitely a rare edge case.

# Why this helps

The main benefit is the thread local state tracking. Since there are typically multiple video threads active, it's important each thread has its own `status` variable which is safe from the others. It is necessary to give each individual decoding thread awareness of its own state for this to work.

# Testing it yourself

To set up the edge case described in this PR, you need a pack that has video banners on all consecutive songs. Then you need to hover over each one for a few seconds so that you get multiple videos looping. If you check the log window you should be able to get 5+ videos looping this way.

All you need to do is watch the value of the variable `status` for any given video thread.

An easy way to trigger breaking out of the loop is to let a video banner idle for a while in the song wheel, and then press "Scroll Lock" to suddenly enter the Operator Menu, or select a song. This will send the `-2` (cancel) status to all looping videos that should be stopped.