### PR TITLE
DSoundHelpers: move buffer size allocation into the initialization list

### DIFF
--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -184,7 +184,7 @@ DSoundBuf::DSoundBuf()
 	m_iExtraWriteahead(0),
 	m_bBufferLocked(false),
 	m_bPlaying(false),
-	m_iBufferSize(0),
+	m_iBufferSize(65536),
 	m_iChannels(0),
 	m_iLastPosition(0),
 	m_iSampleBits(0),

--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -209,6 +209,8 @@ RString DSoundBuf::Init( DSound &ds, DSoundBuf::hw hardware,
 	m_bPlaying = false;
 	memset( &(m_iLastCursors), 0, sizeof(m_iLastCursors) );
 
+	m_iBufferSize = std::max( m_iBufferSize, m_iWriteAhead );
+	
 	WAVEFORMATEX waveformat;
 	memset( &waveformat, 0, sizeof(waveformat) );
 	waveformat.cbSize = 0;

--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -191,11 +191,6 @@ RString DSoundBuf::Init( DSound &ds, DSoundBuf::hw hardware,
 	m_bPlaying = false;
 	ZERO( m_iLastCursors );
 
-	/* The size of the actual DSound buffer.  This can be large; we generally
-	 * won't fill it completely. */
-	m_iBufferSize = 1024*64;
-	m_iBufferSize = std::max( m_iBufferSize, m_iWriteAhead );
-
 	WAVEFORMATEX waveformat;
 	memset( &waveformat, 0, sizeof(waveformat) );
 	waveformat.cbSize = 0;


### PR DESCRIPTION
Directly allocating the minimum acceptable buffer size (65536) in the initialization list, rather than initializating to 0 and having `Init` resize it, without affecting the existing buffer resizing logic in `Init`.