### PR TITLE
Enable CRC32 verification of all files via RageFile

### DIFF
--- a/src/RageFile.cpp
+++ b/src/RageFile.cpp
@@ -118,6 +118,21 @@ bool RageFile::GetCRC32( uint32_t *iRet )
 	return m_File->GetCRC32( iRet );
 }
 
+RString RageFile::GetCRC32AsString()
+{
+	ASSERT_OPEN;
+
+	uint32_t crc = 0;
+	if (!m_File->GetCRC32(&crc)) {
+		LOG->Warn(
+			"GetCRC32AsString: Failed to compute CRC32 for file '%s'",
+			m_Path.c_str());
+		return "";
+	}
+
+	// Convert the CRC32 value to a hexadecimal string
+	return ssprintf("%08x", crc);
+}
 
 bool RageFile::AtEOF() const
 {

--- a/src/RageFile.cpp
+++ b/src/RageFile.cpp
@@ -78,6 +78,8 @@ bool RageFile::Open( const RString& path, int mode )
 		return false;
 	}
 
+	m_File->EnableCRC32(true);
+
 	return true;
 }
 

--- a/src/RageFile.h
+++ b/src/RageFile.h
@@ -79,6 +79,7 @@ public:
 
 	void EnableCRC32( bool on=true );
 	bool GetCRC32( uint32_t *iRet );
+	RString GetCRC32AsString();
 
 	// Lua
 	virtual void PushSelf( lua_State *L );


### PR DESCRIPTION
RageFile already provides methods to enable CRC32 support for any files you open. However, it is disabled by default, and there is no existing method to retrieve a CRC32 hash as a string from RageFile.

This PR introduces a new method, `RString RageFile::GetCRC32AsString()`, which handles converting the checksum to a hex value and formatting it as a string (the returned string will use lowecase letters, such as "1a2b3c4d").

This change is being proposed with the ultimate goal of improving functions in Song.cpp related to loading/reloading songs. The code in my [rfsd-poc](https://github.com/sukibaby/itgmania-testing/tree/rfsd-poc) branch behaves more correctly than the existing code, including with edge cases when calling ReloadFromDisk.