### PR TITLE
DirectSound: keep the main buffer active.

### DIFF
--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -100,7 +100,7 @@ void DSound::SetPrimaryBufferMode()
 	 *
 	 * However, I just added the above code and I don't want to change more until it's tested.
 	 */
-//	pBuffer->Play( 0, 0, DSBPLAY_LOOPING );
+	pBuffer->Play( 0, 0, DSBPLAY_LOOPING );
 
 	pBuffer->Release();
 }


### PR DESCRIPTION
This was actually already considered in the surrounding code. I just had to uncomment it. This recommendation has remained consistent in the Microsoft documentation since this code was written. It's safe to uncomment it to ensure our main buffer stays active, since shutdown of the mixer engine is unwanted.