### PR TITLE
Generate signed build provenance attestations for nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,6 +10,9 @@ name: Nightly release
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -71,8 +74,13 @@ jobs:
       - name: Create nightly release
         run: ${{ matrix.release }}
       - name: Upload artifacts
+        id: upload
         uses: actions/upload-artifact@v4
         with:
           name: ITGmania-${{ github.sha }}-${{ matrix.name }}
           path: ${{ matrix.path }}
           compression-level: 0
+      - uses: actions/attest-build-provenance@v2
+          with:
+            subject-name: ITGmania-${{ github.sha }}-${{ matrix.name }}
+            subject-digest: sha256:${{ steps.upload.outputs.artifact-digest }}


### PR DESCRIPTION
Reference https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds & https://github.com/actions/attest-build-provenance?tab=readme-ov-file#integration-with-actionsupload-artifact

Example output on my fork - https://github.com/ScottBrenner/itgmania/attestations/7830792