### PR TITLE
build-release-linux script: fixed missing cmake variable for ARM

### DIFF
--- a/Utils/build-release-linux.sh
+++ b/Utils/build-release-linux.sh
@@ -9,12 +9,13 @@ docker build --platform=${ARCH} -f Dockerfile-linux . -t itgmania-linux-build:${
 
 docker run -i -v $(pwd)/..:/data:Z --platform=linux/${ARCH} itgmania-linux-build:${ARCH} sh -eux <<'EOF'
 WITH_MINIMAID=On ; [ "$(arch)" != "x86_64" ] && WITH_MINIMAID=Off
-export WITH_MINIMAID
 git config --global --add safe.directory /data
-cmake -S /data -B /tmp/Build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DWITH_CLUB_FANTASTIC=On
+cmake -S /data -B /tmp/Build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On \
+	-DWITH_CLUB_FANTASTIC=On -DWITH_MINIMAID=${WITH_MINIMAID}
 cmake --build /tmp/Build -j $(nproc)
 cmake --build /tmp/Build --target package
-cmake -S /data -B /tmp/Build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
+cmake -S /data -B /tmp/Build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On \
+	-DWITH_CLUB_FANTASTIC=Off -DWITH_MINIMAID=${WITH_MINIMAID}
 cmake --build /tmp/Build --target package
 mkdir -p /data/Build/release
 cp /tmp/Build/ITGmania-* /data/Build/release/


### PR DESCRIPTION
This a minor change to fix something I missed in #784:

I added `WITH_MINIMAID` as an environment variable in the PR, but this needs to be set as a cmake variable.

(Sorry about this, now it works)