### PR TITLE
ReloadFromSongDir: fix error in Group offset application logic

### DIFF
--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -519,7 +519,7 @@ bool Song::ReloadFromSongDir( RString sDir )
 		}
 		else
 		{
-			m_SongTiming.m_fBeat0GroupOffsetInSeconds = PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL ? 0 : -0.009;
+			mNewSteps[id]->m_Timing.m_fBeat0GroupOffsetInSeconds = PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL ? 0 : -0.009;
 			LOG->Warn("Song %s has no group, using default sync offset.", m_sMainTitle.c_str());
 		}
 	}


### PR DESCRIPTION
# Description

When the group can't be found, `m_SongTiming` is updated instead of `mNewSteps[id]->m_Timing`. This seems to be an unintentional error, because the non-failure case and surrounding code properly reference `mNewSteps[id]->m_Timing`.

# Context

I was trying to figure out why #816 "Hash-based ReloadFromSongDir" resolved this rare bug that offsets songs improperly when the song does not have a group.

I found this error when doing a closer inspection of ReloadFromSongDir.

Additional evidence that this may have been an unintentional error is that the affected code is nearly identical to the code referenced above on lines 493 thru 497, where `m_SongTiming` is used.