### PR TITLE
ci.yml: use windows-2025 instead of windows-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13, windows-2025]
         include:
           - os: ubuntu-latest
             name: Ubuntu (x86_64)
@@ -34,7 +34,7 @@ jobs:
             install: brew install nasm
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
             build: cmake --build build --parallel "$(sysctl -n hw.logicalcpu)"
-          - os: windows-latest
+          - os: windows-2025
             name: Windows
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
             build: cmake --build build --parallel "$env:NUMBER_OF_PROCESSORS"
@@ -52,10 +52,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-cmake-build-ci-
       - name: Install dependencies
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-2025'
         run: ${{ matrix.install }}
       - name: Add msbuild to PATH
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2025'
         uses: microsoft/setup-msbuild@v2
         with:
           msbuild-architecture: x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13, windows-2025]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13, windows-2022]
         include:
           - os: ubuntu-latest
             name: Ubuntu (x86_64)
@@ -34,7 +34,7 @@ jobs:
             install: brew install nasm
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
             build: cmake --build build --parallel "$(sysctl -n hw.logicalcpu)"
-          - os: windows-2025
+          - os: windows-2022
             name: Windows
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
             build: cmake --build build --parallel "$env:NUMBER_OF_PROCESSORS"
@@ -52,10 +52,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-cmake-build-ci-
       - name: Install dependencies
-        if: matrix.os != 'windows-2025'
+        if: matrix.os != 'windows-2022'
         run: ${{ matrix.install }}
       - name: Add msbuild to PATH
-        if: matrix.os == 'windows-2025'
+        if: matrix.os == 'windows-2022'
         uses: microsoft/setup-msbuild@v2
         with:
           msbuild-architecture: x64


### PR DESCRIPTION
As a stopgap measure to resolve CI failures happening at the moment following a Visual Studio 2022 update.

https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources