### PR TITLE
Sample rate detection

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -427,6 +427,7 @@ else() # Unix / Linux TODO: Remember to find and locate the zip archive files.
     target_compile_definitions("${SM_EXE_NAME}" PRIVATE "HAVE_OSS_VERSION=1")
   endif()
 
+  add_definitions(-DHAS_PULSE)
   if(HAS_PULSE)
     list(APPEND SMDATA_LINK_LIB ${PULSEAUDIO_LIBRARY})
   endif()

--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -147,7 +147,7 @@ public:
 	int SetPosition( int iFrame )  { return 1; }
 	int Read( float *pBuf, int iFrames ) { return RageSoundReader::END_OF_FILE; }
 	RageSoundReader *Copy() const { return new RageSoundReader_Silence; }
-	int GetSampleRate() const { return kFallbackSampleRate; }
+	int GetSampleRate() const { return g_FallbackSampleRate.load(); }
 	unsigned GetNumChannels() const { return 1; }
 	int GetNextSourceFrame() const { return 0; }
 	float GetStreamToSourceRatio() const { return 1.0f; }

--- a/src/RageSound.h
+++ b/src/RageSound.h
@@ -9,8 +9,6 @@
 
 #include <cstdint>
 
-constexpr int kFallbackSampleRate = 44100;
-
 class RageSoundReader;
 struct lua_State;
 

--- a/src/RageSoundManager.cpp
+++ b/src/RageSoundManager.cpp
@@ -132,11 +132,15 @@ float RageSoundManager::GetPlayLatency() const
 
 int RageSoundManager::GetDriverSampleRate() const
 {
-	if( m_pDriver == nullptr )
-		return kFallbackSampleRate;
-
-	// Returns the *actual* operating rate of the loaded driver
-	return m_pDriver->GetSampleRate();
+	int global_value= g_FallbackSampleRate.load();
+	int driver_value= m_pDriver->GetSampleRate();
+	if (global_value != driver_value)
+	{
+		LOG->Warn("RageSoundManager::GetDriverSampleRate value mismatch!! "
+		          "g_FallbackSampleRate: %d, driver sample rate: %d",
+		          global_value, driver_value);
+	}
+	return global_value;
 }
 
 /* If the given path is loaded, return a copy; otherwise return nullptr.

--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -1,5 +1,4 @@
 #include "global.h"
-#include "PrefsManager.h"
 #include "RageSoundReader_Chain.h"
 #include "RageSoundReader_FileReader.h"
 #include "RageSoundReader_Resample_Good.h"
@@ -7,12 +6,12 @@
 #include "RageSoundReader_Pan.h"
 #include "RageLog.h"
 #include "RageUtil.h"
-#include "RageSound.h"
 #include "RageSoundMixBuffer.h"
 #include "RageSoundUtil.h"
 
 #include <cmath>
 #include <vector>
+#include <algorithm>
 
 
 /*

--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -25,12 +25,7 @@
  */
 RageSoundReader_Chain::RageSoundReader_Chain()
 {
-	m_iPreferredSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
-	if (m_iPreferredSampleRate == 0)
-	{
-		m_iPreferredSampleRate = kFallbackSampleRate;
-	}
-	
+	m_iPreferredSampleRate = g_FallbackSampleRate.load();
 	m_iActualSampleRate = -1;
 	m_iChannels = 0;
 	m_iCurrentFrame = 0;

--- a/src/arch/ArchHooks/ArchHooks.h
+++ b/src/arch/ArchHooks/ArchHooks.h
@@ -89,6 +89,11 @@ public:
 	 */
 	static int64_t GetSystemTimeInMicroseconds();
 
+	// Determine the sample rate of the default audio endpoint.
+	// This is only called before the sound driver is initialized.
+	// If this returns 0, the sound driver will use a fallback sample rate.
+	virtual uint32_t DetermineSampleRate() const { return 0; }
+
 	/*
 	 * Add file search paths, higher priority first.
 	 */

--- a/src/arch/ArchHooks/ArchHooks_MacOSX.h
+++ b/src/arch/ArchHooks/ArchHooks_MacOSX.h
@@ -2,6 +2,7 @@
 #define ARCH_HOOKS_MACOSX_H
 
 #include "ArchHooks.h"
+#include <cstdint>
 
 class ArchHooks_MacOSX : public ArchHooks
 {
@@ -11,6 +12,7 @@ public:
 	void DumpDebugInfo();
 	RString GetPreferredLanguage();
 	float GetDisplayAspectRatio();
+	uint32_t DetermineSampleRate() const override;
 };
 
 #ifdef ARCH_HOOKS

--- a/src/arch/ArchHooks/ArchHooks_MacOSX.mm
+++ b/src/arch/ArchHooks/ArchHooks_MacOSX.mm
@@ -386,6 +386,47 @@ float ArchHooks_MacOSX::GetDisplayAspectRatio()
 	return screen.frame.size.width / screen.frame.size.height;
 }
 
+// UNTESTED!!!!! no access to a Mac
+#include <CoreAudio/CoreAudio.h>
+uint32_t ArchHooks_MacOSX::DetermineSampleRate() const
+{
+	// This structure holds the default output device ID.
+	// We need to store the key for the default output device,
+	// global scope (properties not specific to input or output),
+	// and not specific to a particular channel (master element).
+	AudioDeviceID deviceID = 0;
+	UInt32 size = sizeof(deviceID);
+	AudioObjectPropertyAddress addr = {
+		kAudioHardwarePropertyDefaultOutputDevice,
+		kAudioObjectPropertyScopeGlobal,
+		kAudioObjectPropertyElementMaster  
+	};
+
+	// Return early if we can't get the default output device ID,
+	// since that implies we're not talking to CoreAudio at all.
+	if (AudioObjectGetPropertyData(kAudioObjectSystemObject, &addr, 0, nullptr, &size, &deviceID) != noErr)
+	{
+		return 0;
+	}
+
+	// Similar to above, but stores the sample rate instead of the device ID
+	Float64 sampleRate = 0;
+	size = sizeof(sampleRate);
+	AudioObjectPropertyAddress rateAddr = {
+		kAudioDevicePropertyNominalSampleRate,
+		kAudioObjectPropertyScopeGlobal,
+		kAudioObjectPropertyElementMaster
+	};
+
+	// Return early if there was an error getting the sample rate.
+	if (AudioObjectGetPropertyData(deviceID, &rateAddr, 0, nullptr, &size, &sampleRate) != noErr)
+	{
+		return 0;
+	}
+
+	return static_cast<uint32_t>(sampleRate);
+}
+
 /*
  * (c) 2003-2006 Steve Checkoway
  * All rights reserved.

--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -13,6 +13,8 @@
 #include "archutils/Unix/AssertionHandler.h"
 
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 
 #if defined(HAVE_UNISTD_H)
 #include <unistd.h>
@@ -37,6 +39,10 @@ extern "C"
 #include "archutils/Unix/X11Helper.h"
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
+#endif
+
+#if defined(HAS_PULSE)
+#include <pulse/pulseaudio.h>
 #endif
 
 static bool IsFatalSignal( int signal )
@@ -402,6 +408,16 @@ void ArchHooks::MountUserFilesystems( const RString &sDirOfExecutable )
 	FILEMAN->Mount( "dir", sUserDataPath + "/Songs", "/Songs" );
 	FILEMAN->Mount( "dir", sUserDataPath + "/RandomMovies", "/RandomMovies" );
 	FILEMAN->Mount( "dir", sUserDataPath + "/Themes", "/Themes" );
+}
+
+uint32_t ArchHooks_Unix::DetermineSampleRate() const {
+#if defined(HAS_PULSE)
+	LOG->Warn("ITGmania was compiled with support for PulseAudio sample rate auto-detection, but it is not yet implemented.");
+#else
+	LOG->Trace("ITGmania was not compiled with support for PulseAudio sample rate auto-detection. Falling back to 48KHz for ALSA/OSS compatibility.");
+#endif
+	// 48khz is likely to prevent ALSA or OSS from having to resample on its own.
+	return 48000U;
 }
 
 /*

--- a/src/arch/ArchHooks/ArchHooks_Unix.h
+++ b/src/arch/ArchHooks/ArchHooks_Unix.h
@@ -21,6 +21,8 @@ public:
 	static clockid_t GetClock();
 
 	RString GetClipboard();
+
+	uint32_t DetermineSampleRate() const override;
 };
 
 #ifdef ARCH_HOOKS

--- a/src/arch/ArchHooks/ArchHooks_Win32.h
+++ b/src/arch/ArchHooks/ArchHooks_Win32.h
@@ -2,6 +2,9 @@
 #define ARCH_HOOKS_WIN32_H
 
 #include "ArchHooks.h"
+
+#include <cstdint>
+
 class RageMutex;
 
 class ArchHooks_Win32: public ArchHooks
@@ -19,6 +22,8 @@ public:
 	void BoostPriority();
 	void UnBoostPriority();
 	void SetupConcurrentRenderingThread();
+
+	uint32_t DetermineSampleRate() const override;
 
 	virtual float GetDisplayAspectRatio();
 	RString GetClipboard();

--- a/src/arch/Sound/ALSA9Helpers.cpp
+++ b/src/arch/Sound/ALSA9Helpers.cpp
@@ -231,7 +231,7 @@ RString Alsa9Buf::Init( int channels_,
 	preferred_chunksize = iChunkSize;
 	if( iSampleRate == 0 )
 	{
-		samplerate = kFallbackSampleRate;
+		samplerate = g_FallbackSampleRate.load();
 	}
 	else
 	{

--- a/src/arch/Sound/ALSA9Helpers.cpp
+++ b/src/arch/Sound/ALSA9Helpers.cpp
@@ -1,5 +1,4 @@
 #include "global.h"
-#include "RageSound.h"
 #include "RageLog.h"
 #include "RageUtil.h"
 #include "ALSA9Helpers.h"

--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -20,6 +20,8 @@
 #pragma comment(lib, "dsound.lib")
 #endif
 
+const uint32_t reported_sample_rate = g_FallbackSampleRate.load();
+
 BOOL CALLBACK DSound::EnumCallback( LPGUID lpGuid, LPCSTR lpcstrDescription, LPCSTR lpcstrModule, LPVOID lpContext )
 {
 	RString sLine = ssprintf( "DirectSound Driver: %s", lpcstrDescription );
@@ -58,18 +60,15 @@ void DSound::SetPrimaryBufferMode()
 		return;
 	}
 
+	uint32_t reported_sample_rate = g_FallbackSampleRate.load();
+
 	WAVEFORMATEX waveformat;
 	memset( &waveformat, 0, sizeof(waveformat) );
 	waveformat.cbSize = 0;
 	waveformat.wFormatTag = WAVE_FORMAT_PCM;
 	waveformat.wBitsPerSample = 16;
 	waveformat.nChannels = 2;
-	int preferredSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
-	if (preferredSampleRate == 0)
-	{
-		preferredSampleRate = kFallbackSampleRate;
-	}
-	waveformat.nSamplesPerSec = preferredSampleRate;
+	waveformat.nSamplesPerSec = (DWORD)reported_sample_rate;
 	waveformat.nBlockAlign = (waveformat.nChannels * waveformat.wBitsPerSample) / 8;
 	waveformat.nAvgBytesPerSec = waveformat.nSamplesPerSec * waveformat.nBlockAlign;
 
@@ -223,7 +222,7 @@ RString DSoundBuf::Init( DSound &ds, DSoundBuf::hw hardware,
 	// DYNAMIC_SAMPLERATE is usually 0 or some special value
 	if( m_iSampleRate == DYNAMIC_SAMPLERATE )
 	{
-		m_iSampleRate = kFallbackSampleRate;
+		m_iSampleRate = static_cast<int>(g_FallbackSampleRate.load());
 		bNeedCtrlFrequency = true;
 	}
 

--- a/src/arch/Sound/RageSoundDriver.cpp
+++ b/src/arch/Sound/RageSoundDriver.cpp
@@ -8,6 +8,8 @@
 
 #include <cstddef>
 #include <vector>
+#include <cstdint>
+#include <algorithm>
 
 namespace
 {
@@ -19,6 +21,25 @@ namespace
 		LOG->Trace("%s", trace.c_str());
 		LOG->Trace(" - Make sure the driver entry is spelled correctly, and is supported on your OS.");
 	}
+
+	uint32_t TryToGetSampleRate()
+	{
+		const uint32_t kMin = 44100;  // Minimum supported sample rate (44.1 kHz)
+		const uint32_t kMax = 192000; // Maximum supported sample rate (192 kHz)
+
+		uint32_t reported_sample_rate = HOOKS->DetermineSampleRate();
+		if (reported_sample_rate == 0) {
+			LOG->Trace("RageSoundDriver: Couldn't determine sample rate for some reason. Using fallback value.");
+		}
+
+		else if (reported_sample_rate < kMin || reported_sample_rate > kMax) {
+			LOG->Warn("RageSoundDriver: OS reported a sample rate outside of the expected range (%u)", reported_sample_rate);
+			reported_sample_rate = std::clamp(reported_sample_rate, kMin, kMax);
+		}
+
+		return reported_sample_rate;
+	}
+
 }  // namespace
 
 DriverList RageSoundDriver::m_pDriverList;
@@ -64,6 +85,13 @@ RageSoundDriver *RageSoundDriver::Create( const RString& drivers )
 			driversToTry = GetDefaultSoundDriverList();
 		}
 	}
+
+	const uint32_t validated_samplerate = TryToGetSampleRate();
+	const uint32_t old_samplerate = g_FallbackSampleRate.load();
+	if (validated_samplerate != old_samplerate) {
+		g_FallbackSampleRate.store(validated_samplerate);
+	}
+	LOG->Info("RageSoundDriver: Using sample rate %u", validated_samplerate);
 
 	for (RString const &Driver : driversToTry)
 	{

--- a/src/arch/Sound/RageSoundDriver.h
+++ b/src/arch/Sound/RageSoundDriver.h
@@ -67,7 +67,7 @@ public:
 	 * hearing it.  (This isn't necessarily the same as the buffer latency.) */
 	virtual float GetPlayLatency() const { return 0.0f; }
 
-	virtual int GetSampleRate() const { return kFallbackSampleRate; }
+	virtual int GetSampleRate() const { return g_FallbackSampleRate.load(); }
 
 protected:
 	/* Start the decoding.  This should be called once the hardware is set up and

--- a/src/arch/Sound/RageSoundDriver.h
+++ b/src/arch/Sound/RageSoundDriver.h
@@ -6,7 +6,6 @@
 #include "RageThreads.h"
 #include "RageTimer.h"
 #include "RageUtil_CircularBuffer.h"
-#include "RageSound.h"
 
 #include <cstdint>
 

--- a/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
@@ -115,7 +115,7 @@ RString RageSoundDriver_ALSA9_Software::Init()
 	sError = m_pPCM->Init( channels,
 			g_iMaxWriteahead,
 			g_iMaxWriteahead / num_chunks,
-			PREFSMAN->m_iSoundPreferredSampleRate );
+			g_FallbackSampleRate.load() );
 	if( sError != "" )
 		return sError;
 

--- a/src/arch/Sound/RageSoundDriver_AU.mm
+++ b/src/arch/Sound/RageSoundDriver_AU.mm
@@ -141,7 +141,9 @@ RString RageSoundDriver_AU::Init()
 
 	AudioStreamBasicDescription streamFormat;
 
-	streamFormat.mSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
+	const uint32_t sample_Rate = g_FallbackSampleRate.load();
+
+	streamFormat.mSampleRate = sample_Rate;
 	streamFormat.mFormatID = kAudioFormatLinearPCM;
 	streamFormat.mFormatFlags = kFormatFlags;
 	streamFormat.mBytesPerPacket = kBytesPerPacket;
@@ -152,9 +154,9 @@ RString RageSoundDriver_AU::Init()
 
 	if( streamFormat.mSampleRate <= 0.0 )
 	{
-		streamFormat.mSampleRate = kFallbackSampleRate;
+		streamFormat.mSampleRate = sample_Rate;
 	}
-	m_iSampleRate = int( streamFormat.mSampleRate );
+	m_iSampleRate = int( sample_Rate );
 	m_TimeScale = streamFormat.mSampleRate / AudioGetHostClockFrequency();
 
 	// Try to set the hardware sample rate.

--- a/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
@@ -95,11 +95,7 @@ RString RageSoundDriver_DSound_Software::Init()
 
 	/* Create a DirectSound stream, but don't force it into hardware. */
 	m_pPCM = new DSoundBuf;
-	m_iSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
-	if( m_iSampleRate == 0 )
-	{
-		m_iSampleRate = kFallbackSampleRate;
-	}
+	m_iSampleRate = g_FallbackSampleRate.load();
 	// This m_iSampleRate (driver's) is then passed as the iSampleRate parameter to DSoundBuf::Init()
 	sError = m_pPCM->Init( ds, DSoundBuf::HW_DONT_CARE, channels, m_iSampleRate, 16, g_iMaxWriteahead );
 	if( sError != "" )

--- a/src/arch/Sound/RageSoundDriver_Null.cpp
+++ b/src/arch/Sound/RageSoundDriver_Null.cpp
@@ -30,10 +30,7 @@ int64_t RageSoundDriver_Null::GetPosition() const
 
 RageSoundDriver_Null::RageSoundDriver_Null()
 {
-	m_iSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
-	{
-    	m_iSampleRate = kFallbackSampleRate;
-	}
+	m_iSampleRate = g_FallbackSampleRate.load();
 	m_iLastCursorPos = GetPosition();
 	StartDecodeThread();
 }

--- a/src/arch/Sound/RageSoundDriver_OSS.cpp
+++ b/src/arch/Sound/RageSoundDriver_OSS.cpp
@@ -194,12 +194,7 @@ RString RageSoundDriver_OSS::Init()
 		return ssprintf( "RageSoundDriver_OSS: Wanted %i channels, got %i instead", channels, channels_val );
 
 	// Determine the target sample rate based on preference
-	int targetSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
-	if (targetSampleRate == 0)
-	{
-		targetSampleRate = kFallbackSampleRate;
-	}
-	
+	int targetSampleRate = g_FallbackSampleRate.load();
 	samplerate = targetSampleRate; // Attempt to set this rate
 	if(ioctl(fd, SNDCTL_DSP_SPEED, &samplerate) == -1 ) // Pass 'samplerate' (member var) by address
 		return ssprintf( "RageSoundDriver_OSS: ioctl(SNDCTL_DSP_SPEED, %i): %s", targetSampleRate, strerror(errno) );

--- a/src/arch/Sound/RageSoundDriver_PulseAudio.cpp
+++ b/src/arch/Sound/RageSoundDriver_PulseAudio.cpp
@@ -27,11 +27,7 @@ m_LastPosition(0), m_Error(nullptr),
 m_Sem("Pulseaudio Synchronization Semaphore"),
 m_PulseMainLoop(nullptr), m_PulseCtx(nullptr), m_PulseStream(nullptr)
 {
-	m_ss.rate = PREFSMAN->m_iSoundPreferredSampleRate;
-	if( m_ss.rate == 0 )
-	{
-		m_ss.rate = kFallbackSampleRate;
-	}
+	m_ss.rate = g_FallbackSampleRate.load();
 }
 
 RageSoundDriver_PulseAudio::~RageSoundDriver_PulseAudio()

--- a/src/arch/Sound/RageSoundDriver_WDMKS.cpp
+++ b/src/arch/Sound/RageSoundDriver_WDMKS.cpp
@@ -1314,7 +1314,7 @@ RString RageSoundDriver_WDMKS::Init()
 		PREFSMAN->m_iSoundWriteAhead,
 		DeviceSampleFormat_Int16,
 		0, // don't care
-		PREFSMAN->m_iSoundPreferredSampleRate,
+		g_FallbackSampleRate.load(),
 		sError ) )
 	{
 		return sError;

--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -138,12 +138,7 @@ RageSoundDriver_WaveOut::RageSoundDriver_WaveOut()
 RString RageSoundDriver_WaveOut::Init()
 {
 	wo_init_success_ = false;
-	wo_samplerate_ = PREFSMAN->m_iSoundPreferredSampleRate;
-	if( wo_samplerate_ == 0 )
-	{
-		wo_samplerate_ = kFallbackSampleRate;
-	}
-
+	wo_samplerate_ = g_FallbackSampleRate.load();
 	wo_num_blocks_ = CalculateNumBlocks( wo_samplerate_ );
 
 	// Clamp wo_num_blocks_ to the range of kMaximumNumBlocks.

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -1,6 +1,8 @@
 #include "global.h"
 
 #include <cstdlib>
+#include <atomic>
+
 
 #if defined(HAVE_UNISTD_H)
     #include <unistd.h>
@@ -61,6 +63,8 @@ void sm_crash( const char *reason )
 	_exit( 1 );
 #endif
 }
+
+std::atomic<int> g_FallbackSampleRate{48000};
 
 /*
  * (c) 2004 Glenn Maynard

--- a/src/global.h
+++ b/src/global.h
@@ -110,6 +110,16 @@ void ShowWarningOrTrace( const char *file, int line, const char *message, bool b
 #define SM_UNIQUE_NAME2(x,line) SM_UNIQUE_NAME3(x, line)
 #define SM_UNIQUE_NAME(x) SM_UNIQUE_NAME2(x, __LINE__)
 
+// Declare the global sample rate variable and
+// the include for atomic.
+// Many different places need access to this;
+// this allows us to avoid including RageSound.h
+// in a bunch of places where it isn't wanted.
+#include <atomic>
+
+extern std::atomic<int> g_FallbackSampleRate;
+
+
 #include "RageException.h"
 
 // Call a function every `n` frames.


### PR DESCRIPTION
Windows:
 -  100% done and working

Linux:
 - PulseAudio auto detection is not implemented, but I have established the framework for conditional behavior depending on whether the game is built with PulseAudio support.
 - Since PulseAudio still uses something like ALSA, the fallback of 48000 Hz for Unix OS's is based on the most likely value to prevent ALSA from needing to resample. It is also the default OSS sample rate.
 - I would leave it up to others to implement the PulseAudio solution.
 - The original `pactl`-based method is [here](https://github.com/itgmania/itgmania/pull/942/files#diff-2031301a15cc510b2303cf62a8a41016d266d37096cff09ebbd96f181076d58a), which works, but I don't like it.

Mac:
 -  hasn't been tested
 -  should be working 

------------------

More details below:

<details>

# Automatic sample rate detection

Here is the code that can detect the default audio device's sample rate and set the game's sample rate accordingly.

It is fully working, but not tested on Mac due to not having access to a Mac.

![image](https://github.com/user-attachments/assets/8c5c7f13-fd1c-4cf1-bab4-5c89076b77e1)
_Sample rate detection working while SoundPreferredSampleRate is set to 0._

# Summary of changes

First of all I implemented a new virtual function within ArchHooks. This is because the sample rate detection is done thru the OS rather than the sound driver. The function is called `DetermineSampleRate()`.

Second I changed the constexpr `kFallbackSampleRate` to an atomic `int`. This is because we want one singular reference that is global state, but we want to be able to overwrite it too. This allows existing logic using `kFallbackSampleRate` to remain in place while allowing for needed behavior.

RageSoundDriver gets a new static function,  `TryToGetSampleRate()`, which reads the value of `DetermineSampleRate()`.  First, it determines if there was any error, and clamps the value to a reasonable range, and logs any error. It also updates the atomic variable with the clamped value.

Finally, RageSoundDriver gets a new variable `validated_samplerate` which is populated and its value logged just before the loop to attempt to initialize an audio driver.

At that point the audio driver initializes as expected with a sample rate that matches the OS setting.

# Mac

The Mac implementation is untested.
Testing on Mac would be greatly appreciated.
</details>