### PR TITLE
Reapply "Change some RString methods to free functions"

### DIFF
--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -141,9 +141,9 @@ void Actor::InitState()
 
 static bool GetMessageNameFromCommandName( const RString &sCommandName, RString &sMessageNameOut )
 {
-	if( sCommandName.Right(7) == "Message" )
+	if( Right(sCommandName, 7) == "Message" )
 	{
-		sMessageNameOut = sCommandName.Left(sCommandName.size()-7);
+		sMessageNameOut = Left(sCommandName, sCommandName.size()-7);
 		return true;
 	}
 	else
@@ -363,7 +363,7 @@ void Actor::LoadFromNode( const XNode* pNode )
 			LuaReference *pRef = new LuaReference;
 			pValue->PushValue( L );
 			pRef->SetFromStack( L );
-			RString sCmdName = sKeyName.Left( sKeyName.size()-7 );
+			RString sCmdName = Left(sKeyName, sKeyName.size()-7);
 			AddCommand( sCmdName, apActorCommands( pRef ) );
 		}
 		else if( sKeyName == "Name" )			SetName( pValue->GetValue<RString>() );
@@ -867,7 +867,7 @@ void Actor::UpdateTweening(float fDeltaTime)
 			// access TI or TS after, since this may modify the tweening queue.
 			if (!sCommand.empty())
 			{
-				if (sCommand.Left(1) == "!")
+				if (Left(sCommand, 1) == "!")
 					MESSAGEMAN->Broadcast(sCommand.substr(1));
 				else
 					this->PlayCommand(sCommand);
@@ -1118,13 +1118,13 @@ void Actor::ScaleTo( const RectF &rect, StretchType st )
 
 void Actor::SetEffectClockString( const RString &s )
 {
-	if     (s.EqualsNoCase("timer"))	this->SetEffectClock( CLOCK_TIMER );
-	else if(s.EqualsNoCase("timerglobal"))	this->SetEffectClock( CLOCK_TIMER_GLOBAL );
-	else if(s.EqualsNoCase("beat"))		this->SetEffectClock( CLOCK_BGM_BEAT );
-	else if(s.EqualsNoCase("music"))	this->SetEffectClock( CLOCK_BGM_TIME );
-	else if(s.EqualsNoCase("bgm"))		this->SetEffectClock( CLOCK_BGM_BEAT ); // compat, deprecated
-	else if(s.EqualsNoCase("musicnooffset"))this->SetEffectClock( CLOCK_BGM_TIME_NO_OFFSET );
-	else if(s.EqualsNoCase("beatnooffset"))	this->SetEffectClock( CLOCK_BGM_BEAT_NO_OFFSET );
+	if     (EqualsNoCase(s, "timer"))	this->SetEffectClock( CLOCK_TIMER );
+	else if(EqualsNoCase(s, "timerglobal"))	this->SetEffectClock( CLOCK_TIMER_GLOBAL );
+	else if(EqualsNoCase(s, "beat"))		this->SetEffectClock( CLOCK_BGM_BEAT );
+	else if(EqualsNoCase(s, "music"))	this->SetEffectClock( CLOCK_BGM_TIME );
+	else if(EqualsNoCase(s, "bgm"))		this->SetEffectClock( CLOCK_BGM_BEAT ); // compat, deprecated
+	else if(EqualsNoCase(s, "musicnooffset"))this->SetEffectClock( CLOCK_BGM_TIME_NO_OFFSET );
+	else if(EqualsNoCase(s, "beatnooffset"))	this->SetEffectClock( CLOCK_BGM_BEAT_NO_OFFSET );
 	else
 	{
 		CabinetLight cl = StringToCabinetLight( s );

--- a/src/ActorUtil.cpp
+++ b/src/ActorUtil.cpp
@@ -131,7 +131,7 @@ namespace
 		if (pActor->GetAttrValue("File", sFile) && sFile != "")
 		{
 			// Backward compatibility hacks for "special" filenames
-			if (sFile.EqualsNoCase("songbackground"))
+			if (EqualsNoCase(sFile, "songbackground"))
 			{
 				XNodeStringValue *pVal = new XNodeStringValue;
 				Song *pSong = GAMESTATE->m_pCurSong;
@@ -142,7 +142,7 @@ namespace
 				pActor->AppendAttrFrom("Texture", pVal, false);
 				return "Sprite";
 			}
-			else if (sFile.EqualsNoCase("songbanner"))
+			else if (EqualsNoCase(sFile, "songbanner"))
 			{
 				XNodeStringValue *pVal = new XNodeStringValue;
 				Song *pSong = GAMESTATE->m_pCurSong;
@@ -153,7 +153,7 @@ namespace
 				pActor->AppendAttrFrom("Texture", pVal, false);
 				return "Sprite";
 			}
-			else if (sFile.EqualsNoCase("coursebanner"))
+			else if (EqualsNoCase(sFile, "coursebanner"))
 			{
 				XNodeStringValue *pVal = new XNodeStringValue;
 				Course *pCourse = GAMESTATE->m_pCurCourse;
@@ -203,7 +203,7 @@ Actor *ActorUtil::LoadFromNode( const XNode* _pNode, Actor *pParentActor )
 		{
 			RString sPath;
 			// Handle absolute paths correctly
-			if (sFile.Left(1) == "/")
+			if (Left(sFile, 1) == "/")
 				sPath = sFile;
 			else
 				sPath = Dirname(GetSourcePath(&node)) + sFile;
@@ -332,7 +332,7 @@ Actor* ActorUtil::MakeActor( const RString &sPath_, Actor *pParentActor )
 		}
 	case FT_Directory:
 		{
-			if( sPath.Right(1) != "/" )
+			if( Right(sPath, 1) != "/" )
 				sPath += '/';
 
 			RString sXml = sPath + "default.xml";
@@ -412,7 +412,7 @@ bool ActorUtil::GetAttrPath( const XNode *pNode, const RString &sName, RString &
 	if( !pNode->GetAttrValue(sName, sOut) )
 		return false;
 
-	bool bIsRelativePath = sOut.Left(1) != "/";
+	bool bIsRelativePath = Left(sOut, 1) != "/";
 	if( bIsRelativePath )
 	{
 		RString sDir;
@@ -593,7 +593,7 @@ void ActorUtil::AddTypeExtensionsToList(FileType ft, std::vector<RString>& add_t
 FileType ActorUtil::GetFileType( const RString &sPath )
 {
 	RString sExt = GetExtension( sPath );
-	sExt.MakeLower();
+	MakeLower(sExt);
 
 	etft_cont_t::iterator conversion_entry= ExtensionToFileType.find(sExt);
 	if(conversion_entry != ExtensionToFileType.end())

--- a/src/AnnouncerManager.cpp
+++ b/src/AnnouncerManager.cpp
@@ -125,7 +125,7 @@ RString AnnouncerManager::GetPathTo( RString sAnnouncerName, RString sFolderName
 	int i;
 	for(i = 0; aliases[i][0] != nullptr; ++i)
 	{
-		if(!sFolderName.EqualsNoCase(aliases[i][0]))
+		if(!EqualsNoCase(sFolderName, aliases[i][0]))
 			continue; /* no match */
 
 		if( !DirectoryIsEmpty(AnnouncerPath+aliases[i][1]+"/") )
@@ -168,7 +168,7 @@ void AnnouncerManager::NextAnnouncer()
 	{
 		unsigned i;
 		for( i=0; i<as.size(); i++ )
-			if( as[i].EqualsNoCase(m_sCurAnnouncerName) )
+			if( EqualsNoCase(as[i], m_sCurAnnouncerName) )
 				break;
 		if( i==as.size()-1 )
 			SwitchAnnouncer( "" );

--- a/src/AttackDisplay.cpp
+++ b/src/AttackDisplay.cpp
@@ -15,7 +15,7 @@ RString GetAttackPieceName( const RString &sAttack )
 
 	/* 1.5x -> 1_5x.  If we pass a period to THEME->GetPathTo, it'll think
 	 * we're looking for a specific file and not search. */
-	ret.Replace( ".", "_" );
+	Replace(ret, ".", "_");
 
 	return ret;
 }

--- a/src/BGAnimation.cpp
+++ b/src/BGAnimation.cpp
@@ -65,7 +65,7 @@ void BGAnimation::AddLayersFromAniDir( const RString &_sAniDir, const XNode *pNo
 				sImportDir = sAniDir + sImportDir;
 				CollapsePath( sImportDir );
 
-				if( sImportDir.Right(1) != "/" )
+				if( Right(sImportDir, 1) != "/" )
 					sImportDir += "/";
 
 				ASSERT_M( IsADirectory(sImportDir), sImportDir + " isn't a directory" );
@@ -96,7 +96,7 @@ void BGAnimation::LoadFromAniDir( const RString &_sAniDir )
 		 return;
 
 	RString sAniDir = _sAniDir;
-	if( sAniDir.Right(1) != "/" )
+	if( Right(sAniDir, 1) != "/" )
 		sAniDir += "/";
 
 	ASSERT_M( IsADirectory(sAniDir), sAniDir + " isn't a directory" );
@@ -149,7 +149,7 @@ void BGAnimation::LoadFromAniDir( const RString &_sAniDir )
 		for( unsigned i=0; i<asImagePaths.size(); i++ )
 		{
 			const RString sPath = asImagePaths[i];
-			if( Basename(sPath).Left(1) == "_" )
+			if( Left(Basename(sPath), 1) == "_" )
 				continue; // don't directly load files starting with an underscore
 			BGAnimationLayer* pLayer = new BGAnimationLayer;
 			pLayer->LoadFromAniLayerFile( asImagePaths[i] );

--- a/src/BGAnimationLayer.cpp
+++ b/src/BGAnimationLayer.cpp
@@ -77,7 +77,7 @@ void BGAnimationLayer::LoadFromAniLayerFile( const RString& sPath )
 	/* Generic BGAs are new.  Animation directories with no INI are old and obsolete.
 	 * Don't combine them. */
 	RString lcPath = sPath;
-	lcPath.MakeLower();
+	MakeLower(lcPath);
 
 	if( lcPath.find("usesongbg") != RString::npos )
 	{
@@ -348,7 +348,7 @@ void BGAnimationLayer::LoadFromAniLayerFile( const RString& sPath )
 
 
 	RString sHint = sPath;
-	sHint.MakeLower();
+	MakeLower(sHint);
 
 	if( sHint.find("cyclecolor") != RString::npos )
 		for( unsigned i=0; i<m_SubActors.size(); i++ )
@@ -383,7 +383,7 @@ void BGAnimationLayer::LoadFromNode( const XNode* pNode )
 	{
 		RString type = "sprite";
 		pNode->GetAttrValue( "Type", type );
-		type.MakeLower();
+		MakeLower(type);
 
 		/* The preferred way of stretching a sprite to fit the screen is "Type=sprite"
 		 * and "stretch=1".  "type=1" is for backwards-compatibility. */
@@ -392,15 +392,15 @@ void BGAnimationLayer::LoadFromNode( const XNode* pNode )
 		// Check for string match first, then do integer match.
 		// "if(StringType(type)==0)" was matching against all string matches.
 		// -Chris
-		if( type.EqualsNoCase("sprite") )
+		if( EqualsNoCase(type, "sprite") )
 		{
 			m_Type = TYPE_SPRITE;
 		}
-		else if( type.EqualsNoCase("particles") )
+		else if( EqualsNoCase(type, "particles") )
 		{
 			m_Type = TYPE_PARTICLES;
 		}
-		else if( type.EqualsNoCase("tiles") )
+		else if( EqualsNoCase(type, "tiles") )
 		{
 			m_Type = TYPE_TILES;
 		}

--- a/src/BackgroundUtil.cpp
+++ b/src/BackgroundUtil.cpp
@@ -117,7 +117,7 @@ static void StripCvsAndSvn( std::vector<RString> &vsPathsToStrip, std::vector<RS
 	ASSERT( vsPathsToStrip.size() == vsNamesToStrip.size() );
 	for( unsigned i=0; i<vsNamesToStrip.size(); i++ )
 	{
-		if( vsNamesToStrip[i].Right(3).CompareNoCase("CVS") == 0 || vsNamesToStrip[i] == ".svn" )
+		if( CompareNoCase(Right(vsNamesToStrip[i], 3), "CVS") == 0 || vsNamesToStrip[i] == ".svn" )
 		{
 			vsPathsToStrip.erase( vsPathsToStrip.begin()+i );
 			vsNamesToStrip.erase( vsNamesToStrip.begin()+i );
@@ -365,7 +365,7 @@ void BackgroundUtil::GetGlobalRandomMovies(
 
 	for (RString const &s : vsPathsOut)
 	{
-		RString sName = s.Right( s.size() - RANDOMMOVIES_DIR.size() - 1 );
+		RString sName = Right(s, s.size() - RANDOMMOVIES_DIR.size() - 1 );
 		vsNamesOut.push_back( sName );
 	}
 	StripCvsAndSvn( vsPathsOut, vsNamesOut );

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -463,7 +463,7 @@ void BitmapText::SetText( const RString& _sText, const RString& _sAlternateText,
 	RString sNewText = StringWillUseAlternate(_sText,_sAlternateText) ? _sAlternateText : _sText;
 
 	if( m_bUppercase )
-		sNewText.MakeUpper();
+		MakeUpper(sNewText);
 
 	if( iWrapWidthPixels == -1 )	// wrap not specified
 		iWrapWidthPixels = m_iWrapWidthPixels;
@@ -1069,13 +1069,13 @@ public:
 		 * it's confusing for :: to work in some strings and not others.
 		 * Eventually, all strings should be Lua expressions, but until then,
 		 * continue to support this. */
-		s.Replace("::","\n");
+		Replace(s, "::", "\n");
 		FontCharAliases::ReplaceMarkers( s );
 
 		if( lua_gettop(L) > 1 )
 		{
 			sAlt = SArg(2);
-			sAlt.Replace("::","\n");
+			Replace(sAlt, "::", "\n");
 			FontCharAliases::ReplaceMarkers( sAlt );
 		}
 

--- a/src/Character.cpp
+++ b/src/Character.cpp
@@ -17,7 +17,7 @@ Character::Character(): m_sCharDir(""), m_sCharacterID(""),
 bool Character::Load( RString sCharDir )
 {
 	// Save character directory
-	if( sCharDir.Right(1) != "/" )
+	if( Right(sCharDir, 1) != "/" )
 		sCharDir += "/";
 	m_sCharDir = sCharDir;
 

--- a/src/Character.h
+++ b/src/Character.h
@@ -30,7 +30,7 @@ public:
 
 	bool IsDefaultCharacter() const
 	{
-		return m_sCharacterID.CompareNoCase("default") == 0;
+		return CompareNoCase(m_sCharacterID, "default") == 0;
 	}
 
 	void DemandGraphics();

--- a/src/CharacterManager.cpp
+++ b/src/CharacterManager.cpp
@@ -37,9 +37,9 @@ CharacterManager::CharacterManager()
 	{
 		RString sCharName, sDummy;
 		splitpath(as[i], sDummy, sCharName, sDummy);
-		sCharName.MakeLower();
+		MakeLower(sCharName);
 
-		if( sCharName.CompareNoCase("default")==0 )
+		if( CompareNoCase(sCharName, "default")==0 )
 			FoundDefault = true;
 
 		Character* pChar = new Character;

--- a/src/CommonMetrics.cpp
+++ b/src/CommonMetrics.cpp
@@ -34,7 +34,7 @@ ThemeMetricDifficultiesToShow::ThemeMetricDifficultiesToShow( const RString& sGr
 }
 void ThemeMetricDifficultiesToShow::Read()
 {
-	ASSERT( GetName().Right(6) == "ToShow" );
+	ASSERT( Right(GetName(), 6) == "ToShow" );
 
 	ThemeMetric<RString>::Read();
 
@@ -73,7 +73,7 @@ ThemeMetricCourseDifficultiesToShow::ThemeMetricCourseDifficultiesToShow( const 
 }
 void ThemeMetricCourseDifficultiesToShow::Read()
 {
-	ASSERT( GetName().Right(6) == "ToShow" );
+	ASSERT( Right(GetName(), 6) == "ToShow" );
 
 	ThemeMetric<RString>::Read();
 
@@ -132,7 +132,7 @@ ThemeMetricStepsTypesToShow::ThemeMetricStepsTypesToShow( const RString& sGroup,
 }
 void ThemeMetricStepsTypesToShow::Read()
 {
-	ASSERT( GetName().Right(6) == "ToHide" );
+	ASSERT( Right(GetName(), 6) == "ToHide" );
 
 	ThemeMetric<RString>::Read();
 

--- a/src/Course.cpp
+++ b/src/Course.cpp
@@ -54,7 +54,7 @@ OldStyleStringToSongSortMapHolder OldStyleStringToSongSortMapHolder_converter;
 SongSort OldStyleStringToSongSort(const RString &ss)
 {
 	RString s2 = ss;
-	s2.MakeLower();
+	MakeLower(s2);
 	std::map<RString, SongSort>::iterator diff=
 		OldStyleStringToSongSortMapHolder_converter.conversion_map.find(s2);
 	if(diff != OldStyleStringToSongSortMapHolder_converter.conversion_map.end())
@@ -980,7 +980,7 @@ const Style *Course::GetCourseStyle( const Game *pGame, int iNumPlayers ) const
 	{
 		for (RString const &style : m_setStyles)
 		{
-			if( !style.CompareNoCase(pStyle->m_szName) )
+			if( !CompareNoCase(style, pStyle->m_szName) )
 				return pStyle;
 		}
 	}
@@ -1181,7 +1181,7 @@ bool Course::IsRanking() const
 	split(THEME->GetMetric("ScreenRanking", "CoursesToShow"), ",", rankingsongs);
 
 	for(unsigned i=0; i < rankingsongs.size(); i++)
-		if (rankingsongs[i].EqualsNoCase(m_sPath))
+		if (EqualsNoCase(rankingsongs[i], m_sPath))
 			return true;
 
 	return false;
@@ -1243,21 +1243,21 @@ void Course::CalculateRadarValues()
 
 bool Course::Matches( RString sGroup, RString sCourse ) const
 {
-	if( sGroup.size() && sGroup.CompareNoCase(this->m_sGroupName) != 0)
+	if( sGroup.size() && CompareNoCase(sGroup, this->m_sGroupName) != 0)
 		return false;
 
 	RString sFile = m_sPath;
 	if( !sFile.empty() )
 	{
-		sFile.Replace("\\","/");
+		Replace(sFile, "\\", "/");
 		std::vector<RString> bits;
 		split( sFile, "/", bits );
 		const RString &sLastBit = bits[bits.size()-1];
-		if( sCourse.EqualsNoCase(sLastBit) )
+		if( EqualsNoCase(sCourse, sLastBit) )
 			return true;
 	}
 
-	if( sCourse.EqualsNoCase(this->GetTranslitFullTitle()) )
+	if( EqualsNoCase(sCourse, this->GetTranslitFullTitle()) )
 		return true;
 
 	return false;

--- a/src/CourseLoaderCRS.cpp
+++ b/src/CourseLoaderCRS.cpp
@@ -45,9 +45,9 @@ void split_minding_escaped_delims(const RString &sSource, const RString &sDelimi
 	RString sourceCopy = sSource;
 	RString escaped_delim = "||escaped-delim||";
 	RString regular_delim = "||regular-delim||";
-	sourceCopy.Replace("\\" + sDelimitor, escaped_delim);
-	sourceCopy.Replace(sDelimitor, regular_delim);
-	sourceCopy.Replace(escaped_delim, "\\" + sDelimitor);
+	Replace(sourceCopy, "\\" + sDelimitor, escaped_delim);
+	Replace(sourceCopy, sDelimitor, regular_delim);
+	Replace(sourceCopy, escaped_delim, "\\" + sDelimitor);
 	split(sourceCopy, regular_delim, asAddit);
 }
 
@@ -59,7 +59,7 @@ void split_minding_escaped_delims(const RString &sSource, const RString &sDelimi
 static CourseDifficulty CRSStringToDifficulty( const RString& s )
 {
 	FOREACH_ENUM( Difficulty,i)
-		if( !s.CompareNoCase(g_CRSDifficultyNames[i]) )
+		if( !CompareNoCase(s, g_CRSDifficultyNames[i]) )
 			return i;
 	return Difficulty_Invalid;
 }
@@ -82,39 +82,39 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 		const MsdFile::value_t &sParams = msd.GetValue(i);
 
 		// handle the data
-		if( sValueName.EqualsNoCase("COURSE") )
+		if( EqualsNoCase(sValueName, "COURSE") )
 			out.m_sMainTitle = sParams[1];
-		else if( sValueName.EqualsNoCase("COURSETRANSLIT") )
+		else if( EqualsNoCase(sValueName, "COURSETRANSLIT") )
 			out.m_sMainTitleTranslit = sParams[1];
-		else if( sValueName.EqualsNoCase("SCRIPTER") )
+		else if( EqualsNoCase(sValueName, "SCRIPTER") )
 			out.m_sScripter = sParams[1];
-		else if( sValueName.EqualsNoCase("DESCRIPTION") )
+		else if( EqualsNoCase(sValueName, "DESCRIPTION") )
 			out.m_sDescription = sParams[1];
-		else if( sValueName.EqualsNoCase("REPEAT") )
+		else if( EqualsNoCase(sValueName, "REPEAT") )
 		{
 			RString str = sParams[1];
-			str.MakeLower();
+			MakeLower(str);
 			if( str.find("yes") != std::string::npos )
 				out.m_bRepeat = true;
 		}
 
-		else if( sValueName.EqualsNoCase("BANNER") )
+		else if( EqualsNoCase(sValueName, "BANNER") )
 		{
 			out.m_sBannerPath = sParams[1];
 		}
-		else if( sValueName.EqualsNoCase("BACKGROUND") )
+		else if( EqualsNoCase(sValueName, "BACKGROUND") )
 		{
 			out.m_sBackgroundPath = sParams[1];
 		}
-		else if( sValueName.EqualsNoCase("LIVES") )
+		else if( EqualsNoCase(sValueName, "LIVES") )
 		{
 			out.m_iLives = std::max( StringToInt(sParams[1]), 0 );
 		}
-		else if( sValueName.EqualsNoCase("GAINSECONDS") )
+		else if( EqualsNoCase(sValueName, "GAINSECONDS") )
 		{
 			fGainSeconds = StringToFloat( sParams[1] );
 		}
-		else if( sValueName.EqualsNoCase("METER") )
+		else if( EqualsNoCase(sValueName, "METER") )
 		{
 			if( sParams.params.size() == 2 )
 			{
@@ -132,11 +132,11 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 			}
 		}
 
-		else if( sValueName.EqualsNoCase("MODS") )
+		else if( EqualsNoCase(sValueName, "MODS") )
 		{
 			CourseLoaderCRS::ParseCourseMods(sParams, attacks, sPath);
 		}
-		else if( sValueName.EqualsNoCase("SONG") )
+		else if( EqualsNoCase(sValueName, "SONG") )
 		{
 			CourseEntry new_entry;
 			if(CourseLoaderCRS::ParseCourseSong(sParams, new_entry, sPath) == false) {
@@ -149,7 +149,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 			attacks.clear();
 			out.m_vEntries.push_back( new_entry );
 		}
-		else if( sValueName.EqualsNoCase("SONGSELECT") )
+		else if( EqualsNoCase(sValueName, "SONGSELECT") )
 		{
 			CourseEntry new_entry;
 			new_entry.bUseSongSelect = true;
@@ -163,13 +163,13 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 			attacks.clear();
 			out.m_vEntries.push_back( new_entry );
 		}
-		else if( !sValueName.EqualsNoCase("DISPLAYCOURSE") || !sValueName.EqualsNoCase("COMBO") ||
-			 !sValueName.EqualsNoCase("COMBOMODE") )
+		else if( !EqualsNoCase(sValueName, "DISPLAYCOURSE") || !EqualsNoCase(sValueName, "COMBO") ||
+			 !EqualsNoCase(sValueName, "COMBOMODE") )
 		{
 			// Ignore
 		}
 
-		else if( bFromCache && !sValueName.EqualsNoCase("RADAR") )
+		else if( bFromCache && !EqualsNoCase(sValueName, "RADAR") )
 		{
 			StepsType st = (StepsType) StringToInt(sParams[1]);
 			CourseDifficulty cd = (CourseDifficulty) StringToInt( sParams[2] );
@@ -178,7 +178,7 @@ bool CourseLoaderCRS::LoadFromMsd( const RString &sPath, const MsdFile &msd, Cou
 			rv.FromString( sParams[3] );
 			out.m_RadarCache[Course::CacheEntry(st, cd)] = rv;
 		}
-		else if( sValueName.EqualsNoCase("STYLE") )
+		else if( EqualsNoCase(sValueName, "STYLE") )
 		{
 			RString sStyles = sParams[1];
 			std::vector<RString> asStyles;
@@ -351,13 +351,13 @@ bool CourseLoaderCRS::ParseCourseMods( const MsdFile::value_t &sParams, AttackAr
 			continue;
 
 		Trim( sBits[0] );
-		if( !sBits[0].CompareNoCase("TIME") )
+		if( !CompareNoCase(sBits[0], "TIME") )
 			attack.fStartSecond = std::max( StringToFloat(sBits[1]), 0.0f );
-		else if( !sBits[0].CompareNoCase("LEN") )
+		else if( !CompareNoCase(sBits[0], "LEN") )
 			attack.fSecsRemaining = StringToFloat( sBits[1] );
-		else if( !sBits[0].CompareNoCase("END") )
+		else if( !CompareNoCase(sBits[0], "END") )
 			end = StringToFloat( sBits[1] );
-		else if( !sBits[0].CompareNoCase("MODS") )
+		else if( !CompareNoCase(sBits[0], "MODS") )
 		{
 			attack.sModifiers = sBits[1];
 
@@ -393,9 +393,9 @@ bool CourseLoaderCRS::ParseCourseSong( const MsdFile::value_t &sParams, CourseEn
 	// to a lack of songs. -aj
 	int iNumSongs = SONGMAN->GetNumSongs();
 	// most played
-	if( sParams[1].Left(strlen("BEST")) == "BEST" )
+	if( Left(sParams[1], strlen("BEST")) == "BEST" )
 	{
-		int iChooseIndex = StringToInt( sParams[1].Right(sParams[1].size()-strlen("BEST")) ) - 1;
+		int iChooseIndex = StringToInt( Right(sParams[1], sParams[1].size()-strlen("BEST")) ) - 1;
 		if( iChooseIndex > iNumSongs )
 		{
 			// looking up a song that doesn't exist.
@@ -409,9 +409,9 @@ bool CourseLoaderCRS::ParseCourseSong( const MsdFile::value_t &sParams, CourseEn
 		new_entry.songSort = SongSort_MostPlays;
 	}
 	// least played
-	else if( sParams[1].Left(strlen("WORST")) == "WORST" )
+	else if( Left(sParams[1], strlen("WORST")) == "WORST" )
 	{
-		int iChooseIndex = StringToInt( sParams[1].Right(sParams[1].size()-strlen("WORST")) ) - 1;
+		int iChooseIndex = StringToInt( Right(sParams[1], sParams[1].size()-strlen("WORST")) ) - 1;
 		if( iChooseIndex > iNumSongs )
 		{
 			// looking up a song that doesn't exist.
@@ -425,16 +425,16 @@ bool CourseLoaderCRS::ParseCourseSong( const MsdFile::value_t &sParams, CourseEn
 		new_entry.songSort = SongSort_FewestPlays;
 	}
 	// best grades
-	else if( sParams[1].Left(strlen("GRADEBEST")) == "GRADEBEST" )
+	else if( Left(sParams[1], strlen("GRADEBEST")) == "GRADEBEST" )
 	{
-		new_entry.iChooseIndex = StringToInt( sParams[1].Right(sParams[1].size()-strlen("GRADEBEST")) ) - 1;
+		new_entry.iChooseIndex = StringToInt( Right(sParams[1], sParams[1].size()-strlen("GRADEBEST")) ) - 1;
 		CLAMP( new_entry.iChooseIndex, 0, 500 );
 		new_entry.songSort = SongSort_TopGrades;
 	}
 	// worst grades
-	else if( sParams[1].Left(strlen("GRADEWORST")) == "GRADEWORST" )
+	else if( Left(sParams[1], strlen("GRADEWORST")) == "GRADEWORST" )
 	{
-		new_entry.iChooseIndex = StringToInt( sParams[1].Right(sParams[1].size()-strlen("GRADEWORST")) ) - 1;
+		new_entry.iChooseIndex = StringToInt( Right(sParams[1], sParams[1].size()-strlen("GRADEWORST")) ) - 1;
 		CLAMP( new_entry.iChooseIndex, 0, 500 );
 		new_entry.songSort = SongSort_LowestGrades;
 	}
@@ -443,11 +443,11 @@ bool CourseLoaderCRS::ParseCourseSong( const MsdFile::value_t &sParams, CourseEn
 		new_entry.bSecret = true;
 	}
 	// group random
-	else if( sParams[1].Right(1) == "*" )
+	else if( Right(sParams[1], 1) == "*" )
 	{
 		new_entry.bSecret = true;
 		RString sSong = sParams[1];
-		sSong.Replace( "\\", "/" );
+		Replace(sSong, "\\", "/");
 		std::vector<RString> bits;
 		split( sSong, "/", bits );
 		if( bits.size() == 2 )
@@ -470,7 +470,7 @@ bool CourseLoaderCRS::ParseCourseSong( const MsdFile::value_t &sParams, CourseEn
 	else
 	{
 		RString sSong = sParams[1];
-		sSong.Replace( "\\", "/" );
+		Replace(sSong, "\\", "/");
 		std::vector<RString> bits;
 		split( sSong, "/", bits );
 
@@ -527,13 +527,13 @@ bool CourseLoaderCRS::ParseCourseSong( const MsdFile::value_t &sParams, CourseEn
 			RString &sMod = mods[j];
 			TrimLeft( sMod );
 			TrimRight( sMod );
-			if( !sMod.CompareNoCase("showcourse") )
+			if( !CompareNoCase(sMod, "showcourse") )
 				new_entry.bSecret = false;
-			else if( !sMod.CompareNoCase("noshowcourse") )
+			else if( !CompareNoCase(sMod, "noshowcourse") )
 				new_entry.bSecret = true;
-			else if( !sMod.CompareNoCase("nodifficult") )
+			else if( !CompareNoCase(sMod, "nodifficult") )
 				new_entry.bNoDifficult = true;
-			else if( sMod.length() > 5 && !sMod.Left(5).CompareNoCase("award") )
+			else if( sMod.length() > 5 && !CompareNoCase(Left(sMod, 5), "award") )
 				new_entry.iGainLives = StringToInt( sMod.substr(5) );
 			else
 				continue;
@@ -563,28 +563,28 @@ bool CourseLoaderCRS::ParseCourseSongSelect(const MsdFile::value_t &sParams, Cou
 		// For params that accept multiple items, if someone were to define it twice in one #SONGSELECT, 
 		// should we overwrite the first, or append? Currently, it just appends it all together.
 
-		if( sParamName.EqualsNoCase("TITLE") )
+		if( EqualsNoCase(sParamName, "TITLE") )
 		{
 			if(ParseCommaSeparatedList(sParamValue, new_entry.songCriteria.m_vsSongNames, sParamName, sPath) == false)
 			{
 				return false;
 			}
 		}
-		else if( sParamName.EqualsNoCase("GROUP") )
+		else if( EqualsNoCase(sParamName, "GROUP") )
 		{
 			if(ParseCommaSeparatedList(sParamValue, new_entry.songCriteria.m_vsGroupNames, sParamName, sPath) == false)
 			{
 				return false;
 			}
 		}
-		else if( sParamName.EqualsNoCase("ARTIST") )
+		else if( EqualsNoCase(sParamName, "ARTIST") )
 		{
 			if(ParseCommaSeparatedList(sParamValue, new_entry.songCriteria.m_vsArtistNames, sParamName, sPath) == false)
 			{
 				return false;
 			}
 		}
-		else if( sParamName.EqualsNoCase("GENRE") )
+		else if( EqualsNoCase(sParamName, "GENRE") )
 		{
 			if(ParseCommaSeparatedList(sParamValue, new_entry.songCriteria.m_vsSongGenreAllowedList, sParamName, sPath) == false)
 			{
@@ -592,7 +592,7 @@ bool CourseLoaderCRS::ParseCourseSongSelect(const MsdFile::value_t &sParams, Cou
 			}
 			new_entry.songCriteria.m_bUseSongGenreAllowedList = true;
 		}
-		else if( sParamName.EqualsNoCase("DIFFICULTY") )
+		else if( EqualsNoCase(sParamName, "DIFFICULTY") )
 		{
 			std::vector<RString> difficultyStrs;
 			std::vector<Difficulty> difficulties;
@@ -616,7 +616,7 @@ bool CourseLoaderCRS::ParseCourseSongSelect(const MsdFile::value_t &sParams, Cou
 			}
 			new_entry.stepsCriteria.m_vDifficulties.insert(new_entry.stepsCriteria.m_vDifficulties.end(), difficulties.begin(), difficulties.end());
 		}
-		else if( sParamName.EqualsNoCase("SORT") )
+		else if( EqualsNoCase(sParamName, "SORT") )
 		{
 			std::vector<RString> sortParams;
 			split(sParamValue, ",", sortParams);
@@ -643,36 +643,36 @@ bool CourseLoaderCRS::ParseCourseSongSelect(const MsdFile::value_t &sParams, Cou
 				return false;
 			}
 		}
-		else if( sParamName.EqualsNoCase("DURATION") )
+		else if( EqualsNoCase(sParamName, "DURATION") )
 		{
 			if(ParseRangedValue(sParamValue, new_entry.songCriteria.m_fMinDurationSeconds, new_entry.songCriteria.m_fMaxDurationSeconds, sParamName, sPath) == false)
 			{
 				return false;
 			}
 		}
-		else if( sParamName.EqualsNoCase("BPMRANGE") )
+		else if( EqualsNoCase(sParamName, "BPMRANGE") )
 		{
 			if(ParseRangedValue(sParamValue, new_entry.songCriteria.m_fMinBPM, new_entry.songCriteria.m_fMaxBPM, sParamName, sPath) == false)
 			{
 				return false;
 			}
 		}
-		else if( sParamName.EqualsNoCase("METER") )
+		else if( EqualsNoCase(sParamName, "METER") )
 		{
 			if(ParseRangedValue(sParamValue, new_entry.stepsCriteria.m_iLowMeter, new_entry.stepsCriteria.m_iHighMeter, sParamName, sPath) == false)
 			{
 				return false;
 			}
 		}
-		else if( sParamName.EqualsNoCase("GAINLIVES") )
+		else if( EqualsNoCase(sParamName, "GAINLIVES") )
 		{
 			new_entry.iGainLives = StringToInt(sParamValue);
 		}
-		else if( sParamName.EqualsNoCase("GAINSECONDS") )
+		else if( EqualsNoCase(sParamName, "GAINSECONDS") )
 		{
 			new_entry.fGainSeconds = StringToInt(sParamValue);
 		}
-		else if( sParamName.EqualsNoCase("MODS") )
+		else if( EqualsNoCase(sParamName, "MODS") )
 		{
 			std::vector<RString> mods;
 			split( sParamValue, ",", mods, true );
@@ -681,11 +681,11 @@ bool CourseLoaderCRS::ParseCourseSongSelect(const MsdFile::value_t &sParams, Cou
 				RString &sMod = mods[j];
 				TrimLeft( sMod );
 				TrimRight( sMod );
-				if( !sMod.CompareNoCase("showcourse") )
+				if( !CompareNoCase(sMod, "showcourse") )
 					new_entry.bSecret = false;
-				else if( !sMod.CompareNoCase("noshowcourse") )
+				else if( !CompareNoCase(sMod, "noshowcourse") )
 					new_entry.bSecret = true;
-				else if( !sMod.CompareNoCase("nodifficult") )
+				else if( !CompareNoCase(sMod, "nodifficult") )
 					new_entry.bNoDifficult = true;
 				else
 					continue;

--- a/src/CourseUtil.cpp
+++ b/src/CourseUtil.cpp
@@ -24,7 +24,7 @@ static bool CompareCoursePointersByName( const Course* pCourse1, const Course* p
 {
 	RString sName1 = pCourse1->GetDisplayFullTitle();
 	RString sName2 = pCourse2->GetDisplayFullTitle();
-	return sName1.CompareNoCase( sName2 ) < 0;
+	return CompareNoCase(sName1, sName2) < 0;
 }
 
 static bool CompareCoursePointersByAutogen( const Course* pCourse1, const Course* pCourse2 )
@@ -538,7 +538,7 @@ void CourseID::FromCourse( const Course *p )
 
 	// HACK for backwards compatibility:
 	// Strip off leading "/".  2005/05/21 file layer changes added a leading slash.
-	if( sPath.Left(1) == "/" )
+	if( Left(sPath, 1) == "/" )
 		sPath.erase( sPath.begin() );
 }
 
@@ -550,7 +550,7 @@ Course *CourseID::ToCourse() const
 		// HACK for backwards compatibility:
 		// Re-add the leading "/".  2005/05/21 file layer changes added a leading slash.
 		RString slash_path = sPath;
-		if(slash_path.Left(1) != "/")
+		if(Left(slash_path, 1) != "/")
 		{
 			slash_path = "/" + slash_path;
 		}
@@ -587,7 +587,7 @@ void CourseID::LoadFromNode( const XNode* pNode )
 		pNode->GetAttrValue( "FullTitle", sFullTitle );
 
 	// HACK for backwards compatibility: /AdditionalCourses has been merged into /Courses
-	if (sPath.Left(18) == "AdditionalCourses/")
+	if (Left(sPath, 18) == "AdditionalCourses/")
 		sPath.replace(0, 18, "Courses/");
 }
 

--- a/src/CsvFile.cpp
+++ b/src/CsvFile.cpp
@@ -72,7 +72,7 @@ bool CsvFile::ReadFile( RageFileBasic &f )
 				while(true);
 
 				RString sValue = line;
-				sValue = sValue.Left( iEnd );
+				sValue = Left(sValue, iEnd);
 				vs.push_back( sValue );
 
 				line.erase( line.begin(), line.begin()+iEnd );
@@ -87,7 +87,7 @@ bool CsvFile::ReadFile( RageFileBasic &f )
 					iEnd = line.size();	// didn't find an end.  Take the whole line
 
 				RString sValue = line;
-				sValue = sValue.Left( iEnd );
+				sValue = Left(sValue, iEnd);
 				vs.push_back( sValue );
 
 				line.erase( line.begin(), line.begin()+iEnd );
@@ -122,7 +122,7 @@ bool CsvFile::WriteFile( RageFileBasic &f ) const
 		for (auto value = line.begin(); value != line.end(); ++value)
 		{
 			RString sVal = *value;
-			sVal.Replace( "\"", "\"\"" );	// escape quotes to double-quotes
+			Replace(sVal, "\"", "\"\"");	// escape quotes to double-quotes
 			sLine += "\"" + sVal + "\"";
 			if( value != line.end()-1 )
 				sLine += ",";

--- a/src/DateTime.cpp
+++ b/src/DateTime.cpp
@@ -225,16 +225,16 @@ RString LastWeekToString( int iLastWeekIndex )
 RString LastDayToLocalizedString( int iLastDayIndex )
 {
 	RString s = LastDayToString( iLastDayIndex );
-	s.Replace( "Day", "" );
-	s.Replace( "Ago", " Ago" );
+	Replace(s, "Day", "");
+	Replace(s, "Ago", " Ago");
 	return s;
 }
 
 RString LastWeekToLocalizedString( int iLastWeekIndex )
 {
 	RString s = LastWeekToString( iLastWeekIndex );
-	s.Replace( "Week", "" );
-	s.Replace( "Ago", " Ago" );
+	Replace(s, "Week", "");
+	Replace(s, "Ago", " Ago");
 	return s;
 }
 

--- a/src/Difficulty.cpp
+++ b/src/Difficulty.cpp
@@ -79,7 +79,7 @@ OldStyleStringToDifficultyMapHolder OldStyleStringToDifficulty_converter;
 Difficulty OldStyleStringToDifficulty( const RString& sDC )
 {
 	RString s2 = sDC;
-	s2.MakeLower();
+	MakeLower(s2);
 	std::map<RString, Difficulty>::iterator diff=
 		OldStyleStringToDifficulty_converter.conversion_map.find(s2);
 	if(diff != OldStyleStringToDifficulty_converter.conversion_map.end())

--- a/src/EnumHelper.cpp
+++ b/src/EnumHelper.cpp
@@ -31,7 +31,7 @@ int CheckEnum( lua_State *L, LuaReference &table, int iPos, int iInvalid, const 
 		// Get the string and lowercase it
 		lua_pushvalue( L, iPos );
 		LuaHelpers::Pop( L, sLower );
-		sLower.MakeLower();
+		MakeLower(sLower);
 
 		// Try again to read the value
 		table.PushSelf( L );

--- a/src/EnumHelper.h
+++ b/src/EnumHelper.h
@@ -108,7 +108,7 @@ X StringTo##X(const RString&); \
 X StringTo##X( const RString& s ) \
 {	\
 	for( unsigned i = 0; i < ARRAYLEN(X##Names); ++i )	\
-		if( !s.CompareNoCase(X##Names[i]) )	\
+		if( !CompareNoCase(s, X##Names[i]) )	\
 			return (X)i;	\
 	return X##_Invalid;	\
 } \
@@ -148,7 +148,7 @@ static void Lua##X(lua_State* L) \
 		lua_pushnumber( L, i ); /* 0-based */ \
 		lua_rawset( L, -3 ); \
 		/* Compatibility with old, case-insensitive values */ \
-		s.MakeLower(); \
+		MakeLower(s); \
 		lua_pushstring( L, s.c_str() ); \
 		lua_pushnumber( L, i ); /* 0-based */ \
 		lua_rawset( L, -3 ); \

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -44,7 +44,7 @@ void FontPage::Load( const FontPageSettings &cfg )
 	// "arial 20 16x16 [main].png" => "arial 20 16x16 [main-stroke].png"
 	if( ID2.filename.find("]") != std::string::npos )
 	{
-		ID2.filename.Replace( "]", "-stroke]" );
+		Replace(ID2.filename, "]", "-stroke]");
 		if( IsAFile(ID2.filename) )
 		{
 			m_FontPageTextures.m_pTextureStroke = TEXTUREMAN->LoadTexture( ID2 );
@@ -434,7 +434,7 @@ void Font::GetFontPaths( const RString &sFontIniPath, std::vector<RString> &asTe
 
 	for( unsigned i = 0; i < asFiles.size(); ++i )
 	{
-		if( !asFiles[i].Right(4).EqualsNoCase(".ini") )
+		if( !EqualsNoCase(Right(asFiles[i], 4), ".ini") )
 			asTexturePathsOut.push_back( asFiles[i] );
 	}
 }
@@ -496,7 +496,7 @@ void Font::LoadFontPageSettings( FontPageSettings &cfg, IniFile &ini, const RStr
 			RString sName = pAttr->first;
 			const XNodeValue *pValue = pAttr->second;
 
-			sName.MakeUpper();
+			MakeUpper(sName);
 
 			// If val is an integer, it's a width, eg. "10=27".
 			if( IsAnInt(sName) )
@@ -678,7 +678,7 @@ void Font::LoadFontPageSettings( FontPageSettings &cfg, IniFile &ini, const RStr
 
 RString FontPageSettings::MapRange( RString sMapping, int iMapOffset, int iGlyphNo, int iCount )
 {
-	if( !sMapping.CompareNoCase("Unicode") )
+	if( !CompareNoCase(sMapping, "Unicode") )
 	{
 		// Special case.
 		if( iCount == -1 )
@@ -755,7 +755,7 @@ static std::vector<RString> LoadStack;
  */
 void Font::Load( const RString &sIniPath, RString sChars )
 {
-	if(GetExtension(sIniPath).CompareNoCase("ini"))
+	if(CompareNoCase(GetExtension(sIniPath), "ini"))
 	{
 		LuaHelpers::ReportScriptErrorFmt(
 			"%s is not an ini file.  Fonts can only be loaded from ini files.",

--- a/src/FontCharAliases.cpp
+++ b/src/FontCharAliases.cpp
@@ -364,7 +364,7 @@ static void InitCharAliases()
 	{
 		RString from = i->first;
 		RString to = WcharToUTF8(i->second);
-		from.MakeLower();
+		MakeLower(from);
 		CharAliasRepl[from] = to;
 	}
 }

--- a/src/FontCharmaps.cpp
+++ b/src/FontCharmaps.cpp
@@ -222,7 +222,7 @@ const wchar_t *FontCharmaps::get_char_map(RString name)
 {
 	Init();
 
-	name.MakeLower();
+	MakeLower(name);
 
 	std::map<RString, const wchar_t*>::const_iterator i = charmaps.find(name);
 	if(i == charmaps.end())

--- a/src/GameCommand.cpp
+++ b/src/GameCommand.cpp
@@ -612,7 +612,7 @@ bool GameCommand::IsPlayable( RString *why ) const
 		}
 	}
 
-	if( !m_sScreen.CompareNoCase("ScreenEditCoursesMenu") )
+	if( !CompareNoCase(m_sScreen, "ScreenEditCoursesMenu") )
 	{
 		std::vector<Course*> vCourses;
 		SONGMAN->GetAllCourses( vCourses, false );
@@ -625,9 +625,9 @@ bool GameCommand::IsPlayable( RString *why ) const
 		}
 	}
 
-	if( (!m_sScreen.CompareNoCase("ScreenJukeboxMenu") ||
-		!m_sScreen.CompareNoCase("ScreenEditMenu") ||
-		!m_sScreen.CompareNoCase("ScreenEditCoursesMenu")) )
+	if( (!CompareNoCase(m_sScreen, "ScreenJukeboxMenu") ||
+		!CompareNoCase(m_sScreen, "ScreenEditMenu") ||
+		!CompareNoCase(m_sScreen, "ScreenEditCoursesMenu")) )
 	{
 		if( SONGMAN->GetNumSongs() == 0 )
 		{

--- a/src/GameConstantsAndTypes.cpp
+++ b/src/GameConstantsAndTypes.cpp
@@ -51,7 +51,7 @@ RString StepsTypeToString( StepsType st )
 {
 	RString s = GAMEMAN->GetStepsTypeInfo( st ).szName; // "dance-single"
 	/* foo-bar -> Foo_Bar */
-	s.Replace('-','_');
+	Replace(s, '-', '_');
 
 	bool bCapitalizeNextLetter = true;
 	for( int i=0; i<(int)s.length(); i++ )

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -3451,7 +3451,7 @@ const StepsTypeInfo &GameManager::GetStepsTypeInfo( StepsType st )
 
 StepsType GameManager::StringToStepsType( RString sStepsType )
 {
-	sStepsType.MakeLower();
+	MakeLower(sStepsType);
 
 	for( int i=0; i<NUM_StepsType; i++ )
 		if( g_StepsTypeInfos[i].szName == sStepsType )
@@ -3473,7 +3473,7 @@ RString GameManager::StyleToLocalizedString( const Style* style )
 const Game* GameManager::StringToGame( RString sGame )
 {
 	for( size_t i=0; i<ARRAYLEN(g_Games); ++i )
-		if( !sGame.CompareNoCase(g_Games[i]->m_szName) )
+		if( !CompareNoCase(sGame, g_Games[i]->m_szName) )
 			return g_Games[i];
 
 	return nullptr;
@@ -3485,7 +3485,7 @@ const Style* GameManager::GameAndStringToStyle( const Game *game, RString sStyle
 	for( int s=0; game->m_apStyles[s]; ++s )
 	{
 		const Style* style = game->m_apStyles[s];
-		if( sStyle.CompareNoCase(style->m_szName) == 0 )
+		if( CompareNoCase(sStyle, style->m_szName) == 0 )
 			return style;
 	}
 

--- a/src/GameSoundManager.cpp
+++ b/src/GameSoundManager.cpp
@@ -111,7 +111,7 @@ static GameSoundManager::PlayMusicParams g_FallbackMusicParams;
 static void StartMusic( MusicToPlay &ToPlay )
 {
 	LockMutex L( *g_Mutex );
-	if( g_Playing->m_Music->IsPlaying() && g_Playing->m_Music->GetLoadedFilePath().EqualsNoCase(ToPlay.m_sFile) )
+	if( g_Playing->m_Music->IsPlaying() && EqualsNoCase(g_Playing->m_Music->GetLoadedFilePath(), ToPlay.m_sFile) )
 		return;
 
 	/* We're changing or stopping the music.  If we were dimming, reset. */
@@ -295,7 +295,7 @@ static void DoPlayOnceFromDir( RString sPath )
 		return;
 
 	// make sure there's a slash at the end of this path
-	if( sPath.Right(1) != "/" )
+	if( Right(sPath, 1) != "/" )
 		sPath += "/";
 
 	std::vector<RString> arraySoundFiles;

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -2332,7 +2332,7 @@ void GameState::StoreRankingName( PlayerNumber pn, RString sName )
 					break;
 				}
 
-				sLine.MakeUpper();
+				MakeUpper(sLine);
 				if( !sLine.empty() && sName.find(sLine) != std::string::npos )	// name contains a bad word
 				{
 					LOG->Trace( "entered '%s' matches blacklisted item '%s'", sName.c_str(), sLine.c_str() );

--- a/src/Grade.cpp
+++ b/src/Grade.cpp
@@ -61,7 +61,7 @@ Grade GradeToOldGrade( Grade g )
 Grade StringToGrade( const RString &sGrade )
 {
 	RString s = sGrade;
-	s.MakeUpper();
+	MakeUpper(s);
 
 	// new style
 	int iTier;

--- a/src/IniFile.cpp
+++ b/src/IniFile.cpp
@@ -100,8 +100,8 @@ bool IniFile::ReadFile( RageFileBasic &f )
 				size_t iEqualIndex = line.find("=");
 				if( iEqualIndex != std::string::npos )
 				{
-					RString valuename = line.Left((int) iEqualIndex);
-					RString value = line.Right(line.size()-valuename.size()-1);
+					RString valuename = Left(line, (int) iEqualIndex);
+					RString value = Right(line, line.size()-valuename.size()-1);
 					Trim(valuename);
 					if(!valuename.empty())
 					{

--- a/src/InputMapper.cpp
+++ b/src/InputMapper.cpp
@@ -669,7 +669,7 @@ void InputMapper::AutoMapJoysticksForCurrentGame()
 		for( unsigned j=0; j<ARRAYLEN(g_AutoMappings); j++ )
 		{
 			const AutoMappings& mapping = g_AutoMappings[j];
-			if( mapping.m_sGame.EqualsNoCase(m_pInputScheme->m_szName) )
+			if( EqualsNoCase(mapping.m_sGame, m_pInputScheme->m_szName) )
 				vAutoMappings.push_back( mapping );
 		}
 	}

--- a/src/InputQueue.cpp
+++ b/src/InputQueue.cpp
@@ -189,23 +189,23 @@ bool InputQueueCode::Load( RString sButtonsNames )
 			bool bNotHold = false;
 			for(;;)
 			{
-				if( sButtonName.Left(1) == "+" )
+				if( Left(sButtonName, 1) == "+" )
 				{
 					m_aPresses.back().m_InputTypes[IET_REPEAT] = true;
 					sButtonName.erase(0, 1);
 				}
-				else if( sButtonName.Left(1) == "~" )
+				else if( Left(sButtonName, 1) == "~" )
 				{
 					m_aPresses.back().m_InputTypes[IET_FIRST_PRESS] = false;
 					m_aPresses.back().m_InputTypes[IET_RELEASE] = true;
 					sButtonName.erase(0, 1);
 				}
-				else if( sButtonName.Left(1) == "@" )
+				else if( Left(sButtonName, 1) == "@" )
 				{
 					sButtonName.erase(0, 1);
 					bHold = true;
 				}
-				else if( sButtonName.Left(1) == "!" )
+				else if( Left(sButtonName, 1) == "!" )
 				{
 					sButtonName.erase(0, 1);
 					bNotHold = true;

--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -925,7 +925,7 @@ void LuaHelpers::ParseCommandList( Lua *L, const RString &sCommands, const RStri
 		{
 			RString sCmdName = cmd.GetName();
 			if( bLegacy )
-				sCmdName.MakeLower();
+				MakeLower(sCmdName);
 			s << "\tself:" << sCmdName << "(";
 
 			bool bFirstParamIsString = bLegacy && (
@@ -950,7 +950,7 @@ void LuaHelpers::ParseCommandList( Lua *L, const RString &sCommands, const RStri
 
 				if( i==1 && bFirstParamIsString ) // string literal, legacy only
 				{
-					sArg.Replace( "'", "\\'" );	// escape quote
+					Replace(sArg, "'", "\\'");	// escape quote
 					s << "'" << sArg << "'";
 				}
 				else if( sArg[0] == '#' )	// HTML color

--- a/src/LyricsLoader.cpp
+++ b/src/LyricsLoader.cpp
@@ -70,7 +70,7 @@ bool LyricsLoader::LoadFromLRCFile(const RString& sPath, Song& out)
 		StripCrnl(sValueData);
 
 		// handle the data
-		if( sValueName.EqualsNoCase("COLOUR") || sValueName.EqualsNoCase("COLOR") )
+		if( EqualsNoCase(sValueName, "COLOUR") || EqualsNoCase(sValueName, "COLOR") )
 		{
 			// set color var here for this segment
 			unsigned int r, g, b;
@@ -102,7 +102,7 @@ bool LyricsLoader::LoadFromLRCFile(const RString& sPath, Song& out)
 			seg.m_fStartTime = HHMMSSToSeconds(sValueName);
 			seg.m_sLyric = sValueData;
 
-			seg.m_sLyric.Replace( "|","\n" ); // Pipe symbols denote a new line in LRC files
+			Replace(seg.m_sLyric, "|", "\n"); // Pipe symbols denote a new line in LRC files
 			out.AddLyricSegment( seg );
 		}
 	}

--- a/src/MemoryCardManager.cpp
+++ b/src/MemoryCardManager.cpp
@@ -380,7 +380,7 @@ void MemoryCardManager::UpdateAssignments()
 		{
 			// search for card dir match
 			if( !m_sMemoryCardOsMountPoint[p].Get().empty() &&
-				d->sOsMountDir.CompareNoCase(m_sMemoryCardOsMountPoint[p].Get()) )
+				CompareNoCase(d->sOsMountDir, m_sMemoryCardOsMountPoint[p].Get()) )
 				continue; // not a match
 
 			// search for USB bus match
@@ -678,7 +678,7 @@ void MemoryCardManager::UnmountCard( PlayerNumber pn )
 bool MemoryCardManager::PathIsMemCard( RString sDir ) const
 {
 	FOREACH_PlayerNumber( p )
-		if( !sDir.Left(MEM_CARD_MOUNT_POINT[p].size()).CompareNoCase( MEM_CARD_MOUNT_POINT[p] ) )
+		if( !CompareNoCase(Left(sDir, MEM_CARD_MOUNT_POINT[p].size()), MEM_CARD_MOUNT_POINT[p]) )
 			return true;
 	return false;
 }

--- a/src/ModIcon.cpp
+++ b/src/ModIcon.cpp
@@ -56,10 +56,10 @@ void ModIcon::Set( const RString &_sText )
 	RString sText = _sText;
 
 	for( unsigned i = 0; i < m_vStopWords.size(); i++ )
-		if( sText.EqualsNoCase(m_vStopWords[i]) )
+		if( EqualsNoCase(sText, m_vStopWords[i]) )
 			sText = "";
 
-	sText.Replace( " ", "\n" );
+	Replace(sText, " ", "\n");
 
 	bool bVacant = (sText=="");
 	m_sprFilled->SetVisible( !bVacant );

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -64,7 +64,7 @@ void Model::Load( const RString &sFile )
 	if( sFile == "" ) return;
 
 	RString sExt = GetExtension(sFile);
-	sExt.MakeLower();
+	MakeLower(sExt);
 	if( sExt=="txt" )
 		LoadMilkshapeAscii( sFile );
 	RecalcAnimationLengthSeconds();

--- a/src/ModelTypes.cpp
+++ b/src/ModelTypes.cpp
@@ -55,7 +55,7 @@ void AnimatedTexture::Load( const RString &sTexOrIniPath )
 	else
 		m_BlendMode = BLEND_NORMAL;
 
-	if( GetExtension(sTexOrIniPath).CompareNoCase("ini")==0 )
+	if( CompareNoCase(GetExtension(sTexOrIniPath), "ini")==0 )
 	{
 		IniFile ini;
 		if( !ini.ReadFile( sTexOrIniPath ) )

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -134,10 +134,10 @@ bool NetworkManager::IsUrlAllowed(const std::string& url)
 		return false;
 	}
 
-	host.MakeLower();
+	MakeLower(host);
 
 	RString allowedHostsStr = this->httpAllowHosts.Get();
-	allowedHostsStr.MakeLower();
+	MakeLower(allowedHostsStr);
 
 	std::vector<RString> allowedHosts;
 	split(allowedHostsStr, ",", allowedHosts);

--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -121,7 +121,7 @@ void NoteField::SetBeatBarsAlpha(float measure, float fourth, float eighth, floa
 void NoteField::CacheNoteSkin( const RString &sNoteSkin_ )
 {
 	RString sNoteSkinLower = sNoteSkin_;
-	sNoteSkinLower.MakeLower();
+	MakeLower(sNoteSkinLower);
 
 	if( m_NoteDisplays.find(sNoteSkinLower) != m_NoteDisplays.end() )
 		return;
@@ -142,7 +142,7 @@ void NoteField::CacheNoteSkin( const RString &sNoteSkin_ )
 void NoteField::UncacheNoteSkin( const RString &sNoteSkin_ )
 {
 	RString sNoteSkinLower = sNoteSkin_;
-	sNoteSkinLower.MakeLower();
+	MakeLower(sNoteSkinLower);
 
 	LOG->Trace("NoteField::CacheNoteSkin: release %s", sNoteSkinLower.c_str() );
 	ASSERT_M( m_NoteDisplays.find(sNoteSkinLower) != m_NoteDisplays.end(), sNoteSkinLower );
@@ -167,7 +167,7 @@ void NoteField::CacheAllUsedNoteSkins()
 	for (RString &s : asSkinsLower)
 	{
 		NOTESKIN->ValidateNoteSkinName(s);
-		s.MakeLower();
+		MakeLower(s);
 	}
 
 	for( unsigned i=0; i < asSkinsLower.size(); ++i )
@@ -187,7 +187,7 @@ void NoteField::CacheAllUsedNoteSkins()
 
 	RString sCurrentNoteSkinLower = m_pPlayerState->m_PlayerOptions.GetCurrent().m_sNoteSkin;
 	NOTESKIN->ValidateNoteSkinName(sCurrentNoteSkinLower);
-	sCurrentNoteSkinLower.MakeLower();
+	MakeLower(sCurrentNoteSkinLower);
 
 	std::map<RString, NoteDisplayCols*>::iterator it = m_NoteDisplays.find( sCurrentNoteSkinLower );
 	ASSERT_M( it != m_NoteDisplays.end(), sCurrentNoteSkinLower );
@@ -198,7 +198,7 @@ void NoteField::CacheAllUsedNoteSkins()
 	{
 		RString sNoteSkinLower = GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.GetCurrent().m_sNoteSkin;
 		NOTESKIN->ValidateNoteSkinName(sNoteSkinLower);
-		sNoteSkinLower.MakeLower();
+		MakeLower(sNoteSkinLower);
 		it = m_NoteDisplays.find( sNoteSkinLower );
 		ASSERT_M( it != m_NoteDisplays.end(), sNoteSkinLower );
 		m_pDisplays[pn] = it->second;
@@ -279,7 +279,7 @@ void NoteField::ensure_note_displays_have_skin()
 		m_NoteDisplays.insert(std::pair<RString, NoteDisplayCols *> (sNoteSkinLower, badIdea));
 	}
 
-	sNoteSkinLower.MakeLower();
+	MakeLower(sNoteSkinLower);
 	std::map<RString, NoteDisplayCols *>::iterator it = m_NoteDisplays.find( sNoteSkinLower );
 	ASSERT_M( it != m_NoteDisplays.end(), ssprintf("iterator != m_NoteDisplays.end() [sNoteSkinLower = %s]",sNoteSkinLower.c_str()) );
 	memset( m_pDisplays, 0, sizeof(m_pDisplays) );
@@ -299,7 +299,7 @@ void NoteField::ensure_note_displays_have_skin()
 			m_NoteDisplays.insert(std::pair<RString, NoteDisplayCols *> (sNoteSkinLower, badIdea));
 		}
 
-		sNoteSkinLower.MakeLower();
+		MakeLower(sNoteSkinLower);
 		it = m_NoteDisplays.find( sNoteSkinLower );
 		ASSERT_M( it != m_NoteDisplays.end(), sNoteSkinLower );
 		m_pDisplays[pn] = it->second;

--- a/src/NoteSkinManager.cpp
+++ b/src/NoteSkinManager.cpp
@@ -90,7 +90,7 @@ void NoteSkinManager::RefreshNoteSkinData( const Game* pGame )
 	for( unsigned j=0; j<asNoteSkinNames.size(); j++ )
 	{
 		RString sName = asNoteSkinNames[j];
-		sName.MakeLower();
+		MakeLower(sName);
 		// Don't feel like changing the structure of this code to load the skin
 		// into a temp variable and move it, so if the load fails, then just
 		// delete it from the map. -Kyz
@@ -147,9 +147,9 @@ bool NoteSkinManager::LoadNoteSkinDataRecursive( const RString &sNoteSkinName_, 
 		IniFile ini;
 		ini.ReadFile( sDir+"metrics.ini" );
 
-		if( !sNoteSkinName.CompareNoCase(GAME_BASE_NOTESKIN_NAME) )
+		if( !CompareNoCase(sNoteSkinName, GAME_BASE_NOTESKIN_NAME) )
 			bLoadedBase = true;
-		if( !sNoteSkinName.CompareNoCase(GAME_COMMON_NOTESKIN_NAME) )
+		if( !CompareNoCase(sNoteSkinName, GAME_COMMON_NOTESKIN_NAME) )
 			bLoadedCommon = true;
 
 		RString sFallback;
@@ -294,7 +294,7 @@ RString NoteSkinManager::GetMetric( const RString &sButtonName, const RString &s
 		return "";
 	}
 	RString sNoteSkinName = m_sCurrentNoteSkin;
-	sNoteSkinName.MakeLower();
+	MakeLower(sNoteSkinName);
 	std::map<RString, NoteSkinData>::const_iterator it = g_mapNameToData.find(sNoteSkinName);
 	ASSERT_M( it != g_mapNameToData.end(), sNoteSkinName );	// this NoteSkin doesn't exist!
 	const NoteSkinData& data = it->second;
@@ -346,7 +346,7 @@ RString NoteSkinManager::GetPath( const RString &sButtonName, const RString &sEl
 		return "";
 	}
 	RString sNoteSkinName = m_sCurrentNoteSkin;
-	sNoteSkinName.MakeLower();
+	MakeLower(sNoteSkinName);
 	std::map<RString, NoteSkinData>::const_iterator iter = g_mapNameToData.find( sNoteSkinName );
 	ASSERT( iter != g_mapNameToData.end() );
 	const NoteSkinData &data = iter->second;

--- a/src/NotesLoader.cpp
+++ b/src/NotesLoader.cpp
@@ -21,7 +21,7 @@ void NotesLoader::GetMainAndSubTitlesFromFullTitle( const RString &sFullTitle, R
 		size_t iBeginIndex = sFullTitle.find(sep);
 		if (iBeginIndex != std::string::npos)
 		{
-			sMainTitleOut = sFullTitle.Left(static_cast<int>(iBeginIndex));
+			sMainTitleOut = Left(sFullTitle, static_cast<int>(iBeginIndex));
 			sSubTitleOut = sFullTitle.substr(iBeginIndex + sep.size(), fullTitleSize - iBeginIndex - sep.size());
 			return;
 		}

--- a/src/NotesLoaderBMS.cpp
+++ b/src/NotesLoaderBMS.cpp
@@ -75,7 +75,7 @@ static RString FindLargestInitialSubstring( const RString &string1, const RStrin
 
 static void SearchForDifficulty( RString sTag, Steps *pOut )
 {
-	sTag.MakeLower();
+	MakeLower(sTag);
 
 	// Only match "Light" in parentheses.
 	if( sTag.find( "(light" ) != sTag.npos )
@@ -425,7 +425,7 @@ struct bmsCommandTree
 
 		if (space != statement.npos)
 			value = statement.substr(space + 1);
-		name.MakeLower();
+		MakeLower(name);
 
 		if (name == "#if")
 		{
@@ -573,7 +573,7 @@ bool BMSChart::Load( const RString &chartPath )
 				RString value = data.substr(2 * i, 2);
 				if (value != "00")
 				{
-					value.MakeLower();
+					MakeLower(value);
 					BMSObject o = { channel, measure, (float)i / count, flag, value };
 					objects.push_back(o);
 				}
@@ -885,7 +885,7 @@ void BMSChartReader::ReadHeaders()
 		else if( it->first == "#lnobj" )
 		{
 			lnobj = it->second;
-			lnobj.MakeLower();
+			MakeLower(lnobj);
 		}
 		else if( it->first == "#playlevel" )
 		{
@@ -1587,7 +1587,7 @@ void BMSSongLoader::AddToSong()
 			if( title != "" && title.size() != commonSubstring.size() )
 			{
 				RString tag = title.substr( commonSubstring.size(), title.size() - commonSubstring.size() );
-				tag.MakeLower();
+				MakeLower(tag);
 
 				// XXX: We should do this with filenames too, I have plenty of examples.
 				// however, filenames will be trickier, as stuff at the beginning AND

--- a/src/NotesLoaderDWI.cpp
+++ b/src/NotesLoaderDWI.cpp
@@ -151,7 +151,7 @@ const int BEATS_PER_MEASURE = 4;
 Difficulty DwiCompatibleStringToDifficulty( const RString& sDC )
 {
 	RString s2 = sDC;
-	s2.MakeLower();
+	MakeLower(s2);
 	if( s2 == "beginner" )			return Difficulty_Beginner;
 	else if( s2 == "easy" )		return Difficulty_Easy;
 	else if( s2 == "basic" )		return Difficulty_Easy;
@@ -246,10 +246,10 @@ static NoteData ParseNoteData(RString &step1, RString &step2,
 				DEFAULT_FAIL( pad );
 		}
 
-		sStepData.Replace("\n", "");
-		sStepData.Replace("\r", "");
-		sStepData.Replace("\t", "");
-		sStepData.Replace(" ", "");
+		Replace(sStepData, "\n", "");
+		Replace(sStepData, "\r", "");
+		Replace(sStepData, "\t", "");
+		Replace(sStepData, " ", "");
 
 		double fCurrentBeat = 0;
 		double fCurrentIncrementer = 1.0/8 * BEATS_PER_MEASURE;
@@ -521,10 +521,10 @@ bool DWILoader::LoadNoteDataFromSimfile( const RString &path, Steps &out )
 		const MsdFile::value_t &params = msd.GetValue(i);
 		RString valueName = params[0];
 
-		if(valueName.EqualsNoCase("SINGLE")  ||
-		   valueName.EqualsNoCase("DOUBLE")  ||
-		   valueName.EqualsNoCase("COUPLE")  ||
-		   valueName.EqualsNoCase("SOLO") )
+		if(EqualsNoCase(valueName, "SINGLE")  ||
+		   EqualsNoCase(valueName, "DOUBLE")  ||
+		   EqualsNoCase(valueName, "COUPLE")  ||
+		   EqualsNoCase(valueName, "SOLO") )
 		{
 			if (out.m_StepsType != GetTypeFromMode(valueName))
 				continue;
@@ -580,10 +580,10 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 		}
 
 		// handle the data
-		if( sValueName.EqualsNoCase("FILE") )
+		if( EqualsNoCase(sValueName, "FILE") )
 			out.m_sMusicFile = sParams[1];
 
-		else if( sValueName.EqualsNoCase("TITLE") )
+		else if( EqualsNoCase(sValueName, "TITLE") )
 		{
 			NotesLoader::GetMainAndSubTitlesFromFullTitle( sParams[1], out.m_sMainTitle, out.m_sSubTitle );
 
@@ -593,22 +593,22 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 			ConvertString( out.m_sSubTitle, "utf-8,english" );
 		}
 
-		else if( sValueName.EqualsNoCase("ARTIST") )
+		else if( EqualsNoCase(sValueName, "ARTIST") )
 		{
 			out.m_sArtist = sParams[1];
 			ConvertString( out.m_sArtist, "utf-8,english" );
 		}
 
-		else if( sValueName.EqualsNoCase("GENRE") )
+		else if( EqualsNoCase(sValueName, "GENRE") )
 		{
 			out.m_sGenre = sParams[1];
 			ConvertString( out.m_sGenre, "utf-8,english" );
 		}
 
-		else if( sValueName.EqualsNoCase("CDTITLE") )
+		else if( EqualsNoCase(sValueName, "CDTITLE") )
 			out.m_sCDTitleFile = sParams[1];
 
-		else if( sValueName.EqualsNoCase("BPM") )
+		else if( EqualsNoCase(sValueName, "BPM") )
 		{
 			const float fBPM = StringToFloat( sParams[1] );
 
@@ -622,7 +622,7 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 				out.m_SongTiming.AddSegment( BPMSegment(0, fBPM) );
 			}
 		}
-		else if( sValueName.EqualsNoCase("DISPLAYBPM") )
+		else if( EqualsNoCase(sValueName, "DISPLAYBPM") )
 		{
 			// #DISPLAYBPM:[xxx..xxx]|[xxx]|[*];
 		    int iMin, iMax;
@@ -646,14 +646,14 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 			}
 		}
 
-		else if( sValueName.EqualsNoCase("GAP") )
+		else if( EqualsNoCase(sValueName, "GAP") )
 			// the units of GAP is 1/1000 second
 			out.m_SongTiming.m_fBeat0OffsetInSeconds = -StringToInt(sParams[1]) / 1000.0f;
 
-		else if( sValueName.EqualsNoCase("SAMPLESTART") )
+		else if( EqualsNoCase(sValueName, "SAMPLESTART") )
 			out.m_fMusicSampleStartSeconds = ParseBrokenDWITimestamp(sParams[1], sParams[2], sParams[3]);
 
-		else if( sValueName.EqualsNoCase("SAMPLELENGTH") )
+		else if( EqualsNoCase(sValueName, "SAMPLELENGTH") )
 		{
 			float sampleLength = ParseBrokenDWITimestamp(sParams[1], sParams[2], sParams[3]);
 			if (sampleLength > 0 && sampleLength < 1) {
@@ -664,7 +664,7 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 
 		}
 
-		else if( sValueName.EqualsNoCase("FREEZE") )
+		else if( EqualsNoCase(sValueName, "FREEZE") )
 		{
 			std::vector<RString> arrayFreezeExpressions;
 			split( sParams[1], ",", arrayFreezeExpressions );
@@ -686,7 +686,7 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 			}
 		}
 
-		else if( sValueName.EqualsNoCase("CHANGEBPM")  || sValueName.EqualsNoCase("BPMCHANGE") )
+		else if( EqualsNoCase(sValueName, "CHANGEBPM")  || EqualsNoCase(sValueName, "BPMCHANGE") )
 		{
 			std::vector<RString> arrayBPMChangeExpressions;
 			split( sParams[1], ",", arrayBPMChangeExpressions );
@@ -711,10 +711,10 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 			}
 		}
 
-		else if( sValueName.EqualsNoCase("SINGLE")  ||
-			 sValueName.EqualsNoCase("DOUBLE")  ||
-			 sValueName.EqualsNoCase("COUPLE")  ||
-			 sValueName.EqualsNoCase("SOLO") )
+		else if( EqualsNoCase(sValueName, "SINGLE")  ||
+			 EqualsNoCase(sValueName, "DOUBLE")  ||
+			 EqualsNoCase(sValueName, "COUPLE")  ||
+			 EqualsNoCase(sValueName, "SOLO") )
 		{
 			Steps* pNewNotes = out.CreateSteps();
 			LoadFromDWITokens(
@@ -734,8 +734,8 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 			else
 				delete pNewNotes;
 		}
-		else if( sValueName.EqualsNoCase("DISPLAYTITLE") ||
-			sValueName.EqualsNoCase("DISPLAYARTIST") )
+		else if( EqualsNoCase(sValueName, "DISPLAYTITLE") ||
+			EqualsNoCase(sValueName, "DISPLAYARTIST") )
 		{
 			/* We don't want to support these tags.  However, we don't want
 			 * to pick up images used here as song images (eg. banners). */
@@ -756,7 +756,7 @@ bool DWILoader::LoadFromDir( const RString &sPath_, Song &out, std::set<RString>
 
 				pos = endpos + 1;
 
-				sub.MakeLower();
+				MakeLower(sub);
 				BlacklistedImages.insert( sub );
 			}
 		}

--- a/src/NotesLoaderJson.cpp
+++ b/src/NotesLoaderJson.cpp
@@ -173,9 +173,9 @@ static void Deserialize( Song &out, const Json::Value &root )
 	out.m_fMusicSampleStartSeconds = (float)root["SampleStart"].asDouble();
 	out.m_fMusicSampleLengthSeconds = (float)root["SampleLength"].asDouble();
 	RString sSelectable = root["Selectable"].asString();
-	if( sSelectable.EqualsNoCase("YES") )
+	if( EqualsNoCase(sSelectable, "YES") )
 		out.m_SelectionDisplay = out.SHOW_ALWAYS;
-	else if( sSelectable.EqualsNoCase("NO") )
+	else if( EqualsNoCase(sSelectable, "NO") )
 		out.m_SelectionDisplay = out.SHOW_NEVER;
 
 	out.m_sSongFileName = root["SongFileName"].asString();

--- a/src/NotesLoaderKSF.cpp
+++ b/src/NotesLoaderKSF.cpp
@@ -50,7 +50,7 @@ static bool LoadFromKSFFile( const RString &sPath, Steps &out, Song &song, bool 
 	{
 		const MsdFile::value_t &sParams = msd.GetValue( i );
 		RString sValueName = sParams[0];
-		sValueName.MakeUpper();
+		MakeUpper(sValueName);
 
 		/* handle the data...well, not this data: not related to steps.
 		 * Skips INTRO, MUSICINTRO, TITLEFILE, DISCFILE, SONGFILE. */
@@ -150,7 +150,7 @@ static bool LoadFromKSFFile( const RString &sPath, Steps &out, Song &song, bool 
 		else if( sValueName=="PLAYER" )
 		{
 			RString sPlayer = sParams[1];
-			sPlayer.MakeLower();
+			MakeLower(sPlayer);
 			if( sPlayer.find( "double" ) != std::string::npos )
 				bDoublesChart = true;
 		}
@@ -188,7 +188,7 @@ static bool LoadFromKSFFile( const RString &sPath, Steps &out, Song &song, bool 
 	{
 		RString sDir, sFName, sExt;
 		splitpath( sPath, sDir, sFName, sExt );
-		sFName.MakeLower();
+		MakeLower(sFName);
 
 		out.SetDescription(sFName);
 		// Check another before anything else... is this okay? -DaisuMaster
@@ -479,12 +479,12 @@ static void LoadTags( const RString &str, Song &out )
 	split( str, " - ", asBits, false );
 	// Ignore the difficulty, since we get that elsewhere.
 	if( asBits.size() == 3 && (
-		asBits[2].EqualsNoCase("double") ||
-		asBits[2].EqualsNoCase("easy") ||
-		asBits[2].EqualsNoCase("normal") ||
-		asBits[2].EqualsNoCase("hard") ||
-		asBits[2].EqualsNoCase("crazy") ||
-		asBits[2].EqualsNoCase("nightmare"))
+		EqualsNoCase(asBits[2], "double") ||
+		EqualsNoCase(asBits[2], "easy") ||
+		EqualsNoCase(asBits[2], "normal") ||
+		EqualsNoCase(asBits[2], "hard") ||
+		EqualsNoCase(asBits[2], "crazy") ||
+		EqualsNoCase(asBits[2], "nightmare"))
 		)
 	{
 		asBits.erase( asBits.begin()+2, asBits.begin()+3 );
@@ -557,7 +557,7 @@ static bool LoadGlobalData( const RString &sPath, Song &out, bool &bKIUCompliant
 	{
 		const MsdFile::value_t &sParams = msd.GetValue(i);
 		RString sValueName = sParams[0];
-		sValueName.MakeUpper();
+		MakeUpper(sValueName);
 
 		// handle the data
 		if( sValueName=="TITLE" )

--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -146,18 +146,18 @@ void SMSetDisplayBPM(SMSongTagInfo& info)
 }
 void SMSetSelectable(SMSongTagInfo& info)
 {
-	if((*info.params)[1].EqualsNoCase("YES"))
+	if(EqualsNoCase((*info.params)[1], "YES"))
 	{ info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; }
-	else if((*info.params)[1].EqualsNoCase("NO"))
+	else if(EqualsNoCase((*info.params)[1], "NO"))
 	{ info.song->m_SelectionDisplay = info.song->SHOW_NEVER; }
 	// ROULETTE from 3.9. It was removed since UnlockManager can serve
 	// the same purpose somehow. This, of course, assumes you're using
 	// unlocks. -aj
-	else if((*info.params)[1].EqualsNoCase("ROULETTE"))
+	else if(EqualsNoCase((*info.params)[1], "ROULETTE"))
 	{ info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; }
 	/* The following two cases are just fixes to make sure simfiles that
 	 * used 3.9+ features are not excluded here */
-	else if((*info.params)[1].EqualsNoCase("ES") || (*info.params)[1].EqualsNoCase("OMES"))
+	else if(EqualsNoCase((*info.params)[1], "ES") || EqualsNoCase((*info.params)[1], "OMES"))
 	{ info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; }
 	else if(StringToInt((*info.params)[1]) > 0)
 	{ info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; }
@@ -326,11 +326,11 @@ void SMLoader::LoadFromTokens(
 	if( out.GetDifficulty() == Difficulty_Hard )
 	{
 		// HACK: SMANIAC used to be Difficulty_Hard with a special description.
-		if( sDescription.CompareNoCase("smaniac") == 0 )
+		if( CompareNoCase(sDescription, "smaniac") == 0 )
 			out.SetDifficulty( Difficulty_Challenge );
 
 		// HACK: CHALLENGE used to be Difficulty_Hard with a special description.
-		if( sDescription.CompareNoCase("challenge") == 0 )
+		if( CompareNoCase(sDescription, "challenge") == 0 )
 			out.SetDifficulty( Difficulty_Challenge );
 	}
 
@@ -399,13 +399,13 @@ void SMLoader::ProcessAttacks( AttackArray &attacks, MsdFile::value_t params )
 
 		Trim( sBits[0] );
 
-		if( !sBits[0].CompareNoCase("TIME") )
+		if( !CompareNoCase(sBits[0], "TIME") )
 			attack.fStartSecond = strtof( sBits[1].c_str(), nullptr );
-		else if( !sBits[0].CompareNoCase("LEN") )
+		else if( !CompareNoCase(sBits[0], "LEN") )
 			attack.fSecsRemaining = strtof( sBits[1].c_str(), nullptr );
-		else if( !sBits[0].CompareNoCase("END") )
+		else if( !CompareNoCase(sBits[0], "END") )
 			end = strtof( sBits[1].c_str(), nullptr );
-		else if( !sBits[0].CompareNoCase("MODS") )
+		else if( !CompareNoCase(sBits[0], "MODS") )
 		{
 			Trim(sBits[1]);
 			attack.sModifiers = sBits[1];
@@ -983,12 +983,12 @@ bool SMLoader::LoadFromBGChangesVector( BackgroundChange &change, std::vector<RS
 	{
 	case 11:
 		change.m_def.m_sColor2 = aBGChangeValues[10];
-		change.m_def.m_sColor2.Replace( '^', ',' );
+		Replace(change.m_def.m_sColor2, '^', ',');
 		change.m_def.m_sColor2 = RageColor::NormalizeColorString( change.m_def.m_sColor2 );
 		[[fallthrough]];
 	case 10:
 		change.m_def.m_sColor1 = aBGChangeValues[9];
-		change.m_def.m_sColor1.Replace( '^', ',' );
+		Replace(change.m_def.m_sColor1, '^', ',');
 		change.m_def.m_sColor1 = RageColor::NormalizeColorString( change.m_def.m_sColor1 );
 		[[fallthrough]];
 	case 9:
@@ -997,7 +997,7 @@ bool SMLoader::LoadFromBGChangesVector( BackgroundChange &change, std::vector<RS
 	case 8:
 	{
 		RString tmp = aBGChangeValues[7];
-		tmp.MakeLower();
+		MakeLower(tmp);
 		if( ( tmp.find(".ini") != std::string::npos || tmp.find(".xml") != std::string::npos )
 		   && !PREFSMAN->m_bQuirksMode )
 		{
@@ -1041,7 +1041,7 @@ bool SMLoader::LoadFromBGChangesVector( BackgroundChange &change, std::vector<RS
 	case 2:
 	{
 		RString tmp = aBGChangeValues[1];
-		tmp.MakeLower();
+		MakeLower(tmp);
 		if( ( tmp.find(".ini") != std::string::npos || tmp.find(".xml") != std::string::npos )
 		   && !PREFSMAN->m_bQuirksMode )
 		{
@@ -1073,7 +1073,7 @@ bool SMLoader::LoadNoteDataFromSimfile( const RString &path, Steps &out )
 		int iNumParams = msd.GetNumParams(i);
 		const MsdFile::value_t &sParams = msd.GetValue(i);
 		RString sValueName = sParams[0];
-		sValueName.MakeUpper();
+		MakeUpper(sValueName);
 
 		// The only tag we care about is the #NOTES tag.
 		if( sValueName=="NOTES" || sValueName=="NOTES2" )
@@ -1092,27 +1092,27 @@ bool SMLoader::LoadNoteDataFromSimfile( const RString &path, Steps &out )
 			RString difficulty = sParams[3];
 
 			// HACK?: If this is a .edit fudge the edit difficulty
-			if(path.Right(5).CompareNoCase(".edit") == 0) difficulty = "edit";
+			if(CompareNoCase(Right(path, 5), ".edit") == 0) difficulty = "edit";
 
 			Trim(stepsType);
 			Trim(description);
 			Trim(difficulty);
 			// Remember our old versions.
-			if (difficulty.CompareNoCase("smaniac") == 0)
+			if (CompareNoCase(difficulty, "smaniac") == 0)
 			{
 				difficulty = "Challenge";
 			}
 
 			/* Handle hacks that originated back when StepMania didn't have
 			 * Difficulty_Challenge. TODO: Remove the need for said hacks. */
-			if( difficulty.CompareNoCase("hard") == 0 )
+			if( CompareNoCase(difficulty, "hard") == 0 )
 			{
 				/* HACK: Both SMANIAC and CHALLENGE used to be Difficulty_Hard.
 				 * They were differentiated via aspecial description.
 				 * Account for the rogue charts that do this. */
 				// HACK: SMANIAC used to be Difficulty_Hard with a special description.
-				if (description.CompareNoCase("smaniac") == 0 ||
-					description.CompareNoCase("challenge") == 0)
+				if (CompareNoCase(description, "smaniac") == 0 ||
+					CompareNoCase(description, "challenge") == 0)
 					difficulty = "Challenge";
 			}
 
@@ -1155,7 +1155,7 @@ bool SMLoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCache
 		int iNumParams = msd.GetNumParams(i);
 		const MsdFile::value_t &sParams = msd.GetValue(i);
 		RString sValueName = sParams[0];
-		sValueName.MakeUpper();
+		MakeUpper(sValueName);
 
 		reused_song_info.params= &sParams;
 		song_handler_map_t::iterator handler=
@@ -1166,7 +1166,7 @@ bool SMLoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCache
 		 * splitting other formats that *don't* natively support #SUBTITLE. */
 			handler->second(reused_song_info);
 		}
-		else if(sValueName.Left(strlen("BGCHANGES")) == "BGCHANGES")
+		else if(Left(sValueName, strlen("BGCHANGES")) == "BGCHANGES")
 		{
 			SMSetBGChanges(reused_song_info);
 		}
@@ -1241,7 +1241,7 @@ bool SMLoader::LoadEditFromMsd( const MsdFile &msd, const RString &sEditFilePath
 		int iNumParams = msd.GetNumParams(i);
 		const MsdFile::value_t &sParams = msd.GetValue(i);
 		RString sValueName = sParams[0];
-		sValueName.MakeUpper();
+		MakeUpper(sValueName);
 
 		// handle the data
 		if( sValueName=="SONG" )
@@ -1256,7 +1256,7 @@ bool SMLoader::LoadEditFromMsd( const MsdFile &msd, const RString &sEditFilePath
 
 			RString sSongFullTitle = sParams[1];
 			this->SetSongTitle(sParams[1]);
-			sSongFullTitle.Replace( '\\', '/' );
+			Replace(sSongFullTitle, '\\', '/');
 
 			pSong = SONGMAN->FindSong( sSongFullTitle );
 			if( pSong == nullptr )
@@ -1351,7 +1351,7 @@ void SMLoader::TidyUpData( Song &song, bool bFromCache )
 
 		for( unsigned i = 0; !bHasNoSongBgTag && i < bg.size(); ++i )
 		{
-			if( !bg[i].m_def.m_sFile1.CompareNoCase(NO_SONG_BG_FILE) )
+			if( !CompareNoCase(bg[i].m_def.m_sFile1, NO_SONG_BG_FILE) )
 			{
 				bg.erase( bg.begin()+i );
 				bHasNoSongBgTag = true;
@@ -1373,7 +1373,7 @@ void SMLoader::TidyUpData( Song &song, bool bFromCache )
 				break;
 
 			// If the last BGA is already the song BGA, don't add a duplicate.
-			if( !bg.empty() && !bg.back().m_def.m_sFile1.CompareNoCase(song.m_sBackgroundFile) )
+			if( !bg.empty() && !CompareNoCase(bg.back().m_def.m_sFile1, song.m_sBackgroundFile) )
 				break;
 
 			if( !IsAFile( song.GetBackgroundPath() ) )
@@ -1465,7 +1465,7 @@ void SMLoader::ParseBGChangesString(const RString& _sChanges, std::vector<std::v
 					continue;
 
 				// the string itself matches
-				if (f.EqualsNoCase(sChanges.substr(start, f.size()).c_str()))
+				if (EqualsNoCase(f, sChanges.substr(start, f.size()).c_str()))
 				{
 					size_t nextpos = start + f.size();
 

--- a/src/NotesLoaderSMA.cpp
+++ b/src/NotesLoaderSMA.cpp
@@ -187,7 +187,7 @@ bool SMALoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCach
 		int iNumParams = msd.GetNumParams(i);
 		const MsdFile::value_t &sParams = msd.GetValue(i);
 		RString sValueName = sParams[0];
-		sValueName.MakeUpper();
+		MakeUpper(sValueName);
 
 		// handle the data
 		/* Don't use GetMainAndSubTitlesFromFullTitle; that's only for heuristically
@@ -332,18 +332,18 @@ bool SMALoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCach
 
 		else if( sValueName=="SELECTABLE" )
 		{
-			if(sParams[1].EqualsNoCase("YES"))
+			if(EqualsNoCase(sParams[1], "YES"))
 				out.m_SelectionDisplay = out.SHOW_ALWAYS;
-			else if(sParams[1].EqualsNoCase("NO"))
+			else if(EqualsNoCase(sParams[1], "NO"))
 				out.m_SelectionDisplay = out.SHOW_NEVER;
 			// ROULETTE from 3.9. It was removed since UnlockManager can serve
 			// the same purpose somehow. This, of course, assumes you're using
 			// unlocks. -aj
-			else if(sParams[1].EqualsNoCase("ROULETTE"))
+			else if(EqualsNoCase(sParams[1], "ROULETTE"))
 				out.m_SelectionDisplay = out.SHOW_ALWAYS;
 			/* The following two cases are just fixes to make sure simfiles that
 			 * used 3.9+ features are not excluded here */
-			else if(sParams[1].EqualsNoCase("ES") || sParams[1].EqualsNoCase("OMES"))
+			else if(EqualsNoCase(sParams[1], "ES") || EqualsNoCase(sParams[1], "OMES"))
 				out.m_SelectionDisplay = out.SHOW_ALWAYS;
 			else if( StringToInt(sParams[1]) > 0 )
 				out.m_SelectionDisplay = out.SHOW_ALWAYS;
@@ -354,7 +354,7 @@ bool SMALoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCach
 					     sParams[1].c_str() );
 		}
 
-		else if( sValueName.Left(strlen("BGCHANGES"))=="BGCHANGES" || sValueName=="ANIMATIONS" )
+		else if( Left(sValueName, strlen("BGCHANGES"))=="BGCHANGES" || sValueName=="ANIMATIONS" )
 		{
 			SMLoader::ProcessBGChanges( out, sValueName, sPath, sParams[1]);
 		}

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -192,16 +192,16 @@ void SetDisplayBPM(SongTagInfo& info)
 }
 void SetSelectable(SongTagInfo& info)
 {
-	if((*info.params)[1].EqualsNoCase("YES"))
+	if(EqualsNoCase((*info.params)[1], "YES"))
 	{ info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; }
-	else if((*info.params)[1].EqualsNoCase("NO"))
+	else if(EqualsNoCase((*info.params)[1], "NO"))
 	{ info.song->m_SelectionDisplay = info.song->SHOW_NEVER; }
 	// ROULETTE from 3.9 is no longer in use.
-	else if((*info.params)[1].EqualsNoCase("ROULETTE"))
+	else if(EqualsNoCase((*info.params)[1], "ROULETTE"))
 	{ info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; }
 	/* The following two cases are just fixes to make sure simfiles that
 	 * used 3.9+ features are not excluded here */
-	else if((*info.params)[1].EqualsNoCase("ES") || (*info.params)[1].EqualsNoCase("OMES"))
+	else if(EqualsNoCase((*info.params)[1], "ES") || EqualsNoCase((*info.params)[1], "OMES"))
 	{ info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; }
 	else if(StringToInt((*info.params)[1]) > 0)
 	{ info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS; }
@@ -1028,7 +1028,7 @@ bool SSCLoader::LoadNoteDataFromSimfile( const RString & cachePath, Steps &out )
 	{
 		const MsdFile::value_t &params = msd.GetValue(i);
 		RString valueName = params[0];
-		valueName.MakeUpper();
+		MakeUpper(valueName);
 		RString matcher = params[1]; // mainly for debugging.
 		Trim(matcher);
 
@@ -1069,7 +1069,7 @@ bool SSCLoader::LoadNoteDataFromSimfile( const RString & cachePath, Steps &out )
 						// tag. -Kyz
 						if(out.GetDifficulty() != StringToDifficulty(matcher) &&
 							!(out.GetDifficulty() == Difficulty_Edit &&
-								GetExtension(cachePath).MakeLower() == "edit"))
+								MakeLower(GetExtension(cachePath)) == "edit"))
 						{ tryingSteps = false; }
 						break;
 					case LNDID_meter:
@@ -1140,7 +1140,7 @@ bool SSCLoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCach
 	{
 		const MsdFile::value_t &sParams = msd.GetValue(i);
 		RString sValueName = sParams[0];
-		sValueName.MakeUpper();
+		MakeUpper(sValueName);
 
 		switch (state)
 		{
@@ -1153,7 +1153,7 @@ bool SSCLoader::LoadFromSimfile( const RString &sPath, Song &out, bool bFromCach
 				{
 					handler->second(reused_song_info);
 				}
-				else if(sValueName.Left(strlen("BGCHANGES"))=="BGCHANGES")
+				else if(Left(sValueName, strlen("BGCHANGES"))=="BGCHANGES")
 				{
 					SetBGChanges(reused_song_info);
 				}
@@ -1259,7 +1259,7 @@ bool SSCLoader::LoadEditFromMsd(const MsdFile &msd,
 		int iNumParams = msd.GetNumParams(i);
 		const MsdFile::value_t &sParams = msd.GetValue(i);
 		RString sValueName = sParams[0];
-		sValueName.MakeUpper();
+		MakeUpper(sValueName);
 
 		if(pSong != nullptr)
 		{
@@ -1362,7 +1362,7 @@ bool SSCLoader::LoadEditFromMsd(const MsdFile &msd,
 
 				RString sSongFullTitle = sParams[1];
 				this->SetSongTitle(sParams[1]);
-				sSongFullTitle.Replace('\\', '/');
+				Replace(sSongFullTitle, '\\', '/');
 				pSong = SONGMAN->FindSong(sSongFullTitle);
 				reused_steps_info.song= pSong;
 				if(pSong == nullptr)

--- a/src/OptionRow.cpp
+++ b/src/OptionRow.cpp
@@ -202,7 +202,7 @@ RString OptionRow::GetRowTitle() const
 	RString sTitle = m_pHand->OptionTitle();
 
 	// HACK: tack the BPM onto the name of the speed line
-	if( m_pHand->m_Def.m_sName.CompareNoCase("speed")==0 )
+	if( CompareNoCase(m_pHand->m_Def.m_sName, "speed")==0 )
 	{
 		bool bShowBpmInSpeedTitle = m_pParentType->SHOW_BPM_IN_SPEED_TITLE;
 

--- a/src/OptionRowHandler.cpp
+++ b/src/OptionRowHandler.cpp
@@ -351,7 +351,7 @@ public:
 	virtual ReloadChanged Reload()
 	{
 		// HACK: always reload "speed", to update the BPM text in the name of the speed line
-		if( !m_Def.m_sName.CompareNoCase("speed") )
+		if( !CompareNoCase(m_Def.m_sName, "speed") )
 			return RELOAD_CHANGED_ALL;
 
 		return OptionRowHandler::Reload();
@@ -703,7 +703,7 @@ class OptionRowHandlerListCharacters: public OptionRowHandlerList
 		{
 			Character* pCharacter = vpCharacters[i];
 			RString s = pCharacter->GetDisplayName();
-			s.MakeUpper();
+			MakeUpper(s);
 
 			m_Def.m_vsChoices.push_back( s );
 			GameCommand mc;
@@ -1570,18 +1570,18 @@ OptionRowHandler* OptionRowHandlerUtil::Make( const Commands &cmds )
 		ROW_INVALID_IF(command.m_vsArgs.size() != 2 || !sParam.size(),
 			"list row command must be 'list,name' or 'list,type'.", nullptr);
 
-		if(	 sParam.CompareNoCase("NoteSkins")==0 )		MAKE( OptionRowHandlerListNoteSkins )
-		else if( sParam.CompareNoCase("Steps")==0 )		MAKE( OptionRowHandlerListSteps )
-		else if( sParam.CompareNoCase("StepsLocked")==0 )
+		if(	 CompareNoCase(sParam, "NoteSkins")==0 )		MAKE( OptionRowHandlerListNoteSkins )
+		else if( CompareNoCase(sParam, "Steps")==0 )		MAKE( OptionRowHandlerListSteps )
+		else if( CompareNoCase(sParam, "StepsLocked")==0 )
 		{
 			MAKE( OptionRowHandlerListSteps );
 			pHand->m_Def.m_bOneChoiceForAllPlayers = true;
 		}
-		else if( sParam.CompareNoCase("Characters")==0 )	MAKE( OptionRowHandlerListCharacters )
-		else if( sParam.CompareNoCase("Styles")==0 )		MAKE( OptionRowHandlerListStyles )
-		else if( sParam.CompareNoCase("Groups")==0 )		MAKE( OptionRowHandlerListGroups )
-		else if( sParam.CompareNoCase("Difficulties")==0 )	MAKE( OptionRowHandlerListDifficulties )
-		else if( sParam.CompareNoCase("SongsInCurrentSongGroup")==0 )	MAKE( OptionRowHandlerListSongsInCurrentSongGroup )
+		else if( CompareNoCase(sParam, "Characters")==0 )	MAKE( OptionRowHandlerListCharacters )
+		else if( CompareNoCase(sParam, "Styles")==0 )		MAKE( OptionRowHandlerListStyles )
+		else if( CompareNoCase(sParam, "Groups")==0 )		MAKE( OptionRowHandlerListGroups )
+		else if( CompareNoCase(sParam, "Difficulties")==0 )	MAKE( OptionRowHandlerListDifficulties )
+		else if( CompareNoCase(sParam, "SongsInCurrentSongGroup")==0 )	MAKE( OptionRowHandlerListSongsInCurrentSongGroup )
 		else MAKE( OptionRowHandlerList )
 	}
 	else if( name == "lua" )		MAKE( OptionRowHandlerLua )

--- a/src/PercentageDisplay.cpp
+++ b/src/PercentageDisplay.cpp
@@ -184,7 +184,7 @@ void PercentageDisplay::Refresh()
 			}
 
 			// HACK: Use the last frame in the numbers texture as '-'
-			sNumToDisplay.Replace('-','x');
+			Replace(sNumToDisplay, '-', 'x');
 		}
 	}
 

--- a/src/PlayerOptions.cpp
+++ b/src/PlayerOptions.cpp
@@ -648,7 +648,7 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 
 	RString sBit = sOneMod;
 	RString sMod = "";
-	sBit.MakeLower();
+	MakeLower(sBit);
 	Trim( sBit );
 
 	/* "drunk"
@@ -677,7 +677,7 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 			}
 			/* If the last character is a *, they probably said "123*" when
 			 * they meant "*123". */
-			else if( s.Right(1) == "*" )
+			else if( Right(s, 1) == "*" )
 			{
 				// XXX: We know what they want, is there any reason not to handle it?
 				// Yes. We should be strict in handling the format. -Chris
@@ -1224,7 +1224,7 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 				break;
 
 			TimingWindow tw;
-			bool ret = StringConversion::FromString(matches[0].MakeUpper(), tw);
+			bool ret = StringConversion::FromString(MakeUpper(matches[0]), tw);
 			if (ret && TW_W1 <= tw && tw <= TW_W5)
 			{
 				m_twDisabledWindows.set(tw);
@@ -1239,7 +1239,7 @@ bool PlayerOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut
 	{
 		// Maybe the original string is a noteskin name with a space. -Kyz
 		RString name= sOneMod;
-		name.MakeLower();
+		MakeLower(name);
 		if(NOTESKIN && NOTESKIN->DoesNoteSkinExist(name))
 		{
 			m_sNoteSkin = name;

--- a/src/Preference.cpp
+++ b/src/Preference.cpp
@@ -26,7 +26,7 @@ IPreference *IPreference::GetPreferenceByName( const RString &sName )
 {
 	for (IPreference *p : *m_Subscribers.m_pSubscribers)
 	{
-		if( !p->GetName().CompareNoCase( sName ) )
+		if( !CompareNoCase(p->GetName(), sName) )
 			return p;
 	}
 

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -485,7 +485,7 @@ void PrefsManager::ReadGamePrefsFromIni( const RString &sIni )
 		if( !BeginsWith(section_name, GAME_SECTION_PREFIX) )
 			continue;
 
-		RString sGame = section_name.Right( section_name.length() - GAME_SECTION_PREFIX.length() );
+		RString sGame = Right(section_name, section_name.length() - GAME_SECTION_PREFIX.length());
 		GamePrefs &gp = m_mapGameNameToGamePrefs[ sGame ];
 
 		// todo: read more prefs here? -aj

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -246,7 +246,7 @@ Character *Profile::GetCharacter() const
 	CHARMAN->GetCharacters( vpCharacters );
 	for (Character *c : vpCharacters)
 	{
-		if( c->m_sCharacterID.CompareNoCase(m_sCharacterID)==0 )
+		if( CompareNoCase(c->m_sCharacterID, m_sCharacterID)==0 )
 			return c;
 	}
 	return CHARMAN->GetDefaultCharacter();
@@ -1165,7 +1165,7 @@ ProfileLoadResult Profile::LoadAllFromDir( RString sDir, bool bRequireSignature 
 {
 	LOG->Trace( "Profile::LoadAllFromDir( %s )", sDir.c_str() );
 
-	ASSERT( sDir.Right(1) == "/" );
+	ASSERT( Right(sDir, 1) == "/" );
 
 	InitAll();
 
@@ -2162,9 +2162,9 @@ void Profile::LoadCourseScoresFromNode( const XNode* pCourseScores )
 
 				for (Course *c : vpAllCourses)
 				{
-					RString sOther = c->m_sPath.Right(sFullFileName.size());
+					RString sOther = Right(c->m_sPath, sFullFileName.size());
 
-					if( sFullFileName.CompareNoCase(sOther) == 0 )
+					if( CompareNoCase(sFullFileName, sOther) == 0 )
 					{
 						pC = c;
 						courseID.FromCourse( pC );

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -151,7 +151,7 @@ ProfileLoadResult ProfileManager::LoadProfile( PlayerNumber pn, RString sProfile
 	LOG->Trace( "LoadingProfile P%d, %s, %d", pn+1, sProfileDir.c_str(), bIsMemCard );
 
 	ASSERT( !sProfileDir.empty() );
-	ASSERT( sProfileDir.Right(1) == "/" );
+	ASSERT( Right(sProfileDir, 1) == "/" );
 
 
 	m_sProfileDir[pn] = sProfileDir;
@@ -548,7 +548,7 @@ void ProfileManager::LoadLocalProfilesByName()
 	if (PREFSMAN->m_bProfileSortOrderAscending) {
 		auto displayNameAscending = [](const DirAndProfile &a, const DirAndProfile &b)
 		{
-			return a.profile.m_sDisplayName.CompareNoCase(b.profile.m_sDisplayName) < 0;
+			return CompareNoCase(a.profile.m_sDisplayName, b.profile.m_sDisplayName) < 0;
 		};
 		std::sort(guestProfiles.begin(), guestProfiles.end(), displayNameAscending);
 		std::sort(normalProfiles.begin(), normalProfiles.end(), displayNameAscending);
@@ -556,7 +556,7 @@ void ProfileManager::LoadLocalProfilesByName()
 	} else {
 		auto displayNameDescending = [](const DirAndProfile &a, const DirAndProfile &b)
 		{
-			return a.profile.m_sDisplayName.CompareNoCase(b.profile.m_sDisplayName) > 0;
+			return CompareNoCase(a.profile.m_sDisplayName, b.profile.m_sDisplayName) > 0;
 		};
 		std::sort(guestProfiles.begin(), guestProfiles.end(), displayNameDescending);
 		std::sort(normalProfiles.begin(), normalProfiles.end(), displayNameDescending);

--- a/src/RageBitmapTexture.cpp
+++ b/src/RageBitmapTexture.cpp
@@ -112,7 +112,7 @@ void RageBitmapTexture::Create()
 
 	// look in the file name for a format hints
 	RString sHintString = GetID().filename + actualID.AdditionalTextureHints;
-	sHintString.MakeLower();
+	MakeLower(sHintString);
 
 	if( sHintString.find("32bpp") != std::string::npos )			actualID.iColorDepth = 32;
 	else if( sHintString.find("16bpp") != std::string::npos )		actualID.iColorDepth = 16;

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -147,7 +147,7 @@ void RageDisplay::ProcessStatsOnFlip()
 		if( LOG_FPS )
 		{
 			RString sStats = GetStats();
-			sStats.Replace( "\n", ", " );
+			Replace(sStats, "\n", ", ");
 			LOG->Trace( "%s", sStats.c_str() );
 		}
 	}

--- a/src/RageFileDriver.cpp
+++ b/src/RageFileDriver.cpp
@@ -88,7 +88,7 @@ FileDriverEntry::~FileDriverEntry()
 RageFileDriver *MakeFileDriver( const RString &sType, const RString &sRoot )
 {
 	for( const FileDriverEntry *p = g_pFileDriverList; p; p = p->m_pLink )
-		if( !p->m_sType.CompareNoCase(sType) )
+		if( !CompareNoCase(p->m_sType, sType) )
 			return p->Create( sRoot );
 	return nullptr;
 }

--- a/src/RageFileDriverDirectHelpers.cpp
+++ b/src/RageFileDriverDirectHelpers.cpp
@@ -89,7 +89,7 @@ bool CreateDirectories( RString Path )
 	RString curpath;
 
 	// If Path is absolute, add the initial slash ("ignore empty" will remove it).
-	if( Path.Left(1) == "/" )
+	if( Left(Path, 1) == "/" )
 		curpath = "/";
 
 	// Ignore empty, so eg. "/foo/bar//baz" doesn't try to create "/foo/bar" twice.
@@ -156,10 +156,10 @@ void DirectFilenameDB::SetRoot( RString root_ )
 	root = root_;
 
 	// "\abcd\" -> "/abcd/":
-	root.Replace( "\\", "/" );
+	Replace(root, "\\", "/");
 
 	// "/abcd/" -> "/abcd":
-	if( root.Right(1) == "/" )
+	if( Right(root, 1) == "/" )
 		root.erase( root.size()-1, 1 );
 }
 
@@ -227,7 +227,7 @@ void DirectFilenameDB::PopulateFileSet( FileSet &fs, const RString &path )
 #if defined(_WIN32)
 	WIN32_FIND_DATA fd;
 
-	if ( sPath.size() > 0  && sPath.Right(1) == "/" )
+	if ( sPath.size() > 0  && Right(sPath, 1) == "/" )
 		sPath.erase( sPath.size() - 1 );
 
 	HANDLE hFind = DoFindFirstFile( (root+sPath+"/*").c_str(), &fd );
@@ -314,7 +314,7 @@ void DirectFilenameDB::PopulateFileSet( FileSet &fs, const RString &path )
 	{
 		if( !BeginsWith( iter->lname, IGNORE_MARKER_BEGINNING ) )
 			break;
-		RString sFileLNameToIgnore = iter->lname.Right( iter->lname.length() - IGNORE_MARKER_BEGINNING.length() );
+		RString sFileLNameToIgnore = Right(iter->lname, iter->lname.length() - IGNORE_MARKER_BEGINNING.length());
 		vsFilesToRemove.push_back( iter->name );
 		vsFilesToRemove.push_back( sFileLNameToIgnore );
 	}

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -75,7 +75,7 @@ static void UnreferenceAllDrivers( std::vector<LoadedDriver *> &apDriverList )
 RageFileDriver *RageFileManager::GetFileDriver( RString sMountpoint )
 {
 	FixSlashesInPlace( sMountpoint );
-	if( sMountpoint.size() && sMountpoint.Right(1) != "/" )
+	if( sMountpoint.size() && Right(sMountpoint, 1) != "/" )
 		sMountpoint += '/';
 
 	g_Mutex->Lock();
@@ -84,7 +84,7 @@ RageFileDriver *RageFileManager::GetFileDriver( RString sMountpoint )
 	{
 		if( g_pDrivers[i]->m_sType == "mountpoints" )
 			continue;
-		if( g_pDrivers[i]->m_sMountPoint.CompareNoCase( sMountpoint ) )
+		if( CompareNoCase(g_pDrivers[i]->m_sMountPoint, sMountpoint) )
 			continue;
 
 		pRet = g_pDrivers[i]->m_pDriver;
@@ -256,7 +256,7 @@ void RageFileManager::ProtectPath(const std::string& path)
 {
 	RString normalizedPath(path);
 	NormalizePath(normalizedPath);
-	normalizedPath.MakeLower();
+	MakeLower(normalizedPath);
 
 	m_protectedPaths.insert(normalizedPath);
 }
@@ -265,7 +265,7 @@ bool RageFileManager::IsPathProtected(const std::string& path)
 {
 	RString normalizedPath(path);
 	NormalizePath(normalizedPath);
-	normalizedPath.MakeLower();
+	MakeLower(normalizedPath);
 
 	return m_protectedPaths.count(normalizedPath) > 0;
 }
@@ -348,7 +348,7 @@ static RString GetDirOfExecutable( RString argv0 )
 	sPath = argv0;
 #endif
 
-	sPath.Replace( "\\", "/" );
+	Replace(sPath, "\\", "/");
 
 	bool bIsAbsolutePath = false;
 	if( sPath.size() == 0 || sPath[0] == '/' )
@@ -393,7 +393,7 @@ static RString GetDirOfExecutable( RString argv0 )
 		}
 #else
 		sPath = GetCwd() + "/" + sPath;
-		sPath.Replace( "\\", "/" );
+		Replace(sPath, "\\", "/" );
 #endif
 	}
 	return sPath;
@@ -490,16 +490,16 @@ RString LoadedDriver::GetPath( const RString &sPath ) const
 			return RString();
 	}
 
-	if( sPath.Left(m_sMountPoint.size()).CompareNoCase(m_sMountPoint) )
+	if( CompareNoCase(Left(sPath, m_sMountPoint.size()), m_sMountPoint) )
 		return RString(); /* no match */
 
 	/* Add one, so we don't cut off the leading slash. */
-	RString sRet = sPath.Right( sPath.size() - m_sMountPoint.size() + 1 );
+	RString sRet = Right(sPath, sPath.size() - m_sMountPoint.size() + 1);
 	return sRet;
 }
 
-bool ilt( const RString &a, const RString &b ) { return a.CompareNoCase(b) < 0; }
-bool ieq( const RString &a, const RString &b ) { return a.CompareNoCase(b) == 0; }
+bool ilt( const RString &a, const RString &b ) { return CompareNoCase(a, b) < 0; }
+bool ieq( const RString &a, const RString &b ) { return CompareNoCase(a, b) == 0; }
 void RageFileManager::GetDirListing( const RString &sPath_, std::vector<RString> &AddTo, bool bOnlyDirs, bool bReturnPathToo )
 {
 	RString sPath = sPath_;
@@ -676,12 +676,12 @@ static void AdjustMountpoint( RString &sMountPoint )
 {
 	FixSlashesInPlace( sMountPoint );
 
-	ASSERT_M( sMountPoint.Left(1) == "/", "Mountpoints must be absolute: " + sMountPoint );
+	ASSERT_M( Left(sMountPoint, 1) == "/", "Mountpoints must be absolute: " + sMountPoint );
 
-	if( sMountPoint.size() && sMountPoint.Right(1) != "/" )
+	if( sMountPoint.size() && Right(sMountPoint, 1) != "/" )
 		sMountPoint += '/';
 
-	if( sMountPoint.Left(1) != "/" )
+	if( Left(sMountPoint, 1) != "/" )
 		sMountPoint = "/" + sMountPoint;
 
 }
@@ -746,7 +746,7 @@ void RageFileManager::Unmount( const RString &sType, const RString &sRoot_, cons
 	FixSlashesInPlace( sRoot );
 	FixSlashesInPlace( sMountPoint );
 
-	if( sMountPoint.size() && sMountPoint.Right(1) != "/" )
+	if( sMountPoint.size() && Right(sMountPoint, 1) != "/" )
 		sMountPoint += '/';
 
 	/* Find all drivers we want to delete.  Remove them from g_pDrivers, and move them
@@ -755,11 +755,11 @@ void RageFileManager::Unmount( const RString &sType, const RString &sRoot_, cons
 	g_Mutex->Lock();
 	for( unsigned i = 0; i < g_pDrivers.size(); ++i )
 	{
-		if( !sType.empty() && g_pDrivers[i]->m_sType.CompareNoCase( sType ) )
+		if( !sType.empty() && CompareNoCase(g_pDrivers[i]->m_sType, sType) )
 			continue;
-		if( !sRoot.empty() && g_pDrivers[i]->m_sRoot.CompareNoCase( sRoot ) )
+		if( !sRoot.empty() && CompareNoCase(g_pDrivers[i]->m_sRoot, sRoot) )
 			continue;
-		if( !sMountPoint.empty() && g_pDrivers[i]->m_sMountPoint.CompareNoCase( sMountPoint ) )
+		if( !sMountPoint.empty() && CompareNoCase(g_pDrivers[i]->m_sMountPoint, sMountPoint) )
 			continue;
 
 		++g_pDrivers[i]->m_iRefs;
@@ -812,7 +812,7 @@ bool RageFileManager::IsMounted( RString MountPoint )
 	LockMut( *g_Mutex );
 
 	for( unsigned i = 0; i < g_pDrivers.size(); ++i )
-		if( !g_pDrivers[i]->m_sMountPoint.CompareNoCase( MountPoint ) )
+		if( !CompareNoCase(g_pDrivers[i]->m_sMountPoint, MountPoint) )
 			return true;
 
 	return false;
@@ -1167,7 +1167,7 @@ void GetDirListing( const RString &sPath, std::vector<RString> &AddTo, bool bOnl
 
 void GetDirListingRecursive( const RString &sDir, const RString &sMatch, std::vector<RString> &AddTo )
 {
-	ASSERT( sDir.Right(1) == "/" );
+	ASSERT( Right(sDir, 1) == "/" );
 	std::vector<RString> vsFiles;
 	GetDirListing( sDir+sMatch, vsFiles, false, true );
 	std::vector<RString> vsDirs;
@@ -1188,7 +1188,7 @@ void GetDirListingRecursive( const RString &sDir, const RString &sMatch, std::ve
 
 void GetDirListingRecursive( RageFileDriver *prfd, const RString &sDir, const RString &sMatch, std::vector<RString> &AddTo )
 {
-	ASSERT( sDir.Right(1) == "/" );
+	ASSERT( Right(sDir, 1) == "/" );
 	std::vector<RString> vsFiles;
 	prfd->GetDirListing( sDir+sMatch, vsFiles, false, true );
 	std::vector<RString> vsDirs;
@@ -1209,7 +1209,7 @@ void GetDirListingRecursive( RageFileDriver *prfd, const RString &sDir, const RS
 
 bool DeleteRecursive( RageFileDriver *prfd, const RString &sDir )
 {
-	ASSERT( sDir.Right(1) == "/" );
+	ASSERT( Right(sDir, 1) == "/" );
 
 	std::vector<RString> vsFiles;
 	prfd->GetDirListing( sDir+"*", vsFiles, false, true );
@@ -1226,7 +1226,7 @@ bool DeleteRecursive( RageFileDriver *prfd, const RString &sDir )
 
 bool DeleteRecursive( const RString &sDir )
 {
-	ASSERT( sDir.Right(1) == "/" );
+	ASSERT( Right(sDir, 1) == "/" );
 
 	std::vector<RString> vsFiles;
 	GetDirListing( sDir+"*", vsFiles, false, true );

--- a/src/RageSoundManager.cpp
+++ b/src/RageSoundManager.cpp
@@ -146,7 +146,7 @@ RageSoundReader *RageSoundManager::GetLoadedSound( const RString &sPath_ )
 	LockMut(g_SoundManMutex); /* lock for access to m_mapPreloadedSounds */
 
 	RString sPath(sPath_);
-	sPath.MakeLower();
+	MakeLower(sPath);
 	std::map<RString, RageSoundReader_Preload*>::const_iterator it;
 	it = m_mapPreloadedSounds.find( sPath );
 	if( it == m_mapPreloadedSounds.end() )
@@ -165,7 +165,7 @@ void RageSoundManager::AddLoadedSound( const RString &sPath_, RageSoundReader_Pr
 	/* Don't AddLoadedSound a sound that's already registered.  It should have been
 	 * used in GetLoadedSound. */
 	RString sPath(sPath_);
-	sPath.MakeLower();
+	MakeLower(sPath);
 	std::map<RString, RageSoundReader_Preload*>::const_iterator it;
 	it = m_mapPreloadedSounds.find( sPath );
 	ASSERT_M( it == m_mapPreloadedSounds.end(), sPath );

--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -79,7 +79,7 @@ void RageSoundReader_Chain::AddSound( int iIndex, float fOffsetSecs, float fPan 
 
 int RageSoundReader_Chain::LoadSound( RString sPath )
 {
-	sPath.MakeLower();
+	MakeLower(sPath);
 
 	std::map<RString, RageSoundReader*>::const_iterator it = m_apNamedSounds.find( sPath );
 	if( it != m_apNamedSounds.end() )

--- a/src/RageSoundReader_FileReader.cpp
+++ b/src/RageSoundReader_FileReader.cpp
@@ -16,13 +16,13 @@ RageSoundReader_FileReader *RageSoundReader_FileReader::TryOpenFile( RageFileBas
 {
 	RageSoundReader_FileReader *Sample = nullptr;
 
-	if( !format.CompareNoCase("wav") )
+	if( !CompareNoCase(format, "wav") )
 		Sample = new RageSoundReader_WAV;
 
-	if( !format.CompareNoCase("mp3") )
+	if( !CompareNoCase(format, "mp3") )
 		Sample = new RageSoundReader_MP3;
 
-	if( !format.CompareNoCase("oga") || !format.CompareNoCase("ogg") )
+	if( !CompareNoCase(format, "oga") || !CompareNoCase(format, "ogg") )
 		Sample = new RageSoundReader_Vorbisfile;
 
 	if( !Sample )
@@ -121,7 +121,7 @@ RageSoundReader_FileReader *RageSoundReader_FileReader::OpenFile( RString filena
 	}
 
 	RString format = GetExtension( filename );
-	format.MakeLower();
+	MakeLower(format);
 
 	error = "";
 

--- a/src/RageSurface_Load.cpp
+++ b/src/RageSurface_Load.cpp
@@ -17,13 +17,13 @@ static RageSurface *TryOpenFile( RString sPath, bool bHeaderOnly, RString &error
 {
 	RageSurface *ret = nullptr;
 	RageSurfaceUtils::OpenResult result;
-	if( !format.CompareNoCase("png") )
+	if( !CompareNoCase(format, "png") )
 		result = RageSurface_Load_PNG( sPath, ret, bHeaderOnly, error );
-	else if( !format.CompareNoCase("gif") )
+	else if( !CompareNoCase(format, "gif") )
 		result = RageSurface_Load_GIF( sPath, ret, bHeaderOnly, error );
-	else if( !format.CompareNoCase("jpg") || !format.CompareNoCase("jpeg") )
+	else if( !CompareNoCase(format, "jpg") || !CompareNoCase(format, "jpeg") )
 		result = RageSurface_Load_JPEG( sPath, ret, bHeaderOnly, error );
-	else if( !format.CompareNoCase("bmp") )
+	else if( !CompareNoCase(format, "bmp") )
 		result = RageSurface_Load_BMP( sPath, ret, bHeaderOnly, error );
 	else
 	{
@@ -96,7 +96,7 @@ RageSurface *RageSurfaceUtils::LoadFile( const RString &sPath, RString &error, b
 	}
 
 	RString format = GetExtension(sPath);
-	format.MakeLower();
+	MakeLower(format);
 
 	bool bKeepTrying = true;
 

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -568,7 +568,7 @@ const LanguageInfo *GetLanguageInfo( const RString &sIsoCode )
 {
 	for( unsigned i=0; i<ARRAYLEN(g_langs); ++i )
 	{
-		if( sIsoCode.EqualsNoCase(g_langs[i].szIsoCode) )
+		if( EqualsNoCase(sIsoCode, g_langs[i].szIsoCode) )
 			return &g_langs[i];
 	}
 
@@ -695,9 +695,9 @@ std::vector<RString> SmEscape(const std::vector<RString> &vUnescaped, const std:
 RString SmUnescape( const RString &sEscaped )
 {
 	RString unescaped = sEscaped;
-	unescaped.Replace("\\\\", "||escaped-backslash||");
-	unescaped.Replace("\\", "");
-	unescaped.Replace("||escaped-backslash||", "\\");
+	Replace(unescaped, "\\\\", "||escaped-backslash||");
+	Replace(unescaped, "\\", "");
+	Replace(unescaped, "||escaped-backslash||", "\\");
 	return unescaped;
 }
 
@@ -976,7 +976,7 @@ bool FindFirstFilenameContaining(const std::vector<RString>& filenames,
 	for(size_t i= 0; i < filenames.size(); ++i)
 	{
 		RString lower= GetFileNameWithoutExtension(filenames[i]);
-		lower.MakeLower();
+		MakeLower(lower);
 		for(size_t s= 0; s < starts_with.size(); ++s)
 		{
 			if(!lower.compare(0, starts_with[s].size(), starts_with[s]))
@@ -1040,7 +1040,7 @@ bool GetCommandlineArgument( const RString &option, RString *argument, int iInde
 
 		const size_t i = CurArgument.find( "=" );
 		RString CurOption = CurArgument.substr(0,i);
-		if( CurOption.CompareNoCase(optstr) )
+		if( CompareNoCase(CurOption, optstr) )
 			continue; // no match
 
 		// Found it.
@@ -1131,12 +1131,12 @@ bool DirectoryIsEmpty( const RString &sDir )
 
 bool CompareRStringsAsc( const RString &sStr1, const RString &sStr2 )
 {
-	return sStr1.CompareNoCase( sStr2 ) < 0;
+	return CompareNoCase(sStr1, sStr2) < 0;
 }
 
 bool CompareRStringsDesc( const RString &sStr1, const RString &sStr2 )
 {
-	return sStr1.CompareNoCase( sStr2 ) > 0;
+	return CompareNoCase(sStr1, sStr2) > 0;
 }
 
 void SortRStringArray( std::vector<RString> &arrayRStrings, const bool bSortAscending )
@@ -1292,9 +1292,9 @@ RString URLEncode( const RString &sStr )
 // remove various version control-related files
 static bool CVSOrSVN( const RString& s )
 {
-	return s.Right(3).EqualsNoCase("CVS") ||
-			s.Right(4) == ".svn" ||
-			s.Right(3).EqualsNoCase(".hg");
+	return EqualsNoCase(Right(s, 3), "CVS") ||
+			Right(s, 4) == ".svn" ||
+			EqualsNoCase(Right(s, 3), ".hg");
 }
 
 void StripCvsAndSvn( std::vector<RString> &vs )
@@ -1304,7 +1304,7 @@ void StripCvsAndSvn( std::vector<RString> &vs )
 
 static bool MacResourceFork( const RString& s )
 {
-	return s.Left(2).EqualsNoCase("._");
+	return EqualsNoCase(Left(s, 2), "._");
 }
 
 void StripMacResourceForks( std::vector<RString> &vs )
@@ -1501,7 +1501,7 @@ bool Regex::Replace( const RString &sReplacement, const RString &sSubject, RStri
 	{
 		RString sFrom = ssprintf( "\\${%d}", i );
 		RString sTo = asMatches[i];
-		sOut.Replace(sFrom, sTo);
+		::Replace(sOut, sFrom, sTo);
 	}
 
 	return true;
@@ -1961,7 +1961,7 @@ void ReplaceEntityText( RString &sText, const std::map<RString, RString> &m )
 		}
 
 		RString sElement = sText.substr( iStart+1, iEnd-iStart-1 );
-		sElement.MakeLower();
+		MakeLower(sElement);
 
 		std::map<RString, RString>::const_iterator it = m.find( sElement );
 		if( it == m.end() )
@@ -2331,7 +2331,7 @@ namespace StringConversion
 
 bool FileCopy( const RString &sSrcFile, const RString &sDstFile )
 {
-	if( !sSrcFile.CompareNoCase(sDstFile) )
+	if( !CompareNoCase(sSrcFile, sDstFile) )
 	{
 		LOG->Warn( "Tried to copy \"%s\" over itself", sSrcFile.c_str() );
 		return false;
@@ -2407,9 +2407,7 @@ LuaFunction( SecondsToMSS, SecondsToMSS( FArg(1) ) )
 LuaFunction( SecondsToMMSS, SecondsToMMSS( FArg(1) ) )
 LuaFunction( FormatNumberAndSuffix, FormatNumberAndSuffix( IArg(1) ) )
 LuaFunction( Basename, Basename( SArg(1) ) )
-static RString MakeLower( RString s ) { s.MakeLower(); return s; }
 LuaFunction( Lowercase, MakeLower( SArg(1) ) )
-static RString MakeUpper( RString s ) { s.MakeUpper(); return s; }
 LuaFunction( Uppercase, MakeUpper( SArg(1) ) )
 LuaFunction( mbstrlen, (int)RStringToWstring(SArg(1)).length() )
 LuaFunction( URLEncode, URLEncode( SArg(1) ) );

--- a/src/RageUtil_FileDB.cpp
+++ b/src/RageUtil_FileDB.cpp
@@ -14,11 +14,11 @@ void FileSet::GetFilesMatching( const RString &sBeginning_, const RString &sCont
 	/* "files" is a case-insensitive mapping, by filename.  Use lower_bound to figure
 	 * out where to start. */
 	RString sBeginning = sBeginning_;
-	sBeginning.MakeLower();
+	MakeLower(sBeginning);
 	RString sContaining = sContaining_;
-	sContaining.MakeLower();
+	MakeLower(sContaining);
 	RString sEnding = sEnding_;
-	sEnding.MakeLower();
+	MakeLower(sEnding);
 
 	std::set<File>::const_iterator i = files.lower_bound( File(sBeginning) );
 	for( ; i != files.end(); ++i )
@@ -105,7 +105,7 @@ int FileSet::GetFileHash( const RString &sPath ) const
 static void SplitPath( RString sPath, RString &sDir, RString &sName )
 {
 	CollapsePath( sPath );
-	if( sPath.Right(1) == "/" )
+	if( Right(sPath, 1) == "/" )
 		sPath.erase( sPath.size()-1 );
 
 	size_t iSep = sPath.find_last_of( '/' );
@@ -277,14 +277,14 @@ FileSet *FilenameDB::GetFileSet( const RString &sDir_, bool bCreate )
 		LOG->Warn( "FilenameDB::GetFileSet: m_Mutex was locked" );
 
 	/* Normalize the path. */
-	sDir.Replace("\\", "/"); /* foo\bar -> foo/bar */
-	sDir.Replace("//", "/"); /* foo//bar -> foo/bar */
+	Replace(sDir, "\\", "/"); /* foo\bar -> foo/bar */
+	Replace(sDir, "//", "/"); /* foo//bar -> foo/bar */
 
 	if( sDir == "" )
 		sDir = "/";
 
 	RString sLower = sDir;
-	sLower.MakeLower();
+	MakeLower(sLower);
 
 	m_Mutex.Lock();
 
@@ -465,7 +465,7 @@ void FilenameDB::DelFile( const RString &sPath )
 {
 	LockMut(m_Mutex);
 	RString lower = sPath;
-	lower.MakeLower();
+	MakeLower(lower);
 
 	std::map<RString, FileSet*>::iterator fsi = dirs.find( lower );
 	DelFileSet( fsi );

--- a/src/RageUtil_FileDB.h
+++ b/src/RageUtil_FileDB.h
@@ -20,7 +20,7 @@ struct File
 	{
 		name = fn;
 		lname = name;
-		lname.MakeLower();
+		MakeLower(lname);
 	}
 
 	bool dir;
@@ -49,7 +49,7 @@ struct File
 	bool equal(const RString &rhs) const
 	{
 		RString l = rhs;
-		l.MakeLower();
+		MakeLower(l);
 		return lname == l;
 	}
 };

--- a/src/RandomSample.cpp
+++ b/src/RandomSample.cpp
@@ -48,7 +48,7 @@ bool RandomSample::LoadSoundDir( RString sDir, int iMaxToLoad )
 		sDir += "/";
 #else
 	// make sure there's a slash at the end of this path
-	if( sDir.Right(1) != "/" )
+	if( Right(sDir, 1) != "/" )
 		sDir += "/";
 #endif
 

--- a/src/ScreenBookkeeping.cpp
+++ b/src/ScreenBookkeeping.cpp
@@ -172,7 +172,7 @@ void ScreenBookkeeping::UpdateView()
 						iCount = pProfile->GetSongNumTimesPlayed( pSong );
 						RString sTitle = ssprintf("%4d",iCount) + " " + pSong->GetDisplayFullTitle();
 						if( sTitle.length() > 22 )
-							sTitle = sTitle.Left(20) + "...";
+							sTitle = Left(sTitle, 20) + "...";
 						s += sTitle + "\n";
 						iSongIndex++;
 					}

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -3736,8 +3736,8 @@ void ScreenEdit::HandleScreenMessage( const ScreenMessage SM )
 		if ( !GetAppropriateTiming().DoesLabelExist(sLabel) )
 		{
 			// XXX: these should be in the NotesWriters where they're needed.
-			sLabel.Replace("=", "_");
-			sLabel.Replace(",", "_");
+			Replace(sLabel, "=", "_");
+			Replace(sLabel, ",", "_");
 			GetAppropriateTimingForUpdate().AddSegment( LabelSegment(GetRow(), sLabel) );
 			SetDirty( true );
 		}
@@ -6383,7 +6383,7 @@ static bool IsMapped( EditButton eb, const MapEditToDI &editmap )
 
 static void ProcessKeyName( RString &s )
 {
-	s.Replace( "Key_", "" );
+	Replace(s, "Key_", "");
 }
 
 static void ProcessKeyNames( std::vector<RString> &vs, bool doSort )

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1365,7 +1365,7 @@ void ScreenGameplay::LoadLights()
 	Difficulty d1 = Difficulty_Invalid;
 	if( asDifficulties.size() > 0 )
 	{
-		if( asDifficulties[0].CompareNoCase("selected") == 0 )
+		if( CompareNoCase(asDifficulties[0], "selected") == 0 )
 		{
 			// Base lights off current difficulty of active player
 			// Can be either P1 or P2 if they're individual or P1 if both are active

--- a/src/ScreenGameplaySyncMachine.cpp
+++ b/src/ScreenGameplaySyncMachine.cpp
@@ -26,7 +26,7 @@ void ScreenGameplaySyncMachine::Init()
 	// Allow themers to use either a .ssc or .sm file for this. -aj
 	SSCLoader loaderSSC;
 	SMLoader loaderSM;
-	if(sFile.Right(4) == ".ssc")
+	if(Right(sFile, 4) == ".ssc")
 		loaderSSC.LoadFromSimfile( sFile, m_Song );
 	else
 		loaderSM.LoadFromSimfile( sFile, m_Song );

--- a/src/ScreenHowToPlay.cpp
+++ b/src/ScreenHowToPlay.cpp
@@ -143,7 +143,7 @@ void ScreenHowToPlay::Init()
 		RString sStepsPath = THEME->GetPathO(m_sName, "steps");
 		SSCLoader loaderSSC;
 		SMLoader loaderSM;
-		if( sStepsPath.Right(4) == ".ssc" )
+		if( Right(sStepsPath, 4) == ".ssc" )
 			loaderSSC.LoadFromSimfile( sStepsPath, m_Song, false );
 		else
 			loaderSM.LoadFromSimfile( sStepsPath, m_Song, false );

--- a/src/ScreenInstallOverlay.cpp
+++ b/src/ScreenInstallOverlay.cpp
@@ -50,9 +50,9 @@ static void Parse( const RString &sDir, PlayAfterLaunchInfo &out )
 {
 	std::vector<RString> vsDirParts;
 	split( sDir, "/", vsDirParts, true );
-	if( vsDirParts.size() == 3 && vsDirParts[0].EqualsNoCase("Songs") )
+	if( vsDirParts.size() == 3 && EqualsNoCase(vsDirParts[0], "Songs") )
 		out.sSongDir = "/" + sDir;
-	else if( vsDirParts.size() == 2 && vsDirParts[0].EqualsNoCase("Themes") )
+	else if( vsDirParts.size() == 2 && EqualsNoCase(vsDirParts[0], "Themes") )
 		out.sTheme = vsDirParts[1];
 }
 
@@ -72,12 +72,12 @@ static void InstallSmzip( const RString &sZipFile, PlayAfterLaunchInfo &out )
 		std::vector<RString> vsPrettyFiles;
 		for (RString const &s : vsRawFiles)
 		{
-			if( GetExtension(s).EqualsNoCase("ctl") )
+			if( EqualsNoCase(GetExtension(s), "ctl") )
 				continue;
 
 			vsFiles.push_back( s);
 
-			RString s2 = s.Right( s.length() - TEMP_ZIP_MOUNT_POINT.length() );
+			RString s2 = Right(s, s.length() - TEMP_ZIP_MOUNT_POINT.length());
 			vsPrettyFiles.push_back( s2 );
 		}
 		sort( vsPrettyFiles.begin(), vsPrettyFiles.end() );
@@ -87,7 +87,7 @@ static void InstallSmzip( const RString &sZipFile, PlayAfterLaunchInfo &out )
 	for (RString &tmpFile : vsFiles)
 	{
 		RString sDestFile = tmpFile;
-		sDestFile = sDestFile.Right( sDestFile.length() - TEMP_ZIP_MOUNT_POINT.length() );
+		sDestFile = Right(sDestFile, sDestFile.length() - TEMP_ZIP_MOUNT_POINT.length());
 
 		RString sDir, sThrowAway;
 		splitpath( sDestFile, sDir, sThrowAway, sThrowAway );
@@ -125,7 +125,7 @@ void InstallSmzipOsArg( const RString &sOsZipFile, PlayAfterLaunchInfo &out )
 static bool IsPackageFile(const RString &arg)
 {
 	RString ext = GetExtension(arg);
-	return ext.EqualsNoCase("smzip") || ext.EqualsNoCase("zip");
+	return EqualsNoCase(ext, "smzip") || EqualsNoCase(ext, "zip");
 }
 
 PlayAfterLaunchInfo DoInstalls( CommandLineActions::CommandLineArgs args )

--- a/src/ScreenJukebox.cpp
+++ b/src/ScreenJukebox.cpp
@@ -127,7 +127,7 @@ void ScreenJukebox::SetSong()
 					for (Attack const &a: aAttacks)
 					{
 						RString s = a.sModifiers;
-						s.MakeLower();
+						MakeLower(s);
 						// todo: allow themers to modify this list? -aj
 						if( s.find("dark") != std::string::npos ||
 							s.find("stealth") != std::string::npos )

--- a/src/ScreenMapControllers.cpp
+++ b/src/ScreenMapControllers.cpp
@@ -823,7 +823,7 @@ void ScreenMapControllers::ActionRow::Load(RString const& scr_name,
 {
 	m_action= action;
 	RString lower_name= name;
-	lower_name.MakeLower();
+	MakeLower(lower_name);
 	// Make the specific actor optional, use a fallback if it doesn't exist.
 	RString path= THEME->GetPathG(scr_name, lower_name, true);
 	if(path.empty())

--- a/src/ScreenOptionsExportPackage.cpp
+++ b/src/ScreenOptionsExportPackage.cpp
@@ -190,7 +190,7 @@ static RString ReplaceInvalidFileNameChars( RString sOldFileName )
 		'<', '>', ',', '?', '/'
 	};
 	for( unsigned i=0; i<sizeof(charsToReplace); i++ )
-		sNewFileName.Replace( charsToReplace[i], '_' );
+		Replace(sNewFileName, charsToReplace[i], '_');
 	return sNewFileName;
 }
 

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -976,7 +976,7 @@ ConfOption *ConfOption::Find( RString name )
 	{
 		ConfOption *opt = &g_ConfOptions[i];
 		RString match(opt->name);
-		if( match.CompareNoCase(name) )
+		if( CompareNoCase(match, name) )
 			continue;
 		return opt;
 	}

--- a/src/ScreenSelect.cpp
+++ b/src/ScreenSelect.cpp
@@ -36,9 +36,9 @@ void ScreenSelect::Init()
 	// Load choices
 	// Allow lua as an alternative to metrics.
 	RString choice_names= CHOICE_NAMES;
-	if(choice_names.Left(4) == "lua,")
+	if(Left(choice_names, 4) == "lua,")
 	{
-		RString command= choice_names.Right(choice_names.size()-4);
+		RString command= Right(choice_names, choice_names.size()-4);
 		Lua* L= LUA->Get();
 		if(LuaHelpers::RunExpression(L, command, m_sName + "::ChoiceNames"))
 		{

--- a/src/ScreenSelectMaster.cpp
+++ b/src/ScreenSelectMaster.cpp
@@ -94,7 +94,7 @@ void ScreenSelectMaster::Init()
 		{
 			RString sElement = "Cursor" + PLAYER_APPEND_NO_SPACE(p);
 			m_sprCursor[p].Load( THEME->GetPathG(m_sName,sElement) );
-			sElement.Replace( " ", "" );
+			Replace(sElement, " ", "");
 			m_sprCursor[p]->SetName( sElement );
 			this->AddChild( m_sprCursor[p] );
 			LOAD_ALL_COMMANDS( m_sprCursor[p] );

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -289,7 +289,7 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
 	ASSERT_M( sDir != "", "Songs can't be loaded from an empty directory!" );
 
 	// make sure there is a trailing slash at the end of sDir
-	if( sDir.Right(1) != "/" )
+	if( Right(sDir, 1) != "/" )
 		sDir += "/";
 
 	// save song dir
@@ -665,7 +665,7 @@ void FixupPath( RString &path, const RString &sSongPath )
 void Song::TidyUpData( bool from_cache, bool /* duringCache */ )
 {
 	// We need to do this before calling any of HasMusic, HasHasCDTitle, etc.
-	ASSERT_M(m_sSongDir.Left(3) != "../", m_sSongDir); // meaningless
+	ASSERT_M(Left(m_sSongDir, 3) != "../", m_sSongDir); // meaningless
 	FixupPath(m_sSongDir, "");
 	FixupPath(m_sMusicFile, m_sSongDir);
 	FOREACH_ENUM(InstrumentTrack, i)
@@ -773,7 +773,7 @@ void Song::TidyUpData( bool from_cache, bool /* duringCache */ )
 				filename != song_dir_listing.end(); ++filename)
 		{
 			bool matched_something= false;
-			RString file_ext= GetExtension(*filename).MakeLower();
+			RString file_ext= MakeLower(GetExtension(*filename));
 			if(!file_ext.empty())
 			{
 				for(size_t tf= 0; tf < lists_to_fill.size(); ++ tf)
@@ -807,7 +807,7 @@ void Song::TidyUpData( bool from_cache, bool /* duringCache */ )
 				m_bHasMusic= true;
 				m_sMusicFile= music_list[0];
 				if(music_list.size() > 1 &&
-					!m_sMusicFile.Left(5).CompareNoCase("intro"))
+					!CompareNoCase(Left(m_sMusicFile, 5), "intro"))
 				{
 					m_sMusicFile= music_list[1];
 				}
@@ -1012,28 +1012,28 @@ void Song::TidyUpData( bool from_cache, bool /* duringCache */ )
 
 				// ignore DWI "-char" graphics
 				RString lower = image_list[i];
-				lower.MakeLower();
+				MakeLower(lower);
 				if(BlacklistedImages.find(lower) != BlacklistedImages.end())
 				continue;	// skip
 
 				// Skip any image that we've already classified
 
-				if(m_bHasBanner && m_sBannerFile.EqualsNoCase(image_list[i]))
+				if(m_bHasBanner && EqualsNoCase(m_sBannerFile, image_list[i]))
 				continue;	// skip
 
-				if(m_bHasBackground && m_sBackgroundFile.EqualsNoCase(image_list[i]))
+				if(m_bHasBackground && EqualsNoCase(m_sBackgroundFile, image_list[i]))
 				continue;	// skip
 
-				if(has_cdtitle && m_sCDTitleFile.EqualsNoCase(image_list[i]))
+				if(has_cdtitle && EqualsNoCase(m_sCDTitleFile, image_list[i]))
 				continue;	// skip
 
-				if(has_jacket && m_sJacketFile.EqualsNoCase(image_list[i]))
+				if(has_jacket && EqualsNoCase(m_sJacketFile, image_list[i]))
 				continue;	// skip
 
-				if(has_disc && m_sDiscFile.EqualsNoCase(image_list[i]))
+				if(has_disc && EqualsNoCase(m_sDiscFile, image_list[i]))
 				continue;	// skip
 
-				if(has_cdimage && m_sCDFile.EqualsNoCase(image_list[i]))
+				if(has_cdimage && EqualsNoCase(m_sCDFile, image_list[i]))
 				continue;	// skip
 
 				RString sPath = m_sSongDir + image_list[i];
@@ -1815,7 +1815,7 @@ RString Song::GetSongAssetPath( RString sPath, const RString &sSongPath )
 		return sRelPath;
 
 	// The song contains a path; treat it as relative to the top SM directory.
-	if( sPath.Left(3) == "../" )
+	if( Left(sPath, 3) == "../" )
 	{
 		// The path begins with "../".  Resolve it wrt. the song directory.
 		sPath = sRelPath;
@@ -1825,7 +1825,7 @@ RString Song::GetSongAssetPath( RString sPath, const RString &sSongPath )
 
 	/* If the path still begins with "../", then there were an unreasonable number
 	 * of them at the beginning of the path. Ignore the path entirely. */
-	if( sPath.Left(3) == "../" )
+	if( Left(sPath, 3) == "../" )
 		return RString();
 
 	return sPath;
@@ -1996,13 +1996,13 @@ void Song::DeleteSteps( const Steps* pSteps, bool bReAutoGen )
 
 bool Song::Matches(RString sGroup, RString sSong) const
 {
-	if( sGroup.size() && sGroup.CompareNoCase(this->m_sGroupName) != 0)
+	if( sGroup.size() && CompareNoCase(sGroup, this->m_sGroupName) != 0)
 		return false;
 
 	// match on song dir or title (ala DWI)
-	if( !sSong.CompareNoCase(m_sSongName) )
+	if( !CompareNoCase(sSong, m_sSongName) )
 		return true;
-	if( !sSong.CompareNoCase(this->GetTranslitFullTitle()) )
+	if( !CompareNoCase(sSong, this->GetTranslitFullTitle()) )
 		return true;
 
 	return false;

--- a/src/SongCacheIndex.cpp
+++ b/src/SongCacheIndex.cpp
@@ -144,7 +144,7 @@ RString SongCacheIndex::MangleName( const RString &Name )
 {
 	/* We store paths in an INI.  We can't store '='. */
 	RString ret = Name;
-	ret.Replace( "=", "");
+	Replace(ret, "=", "");
 	return ret;
 }
 

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -371,7 +371,7 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 	RageTimer loading_window_last_update_time;
 	loading_window_last_update_time.Touch();
 	// Make sure sDir has a trailing slash.
-	if( sDir.Right(1) != "/" )
+	if( Right(sDir, 1) != "/" )
 		sDir += "/";
 
 	// Find all group directories in "Songs" folder
@@ -1168,7 +1168,7 @@ void SongManager::InitAutogenCourses()
 		do {
 			RString sArtist = i >= apSongs.size()? RString(""): apSongs[i]->GetDisplayArtist();
 			RString sTranslitArtist = i >= apSongs.size()? RString(""): apSongs[i]->GetTranslitArtist();
-			if( i < apSongs.size() && !sCurArtist.CompareNoCase(sArtist) )
+			if( i < apSongs.size() && !CompareNoCase(sCurArtist, sArtist) )
 			{
 				aSongs.push_back( apSongs[i] );
 				++iCurArtistCount;
@@ -1178,8 +1178,8 @@ void SongManager::InitAutogenCourses()
 			/* Different artist, or we're at the end. If we have enough entries for
 			 * the last artist, add it. Skip blanks and "Unknown artist". */
 			if( iCurArtistCount >= 3 && sCurArtistTranslit != "" &&
-				sCurArtistTranslit.CompareNoCase("Unknown artist") &&
-				sCurArtist.CompareNoCase("Unknown artist") )
+				CompareNoCase(sCurArtistTranslit, "Unknown artist") &&
+				CompareNoCase(sCurArtist, "Unknown artist") )
 			{
 				pCourse = new Course;
 				CourseUtil::AutogenOniFromArtist( sCurArtist, sCurArtistTranslit, aSongs, Difficulty_Hard, *pCourse );
@@ -1227,7 +1227,7 @@ void SongManager::InitRandomAttacks()
 					continue;
 				}
 
-				if( !sType.EqualsNoCase("ATTACK") )
+				if( !EqualsNoCase(sType, "ATTACK") )
 				{
 					LuaHelpers::ReportScriptErrorFmt( "Got \"%s:%s\" tag with wrong declaration", sType.c_str(), sAttack.c_str() );
 					continue;
@@ -1583,11 +1583,11 @@ Course* SongManager::GetRandomCourse()
 
 Song* SongManager::GetSongFromDir(RString dir) const
 {
-	if(dir.Right(1) != "/")
+	if(Right(dir, 1) != "/")
 	{ dir += "/"; }
 
-	dir.Replace('\\', '/');
-	dir.MakeLower();
+	Replace(dir, '\\', '/');
+	MakeLower(dir);
 	std::map<RString, Song*>::const_iterator entry= m_SongsByDir.find(dir);
 	if(entry != m_SongsByDir.end())
 	{
@@ -1603,7 +1603,7 @@ Course* SongManager::GetCourseFromPath( RString sPath ) const
 
 	for (Course *c : m_pCourses)
 	{
-		if( sPath.CompareNoCase(c->m_sPath) == 0 )
+		if( CompareNoCase(sPath, c->m_sPath) == 0 )
 			return c;
 	}
 
@@ -1616,7 +1616,7 @@ Course* SongManager::GetCourseFromName( RString sName ) const
 		return nullptr;
 
 	for (Course *c : m_pCourses)
-		if( sName.CompareNoCase(c->GetDisplayFullTitle()) == 0 )
+		if( CompareNoCase(sName, c->GetDisplayFullTitle()) == 0 )
 			return c;
 
 	return nullptr;
@@ -1638,7 +1638,7 @@ Course* SongManager::GetCourseFromName( RString sName ) const
 
 Song *SongManager::FindSong( RString sPath ) const
 {
-	sPath.Replace( '\\', '/' );
+	Replace(sPath, '\\', '/');
 	std::vector<RString> bits;
 	split( sPath, "/", bits );
 
@@ -1665,7 +1665,7 @@ Song *SongManager::FindSong( RString sGroup, RString sSong ) const
 
 Course *SongManager::FindCourse( RString sPath ) const
 {
-	sPath.Replace( '\\', '/' );
+	Replace(sPath, '\\', '/');
 	std::vector<RString> bits;
 	split( sPath, "/", bits );
 
@@ -1789,7 +1789,7 @@ void SongManager::SetPreferredSongs(RString sPreferredSongs, bool bIsAbsolute) {
 				section = PreferredSortSection();
 			}
 
-			section.sName = sLine.Right( sLine.length() - RString("---").length() );
+			section.sName = Right(sLine, sLine.length() - RString("---").length());
 			TrimLeft( section.sName );
 			TrimRight( section.sName );
 		}
@@ -1799,7 +1799,7 @@ void SongManager::SetPreferredSongs(RString sPreferredSongs, bool bIsAbsolute) {
 				* and if it does, add all the songs in that group to the list. */
 			if( EndsWith(sLine,"/*") )
 			{
-				RString group = sLine.Left( sLine.length() - RString("/*").length() );
+				RString group = Left(sLine, sLine.length() - RString("/*").length());
 				if( DoesSongGroupExist(group) )
 				{
 					// add all songs in group
@@ -1985,7 +1985,7 @@ void SongManager::UpdateRankingCourses()
 		c->m_SortOrder_Ranking = bLotsOfStages? 3 : 2;
 
 		for( unsigned j = 0; j < RankingCourses.size(); j++ )
-			if( !RankingCourses[j].CompareNoCase(c->m_sPath) )
+			if( !CompareNoCase(RankingCourses[j], c->m_sPath) )
 				c->m_SortOrder_Ranking = 1;
 	}
 }
@@ -2123,7 +2123,7 @@ void SongManager::AddSongToList(Song* new_song)
 	new_song->SetEnabled(true);
 	m_pSongs.push_back(new_song);
 	RString dir= new_song->GetSongDir();
-	dir.MakeLower();
+	MakeLower(dir);
 	m_SongsByDir.insert(std::make_pair(dir, new_song));
 }
 

--- a/src/SongOptions.cpp
+++ b/src/SongOptions.cpp
@@ -141,7 +141,7 @@ void SongOptions::FromString( const RString &sMultipleMods )
 bool SongOptions::FromOneModString( const RString &sOneMod, RString &sErrorOut )
 {
 	RString sBit = sOneMod;
-	sBit.MakeLower();
+	MakeLower(sBit);
 	Trim( sBit );
 
 	Regex mult("^([0-9]+(\\.[0-9]+)?)xmusic$");

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -407,7 +407,7 @@ static bool CompareSongPointersBySortValueDescending( const Song *pSong1, const 
 
 RString SongUtil::MakeSortString( RString s )
 {
-	s.MakeUpper();
+	MakeUpper(s);
 
 	// Make sure that non-alphanumeric strings are placed at the very end.
 	if( s.size() > 0 )
@@ -441,7 +441,7 @@ static bool CompareSongPointersByTitle( const Song *pSong1, const Song *pSong2 )
 
 	/* The titles are the same.  Ensure we get a consistent ordering
 	 * by comparing the unique SongFilePaths. */
-	return pSong1->GetSongFilePath().CompareNoCase(pSong2->GetSongFilePath()) < 0;
+	return CompareNoCase(pSong1->GetSongFilePath(), pSong2->GetSongFilePath()) < 0;
 }
 
 void SongUtil::SortSongPointerArrayByTitle( std::vector<Song*> &vpSongsInOut )
@@ -716,7 +716,7 @@ RString SongUtil::GetSectionNameFromSongAndSort( const Song* pSong, SortOrder so
 			else if( s[0] < 'A' || s[0] > 'Z')
 				return SORT_OTHER.GetValue();
 			else
-				return s.Left(1);
+				return Left(s, 1);
 		}
 	case SORT_GENRE:
 		if( !pSong->m_sGenre.empty() )
@@ -940,7 +940,7 @@ RString SongUtil::MakeUniqueEditDescription( const Song *pSong, StepsType st, co
 	{
 		// make name "My Edit" -> "My Edit2"
 		RString sNum = ssprintf("%d", i+1);
-		sTemp = sPreferredDescription.Left( MAX_STEPS_DESCRIPTION_LENGTH - sNum.size() ) + sNum;
+		sTemp = Left(sPreferredDescription, MAX_STEPS_DESCRIPTION_LENGTH - sNum.size()) + sNum;
 
 		if( IsEditDescriptionUnique(pSong, st, sTemp, nullptr) )
 			return sTemp;
@@ -1279,7 +1279,7 @@ void SongID::FromSong( const Song *p )
 
 	// HACK for backwards compatibility:
 	// Strip off leading "/".  2005/05/21 file layer changes added a leading slash.
-	if( sDir.Left(1) == "/" )
+	if( Left(sDir, 1) == "/" )
 		sDir.erase( sDir.begin() );
 }
 
@@ -1291,7 +1291,7 @@ Song *SongID::ToSong() const
 		// HACK for backwards compatibility: Re-add the leading "/".
 		// 2005/05/21 file layer changes added a leading slash.
 		RString sDir2 = sDir;
-		if(sDir2.Left(1) != "/")
+		if(Left(sDir2, 1) != "/")
 		{
 			sDir2 = "/" + sDir2;
 		}
@@ -1313,7 +1313,7 @@ void SongID::LoadFromNode( const XNode* pNode )
 	pNode->GetAttrValue("Dir", sDir);
 
 	// HACK for backwards compatibility: /AdditionalSongs has been merged into /Songs
-	if (sDir.Left(16) == "AdditionalSongs/")
+	if (Left(sDir, 16) == "AdditionalSongs/")
 		sDir.replace(0, 16, "Songs/");
 }
 

--- a/src/StatsManager.cpp
+++ b/src/StatsManager.cpp
@@ -286,7 +286,7 @@ void StatsManager::SaveUploadFile( const StageStats *pSS )
 	}
 
 	RString sDate = DateTime::GetNowDate().GetString();
-	sDate.Replace(":","-");
+	Replace(sDate, ":", "-");
 
 	const RString UPLOAD_DIR = "/Save/Upload/";
 	RString sFileNameNoExtension = Profile::MakeUniqueFileNameNoExtension(UPLOAD_DIR, sDate + " " );
@@ -308,7 +308,7 @@ void StatsManager::SavePadmissScore( const StageStats *pSS, PlayerNumber pn )
 	std::unique_ptr<XNode> xml( new XNode("SongScore") );
 
 	RString sDate = DateTime::GetNowDate().GetString();
-	sDate.Replace(":","-");
+	Replace(sDate, ":", "-");
 
 	XNode *taps = xml->AppendChild( "TapNoteScores" );
 	FOREACH_ENUM( TapNoteScore, tns )

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -525,7 +525,7 @@ bool CheckVideoDefaultSettings()
 		// Update last seen video card
 		PREFSMAN->m_sLastSeenVideoDriver.Set( GetVideoDriverName() );
 	}
-	else if( PREFSMAN->m_sVideoRenderers.Get().CompareNoCase(defaults.sVideoRenderers) )
+	else if( CompareNoCase(PREFSMAN->m_sVideoRenderers.Get(), defaults.sVideoRenderers) )
 	{
 		LOG->Warn("Video renderer list has been changed from '%s' to '%s'",
 				defaults.sVideoRenderers.c_str(), PREFSMAN->m_sVideoRenderers.Get().c_str() );
@@ -589,26 +589,26 @@ RageDisplay *CreateDisplay()
 	{
 		RString sRenderer = asRenderers[i];
 
-		if( sRenderer.CompareNoCase("opengl")==0 )
+		if( CompareNoCase(sRenderer, "opengl")==0 )
 		{
 #if defined(SUPPORT_OPENGL)
 			pRet = new RageDisplay_Legacy;
 #endif
 		}
-		else if( sRenderer.CompareNoCase("gles2")==0 )
+		else if( CompareNoCase(sRenderer, "gles2")==0 )
 		{
 #if defined(SUPPORT_GLES2)
 			pRet = new RageDisplay_GLES2;
 #endif
 		}
-		else if( sRenderer.CompareNoCase("d3d")==0 )
+		else if( CompareNoCase(sRenderer, "d3d")==0 )
 		{
 // TODO: ANGLE/RageDisplay_Modern
 #if defined(SUPPORT_D3D)
 			pRet = new RageDisplay_D3D;
 #endif
 		}
-		else if( sRenderer.CompareNoCase("null")==0 )
+		else if( CompareNoCase(sRenderer, "null")==0 )
 		{
 			return new RageDisplay_Null;
 		}
@@ -1020,9 +1020,9 @@ RString StepMania::SaveScreenshot( RString Dir, bool SaveCompressed, bool MakeSi
 	 * As before, we ignore the extension. -aj */
 	RString FileNameNoExtension = NamePrefix + DateTime::GetNowDateTime().GetString() + NameSuffix;
 	// replace space with underscore.
-	FileNameNoExtension.Replace(" ","_");
+	Replace(FileNameNoExtension, " ", "_");
 	// colons are illegal in filenames.
-	FileNameNoExtension.Replace(":","");
+	Replace(FileNameNoExtension, ":", "");
 
 	// Save the screenshot. If writing lossy to a memcard, use
 	// SAVE_LOSSY_LOW_QUAL, so we don't eat up lots of space.

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -117,7 +117,7 @@ bool Steps::GetNoteDataFromSimfile()
 	// Replace the line below with the Steps' cache file.
 	RString stepFile = this->GetFilename();
 	RString extension = GetExtension(stepFile);
-	extension.MakeLower(); // must do this because the code is expecting lowercase
+	MakeLower(extension); // must do this because the code is expecting lowercase
 
 	if (extension.empty() || extension == "ssc"
 		|| extension == "ats") // remember cache files.
@@ -136,7 +136,7 @@ bool Steps::GetNoteDataFromSimfile()
 			*/
 			SMLoader backup_loader;
 			RString transformedStepFile = stepFile;
-			transformedStepFile.Replace(".ssc", ".sm");
+			Replace(transformedStepFile, ".ssc", ".sm");
 
 			return backup_loader.LoadNoteDataFromSimfile(transformedStepFile, *this);
 		}
@@ -692,7 +692,7 @@ bool Steps::MakeValidEditDescription( RString &sPreferredDescription )
 {
 	if( int(sPreferredDescription.size()) > MAX_STEPS_DESCRIPTION_LENGTH )
 	{
-		sPreferredDescription = sPreferredDescription.Left( MAX_STEPS_DESCRIPTION_LENGTH );
+		sPreferredDescription = Left(sPreferredDescription, MAX_STEPS_DESCRIPTION_LENGTH);
 		return true;
 	}
 	return false;

--- a/src/StepsUtil.cpp
+++ b/src/StepsUtil.cpp
@@ -245,7 +245,7 @@ void StepsUtil::SortStepsByTypeAndDifficulty( std::vector<Steps*> &arraySongPoin
 
 bool StepsUtil::CompareStepsPointersByDescription(const Steps *pStep1, const Steps *pStep2)
 {
-	return pStep1->GetDescription().CompareNoCase( pStep2->GetDescription() ) < 0;
+	return CompareNoCase(pStep1->GetDescription(), pStep2->GetDescription()) < 0;
 }
 
 void StepsUtil::SortStepsByDescription( std::vector<Steps*> &arraySongPointers )

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -139,8 +139,8 @@ static void FileNameToMetricsGroupAndElement( const RString &sFileName, RString 
 	}
 	else
 	{
-		sMetricsGroupOut = sFileName.Left( iIndexOfFirstSpace );
-		sElementOut = sFileName.Right( sFileName.size() - iIndexOfFirstSpace - 1 );
+		sMetricsGroupOut = Left(sFileName, iIndexOfFirstSpace);
+		sElementOut = Right(sFileName, sFileName.size() - iIndexOfFirstSpace - 1);
 	}
 }
 
@@ -215,7 +215,7 @@ bool ThemeManager::DoesThemeExist( const RString &sThemeName )
 	GetThemeNames( asThemeNames );
 	for( unsigned i=0; i<asThemeNames.size(); i++ )
 	{
-		if( !sThemeName.CompareNoCase(asThemeNames[i]) )
+		if( !CompareNoCase(sThemeName, asThemeNames[i]) )
 			return true;
 	}
 	return false;
@@ -228,7 +228,7 @@ bool ThemeManager::IsThemeSelectable(RString const& name)
 
 bool ThemeManager::IsThemeNameValid(RString const& name)
 {
-	return name.Left(1) != "_";
+	return Left(name, 1) != "_";
 }
 
 RString ThemeManager::GetThemeDisplayName( const RString &sThemeName )
@@ -257,10 +257,6 @@ RString ThemeManager::GetThemeAuthor( const RString &sThemeName )
 	return "[unknown author]";
 }
 
-static bool EqualsNoCase( const RString &s1, const RString &s2 )
-{
-	return s1.EqualsNoCase(s2);
-}
 void ThemeManager::GetLanguages( std::vector<RString>& AddTo )
 {
 	AddTo.clear();
@@ -280,7 +276,7 @@ bool ThemeManager::DoesLanguageExist( const RString &sLanguage )
 	GetLanguages( asLanguages );
 
 	for( unsigned i=0; i<asLanguages.size(); i++ )
-		if( sLanguage.CompareNoCase(asLanguages[i])==0 )
+		if( CompareNoCase(sLanguage, asLanguages[i])==0 )
 			return true;
 	return false;
 }
@@ -321,11 +317,11 @@ void ThemeManager::LoadThemeMetrics( const RString &sThemeName_, const RString &
 				iniStrings.ReadFile( s );
 		}
 		iniStrings.ReadFile( GetLanguageIniPath(sThemeName,SpecialFiles::BASE_LANGUAGE) );
-		if( sLanguage.CompareNoCase(SpecialFiles::BASE_LANGUAGE) )
+		if( CompareNoCase(sLanguage, SpecialFiles::BASE_LANGUAGE) )
 		{
 			iniStrings.ReadFile( GetLanguageIniPath(sThemeName,sLanguage) );
 		}
-		bool bIsBaseTheme = !sThemeName.CompareNoCase(SpecialFiles::BASE_THEME_NAME);
+		bool bIsBaseTheme = !CompareNoCase(sThemeName, SpecialFiles::BASE_THEME_NAME);
 		iniMetrics.GetValue( "Global", "IsBaseTheme", bIsBaseTheme );
 		if( bIsBaseTheme )
 		{
@@ -338,7 +334,7 @@ void ThemeManager::LoadThemeMetrics( const RString &sThemeName_, const RString &
 		RString sFallback;
 		if( !iniMetrics.GetValue("Global","FallbackTheme",sFallback) )
 		{
-			if( sThemeName.CompareNoCase( SpecialFiles::BASE_THEME_NAME ) && !bLoadedBase )
+			if( CompareNoCase(sThemeName, SpecialFiles::BASE_THEME_NAME) && !bLoadedBase )
 			{
 				sFallback = SpecialFiles::BASE_THEME_NAME;
 			}
@@ -577,13 +573,13 @@ struct CompareLanguageTag
 	{
 		m_sLanguageString = RString("(lang ") + sLang + ")";
 		LOG->Trace( "try \"%s\"", sLang.c_str() );
-		m_sLanguageString.MakeLower();
+		MakeLower(m_sLanguageString);
 	}
 
 	bool operator()( const RString &sFile ) const
 	{
 		RString sLower( sFile );
-		sLower.MakeLower();
+		MakeLower(sLower);
 		size_t iPos = sLower.find( m_sLanguageString );
 		return iPos != RString::npos;
 	}
@@ -733,7 +729,7 @@ bool ThemeManager::GetPathInfoToRaw( PathInfo &out, const RString &sThemeName_, 
 
 
 	RString sPath = asElementPaths[0];
-	bool bIsARedirect = GetExtension(sPath).CompareNoCase("redir")==0;
+	bool bIsARedirect = CompareNoCase(GetExtension(sPath), "redir")==0;
 
 	if( !bIsARedirect )
 	{
@@ -1149,7 +1145,7 @@ RString ThemeManager::GetNextTheme()
 	GetThemeNames( as );
 	unsigned i;
 	for( i=0; i<as.size(); i++ )
-		if( as[i].CompareNoCase(m_sCurThemeName)==0 )
+		if( CompareNoCase(as[i], m_sCurThemeName)==0 )
 			break;
 	int iNewIndex = (i+1)%as.size();
 	return as[iNewIndex];
@@ -1161,7 +1157,7 @@ RString ThemeManager::GetNextSelectableTheme()
 	GetSelectableThemeNames( as );
 	unsigned i;
 	for( i=0; i<as.size(); i++ )
-		if( as[i].CompareNoCase(m_sCurThemeName)==0 )
+		if( CompareNoCase(as[i], m_sCurThemeName)==0 )
 			break;
 	int iNewIndex = (i+1)%as.size();
 	return as[iNewIndex];
@@ -1176,7 +1172,7 @@ void ThemeManager::GetLanguagesForTheme( const RString &sThemeName, std::vector<
 	for (RString const &s : as)
 	{
 		// ignore metrics.ini
-		if( s.CompareNoCase(SpecialFiles::METRICS_FILE)==0 )
+		if( CompareNoCase(s, SpecialFiles::METRICS_FILE)==0 )
 			continue;
 
 		// Ignore filenames with a space.  These are optional language inis that probably came from a mounted package.
@@ -1184,7 +1180,7 @@ void ThemeManager::GetLanguagesForTheme( const RString &sThemeName, std::vector<
 			continue;
 
 		// strip ".ini"
-		RString s2 = s.Left( s.size()-4 );
+		RString s2 = Left(s, s.size()-4);
 
 		asLanguagesOut.push_back( s2 );
 	}
@@ -1213,24 +1209,24 @@ void ThemeManager::GetOptionNames( std::vector<RString>& AddTo )
 
 static RString PseudoLocalize( RString s )
 {
-	s.Replace( "a", "\xc3\xa0\xc3\xa1" ); // àá
-	s.Replace( "A", "\xc3\x80\xc3\x80" ); // ÀÀ
-	s.Replace( "e", "\xc3\xa9\xc3\xa9" ); // éé
-	s.Replace( "E", "\xc3\x89\xc3\x89" ); // ÉÉ
-	s.Replace( "i", "\xc3\xad\xc3\xad" ); // íí
-	s.Replace( "I", "\xc3\x8d\xc3\x8d" ); // ÍÍ
-	s.Replace( "o", "\xc3\xb3\xc3\xb3" ); // óó
-	s.Replace( "O", "\xc3\x93\xc3\x93" ); // ÓÓ
-	s.Replace( "u", "\xc3\xbc\xc3\xbc" ); // üü
-	s.Replace( "U", "\xc3\x9c\xc3\x9c" ); // ÜÜ
-	s.Replace( "n", "\xc3\xb1" ); // ñ
-	s.Replace( "N", "\xc3\x91" ); // Ñ
-	s.Replace( "c", "\xc3\xa7" ); // ç
-	s.Replace( "C", "\xc3\x87" ); // Ç
+	Replace(s, "a", "\xc3\xa0\xc3\xa1"); // àá
+	Replace(s, "A", "\xc3\x80\xc3\x80"); // ÀÀ
+	Replace(s, "e", "\xc3\xa9\xc3\xa9"); // éé
+	Replace(s, "E", "\xc3\x89\xc3\x89"); // ÉÉ
+	Replace(s, "i", "\xc3\xad\xc3\xad"); // íí
+	Replace(s, "I", "\xc3\x8d\xc3\x8d"); // ÍÍ
+	Replace(s, "o", "\xc3\xb3\xc3\xb3"); // óó
+	Replace(s, "O", "\xc3\x93\xc3\x93"); // ÓÓ
+	Replace(s, "u", "\xc3\xbc\xc3\xbc"); // üü
+	Replace(s, "U", "\xc3\x9c\xc3\x9c"); // ÜÜ
+	Replace(s, "n", "\xc3\xb1"); // ñ
+	Replace(s, "N", "\xc3\x91"); // Ñ
+	Replace(s, "c", "\xc3\xa7"); // ç
+	Replace(s, "C", "\xc3\x87"); // Ç
 	// transformations that help expose punctuation assumptions
 	//s.Replace( ":", " :" );	// this messes up "::" help text tip separator markers
-	s.Replace( "?", " ?" );
-	s.Replace( "!", " !" );
+	Replace(s, "?", " ?");
+	Replace(s, "!", " !");
 
 	return s;
 }
@@ -1248,8 +1244,8 @@ RString ThemeManager::GetString( const RString &sMetricsGroup, const RString &sV
 	DEBUG_ASSERT( sValueName.find('=') == sValueName.npos );
 
 	// TODO: Move this escaping into IniFile?
-	sValueName.Replace( "\r\n", "\\n" );
-	sValueName.Replace( "\n", "\\n" );
+	Replace(sValueName, "\r\n", "\\n");
+	Replace(sValueName, "\n", "\\n");
 
 	ASSERT( g_pLoadedThemeData != nullptr );
 	RString s = GetMetricRaw( g_pLoadedThemeData->iniStrings, sMetricsGroup, sValueName );
@@ -1258,7 +1254,7 @@ RString ThemeManager::GetString( const RString &sMetricsGroup, const RString &sV
 	// Don't EvalulateString.  Strings are raw and shouldn't allow Lua.
 	//EvaluateString( s );
 
-	s.Replace( "\\n", "\n" );
+	Replace(s, "\\n", "\n");
 
 	if( m_bPseudoLocalize )
 	{
@@ -1303,7 +1299,7 @@ void ThemeManager::GetMetricsThatBeginWith( const RString &sMetricsGroup_, const
 			for( XAttrs::const_iterator j = cur->m_attrs.lower_bound( sValueName ); j != cur->m_attrs.end(); ++j )
 			{
 				const RString &sv = j->first;
-				if( sv.Left(sValueName.size()) == sValueName )
+				if( Left(sv, sValueName.size()) == sValueName )
 					vsValueNamesOut.insert( sv );
 				else	// we passed the last metric that matched sValueName
 					break;

--- a/src/UnlockManager.cpp
+++ b/src/UnlockManager.cpp
@@ -240,7 +240,7 @@ const UnlockEntry *UnlockManager::FindCourse( const Course *pCourse ) const
 const UnlockEntry *UnlockManager::FindModifier( const RString &sOneMod ) const
 {
 	for (UnlockEntry const &e : m_UnlockEntries)
-		if( e.GetModifier().CompareNoCase(sOneMod) == 0 )
+		if( CompareNoCase(e.GetModifier(), sOneMod) == 0 )
 			return &e;
 	return nullptr;
 }

--- a/src/XmlToLua.cpp
+++ b/src/XmlToLua.cpp
@@ -96,7 +96,7 @@ RString add_extension_to_relative_path_from_found_file(
 {
 	size_t rel_last_slash= after_slash_or_zero(relative_path);
 	size_t found_last_slash= after_slash_or_zero(found_file);
-	return relative_path.Left(rel_last_slash) +
+	return Left(relative_path, rel_last_slash) +
 		found_file.substr(found_last_slash, std::string::npos);
 }
 
@@ -143,7 +143,7 @@ void string_arg_conv(std::vector<RString>& args)
 }
 void lower_string_conv(std::vector<RString>& args)
 {
-	args[0].MakeLower();
+	MakeLower(args[0]);
 }
 void hidden_conv(std::vector<RString>& args)
 {
@@ -183,7 +183,7 @@ void blend_conv(std::vector<RString>& args)
 	for(int i= 0; i < NUM_BlendMode; ++i)
 	{
 		RString blend_str= BlendModeToString(static_cast<BlendMode>(i));
-		blend_str.MakeLower();
+		MakeLower(blend_str);
 		if(args[1] == blend_str)
 		{
 			args[1]= "\"BlendMode_" + BlendModeToString(static_cast<BlendMode>(i)) + "\"";
@@ -197,7 +197,7 @@ void cull_conv(std::vector<RString>& args)
 	for(int i= 0; i < NUM_CullMode; ++i)
 	{
 		RString cull_str= CullModeToString(static_cast<CullMode>(i));
-		cull_str.MakeLower();
+		MakeLower(cull_str);
 		if(args[1] == cull_str)
 		{
 			args[1]= "\"CullMode_" + CullModeToString(static_cast<CullMode>(i)) + "\"";
@@ -250,7 +250,7 @@ void convert_lua_chunk(RString& chunk_text)
 	for(std::map<RString, RString>::iterator chunk= chunks_to_replace.begin();
 			chunk != chunks_to_replace.end(); ++chunk)
 	{
-		chunk_text.Replace(chunk->first.c_str(), chunk->second.c_str());
+		Replace(chunk_text, chunk->first.c_str(), chunk->second.c_str());
 	}
 }
 
@@ -299,9 +299,9 @@ void actor_template_t::make_space_for_frame(int id)
 
 void actor_template_t::store_cmd(RString const& cmd_name, RString const& full_cmd)
 {
-	if(full_cmd.Left(1) == "%")
+	if(Left(full_cmd, 1) == "%")
 	{
-		RString cmd_text= full_cmd.Right(full_cmd.size()-1);
+		RString cmd_text= Right(full_cmd, full_cmd.size()-1);
 		convert_lua_chunk(cmd_text);
 		fields[cmd_name]= cmd_text;
 		return;
@@ -392,13 +392,13 @@ void actor_template_t::store_cmd(RString const& cmd_name, RString const& full_cm
 void actor_template_t::store_field(RString const& field_name, RString const& value, bool cmd_convert, RString const& pref, RString const& suf)
 {
 	// OITG apparently allowed "Oncommand" as valid.
-	if(field_name.Right(7).MakeLower() != "command")
+	if(MakeLower(Right(field_name, 7)) != "command")
 	{
 		cmd_convert= false;
 	}
 	if(cmd_convert)
 	{
-		RString real_field_name= field_name.Left(field_name.size()-7) + "Command";
+		RString real_field_name= Left(field_name, field_name.size()-7) + "Command";
 		store_cmd(real_field_name, value);
 	}
 	else
@@ -450,16 +450,16 @@ void actor_template_t::load_frames_from_file(RString const& fname, RString const
 		{
 			// Frame and Delay fields have names of the form "Frame0000" where the
 			// "0000" part is the id of the frame.
-			RString field_type= attr->first.Left(5);
+			RString field_type= Left(attr->first, 5);
 			if(field_type == "Frame")
 			{
-				int id= StringToInt(attr->first.Right(attr->first.size()-5));
+				int id= StringToInt(Right(attr->first, attr->first.size()-5));
 				make_space_for_frame(id);
 				attr->second->GetValue(frames[id].frame);
 			}
 			else if(field_type == "Delay")
 			{
-				int id= StringToInt(attr->first.Right(attr->first.size()-5));
+				int id= StringToInt(Right(attr->first, attr->first.size()-5));
 				make_space_for_frame(id);
 				attr->second->GetValue(frames[id].delay);
 			}
@@ -737,7 +737,7 @@ void convert_xml_file(RString const& fname, RString const& dirname)
 	condition_set_t conditions;
 	plate.load_node(xml, dirname, conditions);
 	RageFile* file= new RageFile;
-	RString out_name= fname.Left(fname.size()-4) + ".lua";
+	RString out_name= Left(fname, fname.size()-4) + ".lua";
 	if(!file->Open(out_name, RageFile::WRITE))
 	{
 		LOG->Trace("Could not open %s: %s", out_name.c_str(), file->GetError().c_str());

--- a/src/arch/Dialog/Dialog.cpp
+++ b/src/arch/Dialog/Dialog.cpp
@@ -31,13 +31,13 @@ DialogDriver *MakeDialogDriver()
 		sDriver = asDriversToTry[i];
 
 #ifdef USE_DIALOG_DRIVER_COCOA
-		if( !asDriversToTry[i].CompareNoCase("Cocoa") )	pRet = new DialogDriver_MacOSX;
+		if( !CompareNoCase(asDriversToTry[i], "Cocoa") )	pRet = new DialogDriver_MacOSX;
 #endif
 #ifdef USE_DIALOG_DRIVER_WIN32
-		if( !asDriversToTry[i].CompareNoCase("Win32") )	pRet = new DialogDriver_Win32;
+		if( !CompareNoCase(asDriversToTry[i], "Win32") )	pRet = new DialogDriver_Win32;
 #endif
 #ifdef USE_DIALOG_DRIVER_NULL
-		if( !asDriversToTry[i].CompareNoCase("Null") )	pRet = new DialogDriver_Null;
+		if( !CompareNoCase(asDriversToTry[i], "Null") )	pRet = new DialogDriver_Null;
 #endif
 
 		if( pRet == nullptr )
@@ -89,7 +89,7 @@ static bool MessageIsIgnored( RString sID )
 	std::vector<RString> asList;
 	split( g_sIgnoredDialogs, ",", asList );
 	for( unsigned i = 0; i < asList.size(); ++i )
-		if( !sID.CompareNoCase(asList[i]) )
+		if( !CompareNoCase(sID, asList[i]) )
 			return true;
 #endif
 	return false;

--- a/src/arch/Dialog/DialogDriver_Win32.cpp
+++ b/src/arch/Dialog/DialogDriver_Win32.cpp
@@ -52,7 +52,7 @@ static INT_PTR CALLBACK OKWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lP
 
 			// Set static text.
 			RString sMessage = g_sMessage;
-			sMessage.Replace( "\n", "\r\n" );
+			Replace(sMessage, "\n", "\r\n" );
 			SetWindowText( GetDlgItem(hWnd, IDC_MESSAGE), sMessage.c_str() );
 
 			// Focus is on any of the controls in the dialog by default.
@@ -148,7 +148,7 @@ static INT_PTR CALLBACK ErrorWndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM
 
 			// Set static text
 			RString sMessage = g_sErrorString;
-			sMessage.Replace( "\n", "\r\n" );
+			Replace(sMessage, "\n", "\r\n" );
 			SetWindowText( GetDlgItem(hWnd, IDC_EDIT_ERROR), sMessage.c_str() );
 		}
 		break;

--- a/src/arch/Lights/LightsDriver_GenericHID.cpp
+++ b/src/arch/Lights/LightsDriver_GenericHID.cpp
@@ -50,7 +50,7 @@ LightsDriver_GenericHID::LightsDriver_GenericHID()
 	WriteDevice( 0 );
 
 	RString lightOrder = g_sGenericHIDLightsOrdering.Get();
-	if (lightOrder.CompareNoCase("lumenar") == 0 || lightOrder.CompareNoCase("openitg") == 0) {
+	if (CompareNoCase(lightOrder, "lumenar") == 0 || CompareNoCase(lightOrder, "openitg") == 0) {
 		iLightsOrder = 1;
 	}
 }

--- a/src/arch/Lights/LightsDriver_Linux_Leds.cpp
+++ b/src/arch/Lights/LightsDriver_Linux_Leds.cpp
@@ -49,7 +49,7 @@ bool LightsDriver_Linux_Leds::IsDance()
 	pInput = &GAMESTATE->GetCurrentGame()->m_InputScheme;
 	sInputName = pInput->m_szName;
 
-	return sInputName.EqualsNoCase("dance");
+	return EqualsNoCase(sInputName, "dance");
 }
 
 bool LightsDriver_Linux_Leds::IsPump()
@@ -57,7 +57,7 @@ bool LightsDriver_Linux_Leds::IsPump()
 	pInput = &GAMESTATE->GetCurrentGame()->m_InputScheme;
 	sInputName = pInput->m_szName;
 
-	return sInputName.EqualsNoCase("pump");
+	return EqualsNoCase(sInputName, "pump");
 }
 
 void LightsDriver_Linux_Leds::SetLight(const char *filename, bool previous, bool desired)

--- a/src/arch/Lights/LightsDriver_Linux_PIUIO.cpp
+++ b/src/arch/Lights/LightsDriver_Linux_PIUIO.cpp
@@ -48,7 +48,7 @@ void LightsDriver_Linux_PIUIO::Set( const LightsState *ls )
 	if (ls->m_bCabinetLights[LIGHT_BASS_LEFT] || ls->m_bCabinetLights[LIGHT_BASS_RIGHT]) buf[1] |= 0x04;
 
 	RString sInput = GAMESTATE->GetCurrentGame()->m_InputScheme.m_szName;
-	if (sInput.EqualsNoCase("dance")) {
+	if (EqualsNoCase(sInput, "dance")) {
 		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_UP]) buf[2] |= 0x04;
 		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_DOWN]) buf[2] |= 0x08;
 		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_LEFT]) buf[2] |= 0x10;
@@ -58,7 +58,7 @@ void LightsDriver_Linux_PIUIO::Set( const LightsState *ls )
 		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_DOWN]) buf[0] |= 0x08;
 		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_LEFT]) buf[0] |= 0x10;
 		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_RIGHT]) buf[0] |= 0x20;
-	} else if (sInput.EqualsNoCase("pump")) {
+	} else if (EqualsNoCase(sInput, "pump")) {
 		if (ls->m_bGameButtonLights[GameController_1][PUMP_BUTTON_UPLEFT]) buf[0] |= 0x04;
 		if (ls->m_bGameButtonLights[GameController_1][PUMP_BUTTON_UPRIGHT]) buf[0] |= 0x08;
 		if (ls->m_bGameButtonLights[GameController_1][PUMP_BUTTON_CENTER]) buf[0] |= 0x10;

--- a/src/arch/Lights/LightsDriver_PacDrive.cpp
+++ b/src/arch/Lights/LightsDriver_PacDrive.cpp
@@ -15,7 +15,7 @@ LightsDriver_PacDrive::LightsDriver_PacDrive() : dev{PACDRIVE_VID, make_pids(PAC
 	memset(state.raw_state, 0x00, sizeof(state.raw_state));
 
 	RString lightOrder = g_sPacDriveLightOrdering.Get();
-	if (lightOrder.CompareNoCase("lumenar") == 0 || lightOrder.CompareNoCase("openitg") == 0)
+	if (CompareNoCase(lightOrder, "lumenar") == 0 || CompareNoCase(lightOrder, "openitg") == 0)
 	{
 		iPacDriveLightOrder = 1;
 	}

--- a/src/arch/Lights/LightsDriver_stac.cpp
+++ b/src/arch/Lights/LightsDriver_stac.cpp
@@ -49,14 +49,14 @@ void LightsDriver_stac::HandleState(const LightsState *ls, GameController ctrlNu
 	const InputScheme *pInput = &GAMESTATE->GetCurrentGame()->m_InputScheme;
 	RString sInputName = pInput->m_szName;
 
-	if (sInputName.EqualsNoCase("dance"))
+	if (EqualsNoCase(sInputName, "dance"))
 	{
 		SetBuffer(STAC_LIGHTINDEX_BTN1, ls->m_bGameButtonLights[ctrlNum][DANCE_BUTTON_UP], ctrlNum);
 		SetBuffer(STAC_LIGHTINDEX_BTN2, ls->m_bGameButtonLights[ctrlNum][DANCE_BUTTON_DOWN], ctrlNum);
 		SetBuffer(STAC_LIGHTINDEX_BTN3, ls->m_bGameButtonLights[ctrlNum][DANCE_BUTTON_LEFT], ctrlNum);
 		SetBuffer(STAC_LIGHTINDEX_BTN4, ls->m_bGameButtonLights[ctrlNum][DANCE_BUTTON_RIGHT], ctrlNum);
 	}
-	else if (sInputName.EqualsNoCase("pump"))
+	else if (EqualsNoCase(sInputName, "pump"))
 	{
 		SetBuffer(STAC_LIGHTINDEX_BTN1, ls->m_bGameButtonLights[ctrlNum][PUMP_BUTTON_UPLEFT], ctrlNum);
 		SetBuffer(STAC_LIGHTINDEX_BTN2, ls->m_bGameButtonLights[ctrlNum][PUMP_BUTTON_UPRIGHT], ctrlNum);

--- a/src/arch/LoadingWindow/LoadingWindow.cpp
+++ b/src/arch/LoadingWindow/LoadingWindow.cpp
@@ -29,15 +29,15 @@ LoadingWindow *LoadingWindow::Create()
 		Driver = DriversToTry[i];
 
 #ifdef USE_LOADING_WINDOW_MACOSX
-		if( !DriversToTry[i].CompareNoCase("MacOSX") )	ret = new LoadingWindow_MacOSX;
+		if( !CompareNoCase(DriversToTry[i], "MacOSX") )	ret = new LoadingWindow_MacOSX;
 #endif
 #ifdef USE_LOADING_WINDOW_GTK
-		if( !DriversToTry[i].CompareNoCase("Gtk") )	ret = new LoadingWindow_Gtk;
+		if( !CompareNoCase(DriversToTry[i], "Gtk") )	ret = new LoadingWindow_Gtk;
 #endif
 #ifdef USE_LOADING_WINDOW_WIN32
-		if( !DriversToTry[i].CompareNoCase("Win32") )	ret = new LoadingWindow_Win32;
+		if( !CompareNoCase(DriversToTry[i], "Win32") )	ret = new LoadingWindow_Win32;
 #endif
-		if( !DriversToTry[i].CompareNoCase("Null") )	ret = new LoadingWindow_Null;
+		if( !CompareNoCase(DriversToTry[i], "Null") )	ret = new LoadingWindow_Null;
 
 		if( ret == nullptr )
 			continue;

--- a/src/arch/MemoryCard/MemoryCardDriverThreaded_Linux.cpp
+++ b/src/arch/MemoryCard/MemoryCardDriverThreaded_Linux.cpp
@@ -244,7 +244,7 @@ void MemoryCardDriverThreaded_Linux::GetUSBStorageDevices( std::vector<UsbStorag
 						sHostPort.erase( pos );
 
 					/* sHostPort is eg. 2-2.1. */
-					sHostPort.Replace( "-", "." );
+					Replace(sHostPort, "-", ".");
 					asBits.clear();
 					split( sHostPort, ".", asBits );
 					if( asBits.size() > 1 )

--- a/src/arch/MemoryCard/MemoryCardDriverThreaded_Windows.cpp
+++ b/src/arch/MemoryCard/MemoryCardDriverThreaded_Windows.cpp
@@ -128,7 +128,7 @@ void MemoryCardDriverThreaded_Windows::GetUSBStorageDevices( std::vector<UsbStor
 
 		bool bIsSpecifiedMountPoint = false;
 		FOREACH_ENUM( PlayerNumber, p )
-			bIsSpecifiedMountPoint |= MEMCARDMAN->m_sMemoryCardOsMountPoint[p].Get().EqualsNoCase(sDrive.c_str());
+			bIsSpecifiedMountPoint |= EqualsNoCase(MEMCARDMAN->m_sMemoryCardOsMountPoint[p].Get(), sDrive.c_str());
 
 		RString sDrivePath = sDrive + "\\";
 

--- a/src/arch/MovieTexture/MovieTexture.cpp
+++ b/src/arch/MovieTexture/MovieTexture.cpp
@@ -23,15 +23,15 @@ bool RageMovieTexture::GetFourCC( RString fn, RString &handler, RString &type )
 {
 	RString ignore, ext;
 	splitpath( fn, ignore, ignore, ext);
-	if( !ext.CompareNoCase(".mpg") ||
-		!ext.CompareNoCase(".mpeg") ||
-		!ext.CompareNoCase(".mpv") ||
-		!ext.CompareNoCase(".mpe") )
+	if( !CompareNoCase(ext, ".mpg") ||
+		!CompareNoCase(ext, ".mpeg") ||
+		!CompareNoCase(ext, ".mpv") ||
+		!CompareNoCase(ext, ".mpe") )
 	{
 		handler = type = "MPEG";
 		return true;
 	}
-	if( !ext.CompareNoCase(".ogv") )
+	if( !CompareNoCase(ext, ".ogv") )
 	{
 		handler = type = "Ogg";
 		return true;

--- a/src/archutils/Unix/BacktraceNames.cpp
+++ b/src/archutils/Unix/BacktraceNames.cpp
@@ -282,13 +282,13 @@ void BacktraceNames::FromAddr( void * const p )
 	 * __start   -> _start
 	 * __ZN7RageLog5TraceEPKcz -> _ZN7RageLog5TraceEPKcz (so demangling will work)
 	 */
-	if( Symbol.Left(1) == "_" )
+	if( Left(Symbol, 1) == "_" )
 		Symbol = Symbol.substr(1);
 	/* After stripping off the leading _
 	 * _GLOBAL__I__ZN5ModelC2Ev -> _ZN5ModelC2Ev
 	 * _GLOBAL__D__Z12ForceToAsciiR7CStdStrIcE -> _Z12ForceToAsciiR7CStdStrIcE
 	 */
-	if( Symbol.Left(9) == "_GLOBAL__" )
+	if( Left(Symbol, 9) == "_GLOBAL__" )
 		Symbol = Symbol.substr(11);
 
 }

--- a/src/archutils/Win32/ErrorStrings.cpp
+++ b/src/archutils/Win32/ErrorStrings.cpp
@@ -13,8 +13,8 @@ RString werr_ssprintf( int err, const char *fmt, ... )
 	// Why is FormatMessage returning text ending with \r\n? (who? -aj)
 	// Perhaps it's because you're on Windows, where newlines are \r\n. -aj
 	RString text = buf;
-	text.Replace( "\n", "" );
-	text.Replace( "\r", " " ); // foo\r\nbar -> foo bar
+	Replace(text, "\n", "" );
+	Replace(text, "\r", " " ); // foo\r\nbar -> foo bar
 	TrimRight( text ); // "foo\r\n" -> "foo"
 
 	va_list	va;

--- a/src/archutils/Win32/RegistryAccess.cpp
+++ b/src/archutils/Win32/RegistryAccess.cpp
@@ -22,11 +22,11 @@ static bool GetRegKeyType( const RString &sIn, RString &sOut, HKEY &key )
 
 	RString sType = sIn.substr( 0, iBackslash );
 
-	if( !sType.CompareNoCase( "HKEY_CLASSES_ROOT" ) )		key = HKEY_CLASSES_ROOT;
-	else if( !sType.CompareNoCase( "HKEY_CURRENT_CONFIG" ) )	key = HKEY_CURRENT_CONFIG;
-	else if( !sType.CompareNoCase( "HKEY_CURRENT_USER" ) )	key = HKEY_CURRENT_USER;
-	else if( !sType.CompareNoCase( "HKEY_LOCAL_MACHINE" ) )	key = HKEY_LOCAL_MACHINE;
-	else if( !sType.CompareNoCase( "HKEY_USERS" ) )			key = HKEY_USERS;
+	if( !CompareNoCase(sType, "HKEY_CLASSES_ROOT" ) )		key = HKEY_CLASSES_ROOT;
+	else if( !CompareNoCase(sType, "HKEY_CURRENT_CONFIG" ) )	key = HKEY_CURRENT_CONFIG;
+	else if( !CompareNoCase(sType, "HKEY_CURRENT_USER" ) )	key = HKEY_CURRENT_USER;
+	else if( !CompareNoCase(sType, "HKEY_LOCAL_MACHINE" ) )	key = HKEY_LOCAL_MACHINE;
+	else if( !CompareNoCase(sType, "HKEY_USERS" ) )			key = HKEY_USERS;
 	else
 	{
 		LOG->Warn( "Invalid registry key: \"%s\" ", sIn.c_str() );

--- a/src/tests/test_file_errors.cpp
+++ b/src/tests/test_file_errors.cpp
@@ -99,7 +99,7 @@ RageFileDriverTest::RageFileDriverTest( RString root_ ):
 	RageFileDriver( new TestFilenameDB(root_) ),
 	root(root_)
 {
-	if( root.Right(1) != "/" )
+	if( Right(root, 1) != "/" )
 		root += '/';
 }
 


### PR DESCRIPTION
This reverts commit 53dcbed80d38bf62b799e33af01d4a26a61251ae.

This was originally #788. One one fix here on top of that PR is to qualify the `Replace()` call in `Regex::Replace()` to call the unnamespaced `Replace()`, rather than itself.