### PR TITLE
Automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,9 @@ on:
   push:
     branches:
       - beta
-    paths-ignore:
-      - '**.md'
+      - release
 
-name: Nightly release
+name: Release
 
 jobs:
   build:
@@ -22,33 +21,33 @@ jobs:
             name: Ubuntu (x86_64)
             install: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
-            release: |
-              cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
-              cmake --build build --target package
-            path: build/ITGmania-*-NIGHTLY-git-*-Linux-no-songs.tar.gz
+            release-nightly: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
+            release-full: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DWITH_NIGHTLY_RELEASE=Off -DWITH_CLUB_FANTASTIC=Off
+            package: cmake --build build --target package
+            path: build/ITGmania-*.tar.gz
           - os: ubuntu-24.04-arm
             name: Ubuntu (ARM)
             install: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
-            release: |
-              cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
-              cmake --build build --target package
-            path: build/ITGmania-*-NIGHTLY-git-*-Linux-arm64-no-songs.tar.gz
+            release-nightly: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
+            release-full: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DWITH_NIGHTLY_RELEASE=Off -DWITH_CLUB_FANTASTIC=Off
+            package: cmake --build build --target package
+            path: build/ITGmania-*.tar.gz
           - os: macos-latest
             name: macOS (M1)
             install: brew install nasm
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
-            release: |
-              cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_CLUB_FANTASTIC=Off
-              cmake --build build --target package
-            path: build/ITGmania-*-NIGHTLY-git-*-macOS-M1-no-songs.dmg
+            release-nightly: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_CLUB_FANTASTIC=Off
+            release-full: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DWITH_NIGHTLY_RELEASE=Off -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_CLUB_FANTASTIC=Off
+            package: cmake --build build --target package
+            path: build/ITGmania-*.dmg
           - os: windows-latest
             name: Windows
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
-            release: |
-              cmake -B build -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
-              cmake --build build --config Release --target package
-            path: build/ITGmania-*-NIGHTLY-git-*-Windows-no-songs.exe
+            release-nightly: cmake -B build -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
+            release-full: cmake -B build -DWITH_FULL_RELEASE=On -DWITH_NIGHTLY_RELEASE=Off -DWITH_CLUB_FANTASTIC=Off
+            package: cmake --build build --config Release --target package
+            path: build/ITGmania-*.exe
     name: ${{ matrix.name }}
     steps:
       - uses: actions/checkout@v4
@@ -60,9 +59,9 @@ jobs:
           path: |
             build/*
             !${{ matrix.path }}
-          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-nightly-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ github.ref_name }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-cmake-build-nightly-
+            ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ github.ref_name }}-
       - name: Install dependencies
         if: matrix.os != 'windows-latest'
         run: ${{ matrix.install }}
@@ -72,7 +71,15 @@ jobs:
         with:
           msbuild-architecture: x64
       - name: Create nightly release
-        run: ${{ matrix.release }}
+        if: github.ref_name == 'beta'
+        run: ${{ matrix.release-nightly }}
+      - name: Create full release
+        if: github.ref_name == 'release'
+        run: ${{ matrix.release-full }}
+      - name: Create package
+        id: package
+        run: |
+          ${{ matrix.package }}
       - name: Upload artifacts
         id: upload
         uses: actions/upload-artifact@v4

--- a/Build/README.md
+++ b/Build/README.md
@@ -3,7 +3,7 @@
 Most users will find everything they need in this README. There are differences in the build process for ITGmania as compared to Stepmania, so it is recommended to stick with these ITGmania instructions. For anything not covered in this guide, you can usually refer to the original Stepmania documents [here](https://github.com/stepmania/stepmania/wiki/Compiling-StepMania), as long as you replace references to Stepmania with ITGmania.
 
 ## Continuous Integration
-Pushes and pull requests to the `beta` branch of the repository are built with a [GitHub Actions workflow](https://github.com/itgmania/itgmania/actions/workflows/nightly.yml), in which "nightly releases" are compiled for a matrix of operating systems and architectures.
+Pushes to the `beta` branch of the repository are built with a [GitHub Actions workflow](https://github.com/itgmania/itgmania/actions/workflows/release.yml), in which "nightly releases" are compiled for a matrix of operating systems and architectures. Full releases are built on pushses to the `release` branch.
 
 By default, GitHub stores build artifacts for 90 days. People who are signed into GitHub and have read access to a repository can download workflow artifacts. They can be downloaded from the Artifacts section of the Summary page on an execution of the workflow.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ITGmania
 
 ITGmania is a fork of [StepMania 5.1](https://github.com/stepmania/stepmania/tree/5_1-new), an advanced cross-platform rhythm game for home and arcade use.
 
-[![Continuous integration](https://github.com/itgmania/itgmania/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/itgmania/itgmania/actions/workflows/ci.yml) [![Nightly release](https://github.com/itgmania/itgmania/actions/workflows/nightly.yml/badge.svg?branch=beta&event=push)](https://github.com/itgmania/itgmania/actions/workflows/nightly.yml?query=branch%3Abeta+event%3Apush)
+[![Continuous integration](https://github.com/itgmania/itgmania/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/itgmania/itgmania/actions/workflows/ci.yml) [![Nightly release](https://github.com/itgmania/itgmania/actions/workflows/release.yml/badge.svg?branch=beta&event=push)](https://github.com/itgmania/itgmania/actions/workflows/release.yml?query=branch%3Abeta+event%3Apush)
 
 ## Changes to StepMania 5.1
 


### PR DESCRIPTION
Extending the 'nightly release' workflow to conditionally create a 'full release' on pushes to the `release` branch-

1. Pushes to the `beta` branch still create the 'nightly release' as before, unchanged
2. Pushes to the `release` branch will now create a 'full release', _without Club Fantastic_*

To do this I added a 'release' parameter to the matrix and conditionally added a step for it depending on the branch that calls the workflow.

As proposed, two things are missing-

1. macOS _(Intel)_ builds are still not included, due to failures & findings in https://github.com/itgmania/itgmania/pull/819
2. *The workflow does not create builds with Club Fantastic. It can, but as they are built on the same runner as builds without, they get combined into a single artifact - I'm not sure how to split these into separate artifacts

Examples on my fork-
`beta` https://github.com/ScottBrenner/itgmania/actions/runs/15792301634
`release` https://github.com/ScottBrenner/itgmania/actions/runs/15792311656
