### PR TITLE
DSoundHelpers: use `sizeof(DSBUFFERDESC)` rather than `sizeof(variable)`

### DIFF
--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -45,7 +45,7 @@ void DSound::SetPrimaryBufferMode()
 {
 	DSBUFFERDESC format;
 	memset( &format, 0, sizeof(format) );
-	format.dwSize = sizeof(format);
+	format.dwSize = sizeof(DSBUFFERDESC);
 	format.dwFlags = DSBCAPS_PRIMARYBUFFER;
 	format.dwBufferBytes = 0;
 	format.lpwfxFormat = nullptr;
@@ -219,7 +219,7 @@ RString DSoundBuf::Init( DSound &ds, DSoundBuf::hw hardware,
 	/* Try to create the secondary buffer */
 	DSBUFFERDESC format;
 	memset( &format, 0, sizeof(format) );
-	format.dwSize = sizeof(format);
+	format.dwSize = sizeof(DSBUFFERDESC);
 
 	if (IsWindowsVistaOrGreater())
 	{


### PR DESCRIPTION
Microsoft documentation and samples always use `sizeof(DSBUFFERDESC)`, not `sizeof(variable)`.

random example: https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ee416355(v=vs.85)