### PR TITLE
MovieTexture: make `total_frames_` atomic, and implement a mutex for protecting member variables which track decoder status

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -275,6 +275,10 @@ int MovieDecoder_FFMpeg::DecodeMovie()
 	// Never exit when the movie is looping. Otherwise exit when the last frame
 	// is added to the FrameBuffer.
 	while (looping_ || (!looping_ && display_frame_num_ < total_frames_)) {
+		if (cancel_) {
+			return -2;
+		}
+    
 		if (reset_) {
 			HandleReset();
 		}

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <thread>
+#include <atomic>
 
 static void FixLilEndian()
 {
@@ -197,7 +198,8 @@ bool MovieDecoder_FFMpeg::IsCurrentFrameReady() {
 	// opposites. If the frame hasn't been displayed, it's ready. If it has
 	// been displayed, then it hasn't been overwritten and reset yet.
 	if (frame->displayed) {
-		LOG->Info("Frame %zu not decoded, total frames: %zu", display_frame_num_, total_frames_);
+		const size_t frames = total_frames_.load();
+		LOG->Info("Frame %zu not decoded, total frames: %zu", display_frame_num_, frames);
 	}
 	return !frame->displayed;
 }
@@ -289,7 +291,7 @@ int MovieDecoder_FFMpeg::DecodeMovie()
 		// there actually are. Increment to keep up so we don't end the video
 		// early during display.
 		if (packet_buffer_position_ >= total_frames_ - 1 && !end_of_file_) {
-			total_frames_++;
+			std::atomic_fetch_add(&total_frames_, 1);
 		}
 	}
 
@@ -567,10 +569,11 @@ RString MovieDecoder_FFMpeg::Open(RString file)
 	LOG->Trace("Bitrate: %i", static_cast<int>(av_stream_codec_->bit_rate));
 	LOG->Trace("Codec pixel format: %s", avcodec::av_get_pix_fmt_name(av_stream_codec_->pix_fmt));
 	total_frames_ = av_stream_->nb_frames;
+	size_t frame_count = total_frames_.load();
 
 	// Sometimes we might not get a correct frame count.
 	// In that case, approximate and fix it later.
-	if (total_frames_ <= 0) {
+	if (frame_count <= 0) {
 		total_frames_ = av_format_context_->duration // microseconds
 			* (av_stream_->avg_frame_rate.num) / (av_stream_->avg_frame_rate.den) / (1000000);
 		LOG->Trace("Number of frames provided is inaccurate, estimating.");
@@ -580,16 +583,17 @@ RString MovieDecoder_FFMpeg::Open(RString file)
 	// might still be playable. Set total_frames_ to an arbitrary value and
 	// the code will expand or shrink it later. Empty packets are cheap to
 	// store, so it's fine if this value overshoots.
-	if (total_frames_ <= 0) {
+	if (frame_count <= 0) {
 		LOG->Trace("Unable to estimate the total number of frames. Setting to 2000.");
 		total_frames_ = 2000;
 	}
 
-	if (total_frames_ < frame_buffer_.size()) {
+	if (frame_count < frame_buffer_.size()) {
 		LOG->Trace("Video shorter than frame buffer, shrinking the buffer.");
-		frame_buffer_.resize(total_frames_);
+		frame_buffer_.resize(frame_count);
 	}
-	LOG->Trace("Number of frames detected: %zu", total_frames_);
+
+	LOG->Trace("Number of frames detected: %zu", frame_count);
 
 	return RString();
 }

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <limits>
 #include <mutex>
+#include <atomic>
 
 struct RageSurface;
 
@@ -148,7 +149,7 @@ private:
 	avcodec::SwsContext* av_sws_context_;
 	avcodec::AVCodecContext* av_stream_codec_;
 	avcodec::AVFormatContext* av_format_context_;
-	std::size_t total_frames_; // Total number of frames in the movie.
+	std::atomic<std::size_t> total_frames_; // Total number of frames in the movie.
 
 	unsigned char* av_buffer_;
 	avcodec::AVIOContext* av_io_context_;

--- a/src/arch/MovieTexture/MovieTexture_Generic.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Generic.cpp
@@ -58,12 +58,24 @@ RString MovieTexture_Generic::Init()
 		auto timer = RageTimer();
 
 		int ret = decoder_->DecodeMovie();
-		if (ret == -1) {
+
+		std::lock_guard<std::mutex> lock(state_mutex_);
+		switch(ret)
+		{
+		case -1:
 			failure_ = true;
+			break;
+		case -2:
+			failure_ = false;
+			break;
+		default:
+			LOG->Warn("MovieDecoder::DecodeMovie returned unexpected value %d", ret);
+			failure_ = true;
+			break;
 		}
 
 		LOG->Trace("Done decoding video file \"%s\", took %f seconds", GetID().filename.c_str(), timer.Ago());
-		});
+	});
 
 	LOG->Trace("Resolution: %ix%i (%ix%i, %ix%i)",
 		m_iSourceWidth, m_iSourceHeight,
@@ -314,6 +326,7 @@ void MovieTexture_Generic::UpdateMovie(float seconds)
 	// Quick exit in case we failed to decode the movie.
 	if (failure_) {
 		return;
+			return;
 	}
 	clock_ += seconds * rate_;
 

--- a/src/arch/MovieTexture/MovieTexture_Generic.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Generic.cpp
@@ -324,10 +324,13 @@ float MovieTexture_Generic::CheckFrameTime()
 void MovieTexture_Generic::UpdateMovie(float seconds)
 {
 	// Quick exit in case we failed to decode the movie.
-	if (failure_) {
-		return;
+	{
+		std::lock_guard<std::mutex> lock(state_mutex_);
+		if (failure_) {
 			return;
+		}
 	}
+
 	clock_ += seconds * rate_;
 
 	// If the frame isn't ready, don't update. This does mean the video

--- a/src/arch/MovieTexture/MovieTexture_Generic.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Generic.cpp
@@ -12,12 +12,14 @@
 
 #include <cmath>
 #include <cstdint>
+#include <mutex>
 
 #if defined(WIN32)
 #include "archutils/Win32/ErrorStrings.h"
 #include <windows.h>
 #endif
 
+std::mutex state_mutex_;
 
 static Preference<bool> g_bMovieTextureDirectUpdates("MovieTextureDirectUpdates", true);
 


### PR DESCRIPTION
#  Note: this was opened for the 1.1.0 release but not used,  so it is being closed while i do a deeper dive on the FFmpeg issues.


-----


## Making `total_frames_` atomic

I think the crux of the problem is the `total_frames_` member variable has no atomicity.  It is shared between threads, and this is the likely cause of data races or bugs caused by simoltaneous access attempts.

The main change in this PR is to change this variable from a `size_t` to a `std::atomic<size_t>`.


This is because the status is shared between the decoding thread and the main thread.  I knew it had to be something that would be obscured by storing the `MovieDecoder_FFMpeg::DecodeMovie()` status variable in TLS; I think this was the main problem.

Most of the changes involve simply declaring a local variable to fill with the value of `total_frames_` to do things like comparisons or logging.

## Other changes

We explicitly add a return of the cancellation status (-2) in `MovieDecoder_FFMpeg::DecodeMovie()` to ensure any cancellation status is promptly detected and handled.

We add a single mutex to MovieTexture_Generic to protect variables which track the decoding status.

MovieTexture_Generic also has a new switch case protected by the state mutex to handle the return value of DecodeMovie.

Finally we use that same mutex lock when checking  `failure_` in UpdateMovie.