### PR TITLE
WaveOut: move error logging out of the mixer thread

### DIFF
--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -44,6 +44,10 @@ static RString wo_ssprintf( MMRESULT err, const char *szFmt, ...)
 
 void RageSoundDriver_WaveOut::LogMixerThreadError()
 {
+	const char* errorMessage =
+		"WaveOut thread is running in a console window!\n"
+		"This may cause issues with sound playback, and the game\n"
+		"will crash if the console window is interrupted.\n";
 
 	switch (m_ThreadError)
 	{
@@ -51,6 +55,7 @@ void RageSoundDriver_WaveOut::LogMixerThreadError()
 		LOG->Warn( werr_ssprintf(GetLastError(), "Failed to set sound thread priority") );
 		break;
 	case WaveOutMixerThreadError::ConsoleWindowWarning:
+		LOG->Warn(errorMessage);
 		break;
 	default:
 		break;
@@ -71,6 +76,9 @@ void RageSoundDriver_WaveOut::MixerThread()
 		m_ThreadError = WaveOutMixerThreadError::SetPriorityFailed;
 	}
 
+	if( GetConsoleWindow() != NULL ) {
+		m_ThreadError = WaveOutMixerThreadError::ConsoleWindowWarning;
+	}
 
 	if( m_ThreadError != WaveOutMixerThreadError::None )
 	{

--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -42,6 +42,21 @@ static RString wo_ssprintf( MMRESULT err, const char *szFmt, ...)
 	return s += ssprintf( "(%s)", szBuf );
 }
 
+void RageSoundDriver_WaveOut::LogMixerThreadError()
+{
+
+	switch (m_ThreadError)
+	{
+	case WaveOutMixerThreadError::SetPriorityFailed:
+		LOG->Warn( werr_ssprintf(GetLastError(), "Failed to set sound thread priority") );
+		break;
+	case WaveOutMixerThreadError::ConsoleWindowWarning:
+		break;
+	default:
+		break;
+	}
+}
+
 int RageSoundDriver_WaveOut::MixerThread_start( void *p )
 {
 	((RageSoundDriver_WaveOut *) p)->MixerThread();
@@ -50,9 +65,18 @@ int RageSoundDriver_WaveOut::MixerThread_start( void *p )
 
 void RageSoundDriver_WaveOut::MixerThread()
 {
-	if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL) )
-		LOG->Warn( werr_ssprintf(GetLastError(), "Failed to set sound thread priority") );
+	m_ThreadError = WaveOutMixerThreadError::None;
 
+	if( !SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL) ) {
+		m_ThreadError = WaveOutMixerThreadError::SetPriorityFailed;
+	}
+
+
+	if( m_ThreadError != WaveOutMixerThreadError::None )
+	{
+		LogMixerThreadError();
+	}
+	
 	while( !m_bShutdown )
 	{
 		while( GetData() )

--- a/src/arch/Sound/RageSoundDriver_WaveOut.h
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.h
@@ -9,6 +9,15 @@
 #include <windows.h>
 #include <mmsystem.h>
 
+enum class WaveOutMixerThreadError {
+	None,
+	SetPriorityFailed,
+	ConsoleWindowWarning,
+	Unknown
+};
+
+WaveOutMixerThreadError m_ThreadError;
+
 class RageSoundDriver_WaveOut: public RageSoundDriver
 {
 public:
@@ -18,6 +27,7 @@ public:
 	int64_t GetPosition() const;
 	float GetPlayLatency() const;
 	int GetSampleRate() const { return m_iSampleRate; }
+	void LogMixerThreadError();
 	static const int NUM_BUFFERS = 32;
 private:
 	static int MixerThread_start( void *p );


### PR DESCRIPTION
The purpose of this commit is to move logging calls out of the mixing thread itself. Looks like I have merge conflicts, so I will rebase the beta onto this later and re-open then.