### PR TITLE
Refactored handling of chart loading: Working proof-of-concept

### DIFF
--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -23,20 +23,42 @@
 const RString INI_FILE = "Pack.ini";
 const int INI_VERSION = 1;
 
-Group::Group() {
-    m_sDisplayTitle = "";
-    m_sSortTitle = "";
-    m_sPath = "";
-    m_sGroupName = "";
-    m_sTranslitTitle = "";
-    m_sSeries = "";
-    m_fSyncOffset = 0.0f;
-    m_bHasPackIni = false;
-    m_iYearReleased = 0;
-    m_sBannerPath = "";
+Group::Group()
+    : m_sDisplayTitle(""),
+      m_sSortTitle(""),
+      m_sPath(""),
+      m_sGroupName(""),
+      m_sTranslitTitle(""),
+      m_sSeries(""),
+      m_fSyncOffset(0.0f),
+      m_bHasPackIni(false),
+      m_sBannerPath(""),
+      m_iYearReleased(0),
+      m_iVersion(0)
+{
 }
 
-Group::Group(const RString& sDir, const RString& sGroupDirName, bool bFromProfile) {
+Group::Group(const RString& sDir, const RString& sGroupDirName, bool bFromProfile)
+    : m_sDisplayTitle(""),
+      m_sSortTitle(""),
+      m_sPath(""),
+      m_sGroupName(""),
+      m_sTranslitTitle(""),
+      m_sSeries(""),
+      // The m_DefaultSyncOffset preference corresponds to what offset the user
+      // would like to assume as a "default" for packs without a Pack.ini.
+      //
+      // If the m_DefaultSyncOffset is set to ITG, we want to remove the 9ms ITG
+      // bias for all packs without a Pack.ini.
+      //
+      // We can start with that as our default value, and potentially update it
+      // below.
+      m_fSyncOffset((PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL) ? 0.0f : -0.009f),
+      m_bHasPackIni(false),
+      m_sBannerPath(""),
+      m_iYearReleased(0),
+      m_iVersion(INI_VERSION)
+{
     if (sDir.empty() || sGroupDirName.empty()) {
         LOG->Warn("Group::Group: Empty directory or group name provided.");
         return;
@@ -56,20 +78,7 @@ Group::Group(const RString& sDir, const RString& sGroupDirName, bool bFromProfil
     }
     m_sSortTitle = m_sGroupName;
     m_sTranslitTitle = m_sGroupName;
-    m_sSeries = "";
-    // The m_DefaultSyncOffset preference corresponds to what offset the user
-    // would like to assume as a "default" for packs without a Pack.ini.
-    //
-    // If the m_DefaultSyncOffset is set to ITG, we want to remove the 9ms ITG
-    // bias for all packs without a Pack.ini.
-    //
-    // We can start with that as our default value, and potentially update it below.
-    m_fSyncOffset = (PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL) ? 0.0f : -0.009f;
-    m_bHasPackIni = false;
-    m_iYearReleased = 0;
-    m_sBannerPath = "";
-    m_iVersion = INI_VERSION;
-    
+
     if (FILEMAN->DoesFileExist(sPackIniPath)) {
         IniFile ini;
         if (!ini.ReadFile(sPackIniPath)) {

--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -78,7 +78,6 @@ Group::Group(const RString& sDir, const RString& sGroupDirName, bool bFromProfil
     }
     m_sSortTitle = m_sGroupName;
     m_sTranslitTitle = m_sGroupName;
-
     if (FILEMAN->DoesFileExist(sPackIniPath)) {
         IniFile ini;
         if (!ini.ReadFile(sPackIniPath)) {

--- a/src/RageFile.cpp
+++ b/src/RageFile.cpp
@@ -77,6 +77,8 @@ bool RageFile::Open( const RString& path, int mode )
 		return false;
 	}
 
+	m_File->EnableCRC32(true);
+
 	return true;
 }
 

--- a/src/RageFile.cpp
+++ b/src/RageFile.cpp
@@ -117,6 +117,21 @@ bool RageFile::GetCRC32( uint32_t *iRet )
 	return m_File->GetCRC32( iRet );
 }
 
+RString RageFile::GetCRC32AsString()
+{
+	ASSERT_OPEN;
+
+	uint32_t crc = 0;
+	if (!m_File->GetCRC32(&crc)) {
+	LOG->Warn(
+		"GetCRC32AsString: Failed to compute CRC32 for file '%s'",
+		m_Path.c_str());
+	return "";
+	}
+
+	// Convert the CRC32 value to a hexadecimal string
+	return ssprintf("%08x", crc);
+}
 
 bool RageFile::AtEOF() const
 {

--- a/src/RageFile.cpp
+++ b/src/RageFile.cpp
@@ -119,21 +119,6 @@ bool RageFile::GetCRC32( uint32_t *iRet )
 	return m_File->GetCRC32( iRet );
 }
 
-RString RageFile::GetCRC32AsString()
-{
-	ASSERT_OPEN;
-
-	uint32_t crc = 0;
-	if (!m_File->GetCRC32(&crc)) {
-	LOG->Warn(
-		"GetCRC32AsString: Failed to compute CRC32 for file '%s'",
-		m_Path.c_str());
-	return "";
-	}
-
-	// Convert the CRC32 value to a hexadecimal string
-	return ssprintf("%08x", crc);
-}
 
 bool RageFile::AtEOF() const
 {

--- a/src/RageFile.h
+++ b/src/RageFile.h
@@ -79,7 +79,6 @@ public:
 
 	void EnableCRC32( bool on=true );
 	bool GetCRC32( uint32_t *iRet );
-	RString GetCRC32AsString();
 
 	// Lua
 	virtual void PushSelf( lua_State *L );

--- a/src/RageFile.h
+++ b/src/RageFile.h
@@ -79,6 +79,7 @@ public:
 
 	void EnableCRC32( bool on=true );
 	bool GetCRC32( uint32_t *iRet );
+	RString GetCRC32AsString();
 
 	// Lua
 	virtual void PushSelf( lua_State *L );

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -1763,20 +1763,21 @@ RString Song::GetFileHash() {
 		"ssc", "sm", "dwi", "sma", "bms", "ksf", "json", "jso"
 	};
 
+	RString new_hash;
 	for (const RString& ext : extensions) {
 		RString song_file_path = SetExtension(GetSongFilePath(), ext);
 		if (IsAFile(song_file_path)) {
 			RageFile file;
 			if (!file.Open(song_file_path, RageFile::READ)) {
 				LOG->Warn("GetFileHash: Failed to open file '%s': %s", song_file_path.c_str(), file.GetError().c_str());
-				m_sFileHash = "";
-				return m_sFileHash;
+				new_hash = "";
+				return new_hash;
 			}
 
 			if (file.GetFileSize() == 0) {
 				LOG->Warn("GetFileHash: File '%s' is empty.", song_file_path.c_str());
-				m_sFileHash = "";
-				return m_sFileHash;
+				new_hash = "";
+				return new_hash;
 			}
 
 			file.EnableCRC32(true);
@@ -1787,23 +1788,23 @@ RString Song::GetFileHash() {
 			while ((bytes_read = file.Read(buffer, buffer_size)) > 0) {}
 			if (bytes_read < 0) {
 				LOG->Warn("GetFileHash: Error reading file '%s': %s", song_file_path.c_str(), file.GetError().c_str());
-				m_sFileHash = "";
-				return m_sFileHash;
+				new_hash = "";
+				return new_hash;
 			}
 
-			m_sFileHash = file.GetCRC32AsString();
-			if (m_sFileHash.empty()) {
+			new_hash = file.GetCRC32AsString();
+			if (new_hash.empty()) {
 				LOG->Warn("GetFileHash: Failed to compute CRC32 for file '%s'", song_file_path.c_str());
-				return m_sFileHash;
+				return new_hash;
 			}
 
-			LOG->Info("CRC32 hash for file '%s': %s", song_file_path.c_str(), m_sFileHash.c_str());
-			return m_sFileHash;
+			LOG->Info("CRC32 hash for file '%s': %s", song_file_path.c_str(), new_hash.c_str());
+			return new_hash;
 		}
 	}
 
-	m_sFileHash = "";
-	return m_sFileHash;
+	new_hash = "";
+	return new_hash;
 }
 
 std::vector<RString> Song::GetInstrumentTracksToVectorString() const

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -473,6 +473,23 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
  * Song/Steps objects to reload themselves. -- djpohly */
 bool Song::ReloadFromSongDir( RString sDir )
 {
+	// Get the current hash without modifying any files first.
+	// If the hashes match, then return early.
+	// Note, this is scoped because we want to ensure we finish up operations on
+	// m_sFileHash before anything else might try to access that file's hash.
+	{
+		const RString oldHash = m_sFileHash;
+		RString newHash = GetFileHash();
+
+		if (!m_sFileHash.empty() && newHash == oldHash) {
+			LOG->Trace("ReloadFromSongDir: Hashes match, not reloading song %s.", m_sMainTitle.c_str());
+			return true;
+		}
+
+		LOG->Trace("ReloadFromSongDir: Hashes do not match, reloading song %s.", m_sMainTitle.c_str());
+		m_sFileHash = newHash;
+	}
+
 	// Remove the cache file to force the song to reload from its dir instead
 	// of loading from the cache. -Kyz
 	FILEMAN->Remove(GetCacheFilePath());
@@ -494,30 +511,22 @@ bool Song::ReloadFromSongDir( RString sDir )
 		LOG->Warn("Song %s has no group, using default sync offset.", m_sMainTitle.c_str());
 	}
 
-	/* Go through the steps, first setting their Song pointer to this song
-	 * (instead of the copy used above), and constructing a map to let us
-	 * easily find the new steps. */
+	// Reassign Steps
 	std::map<StepsID, Steps*> mNewSteps;
-	for( std::vector<Steps*>::const_iterator it = m_vpSteps.begin(); it != m_vpSteps.end(); ++it )
-	{
-		(*it)->m_pSong = this;
+	for (Steps* step : m_vpSteps) {
+		step->m_pSong = this;
 		StepsID id;
-		id.FromSteps( *it );
-		mNewSteps[id] = *it;
+		id.FromSteps(step);
+		mNewSteps[id] = step;
 
 		// Reapply the Group Offset if the steps have their own timing data.
-		if( mNewSteps[id]->m_Timing.empty() )
-		{
-			continue;
-		}
-		if (SONGMAN->GetGroup(this) != nullptr)
-		{
-			mNewSteps[id]->m_Timing.m_fBeat0GroupOffsetInSeconds = SONGMAN->GetGroup(this)->GetSyncOffset();
-		}
-		else
-		{
-			mNewSteps[id]->m_Timing.m_fBeat0GroupOffsetInSeconds = PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL ? 0 : -0.009;
-			LOG->Warn("Song %s has no group, using default sync offset.", m_sMainTitle.c_str());
+		if (!step->m_Timing.empty()) {
+			if (SONGMAN->GetGroup(this) != nullptr) {
+				step->m_Timing.m_fBeat0GroupOffsetInSeconds = SONGMAN->GetGroup(this)->GetSyncOffset();
+			} else {
+				step->m_Timing.m_fBeat0GroupOffsetInSeconds = PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL ? 0 : -0.009;
+				LOG->Warn("Song %s has no group, using default sync offset.", m_sMainTitle.c_str());
+			}
 		}
 	}
 
@@ -526,37 +535,24 @@ bool Song::ReloadFromSongDir( RString sDir )
 	FOREACH_ENUM( StepsType, i )
 		m_vpStepsByType[i].clear();
 
-	/* Then we copy as many Steps as possible on top of the old pointers.
-	 * The only pointers that change are pointers to Steps that are not in the
-	 * reverted file, which we delete, and pointers to Steps that are in the
-	 * reverted file but not the original *this, which we create new copies of.
-	 * We have to go through these hoops because many places assume the Steps
-	 * pointers don't change - even though there are other ways they can change,
-	 * such as deleting a Steps via the editor. */
-	for( std::vector<Steps*>::const_iterator itOld = vOldSteps.begin(); itOld != vOldSteps.end(); ++itOld )
-	{
+	for (Steps* oldStep : vOldSteps) {
 		StepsID id;
-		id.FromSteps( *itOld );
-		std::map<StepsID, Steps*>::iterator itNew = mNewSteps.find( id );
-		if( itNew == mNewSteps.end() )
-		{
-			// This stepchart didn't exist in the file we reverted from
-			delete *itOld;
-		}
-		else
-		{
-			Steps *OldSteps = *itOld;
-			*OldSteps = *(itNew->second);
-			AddSteps( OldSteps );
-			mNewSteps.erase( itNew );
+		id.FromSteps(oldStep);
+		auto itNew = mNewSteps.find(id);
+		if (itNew == mNewSteps.end()) {
+			delete oldStep;
+		} else {
+			Steps* oldSteps = oldStep;
+			*oldSteps = *(itNew->second);
+			AddSteps(oldSteps);
+			mNewSteps.erase(itNew);
 		}
 	}
-	// The leftovers in the map are steps that didn't exist before we reverted
-	for( std::map<StepsID, Steps*>::const_iterator it = mNewSteps.begin(); it != mNewSteps.end(); ++it )
-	{
-		Steps *NewSteps = new Steps(this);
-		*NewSteps = *(it->second);
-		AddSteps( NewSteps );
+
+	for (auto& it : mNewSteps) {
+		Steps* newSteps = new Steps(this);
+		*newSteps = *(it.second);
+		AddSteps(newSteps);
 	}
 
 	AddAutoGenNotes();

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -469,29 +469,10 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
 	}
 
 	// Populate the CRC32 hash for the song.
+	// GetFileHash() will handle error states etc.
 	m_sFileHash = GetFileHash();
-    if (m_sFileHash == 0u) {
-        LOG->Warn("LoadFromSongDir: Failed to compute initial hash for song '%s'.", m_sMainTitle.c_str());
-    } else {
-        LOG->Trace("LoadFromSongDir: Initial hash for song '%s': %08X", m_sMainTitle.c_str(), m_sFileHash);
-    }
 
 	return true;	// do load this song
-}
-
-static bool DoHashesMatch(const uint32_t old_hash, const uint32_t new_hash)
-{
-	constexpr uint32_t empty_hash = 0u;
-	if (old_hash != empty_hash && old_hash == new_hash) {
-		return true;
-	}
-
-	if (new_hash == empty_hash) {
-		LOG->Warn("DoHashesMatch: Failure when computing hash");
-		return false;
-	}
-
-	return false;
 }
 
 /* This function feels EXTREMELY hacky - copying things on top of pointers so
@@ -507,10 +488,8 @@ bool Song::ReloadFromSongDir( RString sDir )
 		const uint32_t oldHash = m_sFileHash;
 		const uint32_t newHash = GetFileHash();
 
-		// If DoHashesMatch returns true, that means the hashes match.
-		if (DoHashesMatch(oldHash, newHash)) {
-			return true;
-		}
+		// If the old hash is 0, then we don't have a valid hash to compare against.
+		if (oldHash != 0u && oldHash == newHash) return true;
 
 		LOG->Trace("ReloadFromSongDir: Hashes do not match, reloading song"
 			"'%s'. new hash: %08X", m_sMainTitle.c_str(), newHash);
@@ -586,6 +565,7 @@ bool Song::ReloadFromSongDir( RString sDir )
 	}
 
 	AddAutoGenNotes();
+
 	// Reload any images associated with the song. -Kyz
 	std::vector<RString> to_reload;
 	to_reload.reserve(7);
@@ -608,6 +588,7 @@ bool Song::ReloadFromSongDir( RString sDir )
 			}
 		}
 	}
+
 	return true;
 }
 
@@ -1816,7 +1797,6 @@ uint32_t Song::GetFileHash() const
 			continue;
 		}
 
-		file.EnableCRC32(true);
 		std::vector<char> buffer(static_cast<size_t>(file_size));
 		if (file.Read(&buffer[0], file_size) != file_size)
 		{
@@ -1831,7 +1811,7 @@ uint32_t Song::GetFileHash() const
 			continue;
 		}
 
-		LOG->Info("CRC32 hash for file '%s': %08X", song_file_path.c_str(), file_crc32); // %08X gives a prettier output than %u
+		LOG->Info("CRC32 hash for file '%s': %08X", song_file_path.c_str(), file_crc32);
 		return file_crc32;
 	}
 

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -37,6 +37,7 @@
 #include "LyricsLoader.h"
 #include "ActorUtil.h"
 #include "CommonMetrics.h"
+#include "RageTextureID.h"
 
 #include <cfloat>
 #include <cmath>
@@ -472,7 +473,7 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
     if (m_sFileHash == 0u) {
         LOG->Warn("LoadFromSongDir: Failed to compute initial hash for song '%s'.", m_sMainTitle.c_str());
     } else {
-        LOG->Trace("LoadFromSongDir: Initial hash for song '%s': %u", m_sMainTitle.c_str(), m_sFileHash);
+        LOG->Trace("LoadFromSongDir: Initial hash for song '%s': %08X", m_sMainTitle.c_str(), m_sFileHash);
     }
 
 	return true;	// do load this song

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -45,9 +45,6 @@
 #include <set>
 #include <vector>
 
-//-Nick12 Used for song file hashing
-#include <CryptManager.h>
-
 /**
  * @brief The internal version of the cache for StepMania.
  *

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -44,6 +44,7 @@
 #include <ctime>
 #include <set>
 #include <vector>
+#include <cstdint>
 
 /**
  * @brief The internal version of the cache for StepMania.
@@ -468,28 +469,27 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
 
 	// Populate the CRC32 hash for the song.
 	m_sFileHash = GetFileHash();
-    if (m_sFileHash.empty()) {
+    if (m_sFileHash == 0u) {
         LOG->Warn("LoadFromSongDir: Failed to compute initial hash for song '%s'.", m_sMainTitle.c_str());
     } else {
-        LOG->Trace("LoadFromSongDir: Initial hash for song '%s': %s", m_sMainTitle.c_str(), m_sFileHash.c_str());
+        LOG->Trace("LoadFromSongDir: Initial hash for song '%s': %u", m_sMainTitle.c_str(), m_sFileHash);
     }
 
 	return true;	// do load this song
 }
 
-static bool DoHashesMatch(const RString& old_hash, const RString& new_hash)
+static bool DoHashesMatch(const uint32_t old_hash, const uint32_t new_hash)
 {
-	if (!old_hash.empty() && CompareNoCase(old_hash, new_hash) == 0) {
-		LOG->Trace("DoHashesMatch: Song hashes match, not reloading song.");
+	constexpr uint32_t empty_hash = 0u;
+	if (old_hash != empty_hash && old_hash == new_hash) {
 		return true;
 	}
 
-	if (new_hash.empty() || new_hash == RString("00000000")) {
+	if (new_hash == empty_hash) {
 		LOG->Warn("DoHashesMatch: Failure when computing hash");
 		return false;
 	}
 
-	LOG->Trace("DoHashesMatch: Hashes do not match.");
 	return false;
 }
 
@@ -503,15 +503,16 @@ bool Song::ReloadFromSongDir( RString sDir )
 	// Note, this is scoped because we want to ensure we finish up operations on
 	// m_sFileHash before anything else might try to access that file's hash.
 	{
-		const RString oldHash = m_sFileHash;
-		const RString newHash = GetFileHash();
+		const uint32_t oldHash = m_sFileHash;
+		const uint32_t newHash = GetFileHash();
 
 		// If DoHashesMatch returns true, that means the hashes match.
 		if (DoHashesMatch(oldHash, newHash)) {
 			return true;
 		}
 
-		LOG->Trace("ReloadFromSongDir: Hashes do not match, reloading song '%s'.", m_sMainTitle.c_str());
+		LOG->Trace("ReloadFromSongDir: Hashes do not match, reloading song '%s'."
+			"old hash: %u, new hash: %u", m_sMainTitle.c_str(), oldHash, newHash);
 		m_sFileHash = newHash;
 	}
 
@@ -1786,53 +1787,48 @@ RString Song::GetCacheFile(RString sType)
 	return "";
 }
 
-RString Song::GetFileHash() {
-	static const std::vector<RString> extensions = {
+uint32_t Song::GetFileHash()
+{
+	constexpr const char* extensions[] = {
 		"ssc", "sm", "dwi", "sma", "bms", "ksf", "json", "jso"
 	};
+	constexpr size_t extensions_count = sizeof(extensions) / sizeof(extensions[0]);
 
-	RString new_hash;
-	for (const RString& ext : extensions) {
+	for (size_t i = 0; i < extensions_count; ++i)
+	{
+		const char* ext = extensions[i];
 		RString song_file_path = SetExtension(GetSongFilePath(), ext);
-		if (IsAFile(song_file_path)) {
-			RageFile file;
-			if (!file.Open(song_file_path, RageFile::READ)) {
-				LOG->Warn("GetFileHash: Failed to open file '%s': %s", song_file_path.c_str(), file.GetError().c_str());
-				new_hash = "";
-				return new_hash;
-			}
 
-			if (file.GetFileSize() == 0) {
-				LOG->Warn("GetFileHash: File '%s' is empty.", song_file_path.c_str());
-				new_hash = "";
-				return new_hash;
-			}
+		if (!IsAFile(song_file_path)) continue;
 
-			file.EnableCRC32(true);
-
-			const int buffer_size = 4096;
-			char buffer[buffer_size];
-			int bytes_read;
-			while ((bytes_read = file.Read(buffer, buffer_size)) > 0) {}
-			if (bytes_read < 0) {
-				LOG->Warn("GetFileHash: Error reading file '%s': %s", song_file_path.c_str(), file.GetError().c_str());
-				new_hash = "";
-				return new_hash;
-			}
-
-			new_hash = file.GetCRC32AsString();
-			if (new_hash.empty()) {
-				LOG->Warn("GetFileHash: Failed to compute CRC32 for file '%s'", song_file_path.c_str());
-				return new_hash;
-			}
-
-			LOG->Info("CRC32 hash for file '%s': %s", song_file_path.c_str(), new_hash.c_str());
-			return new_hash;
+		RageFile file;
+		if (!file.Open(song_file_path, RageFile::READ))
+		{
+			LOG->Warn("GetFileHash: Failed to open file '%s': %s", song_file_path.c_str(), file.GetError().c_str());
+			continue;
 		}
+
+		int file_size = file.GetFileSize();
+		if (file_size <= 0)
+		{
+			LOG->Warn("GetFileHash: File '%s' is empty.", song_file_path.c_str());
+			continue;
+		}
+
+		file.EnableCRC32(true);
+
+		uint32_t file_crc32 = 0;
+		if (!file.GetCRC32(&file_crc32))
+		{
+			LOG->Warn("GetFileHash: Failed to compute CRC32 for file '%s'", song_file_path.c_str());
+			continue;
+		}
+
+		LOG->Info("CRC32 hash for file '%s': %08X", song_file_path.c_str(), file_crc32); // %08X gives a prettier output than %u
+		return file_crc32;
 	}
 
-	new_hash = "";
-	return new_hash;
+	return 0;
 }
 
 std::vector<RString> Song::GetInstrumentTracksToVectorString() const

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -465,6 +465,15 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
 		LOG->UserLog( "Song", sDir, "has no music; ignored." );
 		return false;	// don't load this song
 	}
+
+	// Populate the CRC32 hash for the song.
+	m_sFileHash = GetFileHash();
+    if (m_sFileHash.empty()) {
+        LOG->Warn("LoadFromSongDir: Failed to compute initial hash for song '%s'.", m_sMainTitle.c_str());
+    } else {
+        LOG->Trace("LoadFromSongDir: Initial hash for song '%s': %s", m_sMainTitle.c_str(), m_sFileHash.c_str());
+    }
+
 	return true;	// do load this song
 }
 

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -1787,7 +1787,7 @@ RString Song::GetCacheFile(RString sType)
 	return "";
 }
 
-uint32_t Song::GetFileHash()
+uint32_t Song::GetFileHash() const
 {
 	constexpr const char* extensions[] = {
 		"ssc", "sm", "dwi", "sma", "bms", "ksf", "json", "jso"
@@ -1816,6 +1816,12 @@ uint32_t Song::GetFileHash()
 		}
 
 		file.EnableCRC32(true);
+		std::vector<char> buffer(static_cast<size_t>(file_size));
+		if (file.Read(&buffer[0], file_size) != file_size)
+		{
+			LOG->Warn("GetFileHash: Failed to read file '%s'", song_file_path.c_str());
+			continue;
+		}
 
 		uint32_t file_crc32 = 0;
 		if (!file.GetCRC32(&file_crc32))

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -477,6 +477,22 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
 	return true;	// do load this song
 }
 
+static bool DoHashesMatch(const RString& old_hash, const RString& new_hash)
+{
+	if (!old_hash.empty() && CompareNoCase(old_hash, new_hash) == 0) {
+		LOG->Trace("DoHashesMatch: Song hashes match, not reloading song.");
+		return true;
+	}
+
+	if (new_hash.empty() || new_hash == RString("00000000")) {
+		LOG->Warn("DoHashesMatch: Failure when computing hash");
+		return false;
+	}
+
+	LOG->Trace("DoHashesMatch: Hashes do not match.");
+	return false;
+}
+
 /* This function feels EXTREMELY hacky - copying things on top of pointers so
  * they don't break elsewhere.  Maybe it could be rewritten to politely ask the
  * Song/Steps objects to reload themselves. -- djpohly */
@@ -487,27 +503,13 @@ bool Song::ReloadFromSongDir( RString sDir )
 	// Note, this is scoped because we want to ensure we finish up operations on
 	// m_sFileHash before anything else might try to access that file's hash.
 	{
-		RString oldHash = m_sFileHash;
-		RString newHash = GetFileHash();
-                LOG->Trace(
-                    "ReloadFromSongDir: oldHash='%s', newHash='%s'",
-                    oldHash.c_str(), newHash.c_str());
+		const RString oldHash = m_sFileHash;
+		const RString newHash = GetFileHash();
 
-				RString oldHashTrimmed = oldHash;
-                RString newHashTrimmed = newHash;
-                Trim(oldHashTrimmed);
-                Trim(newHashTrimmed);
-
-
-if (!oldHashTrimmed.empty() && CompareNoCase(oldHashTrimmed, newHashTrimmed) == 0) {
-    LOG->Trace("ReloadFromSongDir: Hashes match, not reloading song '%s'.", m_sMainTitle.c_str());
-    return true;
-}
-
-    if (newHashTrimmed.empty()) {
-        LOG->Warn("ReloadFromSongDir: Failed to compute new hash for song '%s'.", m_sMainTitle.c_str());
-        return false;
-    }
+		// If DoHashesMatch returns true, that means the hashes match.
+		if (DoHashesMatch(oldHash, newHash)) {
+			return true;
+		}
 
 		LOG->Trace("ReloadFromSongDir: Hashes do not match, reloading song '%s'.", m_sMainTitle.c_str());
 		m_sFileHash = newHash;

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -555,7 +555,10 @@ bool Song::ReloadFromSongDir( RString sDir )
 		}
 	}
 
-	// Now we wipe out the new pointers, which were shallow copied and not deep copied...
+	// Clear existing steps, and fill with the new steps.
+	// Steps that haven't changed will be reused, to avoid
+	// unnecessary memory operations. Steps that have been
+	// reused will have their pointers updated, though.
 	m_vpSteps.clear();
 	FOREACH_ENUM( StepsType, i )
 		m_vpStepsByType[i].clear();

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -1765,19 +1765,47 @@ RString Song::GetCacheFile(RString sType)
 	return "";
 }
 
-RString Song::GetFileHash()
-{
+RString Song::GetFileHash() {
 	static const std::vector<RString> extensions = {
 		"ssc", "sm", "dwi", "sma", "bms", "ksf", "json", "jso"
 	};
 
-	if (m_sFileHash.empty()) {
-		for (const RString& ext : extensions) {
-			RString sPath = SetExtension(GetSongFilePath(), ext);
-			if (IsAFile(sPath)) {
-				m_sFileHash = BinaryToHex(CRYPTMAN->GetSHA1ForFile(sPath));
+	for (const RString& ext : extensions) {
+		RString song_file_path = SetExtension(GetSongFilePath(), ext);
+		if (IsAFile(song_file_path)) {
+			RageFile file;
+			if (!file.Open(song_file_path, RageFile::READ)) {
+				LOG->Warn("GetFileHash: Failed to open file '%s': %s", song_file_path.c_str(), file.GetError().c_str());
+				m_sFileHash = "";
 				return m_sFileHash;
 			}
+
+			if (file.GetFileSize() == 0) {
+				LOG->Warn("GetFileHash: File '%s' is empty.", song_file_path.c_str());
+				m_sFileHash = "";
+				return m_sFileHash;
+			}
+
+			file.EnableCRC32(true);
+
+			const int buffer_size = 4096;
+			char buffer[buffer_size];
+			int bytes_read;
+			while ((bytes_read = file.Read(buffer, buffer_size)) > 0) {}
+			if (bytes_read < 0) {
+				LOG->Warn("GetFileHash: Error reading file '%s': %s", song_file_path.c_str(), file.GetError().c_str());
+				m_sFileHash = "";
+				return m_sFileHash;
+			}
+
+			m_sFileHash = file.GetCRC32AsString();
+			if (m_sFileHash.empty()) {
+				LOG->Warn("GetFileHash: Failed to compute CRC32 for file '%s'", song_file_path.c_str());
+				return m_sFileHash;
+			}
+
+			LOG->Info("CRC32 hash for file '%s': %s", song_file_path.c_str(), m_sFileHash.c_str());
+			return m_sFileHash;
 		}
 	}
 

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -37,7 +37,6 @@
 #include "LyricsLoader.h"
 #include "ActorUtil.h"
 #include "CommonMetrics.h"
-#include "RageTextureID.h"
 
 #include <cfloat>
 #include <cmath>

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -565,7 +565,6 @@ bool Song::ReloadFromSongDir( RString sDir )
 	}
 
 	AddAutoGenNotes();
-
 	// Reload any images associated with the song. -Kyz
 	std::vector<RString> to_reload;
 	to_reload.reserve(7);
@@ -588,7 +587,6 @@ bool Song::ReloadFromSongDir( RString sDir )
 			}
 		}
 	}
-
 	return true;
 }
 

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -480,21 +480,11 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
  * Song/Steps objects to reload themselves. -- djpohly */
 bool Song::ReloadFromSongDir( RString sDir )
 {
-	// Get the current hash without modifying any files first.
-	// If the hashes match, then return early.
-	// Note, this is scoped because we want to ensure we finish up operations on
-	// m_sFileHash before anything else might try to access that file's hash.
-	{
-		const uint32_t oldHash = m_sFileHash;
-		const uint32_t newHash = GetFileHash();
-
-		// If the old hash is 0, then we don't have a valid hash to compare against.
-		if (oldHash != 0u && oldHash == newHash) return true;
-
-		LOG->Trace("ReloadFromSongDir: Hashes do not match, reloading song"
-			"'%s'. new hash: %08X", m_sMainTitle.c_str(), newHash);
-		m_sFileHash = newHash;
-	}
+	const uint32_t oldHash = m_sFileHash;
+	const uint32_t newHash = GetFileHash();
+	if (oldHash != 0U && oldHash == newHash)
+		return true;
+	m_sFileHash = newHash;
 
 	// Remove the cache file to force the song to reload from its dir instead
 	// of loading from the cache. -Kyz

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -478,15 +478,29 @@ bool Song::ReloadFromSongDir( RString sDir )
 	// Note, this is scoped because we want to ensure we finish up operations on
 	// m_sFileHash before anything else might try to access that file's hash.
 	{
-		const RString oldHash = m_sFileHash;
+		RString oldHash = m_sFileHash;
 		RString newHash = GetFileHash();
+                LOG->Trace(
+                    "ReloadFromSongDir: oldHash='%s', newHash='%s'",
+                    oldHash.c_str(), newHash.c_str());
 
-		if (!m_sFileHash.empty() && newHash == oldHash) {
-			LOG->Trace("ReloadFromSongDir: Hashes match, not reloading song %s.", m_sMainTitle.c_str());
-			return true;
-		}
+				RString oldHashTrimmed = oldHash;
+                RString newHashTrimmed = newHash;
+                Trim(oldHashTrimmed);
+                Trim(newHashTrimmed);
 
-		LOG->Trace("ReloadFromSongDir: Hashes do not match, reloading song %s.", m_sMainTitle.c_str());
+
+if (!oldHashTrimmed.empty() && CompareNoCase(oldHashTrimmed, newHashTrimmed) == 0) {
+    LOG->Trace("ReloadFromSongDir: Hashes match, not reloading song '%s'.", m_sMainTitle.c_str());
+    return true;
+}
+
+    if (newHashTrimmed.empty()) {
+        LOG->Warn("ReloadFromSongDir: Failed to compute new hash for song '%s'.", m_sMainTitle.c_str());
+        return false;
+    }
+
+		LOG->Trace("ReloadFromSongDir: Hashes do not match, reloading song '%s'.", m_sMainTitle.c_str());
 		m_sFileHash = newHash;
 	}
 

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -512,8 +512,8 @@ bool Song::ReloadFromSongDir( RString sDir )
 			return true;
 		}
 
-		LOG->Trace("ReloadFromSongDir: Hashes do not match, reloading song '%s'."
-			"old hash: %u, new hash: %u", m_sMainTitle.c_str(), oldHash, newHash);
+		LOG->Trace("ReloadFromSongDir: Hashes do not match, reloading song"
+			"'%s'. new hash: %08X", m_sMainTitle.c_str(), newHash);
 		m_sFileHash = newHash;
 	}
 

--- a/src/Song.h
+++ b/src/Song.h
@@ -12,6 +12,7 @@
 
 #include <set>
 #include <vector>
+#include <cstdint>
 
 
 class Style;
@@ -199,8 +200,8 @@ public:
 	RString m_sArtistTranslit;
 
 
-	RString m_sFileHash;
-	RString GetFileHash();
+	uint32_t m_sFileHash;
+	uint32_t GetFileHash();
 
 	/* If PREFSMAN->m_bShowNative is off, these are the same as GetTranslit*
 	 * below. Otherwise, they return the main titles. */

--- a/src/Song.h
+++ b/src/Song.h
@@ -201,7 +201,7 @@ public:
 
 
 	uint32_t m_sFileHash;
-	uint32_t GetFileHash();
+	uint32_t GetFileHash() const;
 
 	/* If PREFSMAN->m_bShowNative is off, these are the same as GetTranslit*
 	 * below. Otherwise, they return the main titles. */


### PR DESCRIPTION
This is all being done to put a stop to issues with chart, cache, and song offset corruption. It also puts an end to CTRL+R reloading songs in the songwheel not always working as it should.

It was also confirmed to resolve the bug where a song's perceived sync might change between subsequent replays.

What we do here is:

1. Enable CRC32 support - this functionality is already built into RageFile, but is disabled by default
2. Calculate and store a CRC32 hash for each song we load, and store it in m_sFileHash
3. Use the CRC32 to determine whether or not the file changed rather than the convoluted map comparison method in ReloadFromSongDir
4. Ensure the group offset is handled in the Group initializer list to ensure all member variables are containing a valid set of values before we attempt to read them in Song.cpp