### PR TITLE
Temporarily disable CMake build caching in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Cache CMake build directory
-        uses: actions/cache@v4
-        with:
-          path: |
-            build
-          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-ci-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-cmake-build-ci-
+     ### TEMPORARY FIX:  Disable cmake cache until it expires so that windows builds work for the time being
+     # - name: Cache CMake build directory
+     #   uses: actions/cache@v4
+     #   with:
+     #     path: |
+     #       build
+     #     key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-ci-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+     #     restore-keys: |
+     #       ${{ runner.os }}-${{ runner.arch }}-cmake-build-ci-
       - name: Install dependencies
         if: matrix.os != 'windows-latest'
         run: ${{ matrix.install }}


### PR DESCRIPTION
This is to resolve failures in Windows CI following a VS2022 update