### PR TITLE
Group: Use initializer lists which match the declaration order in the header file

### DIFF
--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -23,20 +23,42 @@
 const RString INI_FILE = "Pack.ini";
 const int INI_VERSION = 1;
 
-Group::Group() {
-    m_sDisplayTitle = "";
-    m_sSortTitle = "";
-    m_sPath = "";
-    m_sGroupName = "";
-    m_sTranslitTitle = "";
-    m_sSeries = "";
-    m_fSyncOffset = 0.0f;
-    m_bHasPackIni = false;
-    m_iYearReleased = 0;
-    m_sBannerPath = "";
+Group::Group()
+    : m_sDisplayTitle(""),
+      m_sSortTitle(""),
+      m_sPath(""),
+      m_sGroupName(""),
+      m_sTranslitTitle(""),
+      m_sSeries(""),
+      m_fSyncOffset(0.0f),
+      m_bHasPackIni(false),
+      m_sBannerPath(""),
+      m_iYearReleased(0),
+      m_iVersion(0)
+{
 }
 
-Group::Group(const RString& sDir, const RString& sGroupDirName, bool bFromProfile) {
+Group::Group(const RString& sDir, const RString& sGroupDirName, bool bFromProfile)
+    : m_sDisplayTitle(""),
+      m_sSortTitle(""),
+      m_sPath(""),
+      m_sGroupName(""),
+      m_sTranslitTitle(""),
+      m_sSeries(""),
+      // The m_DefaultSyncOffset preference corresponds to what offset the user
+      // would like to assume as a "default" for packs without a Pack.ini.
+      //
+      // If the m_DefaultSyncOffset is set to ITG, we want to remove the 9ms ITG
+      // bias for all packs without a Pack.ini.
+      //
+      // We can start with that as our default value, and potentially update it
+      // below.
+      m_fSyncOffset((PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL) ? 0.0f : -0.009f),
+      m_bHasPackIni(false),
+      m_sBannerPath(""),
+      m_iYearReleased(0),
+      m_iVersion(INI_VERSION)
+{
     if (sDir.empty() || sGroupDirName.empty()) {
         LOG->Warn("Group::Group: Empty directory or group name provided.");
         return;
@@ -56,20 +78,7 @@ Group::Group(const RString& sDir, const RString& sGroupDirName, bool bFromProfil
     }
     m_sSortTitle = m_sGroupName;
     m_sTranslitTitle = m_sGroupName;
-    m_sSeries = "";
-    // The m_DefaultSyncOffset preference corresponds to what offset the user
-    // would like to assume as a "default" for packs without a Pack.ini.
-    //
-    // If the m_DefaultSyncOffset is set to ITG, we want to remove the 9ms ITG
-    // bias for all packs without a Pack.ini.
-    //
-    // We can start with that as our default value, and potentially update it below.
-    m_fSyncOffset = (PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL) ? 0.0f : -0.009f;
-    m_bHasPackIni = false;
-    m_iYearReleased = 0;
-    m_sBannerPath = "";
-    m_iVersion = INI_VERSION;
-    
+
     if (FILEMAN->DoesFileExist(sPackIniPath)) {
         IniFile ini;
         if (!ini.ReadFile(sPackIniPath)) {


### PR DESCRIPTION
As seen in #935.

Note, failures in CI are unrelated to this PR:
<img width="1147" height="171" alt="image" src="https://github.com/user-attachments/assets/dbf8db30-059f-4071-be54-e3591ff1511a" />
