### PR TITLE
DSoundHelpers: directly call memset instead of using a RageUtil macro

### DIFF
--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -189,7 +189,7 @@ RString DSoundBuf::Init( DSound &ds, DSoundBuf::hw hardware,
 	m_iExtraWriteahead = 0;
 	m_iLastPosition = 0;
 	m_bPlaying = false;
-	ZERO( m_iLastCursors );
+	memset( &(m_iLastCursors), 0, sizeof(m_iLastCursors) );
 
 	/* The size of the actual DSound buffer.  This can be large; we generally
 	 * won't fill it completely. */


### PR DESCRIPTION
Inlines an instance of the `ZERO(x)` macro from `RageUtil.h`.

![image](https://github.com/user-attachments/assets/e367e595-91b2-4555-ab2a-8c7654db4355)
