### PR TITLE
Use uint32_t consistently for CRC32 values

### DIFF
--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -1241,20 +1241,20 @@ bool DeleteRecursive( const RString &sDir )
 	return FILEMAN->Remove( sDir );
 }
 
-unsigned int GetHashForFile( const RString &sPath )
+uint32_t GetHashForFile( const RString &sPath )
 {
 	return FILEMAN->GetFileHash( sPath );
 }
 
-unsigned int GetHashForDirectory( const RString &sDir )
+uint32_t GetHashForDirectory( const RString &sDir )
 {
-	unsigned int hash = 0;
+	uint32_t hash = 0;
 
 	hash += GetHashForString( sDir );
 
 	std::vector<RString> arrayFiles;
 	GetDirListing( sDir+"*", arrayFiles, false );
-	for( unsigned i=0; i<arrayFiles.size(); i++ )
+	for( size_t i=0; i<arrayFiles.size(); i++ )
 	{
 		const RString sFilePath = sDir + arrayFiles[i];
 		hash += GetHashForFile( sFilePath );

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -1078,14 +1078,14 @@ RString GetCwd()
  *   http://www.theorem.com/java/CRC32.java,
  *   http://www.faqs.org/rfcs/rfc1952.html
  */
-void CRC32( unsigned int &iCRC, const void *pVoidBuffer, size_t iSize )
+void CRC32( uint32_t &iCRC, const void *pVoidBuffer, size_t iSize )
 {
-	static unsigned tab[256];
+	static uint32_t tab[256];
 	static bool initted = false;
 	if( !initted )
 	{
 		initted = true;
-		const unsigned POLY = 0xEDB88320;
+		const uint32_t POLY = 0xEDB88320;
 
 		for( int i = 0; i < 256; ++i )
 		{
@@ -1103,15 +1103,15 @@ void CRC32( unsigned int &iCRC, const void *pVoidBuffer, size_t iSize )
 	iCRC ^= 0xFFFFFFFF;
 
 	const char *pBuffer = (const char *) pVoidBuffer;
-	for( unsigned i = 0; i < iSize; ++i )
+	for( size_t i = 0; i < iSize; ++i )
 		iCRC = (iCRC >> 8) ^ tab[(iCRC ^ pBuffer[i]) & 0xFF];
 
 	iCRC ^= 0xFFFFFFFF;
 }
 
-unsigned int GetHashForString( const RString &s )
+uint32_t GetHashForString( const RString &s )
 {
-	unsigned crc = 0;
+	uint32_t crc = 0;
 	CRC32( crc, s.data(), s.size() );
 	return crc;
 }

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -459,10 +459,10 @@ bool GetCommandlineArgument( const RString &option, RString *argument=nullptr, i
 extern int g_argc;
 extern char **g_argv;
 
-void CRC32( unsigned int &iCRC, const void *pBuffer, size_t iSize );
-unsigned int GetHashForString( const RString &s );
-unsigned int GetHashForFile( const RString &sPath );
-unsigned int GetHashForDirectory( const RString &sDir );	// a hash value that remains the same as long as nothing in the directory has changed
+void CRC32( uint32_t &iCRC, const void *pBuffer, size_t iSize );
+uint32_t GetHashForString( const RString &s );
+uint32_t GetHashForFile( const RString &sPath );
+uint32_t GetHashForDirectory( const RString &sDir );	// a hash value that remains the same as long as nothing in the directory has changed
 bool DirectoryIsEmpty( const RString &sPath );
 
 bool CompareRStringsAsc( const RString &sStr1, const RString &sStr2 );

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -54,7 +54,7 @@ LuaXType( DisplayBPM );
 Steps::Steps(Song *song): m_StepsType(StepsType_Invalid), m_pSong(song),
 	parent(nullptr), m_pNoteData(new NoteData), m_bNoteDataIsFilled(false),
 	m_sNoteDataCompressed(""), m_sFilename(""), m_bSavedToDisk(false),
-	m_LoadedFromProfile(ProfileSlot_Invalid), m_iHash(0),
+	m_LoadedFromProfile(ProfileSlot_Invalid), m_iHash(0U),
 	m_sDescription(""), m_sChartStyle(""),
 	m_Difficulty(Difficulty_Invalid), m_iMeter(0),
 	m_bAreCachedRadarValuesJustLoaded(false),
@@ -91,7 +91,7 @@ bool Steps::HasAttacks() const
 	return !this->m_Attacks.empty();
 }
 
-unsigned Steps::GetHash() const
+uint32_t Steps::GetHash() const
 {
 	if( parent )
 		return parent->GetHash();
@@ -100,7 +100,7 @@ unsigned Steps::GetHash() const
 	if( m_sNoteDataCompressed.empty() )
 	{
 		if( !m_bNoteDataIsFilled )
-			return 0; // No data, no hash.
+			return 0U; // No data, no hash.
 		NoteDataUtil::GetSMNoteDataString( *m_pNoteData, m_sNoteDataCompressed );
 	}
 	m_iHash = GetHashForString( m_sNoteDataCompressed );
@@ -191,7 +191,7 @@ void Steps::SetNoteData( const NoteData& noteDataNew )
 	m_bNoteDataIsFilled = true;
 
 	m_sNoteDataCompressed = RString();
-	m_iHash = 0;
+	m_iHash = 0U;
 }
 
 void Steps::GetNoteData( NoteData& noteDataOut ) const
@@ -222,7 +222,7 @@ void Steps::SetSMNoteData( const RString &notes_comp_ )
 	m_bNoteDataIsFilled = false;
 
 	m_sNoteDataCompressed = notes_comp_;
-	m_iHash = 0;
+	m_iHash = 0U;
 }
 
 /* XXX: this function should pull data from m_sFilename, like Decompress() */

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -13,6 +13,7 @@
 #include "TechCounts.h"
 #include "MeasureInfo.h"
 #include <vector>
+#include <cstdint>
 
 
 class Profile;
@@ -280,7 +281,7 @@ private:
 
 	/* These values are pulled from the autogen source first, if there is one. */
 	/** @brief The hash of the steps. This is used only for Edit Steps. */
-	mutable unsigned		m_iHash;
+	mutable uint32_t		m_iHash;
 	/** @brief The name of the edit, or some other useful description.
 	 This used to also contain the step author's name. */
 	RString				m_sDescription;


### PR DESCRIPTION
The problem is that there is a mix of `unsigned` and `unsigned int` used for CRC32 values,  this works because pretty much any compiler treats these two datatypes as 32 bit wide, but it would be more correct to ensure the proper width is used by changing these all to `uint32_t`.

Also adds the "U" literal to some zeros in Steps.cpp, to prevent MSVC from type casting these to signed 0, which can introduce some inconsistency in how these are handled in comparisons.