### PR TITLE
Change video looping log from Trace to Info level.

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_Generic.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Generic.cpp
@@ -344,7 +344,7 @@ void MovieTexture_Generic::UpdateFrame()
 
 	// Are we looping?
 	if (decoder_->EndOfMovie() && loop_) {
-		LOG->Trace("File \"%s\" looping", GetID().filename.c_str());
+		LOG->Info("File \"%s\" looping", GetID().filename.c_str());
 		decoder_->Rollover();
 		clock_ = 0.0;
 	}


### PR DESCRIPTION
At the least, would be nice if this didn't write to a file as the song is playing, but I don't think this has much value in a log for a typical user.

for example, this is simply an overkill amount of logging for a song that is only 2 minutes (even though it has more video changes than the average song):

![image](https://github.com/user-attachments/assets/5739d11a-d21d-4765-8c4a-7f0e2ab131e1)
