### PR TITLE
do not write any logs in disk when LogToDisk=0

### DIFF
--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -90,7 +90,7 @@ m_bUserLogToDisk(false), m_bFlush(false), m_bShowLogOutput(false)
 	g_fileUserLog = new RageFile;
 	g_fileTimeLog = new RageFile;
 
-	if(!g_fileTimeLog->Open(TIME_PATH, RageFile::WRITE|RageFile::STREAMED))
+	if(m_bLogToDisk && !g_fileTimeLog->Open(TIME_PATH, RageFile::WRITE|RageFile::STREAMED))
 	{ fprintf(stderr, "Couldn't open %s: %s\n", TIME_PATH, g_fileTimeLog->GetError().c_str()); }
 
 	g_Mutex = new RageMutex( "Log" );
@@ -294,7 +294,7 @@ void RageLog::Write( int where, const RString &sLine )
 		 * and stdout. */
 		sStr.insert( 0, sTimestamp );
 
-		if(where & WRITE_TO_TIME)
+		if( m_bLogToDisk && (where & WRITE_TO_TIME))
 			g_fileTimeLog->PutLine(sStr);
 
 		AddToRecentLogs( sStr );

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -799,8 +799,8 @@ static void ApplyLogPreferences()
 {
 	LOG->SetShowLogOutput( PREFSMAN->m_bShowLogOutput );
 	LOG->SetLogToDisk( PREFSMAN->m_bLogToDisk );
-	LOG->SetInfoToDisk( true );
-	LOG->SetUserLogToDisk( true );
+	LOG->SetInfoToDisk( PREFSMAN->m_bLogToDisk );
+	LOG->SetUserLogToDisk( PREFSMAN->m_bLogToDisk );
 	LOG->SetFlushing( PREFSMAN->m_bForceLogFlush );
 	Checkpoints::LogCheckpoints( PREFSMAN->m_bLogCheckpoints );
 }


### PR DESCRIPTION
Following the topic of the issue #835, and having a surprise day-off, I am sending a small PR :)

This changes how the `LogToDisk` variable under `Preferences.ini` works. Without this PR, it can only disable writing to `log.txt`, but not to the other files.

Previous behaviour:
```
LogToDisk=1 -> log.txt info.txt timelog.txt userlog.txt are written into the disk
LogToDisk=0 -> info.txt timelog.txt and userlog.txt are written into the disk, but not log.txt
```

New behaviour:
```
LogToDisk=1 -> log.txt info.txt timelog.txt userlog.txt are written into the disk
LogToDisk=0 -> no .txt files are written by itgmania in the Logs directory
```