### PR TITLE
GraphicsWindow: restore display mode before destroying window

### DIFF
--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -512,12 +512,6 @@ void GraphicsWindow::Shutdown()
 {
 	DestroyGraphicsWindow();
 
-	/* Return to the desktop resolution, if needed.
-	 * It'd be nice to not do this: Windows will do it when we quit, and if
-	 * we're shutting down OpenGL to try D3D, this will cause extra mode
-	 * switches. However, we need to do this before displaying dialogs. */
-	ChangeDisplaySettingsEx( g_CurrentParams.sDisplayId, nullptr, nullptr, 0, nullptr );
-
 	AppInstance inst;
 	UnregisterClass( g_sClassName, inst );
 }

--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -425,41 +425,38 @@ void GraphicsWindow::CreateGraphicsWindow( const VideoModeParams &p, bool bForce
 /** @brief Shut down the window, but don't reset the video mode. */
 void GraphicsWindow::DestroyGraphicsWindow()
 {
-	if( g_HDC != nullptr )
+	// If we were in fullscreen, release the display mode before destroying the window
+	if( g_hWndMain && !g_CurrentParams.windowed )
+	{
+		ChangeDisplaySettingsEx(g_CurrentParams.sDisplayId, nullptr, nullptr, 0, nullptr);
+	}
+
+	// Release and destroy the window and its resources.
+	if( g_HDC )
 	{
 		ReleaseDC( g_hWndMain, g_HDC );
 		g_HDC = nullptr;
 	}
 
-	CHECKPOINT;
-
-	if( g_hWndMain != nullptr )
+	if( g_hWndMain )
 	{
 		DestroyWindow( g_hWndMain );
 		g_hWndMain = nullptr;
 		CrashHandler::SetForegroundWindow( g_hWndMain );
 	}
 
-	CHECKPOINT;
-
-	if( g_hIcon != nullptr )
+	if( g_hIcon )
 	{
 		DestroyIcon( g_hIcon );
 		g_hIcon = nullptr;
 	}
 
-	CHECKPOINT;
-
 	MSG msg;
 	while( PeekMessage( &msg, nullptr, 0, 0, PM_NOREMOVE ) )
 	{
-		CHECKPOINT;
 		GetMessage( &msg, nullptr, 0, 0 );
-		CHECKPOINT;
 		DispatchMessage( &msg );
 	}
-
-	CHECKPOINT;
 }
 
 void GraphicsWindow::Initialize( bool bD3D )


### PR DESCRIPTION
On Windows, if fullscreen mode is used, there is an ugly display flicker when the game is quit as the OS tries to restore its display mode.  This is caused by destroying the window before resetting the video mode.

This change will properly reset the display mode for the monitor before destroying the window and its resources. This change ensures a smooth, flicker-free transition as the game is exited.

The `CHECKPOINT`s are not needed or wanted for normal operation, so they were removed.

The `!= nullptr` checks were removed from the global variable checks because the relevant Windows API functions are designed to safely handle `nullptr` arguments, so we can trust the OS to handle it correctly either way.