### PR TITLE
Fix resampling mistake in RageSoundReader_Merge

### DIFF
--- a/src/RageSoundReader_Merge.cpp
+++ b/src/RageSoundReader_Merge.cpp
@@ -74,10 +74,9 @@ void RageSoundReader_Merge::Finish( int iPreferredSampleRate )
 	m_iSampleRate = GetSampleRateInternal();
 	if( m_iSampleRate == -1 )
 	{
-		for (RageSoundReader *it : m_aSounds)
+		for (size_t i = 0; i < m_aSounds.size(); ++i)
 		{
-			RageSoundReader_Resample_Good *pResample = new RageSoundReader_Resample_Good( it, iPreferredSampleRate );
-			it = pResample;
+			m_aSounds[i] = new RageSoundReader_Resample_Good(m_aSounds[i], iPreferredSampleRate);
 		}
 
 		m_iSampleRate = iPreferredSampleRate;


### PR DESCRIPTION
The original code is modifying a copy of pointer. Ultimately, it does not affect the actual elements stored in m_aSounds. The replacement code is ensures the desired element of m_aSounds is resampled. This change is present in the aaa2 branch that made the recently released unofficial beta.

A follow up PR could change more of these `RageSoundReader *it`'s to explicit indexed loops, AFAICT the other's aren't harmful, but it's probably not needed considering everything seems to work as it should with this change.