### PR TITLE
set DisableUploadDir preference default value to 1

### DIFF
--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -263,7 +263,7 @@ PrefsManager::PrefsManager() :
 	m_iMaxHighScoresPerListForMachine	( "MaxHighScoresPerListForMachine",	10 ),
 	m_iMaxHighScoresPerListForPlayer	( "MaxHighScoresPerListForPlayer",	3 ),
 	m_bAllowMultipleHighScoreWithSameName	( "AllowMultipleHighScoreWithSameName",	true ),
-	m_DisableUploadDir("DisableUploadDir", false),
+	m_DisableUploadDir("DisableUploadDir", true),
 	m_bCelShadeModels		( "CelShadeModels",			false ),	// Work-In-Progress.. disable by default.
 	m_bPreferredSortUsesGroups	( "PreferredSortUsesGroups",		true ),
 	m_fDebounceCoinInputTime	( "DebounceCoinInputTime",		0 ),


### PR DESCRIPTION
Currently, the Preference `DisableUploadDir` has a default of `0`, hence after playing a song, an XML file is created under `Save/Upload` with information about the game.

The only code I could find handling this data is commented out:
https://github.com/itgmania/itgmania/blob/427484d1007c92c78753e86a39ed6399fed92f10/src/Profile.cpp#L48
https://github.com/itgmania/itgmania/blob/427484d1007c92c78753e86a39ed6399fed92f10/src/Profile.cpp#L2377

If I understood correctly, when `DisableUploadDir=0`, the files generated under `Save/Upload` are only useful for tools the players could have, but not for the game itself.

From @kyzentun comments [when the variable was added](https://github.com/itgmania/itgmania/blob/427484d1007c92c78753e86a39ed6399fed92f10/src/StatsManager.cpp#L248), this data might not be used for anything nowadays.

How would you see to change the default of this preference (`DisableUploadDir`) to `1`?
- Players who are not aware about these files will not miss them
- By default, `Save/Upload` will not keep growing with more files over time
- If anyone implemented code that uses these files, they will still be able to set the value to `0`