### PR TITLE
Update MovieTexture_FFMpeg Constructor (fixes D3D video banner crash)

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -111,13 +111,21 @@ RageSurface* RageMovieTextureDriver_FFMpeg::AVCodecCreateCompatibleSurface(int i
 }
 
 MovieDecoder_FFMpeg::MovieDecoder_FFMpeg()
+	: av_buffer_(nullptr),
+	av_io_context_(nullptr),
+	av_pixel_format_(avcodec::AV_PIX_FMT_NONE),
+	av_stream_codec_(nullptr),
+	av_sws_context_(nullptr),
+	av_format_context_(nullptr),
+	av_stream_(nullptr),
+	offset_(0),
+	next_offset_(0),
+	display_frame_num_(0),
+	cancel_(false),
+	looping_(false),
+	reset_(false),
+	end_of_movie_(false)
 {
-	FixLilEndian();
-
-	av_format_context_ = nullptr;
-	av_stream_ = nullptr;
-	total_frames_ = 0;
-	end_of_file_ = 0;
 	// Hardcoded frame buffer size of 50. Roughly translates to 100mb of ram.
 	for (int i = 0; i < 50; i++) {
 		frame_buffer_.emplace_back(std::make_unique<FrameHolder>());


### PR DESCRIPTION
# Summary

The issue is a heap corruption caused by initializing either `end_of_file_` or `total_frames_` in the constructor. This heap corruption only applies to the D3D renderer. 

A consistent repro is to enable the D3D renderer and scroll to Violet Pulse. As soon as you stop on the song, the game crashes.  If you inspect the resulting crash dump with WinDbg you can see it's a heap corruption.

# Changes

Changes here are:
1. Use an initialization list for member variables instead of initializing from within the function
2. Initialize member variables which weren't being initialized in the current code.
3. Remove the offending member variables (`end_of_file_`, `total_frames_`) from the constructor.
4. Remove the `FixLilEndian` call since it breaks D3D (it is no regression on OpenGL to remove that call, as far I've been able to find).

# Notes

I've also tested it with that 3.5GB Anime pack that really stresses out the game's video handling and have noticed no regressions anywhere. 

I tested this in conjunction with the small change in #860 .