### PR TITLE
(Major change) Rewrite ReloadFromSongDir from scratch

### DIFF
--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -509,6 +509,10 @@ bool Song::ReloadFromSongDir( const RString &sDir )
 	{
 		AddAutoGenNotes();
 
+		// TODO: move graphics reloading logic elsewhere, and hash these files as well,
+		// so we can effectively determine if the graphics have changed even when the
+		// simfile hasn't. As it is, we only reload graphics automatically when the
+		// simfile has changed.
 		const RString* const toReload[] = { 
 			&m_sBannerFile, &m_sJacketFile, &m_sCDFile, 
 			&m_sDiscFile, &m_sBackgroundFile, &m_sCDTitleFile, &m_sPreviewVidFile 

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -498,18 +498,20 @@ bool Song::ReloadFromSongDir( const RString &sDir )
 	// m_vpSteps represent known charts for a given difficulty or mode.
 	// m_UnknownStyleSteps represent things like unfilled difficulty blocks.
 	RemoveAutoGenNotes();
-	
+
+	m_vpSteps.clear();
 	for (Steps* step : m_vpSteps) {
 		delete step;
 	}
-	m_vpSteps.clear();
-	FOREACH_ENUM( StepsType, i )
-		m_vpStepsByType[i].clear();
 
+	m_UnknownStyleSteps.clear();
 	for (Steps* step : m_UnknownStyleSteps) {
 		delete step;
 	}
-	m_UnknownStyleSteps.clear();
+
+	FOREACH_ENUM(StepsType, i) {
+		m_vpStepsByType[i].clear();
+	}
 
 	// Freshly load into cache directly from disk.
 	if( LoadFromSongDir(sDir) )

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -471,120 +471,74 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
 	return true;	// do load this song
 }
 
-/* This function feels EXTREMELY hacky - copying things on top of pointers so
- * they don't break elsewhere.  Maybe it could be rewritten to politely ask the
- * Song/Steps objects to reload themselves. -- djpohly */
-bool Song::ReloadFromSongDir( RString sDir )
+
+// Get the hash of the song file. This is primarily used to determine if the simfile
+// has changed since it was last seen. The SHA-1 of the file is also validated against
+// the cached file here. This will potentially clear cached song data and reload from disk!
+bool Song::ReloadFromSongDir( const RString &sDir )
 {
-	// Remove the cache file to force the song to reload from its dir instead
-	// of loading from the cache. -Kyz
+	// Store the hash of the cached file before forcing a reload from disk.
+	RString currentHash = m_sFileHash;
 	FILEMAN->Remove(GetCacheFilePath());
 
+	// Hash comparison. If it's a match, return early without changing anything.
+	m_sFileHash = GetFileHash();
+	if (currentHash == m_sFileHash) {
+		return true;
+	}
+
+	// Clear out all old data to prepare for a reload from disk.
+	// m_vpSteps represent known charts for a given difficulty or mode.
+	// m_UnknownStyleSteps represent things like unfilled difficulty blocks.
 	RemoveAutoGenNotes();
-	std::vector<Steps*> vOldSteps = m_vpSteps;
-
-
-	Song copy;
-	if( !copy.LoadFromSongDir( sDir ) )
-		return false;
-	copy.RemoveAutoGenNotes();
-	*this = copy;
 	
-	if (SONGMAN->GetGroup(this) != nullptr) {
-		m_SongTiming.m_fBeat0GroupOffsetInSeconds = SONGMAN->GetGroup(this)->GetSyncOffset();
-	} else {
-		m_SongTiming.m_fBeat0GroupOffsetInSeconds = PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL ? 0 : -0.009;
-		LOG->Warn("Song %s has no group, using default sync offset.", m_sMainTitle.c_str());
+	for (Steps* step : m_vpSteps) {
+		delete step;
 	}
-
-	/* Go through the steps, first setting their Song pointer to this song
-	 * (instead of the copy used above), and constructing a map to let us
-	 * easily find the new steps. */
-	std::map<StepsID, Steps*> mNewSteps;
-	for( std::vector<Steps*>::const_iterator it = m_vpSteps.begin(); it != m_vpSteps.end(); ++it )
-	{
-		(*it)->m_pSong = this;
-		StepsID id;
-		id.FromSteps( *it );
-		mNewSteps[id] = *it;
-
-		// Reapply the Group Offset if the steps have their own timing data.
-		if( mNewSteps[id]->m_Timing.empty() )
-		{
-			continue;
-		}
-		if (SONGMAN->GetGroup(this) != nullptr)
-		{
-			mNewSteps[id]->m_Timing.m_fBeat0GroupOffsetInSeconds = SONGMAN->GetGroup(this)->GetSyncOffset();
-		}
-		else
-		{
-			mNewSteps[id]->m_Timing.m_fBeat0GroupOffsetInSeconds = PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL ? 0 : -0.009;
-			LOG->Warn("Song %s has no group, using default sync offset.", m_sMainTitle.c_str());
-		}
-	}
-
-	// Now we wipe out the new pointers, which were shallow copied and not deep copied...
 	m_vpSteps.clear();
 	FOREACH_ENUM( StepsType, i )
 		m_vpStepsByType[i].clear();
 
-	/* Then we copy as many Steps as possible on top of the old pointers.
-	 * The only pointers that change are pointers to Steps that are not in the
-	 * reverted file, which we delete, and pointers to Steps that are in the
-	 * reverted file but not the original *this, which we create new copies of.
-	 * We have to go through these hoops because many places assume the Steps
-	 * pointers don't change - even though there are other ways they can change,
-	 * such as deleting a Steps via the editor. */
-	for( std::vector<Steps*>::const_iterator itOld = vOldSteps.begin(); itOld != vOldSteps.end(); ++itOld )
-	{
-		StepsID id;
-		id.FromSteps( *itOld );
-		std::map<StepsID, Steps*>::iterator itNew = mNewSteps.find( id );
-		if( itNew == mNewSteps.end() )
-		{
-			// This stepchart didn't exist in the file we reverted from
-			delete *itOld;
-		}
-		else
-		{
-			Steps *OldSteps = *itOld;
-			*OldSteps = *(itNew->second);
-			AddSteps( OldSteps );
-			mNewSteps.erase( itNew );
-		}
+	for (Steps* step : m_UnknownStyleSteps) {
+		delete step;
 	}
-	// The leftovers in the map are steps that didn't exist before we reverted
-	for( std::map<StepsID, Steps*>::const_iterator it = mNewSteps.begin(); it != mNewSteps.end(); ++it )
-	{
-		Steps *NewSteps = new Steps(this);
-		*NewSteps = *(it->second);
-		AddSteps( NewSteps );
-	}
+	m_UnknownStyleSteps.clear();
 
-	AddAutoGenNotes();
-	// Reload any images associated with the song. -Kyz
-	std::vector<RString> to_reload;
-	to_reload.reserve(7);
-	to_reload.push_back(m_sBannerFile);
-	to_reload.push_back(m_sJacketFile);
-	to_reload.push_back(m_sCDFile);
-	to_reload.push_back(m_sDiscFile);
-	to_reload.push_back(m_sBackgroundFile);
-	to_reload.push_back(m_sCDTitleFile);
-	to_reload.push_back(m_sPreviewVidFile);
-	for(std::vector<RString>::iterator file= to_reload.begin(); file != to_reload.end(); ++file)
+	// Freshly load into cache directly from disk.
+	if( LoadFromSongDir(sDir) )
 	{
-		RageTextureID id(*file);
-		if(TEXTUREMAN->IsTextureRegistered(id))
+		AddAutoGenNotes();
+
+		// Reload associated images.
+		const RString* const toReload[] = {
+			&m_sBannerFile,
+			&m_sJacketFile,
+			&m_sCDFile,
+			&m_sDiscFile,
+			&m_sBackgroundFile,
+			&m_sCDTitleFile,
+			&m_sPreviewVidFile
+		};
+
+		for (const RString *file : toReload)
 		{
-			RageTexture* tex= TEXTUREMAN->LoadTexture(id);
-			if(tex)
+			RageTextureID id(*file);
+			if (TEXTUREMAN->IsTextureRegistered(id))
 			{
-				tex->Reload();
+				RageTexture* tex = TEXTUREMAN->LoadTexture(id);
+				if (tex)
+				{
+					tex->Reload();
+				}
 			}
 		}
 	}
+	else
+	{
+		LOG->Trace("Failed to reload song from directory: %s", sDir.c_str());
+		return false;
+	}
+
 	return true;
 }
 

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -509,9 +509,8 @@ bool Song::ReloadFromSongDir( const RString &sDir )
 		delete step;
 	}
 
-	FOREACH_ENUM(StepsType, i) {
+	FOREACH_ENUM( StepsType, i )
 		m_vpStepsByType[i].clear();
-	}
 
 	// Freshly load into cache directly from disk.
 	if( LoadFromSongDir(sDir) )

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -509,32 +509,22 @@ bool Song::ReloadFromSongDir( const RString &sDir )
 	{
 		AddAutoGenNotes();
 
-		// Reload associated images.
-		const RString* const toReload[] = {
-			&m_sBannerFile,
-			&m_sJacketFile,
-			&m_sCDFile,
-			&m_sDiscFile,
-			&m_sBackgroundFile,
-			&m_sCDTitleFile,
-			&m_sPreviewVidFile
+		const RString* const toReload[] = { 
+			&m_sBannerFile, &m_sJacketFile, &m_sCDFile, 
+			&m_sDiscFile, &m_sBackgroundFile, &m_sCDTitleFile, &m_sPreviewVidFile 
 		};
 
-		for (const RString *file : toReload)
-		{
+		for (const RString* file : toReload) {
 			RageTextureID id(*file);
-			if (TEXTUREMAN->IsTextureRegistered(id))
-			{
-				RageTexture* tex = TEXTUREMAN->LoadTexture(id);
-				if (tex)
-				{
-					tex->Reload();
+			if (TEXTUREMAN->IsTextureRegistered(id)) {
+				if (RageTexture* tex = TEXTUREMAN->LoadTexture(id)) {
+					if (tex) {
+						tex->Reload();
+					}
 				}
 			}
 		}
-	}
-	else
-	{
+	} else {
 		LOG->Trace("Failed to reload song from directory: %s", sDir.c_str());
 		return false;
 	}

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -477,15 +477,22 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
 // the cached file here. This will potentially clear cached song data and reload from disk!
 bool Song::ReloadFromSongDir( const RString &sDir )
 {
-	// Store the hash of the cached file before forcing a reload from disk.
-	RString currentHash = m_sFileHash;
-	FILEMAN->Remove(GetCacheFilePath());
+	// Get the current hash without modifying any files first.
+	// If the hashes match, then return early.
+	// Note, this is scoped because we want to ensure we finish up operations on
+	// m_sFileHash before anything else might try to access that file's hash.
+	{
+		RString newHash = GetFileHash();
 
-	// Hash comparison. If it's a match, return early without changing anything.
-	m_sFileHash = GetFileHash();
-	if (currentHash == m_sFileHash) {
-		return true;
+		if (!m_sFileHash.empty() && newHash == m_sFileHash) {
+			return true;
+		}
+
+		m_sFileHash = newHash;
 	}
+	
+	// We're going to reload, so we have to clear the cache file first.
+	FILEMAN->Remove(GetCacheFilePath());
 
 	// Clear out all old data to prepare for a reload from disk.
 	// m_vpSteps represent known charts for a given difficulty or mode.

--- a/src/Song.h
+++ b/src/Song.h
@@ -96,7 +96,7 @@ public:
 	bool LoadFromSongDir(RString sDir, bool load_autosave= false,
 		ProfileSlot from_profile= ProfileSlot_Invalid);
 	// This one takes the effort to reuse Steps pointers as best as it can
-	bool ReloadFromSongDir( RString sDir );
+	bool ReloadFromSongDir( const RString &sDir );
 	bool ReloadFromSongDir() { return ReloadFromSongDir(GetSongDir()); }
 	void LoadEditsFromSongDir(RString dir);
 


### PR DESCRIPTION
# NOTE:  this doesn't change anything functionally when using Simply Love or a theme based on Simply Love, but this could break legacy SM5 themes

Imagine the case where the song is edited on disk while the user is in the song wheel:

If the user tries to play the song, it will either play the old data or the steps will be missing. `ReloadFromSongDir` is supposed to handle it, but it usually doesn't succeed.

If you're in the song wheel, Shift+Ctrl+R will reload the song data. It usually works. If it doesn't, you have to relauch the game or reload from the settings menu. It's occasionally happened that someone had to delete their cache to resolve this problem.

This PR throws away all of the existing unreliable logic, and replaces it with a simple SHA-1 hash comparison of the file on disk against the cached file. So, if the song is edited on disk while the user is in the song wheel, the updated chart will be automatically loaded in next time that song is chosen.

In fact, Ctrl+R is only needed if you want to see updated data in the song wheel, or access a difficulty that wasn't there before.

# What has and has not been tested 

All gameplay, GrooveStats song submissions, etc all continue to work as they did/should.

I did basic tests in edit mode to make sure expected functionality is maintained. The only side effect I've found is that "Reload from Cache" seems to become functionally identical to "Reload from Disk" with this change. 

If accepted I will make a follow-up to restore expected behavior of "Reload from Cache".

# Further detail

<details>

`ReloadFromSongDir` is designed to carefully copy things on top of existing pointers so that references to a particular song don't break. 

Really, we shouldn't be depending on "hoping some pointers don't change" for songs to work. And actually, when using the Simply Love theme, even when you explicitly delete the old pointers and construct a new set of pointers, things do continue to work.

This is a high-level overview of how `ReloadFromSongDir` works:
1. User selects a song
2. The cache is invalidated, and auto-generated notes are deleted
3. The existing vector of `Steps` (m_vpSteps) is copied into a local variable (`vOldSteps`) for use later.
4. The song is loaded into a temporary `Song` object 
5. A map (`mNewSteps`) is created using `Steps` as pointers.
6. Manually iterate over each `Steps` pointer, and have it point to the temporary `Song` object
7. Decide whether to reuse or delete old `Steps` pointers
8. Any steps that were left over after this check are added as new `Steps` pointers
9. Apply a new set of auto-generated notes

When you read thru this, it's hard to imagine why we go thru so much work if things actually work even when we don't retain the old pointers.

We can just get rid of all the careful pointer management logic,  and do a simple comparison of SHA-1 hash between the cached chart and the chart on disk. If they differ, we know we have to reload from disk. If we have to reload from disk, then we handle deletion and addition of autogenerated steps and group offset etc just like usual.

I have not yet found anything that breaks as a result of not holding the old pointers. However, I only did basic tests in edit mode, so I would greatly appreciate any testing and any efforts to find bugs in this commit.

The comments in the existing code kind of make it sound like the old pointers must be held and managed carefully. but I tested basic editor function, as well as autosave and using the editor while making changes on disk, but I couldn't find a way that this PR breaks anything. 

</details>

# Testing

An earlier version of this change has been made it into various test builds that went out between 1.0.2 and 1.1.0. It was not known to introduce any regressions or new bugs.