### PR TITLE
Use a range-based for loop to avoid manual iterator handling

### DIFF
--- a/src/RageSoundReader_ChannelSplit.cpp
+++ b/src/RageSoundReader_ChannelSplit.cpp
@@ -162,9 +162,8 @@ int RageSoundReader_Split::Read( float *pBuf, int iFrames )
 
 	{
 		RageSoundMixBuffer mix;
-		for( int i = 0; i < (int) m_aChannels.size(); ++i )
+		for( const ChannelMap& chan : m_aChannels )
 		{
-			const ChannelMap &chan = m_aChannels[i];
 			mix.SetWriteOffset( chan.m_iToChannel );
 			mix.write( pSrc + chan.m_iFromChannel, iFramesAvailable, m_pImpl->m_pSource->GetNumChannels(), m_iNumOutputChannels );
 		}


### PR DESCRIPTION
A simple change to remove the need for manual iterator handling.