### PR TITLE
Group: explicitly use the default destructor

### DIFF
--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -36,11 +36,6 @@ Group::Group() {
     m_sBannerPath = "";
 }
 
-Group::~Group() 
-{
-
-}
-
 Group::Group(const RString& sDir, const RString& sGroupDirName, bool bFromProfile) {
     if (sDir.empty() || sGroupDirName.empty()) {
         LOG->Warn("Group::Group: Empty directory or group name provided.");

--- a/src/Group.h
+++ b/src/Group.h
@@ -20,7 +20,7 @@ class Group
 public:
 	Group();
     Group( const RString& sDir, const RString& sGroupDirName, bool bFromProfile = false);
-    ~Group();
+    ~Group() = default;
     // Lua
 	void PushSelf( lua_State *L );
 


### PR DESCRIPTION
This makes it more obvious that the default destructor is what we're using, instead of making it look like maybe there was supposed to be a destructor here.