### PR TITLE
bug: pacdrive bytes reversed

### DIFF
--- a/src/arch/Lights/LightsDriver_GenericHID.cpp
+++ b/src/arch/Lights/LightsDriver_GenericHID.cpp
@@ -121,25 +121,27 @@ void LightsDriver_GenericHID::Set( const LightsState *ls )
 		//reference page 7
 		//http://www.peeweepower.com/stepmania/sm509pacdriveinfo.pdf
 
-		if (ls->m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT]) outb |= BIT(0);
-		if (ls->m_bCabinetLights[LIGHT_MARQUEE_UP_RIGHT]) outb |= BIT(1);
-		if (ls->m_bCabinetLights[LIGHT_MARQUEE_LR_LEFT]) outb |= BIT(2);
-		if (ls->m_bCabinetLights[LIGHT_MARQUEE_LR_RIGHT]) outb |= BIT(3);
+		//these are lights 1->8
+		if (ls->m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT]) outb |= BIT(8);
+		if (ls->m_bCabinetLights[LIGHT_MARQUEE_UP_RIGHT]) outb |= BIT(9);
+		if (ls->m_bCabinetLights[LIGHT_MARQUEE_LR_LEFT]) outb |= BIT(10);
+		if (ls->m_bCabinetLights[LIGHT_MARQUEE_LR_RIGHT]) outb |= BIT(11);
 
-		if (ls->m_bCabinetLights[LIGHT_BASS_LEFT] || ls->m_bCabinetLights[LIGHT_BASS_RIGHT]) outb |= BIT(4);
+		if (ls->m_bCabinetLights[LIGHT_BASS_LEFT] || ls->m_bCabinetLights[LIGHT_BASS_RIGHT]) outb |= BIT(12);
 
-		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_LEFT]) outb |= BIT(5);
-		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_RIGHT]) outb |= BIT(6);
-		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_UP]) outb |= BIT(7);
-		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_DOWN]) outb |= BIT(8);
-		if (ls->m_bGameButtonLights[GameController_1][GAME_BUTTON_START]) outb |= BIT(9);
+		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_LEFT]) outb |= BIT(13);
+		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_RIGHT]) outb |= BIT(14);
+		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_UP]) outb |= BIT(15);
+		//these are lights 8->16, note the byte swap to match PacDrive endianness.
+		if (ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_DOWN]) outb |= BIT(0);
+		if (ls->m_bGameButtonLights[GameController_1][GAME_BUTTON_START]) outb |= BIT(1);
 
-		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_LEFT]) outb |= BIT(10);
-		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_RIGHT]) outb |= BIT(11);
-		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_UP]) outb |= BIT(12);
-		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_DOWN]) outb |= BIT(13);
-		if (ls->m_bGameButtonLights[GameController_2][GAME_BUTTON_START]) outb |= BIT(14);
-		//Bit index 15 is unused.
+		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_LEFT]) outb |= BIT(2);
+		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_RIGHT]) outb |= BIT(3);
+		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_UP]) outb |= BIT(4);
+		if (ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_DOWN]) outb |= BIT(5);
+		if (ls->m_bGameButtonLights[GameController_2][GAME_BUTTON_START]) outb |= BIT(6);
+		//Bit index 7 is unused, this is LED16.
 
 		break;
 	}

--- a/src/arch/Lights/LightsDriver_PacDrive.cpp
+++ b/src/arch/Lights/LightsDriver_PacDrive.cpp
@@ -33,55 +33,78 @@ void LightsDriver_PacDrive::Set(const LightsState *ls)
 	switch (iPacDriveLightOrder)
 	{
 	case 1:
-		// Sets the cabinet light values to follow LumenAR/OpenITG wiring standards
-
 		/*
-		 * OpenITG PacDrive Order:
-		 * Taken from LightsDriver_PacDrive::SetLightsMappings() in openitg.
-		 * (index of 1 as the PacDrive labels them as index 1)
+		 * OpenITG (LumenAR) Order:
+		 * http://solid-orange.com/wp-content/uploads/2014/02/ddr_oitg_pacdrive_pins.gif
+		 * Note: The bit order in OpenITG is byte swapped as PacDrive's vendor library byte
+		 * swaps the values.
 		 *
-		 * 1: Marquee UL
-		 * 2: Marquee UR
-		 * 3: Marquee DL
-		 * 4: Marquee DR
+		 * This listing mirrors the PHYSICAL pins each of the lights comes out.
 		 *
-		 * 5: P1 Button
-		 * 6: P2 Button
-		 *
-		 * 7: Bass Left
-		 * 8: Bass Right
-		 *
-		 * 9,19,11,12: P1 L R U D
-		 * 13,14,15,16: P2 L R U D
+		 * 01: P1 Left
+		 * 02: P1 Right
+		 * 03: P1 Up
+		 * 04: P1 Down
+		 * 05: P2 Left
+		 * 06: P2 Right
+		 * 07: P2 Up
+		 * 08: P2 Down
+		 * 09: Marquee UL
+		 * 10: Marquee UR
+		 * 11: Marquee LL
+		 * 12: Marquee LR
+		 * 13: P1 Start
+		 * 14: P2 Start
+		 * 15: Bass Left
+		 * 16: Bass Right
 		 */
 
-		state.leds.led01 = ls->m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT];
-		state.leds.led02 = ls->m_bCabinetLights[LIGHT_MARQUEE_UP_RIGHT];
-		state.leds.led03 = ls->m_bCabinetLights[LIGHT_MARQUEE_LR_LEFT];
-		state.leds.led04 = ls->m_bCabinetLights[LIGHT_MARQUEE_LR_RIGHT];
+		state.leds.led01 = ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_LEFT];
+		state.leds.led02 = ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_RIGHT];
+		state.leds.led03 = ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_UP];
+		state.leds.led04 = ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_DOWN];
 
-		state.leds.led05 = ls->m_bGameButtonLights[GameController_1][GAME_BUTTON_START];
-		state.leds.led06 = ls->m_bGameButtonLights[GameController_2][GAME_BUTTON_START];
+		state.leds.led05 = ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_LEFT];
+		state.leds.led06 = ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_RIGHT];
+		state.leds.led07 = ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_UP];
+		state.leds.led08 = ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_DOWN];
 
-		state.leds.led07 = ls->m_bCabinetLights[LIGHT_BASS_LEFT] || ls->m_bCabinetLights[LIGHT_BASS_RIGHT];
-		state.leds.led08 = ls->m_bCabinetLights[LIGHT_BASS_LEFT] || ls->m_bCabinetLights[LIGHT_BASS_RIGHT];
+		state.leds.led09 = ls->m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT];
+		state.leds.led10 = ls->m_bCabinetLights[LIGHT_MARQUEE_UP_RIGHT];
+		state.leds.led11 = ls->m_bCabinetLights[LIGHT_MARQUEE_LR_LEFT];
+		state.leds.led12 = ls->m_bCabinetLights[LIGHT_MARQUEE_LR_RIGHT];
 
-		state.leds.led09 = ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_LEFT];
-		state.leds.led10 = ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_RIGHT];
-		state.leds.led11 = ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_UP];
-		state.leds.led12 = ls->m_bGameButtonLights[GameController_1][DANCE_BUTTON_DOWN];
+		state.leds.led13 = ls->m_bGameButtonLights[GameController_1][GAME_BUTTON_START];
+		state.leds.led14 = ls->m_bGameButtonLights[GameController_2][GAME_BUTTON_START];
 
-		state.leds.led13 = ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_LEFT];
-		state.leds.led14 = ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_RIGHT];
-		state.leds.led15 = ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_UP];
-		state.leds.led16 = ls->m_bGameButtonLights[GameController_2][DANCE_BUTTON_DOWN];
+		state.leds.led15 = ls->m_bCabinetLights[LIGHT_BASS_LEFT] || ls->m_bCabinetLights[LIGHT_BASS_RIGHT];
+		state.leds.led16 = ls->m_bCabinetLights[LIGHT_BASS_LEFT] || ls->m_bCabinetLights[LIGHT_BASS_RIGHT];
+
 		break;
 
 	case 0:
 	default:
-		// If all else fails, falls back to original order
-		// reference page 7
-		// http://www.peeweepower.com/stepmania/sm509pacdriveinfo.pdf
+		/*
+		* SM5 order.
+		* see pg7 of http://www.peeweepower.com/stepmania/sm509pacdriveinfo.pdf
+		*
+		* 01: Marquee UL
+		* 02: Marquee UR
+		* 03: Marquee LL
+		* 04: Marquee LR
+		* 05: Bass (both)
+		* 06: P1 Left
+		* 07: P1 Right
+		* 08: P1 Up
+		* 09: P1 Down
+		* 10: P1 Start
+		* 11: P2 Left
+		* 12: P2 Right
+		* 13: P2 Up
+		* 14: P2 Down
+		* 15: P2 Start
+		* 16: (unused)
+		*/
 
 		state.leds.led01 = ls->m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT];
 		state.leds.led02 = ls->m_bCabinetLights[LIGHT_MARQUEE_UP_RIGHT];

--- a/src/arch/Lights/LightsDriver_PacDrive.h
+++ b/src/arch/Lights/LightsDriver_PacDrive.h
@@ -45,14 +45,10 @@ typedef union
 {
 	struct
 	{
-		bool led01 : 1;
-		bool led02 : 1;
-		bool led03 : 1;
-		bool led04 : 1;
-		bool led05 : 1;
-		bool led06 : 1;
-		bool led07 : 1;
-		bool led08 : 1;
+		//NOTE: this is intentionally byte swapped
+		//as Ultimarc's library does this, the firmware expects this order.
+		//this matches the physical location of each output with the variable name.
+		//see this code snippet: https://github.com/itgmania/itgmania/issues/921#issuecomment-3008263137
 		bool led09 : 1;
 		bool led10 : 1;
 		bool led11 : 1;
@@ -61,6 +57,15 @@ typedef union
 		bool led14 : 1;
 		bool led15 : 1;
 		bool led16 : 1;
+
+		bool led01 : 1;
+		bool led02 : 1;
+		bool led03 : 1;
+		bool led04 : 1;
+		bool led05 : 1;
+		bool led06 : 1;
+		bool led07 : 1;
+		bool led08 : 1;
 	};
 	uint16_t raw;
 } pacdrive_leds_t;


### PR DESCRIPTION
Fix for adjusting the sm5/"minimaid" order of the pacdrive lights in both `PacDrive` and `GenericHID`.

I have modified the PacDrive code to match the physical world. Each of the LED numbered output matches the screw terminal on the device. I have also left additional references to where these mappings originated from. 

I have modified @jsirex 's bit order in their GenericHID driver to rearrange the bits. Please review and advise if this is how you would like that done. 

This addresses the follow issue. 

https://github.com/itgmania/itgmania/issues/921