### PR TITLE
RageTimer: resolve signed/unsigned conflicts

### DIFF
--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -71,8 +71,8 @@ void RageTimer::Touch()
 {
 	uint64_t usecs = GetTime();
 
-	this->m_secs = uint64_t(usecs / ONE_SECOND_IN_MICROSECONDS_ULL);
-	this->m_us = uint64_t(usecs % ONE_SECOND_IN_MICROSECONDS_ULL);
+	this->m_secs = int64_t(usecs / ONE_SECOND_IN_MICROSECONDS_ULL);
+	this->m_us = int64_t(usecs % ONE_SECOND_IN_MICROSECONDS_ULL);
 }
 
 float RageTimer::Ago() const

--- a/src/RageTimer.h
+++ b/src/RageTimer.h
@@ -43,7 +43,7 @@ public:
 	 * microseconds values into two integers and combining them later allows for
 	 * better precision. Use caution when changing data types, since resolution
 	 * mismatch errors are easy to cause when changing things in RageTimer. */
-	uint64_t m_secs, m_us;
+	int64_t m_secs, m_us;
 
 private:
 	static RageTimer Sum( const RageTimer &lhs, float tm );


### PR DESCRIPTION


Currently a mix of uint64_t and int64_t are used for RageTimer values. It should be a consistent signage.

