### PR TITLE
Use constexpr for MovieTexture_FFMpeg constants; replace a C-style cast with a static_cast

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -535,8 +535,9 @@ RString MovieDecoder_FFMpeg::Open(RString file)
 		return error;
 	}
 
-	av_buffer_ = (unsigned char*)avcodec::av_malloc(STEPMANIA_FFMPEG_BUFFER_SIZE);
-	av_io_context_ = avcodec::avio_alloc_context(av_buffer_, STEPMANIA_FFMPEG_BUFFER_SIZE, 0, f, AVIORageFile_ReadPacket, nullptr, AVIORageFile_Seek);
+	av_buffer_ = (unsigned char*)(avcodec::av_malloc(kFFMpegBufferSize));
+	av_io_context_ = avcodec::avio_alloc_context(av_buffer_, kFFMpegBufferSize, 0, f, AVIORageFile_ReadPacket, nullptr, AVIORageFile_Seek);
+
 	av_format_context_->pb = av_io_context_;
 	int ret = avcodec::avformat_open_input(&av_format_context_, file.c_str(), nullptr, nullptr);
 	if (ret < 0)

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -535,7 +535,7 @@ RString MovieDecoder_FFMpeg::Open(RString file)
 		return error;
 	}
 
-	av_buffer_ = (unsigned char*)(avcodec::av_malloc(kFFMpegBufferSize));
+	av_buffer_ = static_cast<unsigned char*>(avcodec::av_malloc(kFFMpegBufferSize));
 	av_io_context_ = avcodec::avio_alloc_context(av_buffer_, kFFMpegBufferSize, 0, f, AVIORageFile_ReadPacket, nullptr, AVIORageFile_Seek);
 
 	av_format_context_->pb = av_io_context_;

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -22,8 +22,8 @@ namespace avcodec
 	}
 };
 
-#define STEPMANIA_FFMPEG_BUFFER_SIZE 4096
-static const int kSwsFlags = SWS_BICUBIC; // XXX: Reasonable default?
+constexpr size_t kFFMpegBufferSize = 4096;
+constexpr int kSwsFlags = SWS_BICUBIC; // XXX: Reasonable default?
 
 struct FrameHolder {
 	avcodec::AVFrame* frame = avcodec::av_frame_alloc();


### PR DESCRIPTION
constexpr is preferred to static const for values known at compile time.

Sorry for the force push. Made a typo.