### PR TITLE
Lua optimization: Clear the stack in LuaManager::Release

### DIFF
--- a/src/LuaManager.cpp
+++ b/src/LuaManager.cpp
@@ -313,6 +313,9 @@ Lua *LuaManager::Get()
 
 void LuaManager::Release( Lua *&p )
 {
+	// clear the stack
+	lua_settop(p, 0);
+
 	pImpl->g_FreeStateList.push_back( p );
 
 	ASSERT( lua_gettop(p) == 0 );


### PR DESCRIPTION
For predictability/reliability. I don't see any reason not to do this;  is there any reason not to?
