### PR TITLE
Default to 48khz over 44.1khz.

### DIFF
--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -147,7 +147,7 @@ public:
 	int SetPosition( int iFrame )  { return 1; }
 	int Read( float *pBuf, int iFrames ) { return RageSoundReader::END_OF_FILE; }
 	RageSoundReader *Copy() const { return new RageSoundReader_Silence; }
-	int GetSampleRate() const { return 44100; }
+	int GetSampleRate() const { return 48000; }
 	unsigned GetNumChannels() const { return 1; }
 	int GetNextSourceFrame() const { return 0; }
 	float GetStreamToSourceRatio() const { return 1.0f; }

--- a/src/RageSoundManager.cpp
+++ b/src/RageSoundManager.cpp
@@ -133,7 +133,7 @@ float RageSoundManager::GetPlayLatency() const
 int RageSoundManager::GetDriverSampleRate() const
 {
 	if( m_pDriver == nullptr )
-		return 44100;
+		return 48000;
 
 	return m_pDriver->GetSampleRate();
 }

--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -23,7 +23,7 @@
  */
 RageSoundReader_Chain::RageSoundReader_Chain()
 {
-	m_iPreferredSampleRate = 44100;
+	m_iPreferredSampleRate = 48000;
 	m_iActualSampleRate = -1;
 	m_iChannels = 0;
 	m_iCurrentFrame = 0;

--- a/src/arch/Sound/ALSA9Helpers.cpp
+++ b/src/arch/Sound/ALSA9Helpers.cpp
@@ -212,7 +212,7 @@ void Alsa9Buf::GetSoundCardDebugInfo()
 
 Alsa9Buf::Alsa9Buf()
 {
-	samplerate = 44100;
+	samplerate = 48000;
 	samplebits = 16;
 	last_cursor_pos = 0;
 	preferred_writeahead = 8192;
@@ -229,7 +229,7 @@ RString Alsa9Buf::Init( int channels_,
 	preferred_writeahead = iWriteahead;
 	preferred_chunksize = iChunkSize;
 	if( iSampleRate == 0 )
-		samplerate = 44100;
+		samplerate = 48000;
 	else
 		samplerate = iSampleRate;
 

--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -62,7 +62,7 @@ void DSound::SetPrimaryBufferMode()
 	waveformat.wFormatTag = WAVE_FORMAT_PCM;
 	waveformat.wBitsPerSample = 16;
 	waveformat.nChannels = 2;
-	waveformat.nSamplesPerSec = 44100;
+	waveformat.nSamplesPerSec = 48000;
 	waveformat.nBlockAlign = 4;
 	waveformat.nAvgBytesPerSec = waveformat.nSamplesPerSec * waveformat.nBlockAlign;
 
@@ -75,8 +75,8 @@ void DSound::SetPrimaryBufferMode()
 	hr = pBuffer->GetFormat( &waveformat, sizeof(waveformat), &got );
 	if( FAILED(hr) )
 		LOG->Warn( hr_ssprintf(hr, "GetFormat on primary buffer") );
-	else if( waveformat.nSamplesPerSec != 44100 )
-		LOG->Warn( "Primary buffer set to %i instead of 44100", waveformat.nSamplesPerSec );
+	else if( waveformat.nSamplesPerSec != 48000 )
+		LOG->Warn( "Primary buffer set to %i instead of 48000", waveformat.nSamplesPerSec );
 
 	/*
 	 * MS docs:
@@ -197,7 +197,7 @@ RString DSoundBuf::Init( DSound &ds, DSoundBuf::hw hardware,
 	bool bNeedCtrlFrequency = false;
 	if( m_iSampleRate == DYNAMIC_SAMPLERATE )
 	{
-		m_iSampleRate = 44100;
+		m_iSampleRate = 48000;
 		bNeedCtrlFrequency = true;
 	}
 

--- a/src/arch/Sound/RageSoundDriver.h
+++ b/src/arch/Sound/RageSoundDriver.h
@@ -66,7 +66,7 @@ public:
 	 * hearing it.  (This isn't necessarily the same as the buffer latency.) */
 	virtual float GetPlayLatency() const { return 0.0f; }
 
-	virtual int GetSampleRate() const { return 44100; }
+	virtual int GetSampleRate() const { return 48000; }
 
 protected:
 	/* Start the decoding.  This should be called once the hardware is set up and

--- a/src/arch/Sound/RageSoundDriver_AU.mm
+++ b/src/arch/Sound/RageSoundDriver_AU.mm
@@ -151,7 +151,7 @@ RString RageSoundDriver_AU::Init()
 	streamFormat.mBitsPerChannel = kBitsPerChannel;
 
 	if( streamFormat.mSampleRate <= 0.0 )
-		streamFormat.mSampleRate = 44100.0;
+		streamFormat.mSampleRate = 48000.0;
 	m_iSampleRate = int( streamFormat.mSampleRate );
 	m_TimeScale = streamFormat.mSampleRate / AudioGetHostClockFrequency();
 

--- a/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
@@ -97,7 +97,7 @@ RString RageSoundDriver_DSound_Software::Init()
 	m_pPCM = new DSoundBuf;
 	m_iSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
 	if( m_iSampleRate == 0 )
-		m_iSampleRate = 44100;
+		m_iSampleRate = 48000;
 	sError = m_pPCM->Init( ds, DSoundBuf::HW_DONT_CARE, channels, m_iSampleRate, 16, g_iMaxWriteahead );
 	if( sError != "" )
 		return sError;

--- a/src/arch/Sound/RageSoundDriver_Null.cpp
+++ b/src/arch/Sound/RageSoundDriver_Null.cpp
@@ -32,7 +32,7 @@ RageSoundDriver_Null::RageSoundDriver_Null()
 {
 	m_iSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
 	if( m_iSampleRate == 0 )
-		m_iSampleRate = 44100;
+		m_iSampleRate = 48000;
 	m_iLastCursorPos = GetPosition();
 	StartDecodeThread();
 }

--- a/src/arch/Sound/RageSoundDriver_OSS.cpp
+++ b/src/arch/Sound/RageSoundDriver_OSS.cpp
@@ -193,7 +193,7 @@ RString RageSoundDriver_OSS::Init()
 	if(i != channels)
 		return ssprintf( "RageSoundDriver_OSS: Wanted %i channels, got %i instead", channels, i );
 
-	i = 44100;
+	i = 48000;
 	if(ioctl(fd, SNDCTL_DSP_SPEED, &i) == -1 )
 		return ssprintf( "RageSoundDriver_OSS: ioctl(SNDCTL_DSP_SPEED, %i): %s", i, strerror(errno) );
 	samplerate = i;

--- a/src/arch/Sound/RageSoundDriver_PulseAudio.cpp
+++ b/src/arch/Sound/RageSoundDriver_PulseAudio.cpp
@@ -29,7 +29,7 @@ m_PulseMainLoop(nullptr), m_PulseCtx(nullptr), m_PulseStream(nullptr)
 {
 	m_ss.rate = PREFSMAN->m_iSoundPreferredSampleRate;
 	if( m_ss.rate == 0 )
-		m_ss.rate = 44100;
+		m_ss.rate = 48000;
 }
 
 RageSoundDriver_PulseAudio::~RageSoundDriver_PulseAudio()
@@ -133,7 +133,7 @@ void RageSoundDriver_PulseAudio::m_InitStream(void)
 	ss.rate = PREFSMAN->m_iSoundPreferredSampleRate;
 	if(ss.rate == 0)
 	{
-		ss.rate = 44100;
+		ss.rate = 48000;
 	}
 
 	/* init channel map */

--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -125,7 +125,7 @@ RString RageSoundDriver_WaveOut::Init()
 	b_InitSuccess = false;
 	m_iSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
 	if( m_iSampleRate == 0 )
-		m_iSampleRate = 44100;
+		m_iSampleRate = 48000;
 
 	WAVEFORMATEX fmt;
 	fmt.wFormatTag = WAVE_FORMAT_PCM;


### PR DESCRIPTION
Commonly, the OS default sample rate is 48khz or a multiple of it. Windows defaults to 48khz for instance.

44.1khz is likely to be resampled to 48khz by the OS or audio driver. So this sets the default preferred sample rate to 48khz instead of 44.1khz.

No issues noticed in Windows testing. Needs some Linux/Mac testing, but there's a good chance this is the final nail in the coffin on sync issues.



edit: CI never ran here....?? not sure why, so re-squashed just now to get it to run

edit 2: Closing so pnn64 can publish this commit.