### PR TITLE
Fix failing nightly workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
             release: |
               cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
               cmake --build build --target package
-            path: build/ITGmania-*-NIGHTLY-git-*-Linux-x86_64-no-songs.tar.gz
+            path: build/ITGmania-*-NIGHTLY-git-*-Linux-no-songs.tar.gz
           - os: ubuntu-24.04-arm
             name: Ubuntu (ARM)
             install: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
@@ -33,7 +33,7 @@ jobs:
             release: |
               cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off -DWITH_MINIMAID=Off
               cmake --build build --target package
-            path: build/ITGmania-*-NIGHTLY-git-*-Linux-aarch64-no-songs.tar.gz
+            path: build/ITGmania-*-NIGHTLY-git-*-Linux-arm64-no-songs.tar.gz
           - os: macos-latest
             name: macOS (M1)
             install: brew install nasm


### PR DESCRIPTION
Runs are failing because the paths here don't match the package name e.g.
![image](https://github.com/user-attachments/assets/5f3f18fc-4fde-4583-a203-c853beab9685) https://github.com/itgmania/itgmania/actions/runs/15838559448/job/44646945102#step:7:10

Successful run on my fork - https://github.com/ScottBrenner/itgmania/actions/runs/15839597288#artifacts - artifact names do not collide
