### PR TITLE
Song: remove dead code & `CryptManager.h` include

### DIFF
--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -45,9 +45,6 @@
 #include <set>
 #include <vector>
 
-//-Nick12 Used for song file hashing
-#include <CryptManager.h>
-
 /**
  * @brief The internal version of the cache for StepMania.
  *
@@ -1763,26 +1760,6 @@ RString Song::GetCacheFile(RString sType)
 	}
 	// Return empty if nothing found.
 	return "";
-}
-
-RString Song::GetFileHash()
-{
-	static const std::vector<RString> extensions = {
-		"ssc", "sm", "dwi", "sma", "bms", "ksf", "json", "jso"
-	};
-
-	if (m_sFileHash.empty()) {
-		for (const RString& ext : extensions) {
-			RString sPath = SetExtension(GetSongFilePath(), ext);
-			if (IsAFile(sPath)) {
-				m_sFileHash = BinaryToHex(CRYPTMAN->GetSHA1ForFile(sPath));
-				return m_sFileHash;
-			}
-		}
-	}
-
-	m_sFileHash = "";
-	return m_sFileHash;
 }
 
 std::vector<RString> Song::GetInstrumentTracksToVectorString() const

--- a/src/Song.h
+++ b/src/Song.h
@@ -198,10 +198,6 @@ public:
 	/** @brief The transliterated artist of the Song, if it exists. */
 	RString m_sArtistTranslit;
 
-
-	RString m_sFileHash;
-	RString GetFileHash();
-
 	/* If PREFSMAN->m_bShowNative is off, these are the same as GetTranslit*
 	 * below. Otherwise, they return the main titles. */
 	RString GetDisplayMainTitle() const;


### PR DESCRIPTION
We can get rid of the `CryptManager.h` dependency by removing this function which isn't used anywhere.