### PR TITLE
DirectSound: dynamically calculate block alignment to ensure correctness with various bit depths

### DIFF
--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -70,7 +70,7 @@ void DSound::SetPrimaryBufferMode()
 		preferredSampleRate = kFallbackSampleRate;
 	}
 	waveformat.nSamplesPerSec = preferredSampleRate;
-	waveformat.nBlockAlign = 4;
+	waveformat.nBlockAlign = (waveformat.nChannels * waveformat.wBitsPerSample) / 8;
 	waveformat.nAvgBytesPerSec = waveformat.nSamplesPerSec * waveformat.nBlockAlign;
 
 	// Set the primary buffer's format


### PR DESCRIPTION
If the number of channels, or the bit depth, was different from 2 channels 16 bits, then this alignment may be incorrect.