### PR TITLE
Update RefreshRate options to include modern gaming monitor rates

### DIFF
--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -649,7 +649,7 @@ static void MovieColorDepth( int &sel, bool ToSel, const ConfOption *pConfOption
 
 static void RefreshRate( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
-	const int mapping[] = { (int) REFRESH_DEFAULT,60,70,72,75,80,85,90,100,120,150 };
+	const int mapping[] = { (int) REFRESH_DEFAULT,60,75,85,100,120,144,165,180,240,360 };
 	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
 }
 
@@ -928,7 +928,7 @@ static void InitializeConfOptions()
 	ADD( ConfOption( "CelShadeModels",		MovePref<bool>,		"Off","On" ) );
 	ADD( ConfOption( "SmoothLines",			MovePref<bool>,		"Off","On" ) );
 	g_ConfOptions.back().m_iEffects = OPT_APPLY_GRAPHICS;
-	ADD( ConfOption( "RefreshRate",			RefreshRate,		"Default","|60","|70","|72","|75","|80","|85","|90","|100","|120","|150" ) );
+	ADD( ConfOption( "RefreshRate",			RefreshRate,		"Default","|60","|75","|85","|100","|120","|144","|165","|180","|240","|360" ) );
 	g_ConfOptions.back().m_iEffects = OPT_APPLY_GRAPHICS;
 	ADD( ConfOption( "Vsync",			MovePref<bool>,		"No", "Yes" ) );
 	g_ConfOptions.back().m_iEffects = OPT_APPLY_GRAPHICS;


### PR DESCRIPTION
Sorry about the git confusion (the old PR is: https://github.com/itgmania/itgmania/pull/872). Here is the PR ready for merge.

This pull request updates the refresh rate options in the ITGmania options menu to better reflect modern gaming monitor standards and improve the overall user experience—particularly in fullscreen mode. It replaces outdated settings, enhances compatibility, and helps reduce confusion around refresh rate selection.

The original list included values like 70, 72, and 150 Hz, which were relevant for older CRT monitors but are now largely unsupported or redundant on modern displays. Today's gaming monitors commonly support 144, 165, 180, 240, or even 360 Hz. Updating the list ensures ITGmania remains aligned with current hardware trends and meets the expectations of players using high-refresh-rate setups.

For a long time, I assumed borderless fullscreen with the default refresh rate was the only way to access higher refresh rates not included in the predefined list. However, many users experience stuttering in borderless fullscreen mode—especially on lower-end hardware. By including these modern refresh rates directly in the options menu, users can now explicitly select and force a specific rate in fullscreen mode, avoiding the limitations and performance issues of borderless fullscreen.

While it's technically possible to set a custom refresh rate via Preferences.ini, that method is both inconvenient and fragile—changes may not persist after adjusting other graphics settings. Adding these refresh rates to the options menu offers a user-friendly and permanent solution, eliminating the need to rely on "Default" or manual config edits.