### PR TITLE
Update README.md regarding Fedora systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can choose between using the installer or using the portable build. Using th
 
 * **Fedora-based**:
 
-  * `sudo yum install gdk-pixbuf2 gtk3 libusb-compat-0.1 libXinerama libXtst`
+  * `sudo dnf install gdk-pixbuf2 gtk3 libusb-compat-0.1 libXinerama libXtst`
 
 *  **Arch Linux**:
 


### PR DESCRIPTION
Minor edit to the README regarding Fedora systems. The original command technically works as yum is aliased to dnf in Fedora, but it feels better for my soul to see this changed. (Also, I think most of these are installed by default. Not bothering to check atm, but might come back later to do so.)