### PR TITLE
Use mutexes to avoid race conditions on movie operations

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -250,6 +250,10 @@ int MovieDecoder_FFMpeg::DecodeFrame()
 }
 
 void MovieDecoder_FFMpeg::HandleReset() {
+    std::lock_guard<std::mutex> lock(reset_mutex_);
+	if (reset_ == false) {
+		return;
+	}
 	reset_ = false;
 
 	for (std::unique_ptr<FrameHolder>& frame : frame_buffer_) {
@@ -273,8 +277,11 @@ int MovieDecoder_FFMpeg::DecodeMovie()
 	// Never exit when the movie is looping. Otherwise exit when the last frame
 	// is added to the FrameBuffer.
 	while (looping_ || (!looping_ && display_frame_num_ < total_frames_)) {
-		if (reset_) {
-			HandleReset();
+		// Handle the reset flag (if necessary).
+		HandleReset();
+
+        if (IsCancelled()) {
+            return -2;
 		}
 
 		int status = DecodeFrame();
@@ -298,9 +305,6 @@ int MovieDecoder_FFMpeg::DecodeMovie()
 
 int MovieDecoder_FFMpeg::SendPacketToBuffer()
 {
-	if (cancel_) {
-		return -2;
-	}
 	if (end_of_file_ > 0) {
 		return 0;
 	}
@@ -325,10 +329,6 @@ int MovieDecoder_FFMpeg::SendPacketToBuffer()
 }
 
 int MovieDecoder_FFMpeg::DecodePacketToFrame() {
-	if (cancel_) {
-		return -2;
-	}
-
 	frame_buffer_position_ %= frame_buffer_.size();
 	packet_buffer_position_ %= total_frames_;
 	FrameHolder* frame = frame_buffer_[frame_buffer_position_].get();
@@ -340,10 +340,10 @@ int MovieDecoder_FFMpeg::DecodePacketToFrame() {
 		while (!frame->displayed) {
 			// Sleep so the CPU performance stays happy.
 			usleep(1000);  // 1ms
-			if (cancel_) {
+			if (IsCancelled()) {
 				return -2;
 			}
-			if (reset_) {
+			if (IsReset()) {
 				return 0;
 			}
 		}
@@ -636,8 +636,9 @@ void MovieDecoder_FFMpeg::Close()
 
 void MovieDecoder_FFMpeg::Rewind()
 {
-	display_frame_num_ = 0;
-	reset_ = true;
+  display_frame_num_ = 0;
+  std::lock_guard<std::mutex> lock(reset_mutex_);
+  reset_ = true;
 }
 
 void MovieDecoder_FFMpeg::Rollover()

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -79,7 +79,11 @@ public:
 
 	// Rewind sends the reset signal to DecodeMovie. See DecodeMovie
 	// and HandleReset for more information.
-	void Rewind();
+    void Rewind();
+    bool IsReset() {
+        std::lock_guard<std::mutex> lock(reset_mutex_);
+        return reset_;
+    }
 
 	// Like rewind, but handles the case that a looping video reached the end,
 	// and the next frame to display is the first one of the movie.
@@ -118,7 +122,15 @@ public:
 	float GetTimestamp() const;
 
 	// Cancel decoding.
-	void Cancel() { cancel_ = true; };
+    void Cancel() {
+        std::lock_guard<std::mutex> lock(cancel_mutex_);
+        cancel_ = true;
+    };
+
+	bool IsCancelled() {
+      std::lock_guard<std::mutex> lock(cancel_mutex_);
+      return cancel_;
+	}
 
 	// Called by the MovieTexture to tell the decoder if the movie loops.
 	void SetLooping(bool loop) { looping_ = loop; }
@@ -182,6 +194,9 @@ private:
 	bool looping_ = false;
 	bool reset_ = false;
 	bool end_of_movie_ = false;
+
+	std::mutex cancel_mutex_;
+    std::mutex reset_mutex_;
 };
 
 static struct AVPixelFormat_t

--- a/src/arch/MovieTexture/MovieTexture_Generic.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Generic.cpp
@@ -54,10 +54,9 @@ RString MovieTexture_Generic::Init()
 	decoding_thread_ = std::make_unique<std::thread>([this]() {
 		LOG->Trace("Beginning to decode video file \"%s\"", GetID().filename.c_str());
 		auto timer = RageTimer();
-
 		int ret = decoder_->DecodeMovie();
-		if (ret == -1) {
-			failure_ = true;
+		if (ret < 0) {
+			SetFailure();
 		}
 
 		LOG->Trace("Done decoding video file \"%s\", took %f seconds", GetID().filename.c_str(), timer.Ago());
@@ -310,7 +309,7 @@ float MovieTexture_Generic::CheckFrameTime()
 void MovieTexture_Generic::UpdateMovie(float seconds)
 {
 	// Quick exit in case we failed to decode the movie.
-	if (failure_) {
+	if (IsFailure()) {
 		return;
 	}
 	clock_ += seconds * rate_;

--- a/src/arch/MovieTexture/MovieTexture_Generic.h
+++ b/src/arch/MovieTexture/MovieTexture_Generic.h
@@ -4,6 +4,7 @@
 #include "MovieTexture.h"
 
 #include <cstdint>
+#include <mutex>
 #include <thread>
 
 class FFMpeg_Helper;
@@ -103,6 +104,14 @@ public:
 	virtual void UpdateMovie(float seconds);
 	virtual void SetPlaybackRate(float rate) { rate_ = rate; }
 	void SetLooping(bool looping = true) { loop_ = looping; }
+	bool IsFailure() {
+	  std::lock_guard<std::mutex> lock(failure_mutex_);
+	  return failure_;
+	}
+	void SetFailure() {
+	  std::lock_guard<std::mutex> lock(failure_mutex_);
+	  failure_ = true;
+	}
 	uintptr_t GetTexHandle() const;
 
 	static EffectMode GetEffectMode( MovieDecoderPixelFormatYCbCr fmt );
@@ -118,6 +127,7 @@ private:
 
 	// If true, halts all decoding and display.
 	bool failure_ = false;
+	std::mutex failure_mutex_;
 
 	uintptr_t texture_handle_;
 	std::unique_ptr<RageTextureRenderTarget> render_target_;


### PR DESCRIPTION
In https://github.com/itgmania/itgmania/pull/860 sukibaby@ was describing an issue with cancelling movies (via suddenly exiting the song wheel with the operator menu). While I was unable to reproduce the issue, I did notice some thread safety concerns with the `cancel_`, `reset_`, and `failure_` flags.

`cancel_` is set in the destructor, but read in the decoding thread. Likewise, `reset_` is read by the decoding thread, though set by a separate thread via the `Rewind()` call when scrolling to a video banner that was already loaded once. `failure_` is also set within the decoding thread, but read outside by the movie updating code.

Additionally, I've changed the `failure_` flag for the MovieTexture to trigger on the cancelled status as well, and moved the cancelled check to inside the main while loop.