### PR TITLE
WaveOut: Target a specific latency to ensure a consistent experience across different sample rates

### DIFF
--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -27,21 +27,15 @@ namespace {
 	// To achieve this, we use 512 frames per block and determine the number
 	// of blocks and buffer size in frames based on the sample rate.
 	constexpr int kTargetLatency = 118;
-	
-	// CHANNELS should be renamed CHANNELS
-	constexpr int CHANNELS = 2;
-	
-	// CHUNKSIZE_FRAMES should be renamed kBlockSizeFrames
-	constexpr int CHUNKSIZE_FRAMES = 512;
-	
-	// BYTES_PER_FRAME should be renamed kBytesPerFrame
-	constexpr int BYTES_PER_FRAME = CHANNELS * 2;  // 16 bit
+	constexpr int kChannels = 2;
+	constexpr int kBlockSizeFrames = 512;
+	constexpr int kBytesPerFrame = kChannels * 2;  // 16 bit
 
 	inline int CalculateNumBlocks( int sampleRate )
 	{
 		return (sampleRate * kTargetLatency +
-			(1000 * CHUNKSIZE_FRAMES - 1)) /
-			(1000 * CHUNKSIZE_FRAMES);
+			(1000 * kBlockSizeFrames - 1)) /
+			(1000 * kBlockSizeFrames);
 	}
 }  // namespace
 
@@ -69,42 +63,42 @@ void RageSoundDriver_WaveOut::MixerThread()
 	if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL) )
 		LOG->Warn( werr_ssprintf(GetLastError(), "Failed to set sound thread priority") );
 
-	while( !m_bShutdown )
+	while( !wo_shutdown_ )
 	{
 		while( GetData() )
 			;
 
-		WaitForSingleObject( m_hSoundEvent, 10 );
+		WaitForSingleObject( soundevent_handle_, 10 );
 	}
 
-	waveOutReset( m_hWaveOut );
+	waveOutReset( waveout_handle_ );
 }
 
 bool RageSoundDriver_WaveOut::GetData()
 {
 	/* Look for a free buffer. */
 	int b;
-	for( b = 0; b < NUM_CHUNKS; ++b )
-		if( m_aBuffers[b].dwFlags & WHDR_DONE )
+	for( b = 0; b < wo_num_blocks_; ++b )
+		if( wo_buffers_[b].dwFlags & WHDR_DONE )
 			break;
-	if( b == NUM_CHUNKS )
+	if( b == wo_num_blocks_ )
 		return false;
 
 	/* Call the callback. */
-	this->Mix( (int16_t *) m_aBuffers[b].lpData, CHUNKSIZE_FRAMES, m_iLastCursorPos, GetPosition() );
+	this->Mix( (int16_t *) wo_buffers_[b].lpData, kBlockSizeFrames, wo_last_cursor_position_, GetPosition() );
 
-	MMRESULT ret = waveOutWrite( m_hWaveOut, &m_aBuffers[b], sizeof(m_aBuffers[b]) );
+	MMRESULT ret = waveOutWrite( waveout_handle_, &wo_buffers_[b], sizeof(wo_buffers_[b]) );
 	if( ret != MMSYSERR_NOERROR )
 	{
 		Init();
-		if (b_InitSuccess == false)
+		if (wo_init_success_ == false)
 		{
 			FAIL_M(wo_ssprintf(ret, "waveOutWrite failed"));
 		}
 	}
 
-	/* Increment m_iLastCursorPos. */
-	m_iLastCursorPos += CHUNKSIZE_FRAMES;
+	/* Increment wo_last_cursor_position_. */
+	wo_last_cursor_position_ += kBlockSizeFrames;
 
 	return true;
 }
@@ -119,7 +113,7 @@ int64_t RageSoundDriver_WaveOut::GetPosition() const
 {
 	MMTIME tm;
 	tm.wType = TIME_SAMPLES;
-	MMRESULT ret = waveOutGetPosition( m_hWaveOut, &tm, sizeof(tm) );
+	MMRESULT ret = waveOutGetPosition( waveout_handle_, &tm, sizeof(tm) );
   	if( ret != MMSYSERR_NOERROR )
 		FAIL_M( wo_ssprintf(ret, "waveOutGetPosition failed") );
 
@@ -127,39 +121,39 @@ int64_t RageSoundDriver_WaveOut::GetPosition() const
 }
 
 RageSoundDriver_WaveOut::RageSoundDriver_WaveOut()
-    : m_hWaveOut(nullptr)
-    , m_hSoundEvent(CreateEvent(nullptr, false, true, nullptr))
-    , m_iLastCursorPos(0)
-    , m_iSampleRate(0)
-    , m_bShutdown(false)
-    , b_InitSuccess(false)
-    , NUM_CHUNKS(1)
-    , BUFFERSIZE_FRAMES(0)
-    , CHUNKSIZE(0)
-    , m_aBuffers{}
-    , MixingThread()
+	: MixingThread()
+	, waveout_handle_(nullptr)
+	, soundevent_handle_(CreateEvent(nullptr, false, true, nullptr))
+	, wo_buffers_{}
+	, wo_samplerate_(0)
+	, wo_shutdown_(false)
+	, wo_last_cursor_position_(0)
+	, wo_init_success_(false)
+	, wo_frames_per_block_(0)
+	, wo_num_blocks_(1)
+	, wo_blocksize_(0)
 {
 }
 
 RString RageSoundDriver_WaveOut::Init()
 {
-	b_InitSuccess = false;
-	m_iSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
-	if( m_iSampleRate == 0 )
+	wo_init_success_ = false;
+	wo_samplerate_ = PREFSMAN->m_iSoundPreferredSampleRate;
+	if( wo_samplerate_ == 0 )
 	{
-		m_iSampleRate = kFallbackSampleRate;
+		wo_samplerate_ = kFallbackSampleRate;
 	}
 
-	NUM_CHUNKS = CalculateNumBlocks( m_iSampleRate );
-	BUFFERSIZE_FRAMES = CHUNKSIZE_FRAMES * NUM_CHUNKS;
-	CHUNKSIZE = CHUNKSIZE_FRAMES * BYTES_PER_FRAME;
+	wo_num_blocks_ = CalculateNumBlocks( wo_samplerate_ );
+
+	wo_frames_per_block_ = kBlockSizeFrames * wo_num_blocks_;
+	wo_blocksize_ = kBlockSizeFrames * kBytesPerFrame;
 
 	WAVEFORMATEX fmt;
 	fmt.wFormatTag = WAVE_FORMAT_PCM;
-	fmt.nChannels = CHANNELS;
+	fmt.nChannels = kChannels;
 	fmt.cbSize = 0;
-	fmt.nSamplesPerSec = m_iSampleRate;
-	fmt.wBitsPerSample = 16;
+	fmt.nSamplesPerSec = wo_samplerate_;
 	fmt.nBlockAlign = fmt.nChannels * fmt.wBitsPerSample / 8;
 	fmt.nAvgBytesPerSec = fmt.nSamplesPerSec * fmt.nBlockAlign;
 
@@ -178,7 +172,7 @@ RString RageSoundDriver_WaveOut::Init()
 
 	MMRESULT ret = MMSYSERR_ERROR;
 	for (UINT id : deviceIds) {
-		ret = waveOutOpen( &m_hWaveOut, id, &fmt, (DWORD_PTR) m_hSoundEvent, NULL, CALLBACK_EVENT );
+		ret = waveOutOpen( &waveout_handle_, id, &fmt, (DWORD_PTR) soundevent_handle_, NULL, CALLBACK_EVENT );
 		if (ret == MMSYSERR_NOERROR) {
 			break;
 		}
@@ -188,28 +182,28 @@ RString RageSoundDriver_WaveOut::Init()
 	}
 
 
-	ZERO( m_aBuffers );
-	for(int b = 0; b < NUM_CHUNKS; ++b)
+	ZERO( wo_buffers_ );
+	for(int b = 0; b < wo_num_blocks_; ++b)
 	{
-		m_aBuffers[b].dwBufferLength = CHUNKSIZE;
-		m_aBuffers[b].lpData = new char[CHUNKSIZE];
-		ret = waveOutPrepareHeader( m_hWaveOut, &m_aBuffers[b], sizeof(m_aBuffers[b]) );
+		wo_buffers_[b].dwBufferLength = wo_blocksize_;
+		wo_buffers_[b].lpData = new char[wo_blocksize_];
+		ret = waveOutPrepareHeader( waveout_handle_, &wo_buffers_[b], sizeof(wo_buffers_[b]) );
 		if( ret != MMSYSERR_NOERROR )
 			return wo_ssprintf( ret, "waveOutPrepareHeader failed" );
-		m_aBuffers[b].dwFlags |= WHDR_DONE;
+		wo_buffers_[b].dwFlags |= WHDR_DONE;
 	}
 
-	LOG->Info( "WaveOut software mixing at %i hz", m_iSampleRate );
+	LOG->Info( "WaveOut software mixing at %i hz", wo_samplerate_ );
 
 	/* We have a very large writeahead; make sure we have a large enough decode
 	 * buffer to recover cleanly from underruns. */
-	SetDecodeBufferSize( BUFFERSIZE_FRAMES * 3/2 );
+	SetDecodeBufferSize( wo_frames_per_block_ * 3/2 );
 	StartDecodeThread();
 
 	MixingThread.SetName( "Mixer thread" );
 	MixingThread.Create( MixerThread_start, this );
 
-	b_InitSuccess = true;
+	wo_init_success_ = true;
 	return RString();
 }
 
@@ -218,32 +212,32 @@ RageSoundDriver_WaveOut::~RageSoundDriver_WaveOut()
 	/* Signal the mixing thread to quit. */
 	if( MixingThread.IsCreated() )
 	{
-		m_bShutdown = true;
-		SetEvent( m_hSoundEvent );
+		wo_shutdown_ = true;
+		SetEvent( soundevent_handle_ );
 		LOG->Trace( "Shutting down mixer thread ..." );
 		MixingThread.Wait();
 		LOG->Trace( "Mixer thread shut down." );
 	}
 
-	if( m_hWaveOut != nullptr )
+	if( waveout_handle_ != nullptr )
 	{
-		for( int b = 0; b < NUM_CHUNKS && m_aBuffers[b].lpData != nullptr; ++b )
+		for( int b = 0; b < wo_num_blocks_ && wo_buffers_[b].lpData != nullptr; ++b )
 		{
-			waveOutUnprepareHeader( m_hWaveOut, &m_aBuffers[b], sizeof(m_aBuffers[b]) );
-			delete [] m_aBuffers[b].lpData;
+			waveOutUnprepareHeader( waveout_handle_, &wo_buffers_[b], sizeof(wo_buffers_[b]) );
+			delete [] wo_buffers_[b].lpData;
 		}
 
-		waveOutClose( m_hWaveOut );
+		waveOutClose( waveout_handle_ );
 	}
 
-	CloseHandle( m_hSoundEvent );
+	CloseHandle( soundevent_handle_ );
 }
 
 float RageSoundDriver_WaveOut::GetPlayLatency() const
 {
 	/* If we have a 1000-byte buffer, and we fill 100 bytes at a time, we
 	 * almost always have between 900 and 1000 bytes filled; on average, 950. */
-	return (BUFFERSIZE_FRAMES - CHUNKSIZE_FRAMES/2) * (1.0f / m_iSampleRate);
+	return (wo_frames_per_block_ - kBlockSizeFrames/2) * (1.0f / wo_samplerate_);
 }
 
 /*

--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -154,6 +154,7 @@ RString RageSoundDriver_WaveOut::Init()
 	fmt.nChannels = kChannels;
 	fmt.cbSize = 0;
 	fmt.nSamplesPerSec = wo_samplerate_;
+	fmt.wBitsPerSample = 8 * (kBytesPerFrame / kChannels);
 	fmt.nBlockAlign = fmt.nChannels * fmt.wBitsPerSample / 8;
 	fmt.nAvgBytesPerSec = fmt.nSamplesPerSec * fmt.nBlockAlign;
 

--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -146,6 +146,13 @@ RString RageSoundDriver_WaveOut::Init()
 
 	wo_num_blocks_ = CalculateNumBlocks( wo_samplerate_ );
 
+	// Clamp wo_num_blocks_ to the range of kMaximumNumBlocks.
+	if (wo_num_blocks_ < 1 || wo_num_blocks_ > kMaximumNumBlocks)
+	{
+		LOG->Warn("RageSoundDriver_WaveOut: wo_num_blocks_ out of range (%d); clamping", wo_num_blocks_);
+		wo_num_blocks_ = std::clamp(wo_num_blocks_, 1, kMaximumNumBlocks);
+	}
+
 	wo_frames_per_block_ = kBlockSizeFrames * wo_num_blocks_;
 	wo_blocksize_ = kBlockSizeFrames * kBytesPerFrame;
 

--- a/src/arch/Sound/RageSoundDriver_WaveOut.h
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.h
@@ -18,7 +18,6 @@ public:
 	int64_t GetPosition() const;
 	float GetPlayLatency() const;
 	int GetSampleRate() const { return m_iSampleRate; }
-	static const int NUM_BUFFERS = 32;
 private:
 	static int MixerThread_start( void *p );
 	void MixerThread();
@@ -28,11 +27,14 @@ private:
 
 	HWAVEOUT m_hWaveOut;
 	HANDLE m_hSoundEvent;
-	WAVEHDR m_aBuffers[NUM_BUFFERS];
+	WAVEHDR m_aBuffers[32]; // Maximum of 32 output blocks (frame blocks) allowed.
 	int m_iSampleRate;
 	bool m_bShutdown;
 	int m_iLastCursorPos;
 	bool b_InitSuccess;
+	int NUM_CHUNKS; // TODO rename wo_num_blocks
+	int BUFFERSIZE_FRAMES; // TODO rename wo_num_frames_per_block
+	int CHUNKSIZE; // TODO rename wo_block_size
 };
 
 #endif

--- a/src/arch/Sound/RageSoundDriver_WaveOut.h
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.h
@@ -12,12 +12,19 @@
 class RageSoundDriver_WaveOut: public RageSoundDriver
 {
 public:
+	// The size of wo_buffers_ is the -maximum- number of blocks we can have.
+	// We have to pre-allocate this size here. With the default target latency
+	// of 118 ms, 13 buffers is sufficient for both 44100 and 48000 Hz sample
+	// rates, but at least 20 buffers are needed if higher sample rates (such
+	// as 96000 Hz) are used, or the game will crash during initialization.
+	static const int kMaximumNumBlocks = 32;
+
 	RageSoundDriver_WaveOut();
 	~RageSoundDriver_WaveOut();
 	RString Init();
 	int64_t GetPosition() const;
 	float GetPlayLatency() const;
-	int GetSampleRate() const { return m_iSampleRate; }
+	int GetSampleRate() const { return wo_samplerate_; }
 private:
 	static int MixerThread_start( void *p );
 	void MixerThread();
@@ -25,16 +32,16 @@ private:
 	bool GetData();
 	void SetupDecodingThread();
 
-	HWAVEOUT m_hWaveOut;
-	HANDLE m_hSoundEvent;
-	WAVEHDR m_aBuffers[32]; // Maximum of 32 output blocks (frame blocks) allowed.
-	int m_iSampleRate;
-	bool m_bShutdown;
-	int m_iLastCursorPos;
-	bool b_InitSuccess;
-	int NUM_CHUNKS; // TODO rename wo_num_blocks
-	int BUFFERSIZE_FRAMES; // TODO rename wo_num_frames_per_block
-	int CHUNKSIZE; // TODO rename wo_block_size
+	HWAVEOUT waveout_handle_;
+	HANDLE soundevent_handle_;
+	WAVEHDR wo_buffers_[kMaximumNumBlocks];
+	int wo_samplerate_;
+	bool wo_shutdown_;
+	int wo_last_cursor_position_;
+	bool wo_init_success_;
+	int wo_frames_per_block_;
+	int wo_num_blocks_;
+	int wo_blocksize_;
 };
 
 #endif


### PR DESCRIPTION
## Summary

With WaveOut, typically one defines the following values before starting a WaveOut thread:
- sample rate
- number of blocks
- size of each block, in frames

Based on these values, a particular latency will be calculated. StepMania historically follows this approach.

However, it is possible to target a specific latency instead, and extrapolate the needed number of blocks if the sample rate and block size values are known.

This PR refactors the driver to calculate the ideal number of blocks **based on a pre-determined optimal target latency and block size**. This allows us to guarantee a **nearly-imperceptible** difference in WaveOut latency (0.29 ms) between 44.1 kHz and 48 kHz.

## Theory

I've chosen an ideal value which was calculated to provide the smallest possible delta value (0.29 ms) between actual latency at both 44100 and 48000 Hz.

By comparison, there is a very significant delta in WaveOut latency between 44100 and 48000 Hz with the values leftover from SM5 or the current values. This difference would directly impact the player's global offset.

Further elaboration, proofs, and references are below:
<details>
<summary>Click to expand</summary>

When we consider how the WaveOut API works, we need to provide three of four values and the fourth is calculated. So, at 44100 Hz, with 15 blocks of 256 frames each, 15 * 256 gives us 3840 frames of latency (3840 / 44100 = ~87 ms). If we use this same configuration with 48000 Hz, we get a latency of 80ms which is a significant difference.

However, if we increase to 16 blocks at 48000 Hz, we get 4096 frames of latency (~85 ms), which is much closer to the 87 ms when using 15 blocks at 44100 Hz.

A target latency of 118 ms allows for the smallest possible delta when using a block size of 512 frames, and testing with sample rates of 44100 and 48000. At 44100 Hz / 512 frames / 118 ms target latency, we have a calculated latency of 127.7098 ms. At 48000 Hz / 512 frames/ 118 ms target latency, we have a calculated latency of 128 ms - a 0.29 ms difference.

I determined this by simulating the `CalculteNumBufferChunks` calculation for a range of 100 to 300.

For reference, here is the code from StepMania 5 / older ITGMania (pulled from v0.7.0):

```
const int channels = 2;
const int bytes_per_frame = channels*2;		/* 16-bit */
const int buffersize_frames = 1024*8;	/* in frames */
const int buffersize = buffersize_frames * bytes_per_frame; /* in bytes */

const int num_chunks = 8;
const int chunksize_frames = buffersize_frames / num_chunks;
const int chunksize = buffersize / num_chunks; /* in bytes */
```

</details>

## No functional changes

Nothing related to driver functionality is changed. We just change the way the buffer parameters are determined. This PR only changes code which runs before the WaveOut thread is launched.

Some stylistic changes are present in this PR due to the renaming of some incorrectly styled variables and the necessity of moving some variables to the header file.