### PR TITLE
GraphicsWindow: follow MS documentation more closely for `SetScreenMode`

### DIFF
--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -15,6 +15,8 @@
 #include "DirectXHelpers.h"
 #include "PrefsManager.h"
 
+#include <windows.h>
+#include <string>
 #include <set>
 
 static const RString g_sClassName = PRODUCT_ID;
@@ -230,17 +232,25 @@ static void AdjustVideoModeParams( VideoModeParams &p )
  * The refresh setting may be ignored. */
 RString GraphicsWindow::SetScreenMode( const VideoModeParams &p )
 {
+	const DWORD displaySettingsFlag = p.windowed ? CDS_RESET : CDS_FULLSCREEN;
+
 	if( p.windowed )
 	{
-		// We're going windowed. If we were previously fullscreen, reset.
-		ChangeDisplaySettingsEx( p.sDisplayId, nullptr, nullptr, 0, nullptr );
-
+		ChangeDisplaySettingsEx( p.sDisplayId, nullptr, nullptr, displaySettingsFlag, nullptr );
 		return RString();
 	}
 
 	DEVMODE DevMode;
-	ZERO( DevMode );
+	ZeroMemory(&DevMode, sizeof(DEVMODE));
 	DevMode.dmSize = sizeof(DEVMODE);
+
+	// Run DevMode thru EnumDisplaySettings to ensure we only provide modes supported by the display driver.
+	if( !EnumDisplaySettings(p.sDisplayId.c_str(), ENUM_CURRENT_SETTINGS, &DevMode) )
+	{
+		LOG->Warn("EnumDisplaySettings failed for display: %s", p.sDisplayId.c_str());
+		return "Failed to retrieve current display settings.";
+	}
+
 	DevMode.dmPelsWidth = p.width;
 	DevMode.dmPelsHeight = p.height;
 	DevMode.dmBitsPerPel = p.bpp;
@@ -251,13 +261,12 @@ RString GraphicsWindow::SetScreenMode( const VideoModeParams &p )
 		DevMode.dmDisplayFrequency = p.rate;
 		DevMode.dmFields |= DM_DISPLAYFREQUENCY;
 	}
-	ChangeDisplaySettingsEx(p.sDisplayId, nullptr, nullptr, 0, nullptr);
 
-	int ret = ChangeDisplaySettingsEx( p.sDisplayId, &DevMode, nullptr, CDS_FULLSCREEN, nullptr );
+	int ret = ChangeDisplaySettingsEx( p.sDisplayId, &DevMode, nullptr, displaySettingsFlag, nullptr );
 	if( ret != DISP_CHANGE_SUCCESSFUL && (DevMode.dmFields & DM_DISPLAYFREQUENCY) )
 	{
 		DevMode.dmFields &= ~DM_DISPLAYFREQUENCY;
-		ret = ChangeDisplaySettingsEx( p.sDisplayId, &DevMode, nullptr, CDS_FULLSCREEN, nullptr );
+		ret = ChangeDisplaySettingsEx( p.sDisplayId, &DevMode, nullptr, displaySettingsFlag, nullptr );
 	}
 
 	// XXX: append error


### PR DESCRIPTION
Makes some adjustments to more closely follow the proper usage of ChangeDisplaySettingsEx (https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-changedisplaysettingsexa).

1. Use CDS_RESET when switching to windowed mode. It ensures the display settings are properly restored when switching to windowed mode. The existing code does not properly restore the display settings.

2. Store the desired display ChangeDisplaySettings value in a const DWORD so that logic avoids hardcoded values.

3. Validate our possible display modes with EnumDisplaySettings to ensure we have only valid values in DevMode.

4. Use ZeroMemory instead of a RageUtil macro to zero out DevMode.
