### PR TITLE
Implement manual Lua garbage collection

### DIFF
--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -56,6 +56,13 @@ namespace LuaHelpers
 	bool InReportScriptError= false;
 }
 
+void LuaManager::CollectGarbage()
+{
+    Lua *L = Get();
+    lua_gc(L, LUA_GCCOLLECT, 0);
+    Release(L);
+}
+
 void LuaManager::SetGlobal( const RString &sName, int val )
 {
 	Lua *L = Get();

--- a/src/LuaManager.h
+++ b/src/LuaManager.h
@@ -46,6 +46,9 @@ public:
 	// There's no harm in registering when already registered.
 	void RegisterTypes();
 
+	// diagnostics
+	void CollectGarbage();
+
 	void SetGlobal( const RString &sName, int val );
 	void SetGlobal( const RString &sName, const RString &val );
 	void UnsetGlobal( const RString &sName );

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -295,6 +295,7 @@ ScreenSelectMusic::~ScreenSelectMusic()
 {
 	LOG->Trace( "ScreenSelectMusic::~ScreenSelectMusic()" );
 	IMAGECACHE->Undemand("Banner");
+	LUA->CollectGarbage();
 }
 
 // If bForce is true, the next request will be started even if it might cause a skip.


### PR DESCRIPTION
I searched the code base for calls to the Lua garbage collector and did not find references to any.

I have added a function which calls `lua_gc` to LuaManager.

This called from the ScreenSelectMusic destructor, to match up with the timing of texture garbage collection. Manual garbage collection is added in order to ensure garbage collection is not called automatically when we don't expect it.

e.g.

```
00:20.276: Starting thread: Streaming sound buffering
00:22.046: ScreenSelectMusic::~ScreenSelectMusic()
00:22.070: Performing texture garbage collection.
00:22.070: Loading screen: "ScreenGameplay"
```