### PR TITLE
RageTimer: use static_cast instead of floor to truncate a floating point value and remove the cmath dependency

### DIFF
--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -126,7 +126,7 @@ RageTimer RageTimer::Sum(const RageTimer& lhs, float tm)
 	/* Calculate the seconds and microseconds from the time:
 	 * tm == 5.25  -> secs =  5, us = 5.25  - ( 5) = .25
 	 * tm == -1.25 -> secs = -2, us = -1.25 - (-2) = .75 */
-	int64_t seconds = std::floor(tm);
+	int64_t seconds = static_cast<int64_t>(tm);
 	int64_t us = static_cast<int64_t>((tm - seconds) * ONE_SECOND_IN_MICROSECONDS_LL);
 
 	// Prevent unnecessarily checking the time

--- a/src/RageTimer.cpp
+++ b/src/RageTimer.cpp
@@ -27,7 +27,6 @@
 
 #include "arch/ArchHooks/ArchHooks.h"
 
-#include <cmath>
 #include <cstdint>
 
 // Intialize important variables and definitions


### PR DESCRIPTION
It's being stored in a signed integer so no reason not to just static cast it.