### PR TITLE
Undo RageSoundReader "bugfix" regression;  roll back sample rate-related changes to hardcoded 48khz commit ⚠️

### DIFF
--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -147,7 +147,7 @@ public:
 	int SetPosition( int iFrame )  { return 1; }
 	int Read( float *pBuf, int iFrames ) { return RageSoundReader::END_OF_FILE; }
 	RageSoundReader *Copy() const { return new RageSoundReader_Silence; }
-	int GetSampleRate() const { return kFallbackSampleRate; }
+	int GetSampleRate() const { return 48000; }
 	unsigned GetNumChannels() const { return 1; }
 	int GetNextSourceFrame() const { return 0; }
 	float GetStreamToSourceRatio() const { return 1.0f; }

--- a/src/RageSound.h
+++ b/src/RageSound.h
@@ -9,8 +9,6 @@
 
 #include <cstdint>
 
-constexpr int kFallbackSampleRate = 44100;
-
 class RageSoundReader;
 struct lua_State;
 

--- a/src/RageSoundManager.cpp
+++ b/src/RageSoundManager.cpp
@@ -133,7 +133,7 @@ float RageSoundManager::GetPlayLatency() const
 int RageSoundManager::GetDriverSampleRate() const
 {
 	if( m_pDriver == nullptr )
-		return kFallbackSampleRate;
+		return 48000;
 
 	// Returns the *actual* operating rate of the loaded driver
 	return m_pDriver->GetSampleRate();

--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -1,5 +1,4 @@
 #include "global.h"
-#include "PrefsManager.h"
 #include "RageSoundReader_Chain.h"
 #include "RageSoundReader_FileReader.h"
 #include "RageSoundReader_Resample_Good.h"
@@ -7,7 +6,6 @@
 #include "RageSoundReader_Pan.h"
 #include "RageLog.h"
 #include "RageUtil.h"
-#include "RageSound.h"
 #include "RageSoundMixBuffer.h"
 #include "RageSoundUtil.h"
 
@@ -25,12 +23,7 @@
  */
 RageSoundReader_Chain::RageSoundReader_Chain()
 {
-	m_iPreferredSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
-	if (m_iPreferredSampleRate == 0)
-	{
-		m_iPreferredSampleRate = kFallbackSampleRate;
-	}
-	
+	m_iPreferredSampleRate = 48000;
 	m_iActualSampleRate = -1;
 	m_iChannels = 0;
 	m_iCurrentFrame = 0;

--- a/src/RageSoundReader_Merge.cpp
+++ b/src/RageSoundReader_Merge.cpp
@@ -65,6 +65,9 @@ void RageSoundReader_Merge::Finish( int iPreferredSampleRate )
 	for (RageSoundReader *it : m_aSounds)
 		m_iChannels = std::max( m_iChannels, it->GetNumChannels() );
 
+	// NOTE(sukibaby):  fixing the following block of code which resamples a group of sounds
+	// so that it did what the comment says it does was reported to be a regression in sync stability.
+	// Thus, it should be assumed to be incorrect.
 	/*
 	 * We might get different sample rates from our sources.  If they're all the same
 	 * sample rate, just leave it alone, so the whole sound can be resampled as a group.
@@ -74,9 +77,10 @@ void RageSoundReader_Merge::Finish( int iPreferredSampleRate )
 	m_iSampleRate = GetSampleRateInternal();
 	if( m_iSampleRate == -1 )
 	{
-		for (size_t i = 0; i < m_aSounds.size(); ++i)
+		for (RageSoundReader *it : m_aSounds)
 		{
-			m_aSounds[i] = new RageSoundReader_Resample_Good(m_aSounds[i], iPreferredSampleRate);
+			RageSoundReader_Resample_Good *pResample = new RageSoundReader_Resample_Good( it, iPreferredSampleRate );
+			it = pResample;
 		}
 
 		m_iSampleRate = iPreferredSampleRate;

--- a/src/arch/Sound/ALSA9Helpers.cpp
+++ b/src/arch/Sound/ALSA9Helpers.cpp
@@ -1,5 +1,4 @@
 #include "global.h"
-#include "RageSound.h"
 #include "RageLog.h"
 #include "RageUtil.h"
 #include "ALSA9Helpers.h"
@@ -213,7 +212,7 @@ void Alsa9Buf::GetSoundCardDebugInfo()
 
 Alsa9Buf::Alsa9Buf()
 {
-	samplerate = 44100;
+	samplerate = 48000;
 	samplebits = 16;
 	last_cursor_pos = 0;
 	preferred_writeahead = 8192;
@@ -230,13 +229,9 @@ RString Alsa9Buf::Init( int channels_,
 	preferred_writeahead = iWriteahead;
 	preferred_chunksize = iChunkSize;
 	if( iSampleRate == 0 )
-	{
-		samplerate = kFallbackSampleRate;
-	}
+		samplerate = 48000;
 	else
-	{
 		samplerate = iSampleRate;
-	}
 
 	GetSoundCardDebugInfo();
 

--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -64,12 +64,14 @@ void DSound::SetPrimaryBufferMode()
 	waveformat.wFormatTag = WAVE_FORMAT_PCM;
 	waveformat.wBitsPerSample = 16;
 	waveformat.nChannels = 2;
+
 	int preferredSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
 	if (preferredSampleRate == 0)
 	{
-		preferredSampleRate = kFallbackSampleRate;
+		preferredSampleRate = 48000; // Default to 48000 Hz if preference is 0
 	}
-	waveformat.nSamplesPerSec = preferredSampleRate;
+	waveformat.nSamplesPerSec = (DWORD)preferredSampleRate;
+
 	waveformat.nBlockAlign = (waveformat.nChannels * waveformat.wBitsPerSample) / 8;
 	waveformat.nAvgBytesPerSec = waveformat.nSamplesPerSec * waveformat.nBlockAlign;
 
@@ -82,8 +84,8 @@ void DSound::SetPrimaryBufferMode()
 	hr = pBuffer->GetFormat( &waveformat, sizeof(waveformat), &got );
 	if( FAILED(hr) )
 		LOG->Warn( hr_ssprintf(hr, "GetFormat on primary buffer") );
-	else if( waveformat.nSamplesPerSec != 44100 )
-		LOG->Warn( "Primary buffer set to %i instead of 44100", waveformat.nSamplesPerSec );
+	else if( waveformat.nSamplesPerSec != 48000 )
+		LOG->Warn( "Primary buffer set to %i instead of 48000", waveformat.nSamplesPerSec );
 
 	/*
 	 * MS docs:
@@ -220,10 +222,9 @@ RString DSoundBuf::Init( DSound &ds, DSoundBuf::hw hardware,
 	waveformat.wFormatTag = WAVE_FORMAT_PCM;
 
 	bool bNeedCtrlFrequency = false;
-	// DYNAMIC_SAMPLERATE is usually 0 or some special value
-	if( m_iSampleRate == DYNAMIC_SAMPLERATE )
+	if( m_iSampleRate == DYNAMIC_SAMPLERATE ) // DYNAMIC_SAMPLERATE is usually 0 or some special value
 	{
-		m_iSampleRate = kFallbackSampleRate;
+		m_iSampleRate = 48000; // If dynamic, default to 48000 for now
 		bNeedCtrlFrequency = true;
 	}
 

--- a/src/arch/Sound/RageSoundDriver.h
+++ b/src/arch/Sound/RageSoundDriver.h
@@ -6,7 +6,6 @@
 #include "RageThreads.h"
 #include "RageTimer.h"
 #include "RageUtil_CircularBuffer.h"
-#include "RageSound.h"
 
 #include <cstdint>
 
@@ -67,7 +66,7 @@ public:
 	 * hearing it.  (This isn't necessarily the same as the buffer latency.) */
 	virtual float GetPlayLatency() const { return 0.0f; }
 
-	virtual int GetSampleRate() const { return kFallbackSampleRate; }
+	virtual int GetSampleRate() const { return 48000; }
 
 protected:
 	/* Start the decoding.  This should be called once the hardware is set up and

--- a/src/arch/Sound/RageSoundDriver_AU.mm
+++ b/src/arch/Sound/RageSoundDriver_AU.mm
@@ -151,9 +151,7 @@ RString RageSoundDriver_AU::Init()
 	streamFormat.mBitsPerChannel = kBitsPerChannel;
 
 	if( streamFormat.mSampleRate <= 0.0 )
-	{
-		streamFormat.mSampleRate = kFallbackSampleRate;
-	}
+		streamFormat.mSampleRate = 48000.0;
 	m_iSampleRate = int( streamFormat.mSampleRate );
 	m_TimeScale = streamFormat.mSampleRate / AudioGetHostClockFrequency();
 

--- a/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
@@ -97,10 +97,7 @@ RString RageSoundDriver_DSound_Software::Init()
 	m_pPCM = new DSoundBuf;
 	m_iSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
 	if( m_iSampleRate == 0 )
-	{
-		m_iSampleRate = kFallbackSampleRate;
-	}
-	// This m_iSampleRate (driver's) is then passed as the iSampleRate parameter to DSoundBuf::Init()
+		m_iSampleRate = 48000;
 	sError = m_pPCM->Init( ds, DSoundBuf::HW_DONT_CARE, channels, m_iSampleRate, 16, g_iMaxWriteahead );
 	if( sError != "" )
 		return sError;

--- a/src/arch/Sound/RageSoundDriver_Null.cpp
+++ b/src/arch/Sound/RageSoundDriver_Null.cpp
@@ -31,9 +31,8 @@ int64_t RageSoundDriver_Null::GetPosition() const
 RageSoundDriver_Null::RageSoundDriver_Null()
 {
 	m_iSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
-	{
-    	m_iSampleRate = kFallbackSampleRate;
-	}
+	if( m_iSampleRate == 0 )
+		m_iSampleRate = 48000;
 	m_iLastCursorPos = GetPosition();
 	StartDecodeThread();
 }

--- a/src/arch/Sound/RageSoundDriver_OSS.cpp
+++ b/src/arch/Sound/RageSoundDriver_OSS.cpp
@@ -181,34 +181,26 @@ RString RageSoundDriver_OSS::Init()
 	if( sError != "" )
 		return sError;
 
-	int fmt_val = AFMT_S16_LE;
-	if(ioctl(fd, SNDCTL_DSP_SETFMT, &fmt_val) == -1)
-		return ssprintf( "RageSoundDriver_OSS: ioctl(SNDCTL_DSP_SETFMT, %i): %s", fmt_val, strerror(errno) );
-	if(fmt_val != AFMT_S16_LE)
-		return ssprintf( "RageSoundDriver_OSS: Wanted format %i, got %i instead", AFMT_S16_LE, fmt_val );
+	int i = AFMT_S16_LE;
+	if(ioctl(fd, SNDCTL_DSP_SETFMT, &i) == -1)
+		return ssprintf( "RageSoundDriver_OSS: ioctl(SNDCTL_DSP_SETFMT, %i): %s", i, strerror(errno) );
+	if(i != AFMT_S16_LE)
+		return ssprintf( "RageSoundDriver_OSS: Wanted format %i, got %i instead", AFMT_S16_LE, i );
 
-	int channels_val = channels;
-	if(ioctl(fd, SNDCTL_DSP_CHANNELS, &channels_val) == -1)
-		return ssprintf( "RageSoundDriver_OSS: ioctl(SNDCTL_DSP_CHANNELS, %i): %s", channels_val, strerror(errno) );
-	if(channels_val != channels)
-		return ssprintf( "RageSoundDriver_OSS: Wanted %i channels, got %i instead", channels, channels_val );
+	i = channels;
+	if(ioctl(fd, SNDCTL_DSP_CHANNELS, &i) == -1)
+		return ssprintf( "RageSoundDriver_OSS: ioctl(SNDCTL_DSP_CHANNELS, %i): %s", i, strerror(errno) );
+	if(i != channels)
+		return ssprintf( "RageSoundDriver_OSS: Wanted %i channels, got %i instead", channels, i );
 
-	// Determine the target sample rate based on preference
-	int targetSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
-	if (targetSampleRate == 0)
-	{
-		targetSampleRate = kFallbackSampleRate;
-	}
-	
-	samplerate = targetSampleRate; // Attempt to set this rate
-	if(ioctl(fd, SNDCTL_DSP_SPEED, &samplerate) == -1 ) // Pass 'samplerate' (member var) by address
-		return ssprintf( "RageSoundDriver_OSS: ioctl(SNDCTL_DSP_SPEED, %i): %s", targetSampleRate, strerror(errno) );
-	// samplerate now holds the actual rate set by the driver
-	LOG->Trace("RageSoundDriver_OSS: Requested sample rate %i, got %i", targetSampleRate, samplerate);
-
-	int frag_val = (num_chunks << 16) + chunk_order;
-	if(ioctl(fd, SNDCTL_DSP_SETFRAGMENT, &frag_val) == -1)
-		return ssprintf( "RageSoundDriver_OSS: ioctl(SNDCTL_DSP_SETFRAGMENT, %i): %s", frag_val, strerror(errno) );
+	i = 48000;
+	if(ioctl(fd, SNDCTL_DSP_SPEED, &i) == -1 )
+		return ssprintf( "RageSoundDriver_OSS: ioctl(SNDCTL_DSP_SPEED, %i): %s", i, strerror(errno) );
+	samplerate = i;
+	LOG->Trace("RageSoundDriver_OSS: sample rate %i", samplerate);
+	i = (num_chunks << 16) + chunk_order;
+	if(ioctl(fd, SNDCTL_DSP_SETFRAGMENT, &i) == -1)
+		return ssprintf( "RageSoundDriver_OSS: ioctl(SNDCTL_DSP_SETFRAGMENT, %i): %s", i, strerror(errno) );
 	StartDecodeThread();
 
 	MixingThread.SetName( "RageSoundDriver_OSS" );

--- a/src/arch/Sound/RageSoundDriver_PulseAudio.cpp
+++ b/src/arch/Sound/RageSoundDriver_PulseAudio.cpp
@@ -29,9 +29,7 @@ m_PulseMainLoop(nullptr), m_PulseCtx(nullptr), m_PulseStream(nullptr)
 {
 	m_ss.rate = PREFSMAN->m_iSoundPreferredSampleRate;
 	if( m_ss.rate == 0 )
-	{
-		m_ss.rate = kFallbackSampleRate;
-	}
+		m_ss.rate = 48000;
 }
 
 RageSoundDriver_PulseAudio::~RageSoundDriver_PulseAudio()
@@ -126,23 +124,27 @@ RString RageSoundDriver_PulseAudio::Init()
 void RageSoundDriver_PulseAudio::m_InitStream(void)
 {
 	int error;
-	pa_sample_spec ss_local; // Use a local pa_sample_spec for setup
+	pa_sample_spec ss;
 	pa_channel_map map;
 
 	/* init sample spec */
-	ss_local.format = PA_SAMPLE_S16LE;
-	ss_local.channels = 2;
-	ss_local.rate = m_ss.rate; // Use the rate initialized in the constructor's m_ss
+	ss.format = PA_SAMPLE_S16LE;
+	ss.channels = 2;
+	ss.rate = PREFSMAN->m_iSoundPreferredSampleRate;
+	if(ss.rate == 0)
+	{
+		ss.rate = 48000;
+	}
 
 	/* init channel map */
 	pa_channel_map_init_stereo(&map);
 
 	/* check sample spec */
-	if(!pa_sample_spec_valid(&ss_local))
+	if(!pa_sample_spec_valid(&ss))
 	{
 		if(asprintf(&m_Error, "invalid sample spec!") == -1)
 		{
-			m_Error = nullptr; // asprintf failed to allocate memory
+			m_Error = nullptr;
 		}
 		m_Sem.Post();
 		return;
@@ -150,17 +152,17 @@ void RageSoundDriver_PulseAudio::m_InitStream(void)
 
 	/* log the used sample spec */
 	char specstring[PA_SAMPLE_SPEC_SNPRINT_MAX];
-	pa_sample_spec_snprint(specstring, sizeof(specstring), &ss_local);
+	pa_sample_spec_snprint(specstring, sizeof(specstring), &ss);
 	LOG->Trace("Pulse: using sample spec: %s", specstring);
 
 	/* create the stream */
 	LOG->Trace("Pulse: pa_stream_new()...");
-	m_PulseStream = pa_stream_new(m_PulseCtx, PRODUCT_FAMILY " Audio", &ss_local, &map);
+	m_PulseStream = pa_stream_new(m_PulseCtx, PRODUCT_FAMILY " Audio", &ss, &map);
 	if(m_PulseStream == nullptr)
 	{
 		if(asprintf(&m_Error, "pa_stream_new(): %s", pa_strerror(pa_context_errno(m_PulseCtx))) == -1)
 		{
-			m_Error = nullptr; // asprintf failed to allocate memory
+			m_Error = nullptr;
 		}
 		m_Sem.Post();
 		return;
@@ -170,13 +172,13 @@ void RageSoundDriver_PulseAudio::m_InitStream(void)
 	* needs data */
 	pa_stream_set_write_callback(m_PulseStream, StaticStreamWriteCb, this);
 
-	/* set the state callback, it will be called when the stream state will
+	/* set the state callback, it will be called the the stream state will
 	* change */
 	pa_stream_set_state_callback(m_PulseStream, StaticStreamStateCb, this);
 
 	/* configure attributes of the stream */
 	pa_buffer_attr attr;
-	memset(&attr, 0x00, sizeof(attr)); // Initialize all members to 0/nullptr
+	memset(&attr, 0x00, sizeof(attr));
 
 	/* tlength: Target length of the buffer.
 	*
@@ -191,7 +193,7 @@ void RageSoundDriver_PulseAudio::m_InitStream(void)
 	* We don't want the default here, we want a small latency.
 	* We use pa_usec_to_bytes() to convert a latency to a buffer size.
 	*/
-	attr.tlength = pa_usec_to_bytes(20*PA_USEC_PER_MSEC, &ss_local); // Use local ss_local
+	attr.tlength = pa_usec_to_bytes(20*PA_USEC_PER_MSEC, &ss);
 
 	/* maxlength: Maximum length of the buffer
 	*
@@ -213,7 +215,7 @@ void RageSoundDriver_PulseAudio::m_InitStream(void)
 	* (uint32_t)-1 is NOT working here, setting it to 0, like
 	* openal-soft-pulseaudio does.
 	*/
-	attr.minreq = 0; // Setting to (uint32_t)-1 caused issues in some environments. 0 is safer.
+	attr.minreq = 0;
 
 	/* prebuf: Pre-buffering
 	*
@@ -224,21 +226,14 @@ void RageSoundDriver_PulseAudio::m_InitStream(void)
 	*/
 	attr.prebuf = (uint32_t)-1;
 
-	/* fragsize: Deprecated. Use tlength, prebuf, minreq, maxlength instead.
-	 * Ensure it's not used by setting to (uint32_t)-1, as per PA documentation.
-	 */
-	attr.fragsize = (uint32_t)-1;
-
-
 	/* log the used target buffer length */
 	LOG->Trace("Pulse: using target buffer length of %i bytes", attr.tlength);
 
 	 /* connect the stream for playback */
 	LOG->Trace("Pulse: pa_stream_connect_playback()...");
 	const int flags = PA_STREAM_INTERPOLATE_TIMING
-		| PA_STREAM_NOT_MONOTONIC // mHostTime may not be monotonic in some cases
-		| PA_STREAM_AUTO_TIMING_UPDATE
-		| PA_STREAM_ADJUST_LATENCY; // Allow server to adjust latency based on our buffer_attr
+		| PA_STREAM_NOT_MONOTONIC
+		| PA_STREAM_AUTO_TIMING_UPDATE;
 	error = pa_stream_connect_playback(m_PulseStream, nullptr, &attr,
 			static_cast<pa_stream_flags_t>(flags), nullptr, nullptr);
 	if(error < 0)
@@ -246,21 +241,13 @@ void RageSoundDriver_PulseAudio::m_InitStream(void)
 		if(asprintf(&m_Error, "pa_stream_connect_playback(): %s",
 				pa_strerror(pa_context_errno(m_PulseCtx))) == -1)
 		{
-			m_Error = nullptr; // asprintf failed to allocate memory
+			m_Error = nullptr;
 		}
 		m_Sem.Post();
 		return;
 	}
 
-	// m_ss is the member variable. After successfully connecting the stream,
-	// we can be more confident about the sample spec being used.
-	// It's generally good practice to update m_ss with the spec that was
-	// actually used to create the stream, in case the server negotiated
-	// something slightly different (though with PA_SAMPLE_S16LE, 2ch, and specific rates,
-	// it's less likely to change).
-	m_ss = ss_local;
-
-	// Semaphore is posted in StreamStateCb when stream becomes PA_STREAM_READY
+	m_ss = ss;
 }
 
 void RageSoundDriver_PulseAudio::CtxStateCb(pa_context *c)

--- a/src/arch/Sound/RageSoundDriver_PulseAudio.cpp
+++ b/src/arch/Sound/RageSoundDriver_PulseAudio.cpp
@@ -172,7 +172,7 @@ void RageSoundDriver_PulseAudio::m_InitStream(void)
 	* needs data */
 	pa_stream_set_write_callback(m_PulseStream, StaticStreamWriteCb, this);
 
-	/* set the state callback, it will be called the the stream state will
+	/* set the state callback, it will be called when the stream state will
 	* change */
 	pa_stream_set_state_callback(m_PulseStream, StaticStreamStateCb, this);
 

--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -141,7 +141,7 @@ RString RageSoundDriver_WaveOut::Init()
 	wo_samplerate_ = PREFSMAN->m_iSoundPreferredSampleRate;
 	if( wo_samplerate_ == 0 )
 	{
-		wo_samplerate_ = kFallbackSampleRate;
+		wo_samplerate_ = 48000;
 	}
 
 	wo_num_blocks_ = CalculateNumBlocks( wo_samplerate_ );


### PR DESCRIPTION
This is fairly critical;  along with the pacdrive bug fix, should especially be pushed to public setups ASAP in my opinion.

With this PR merged, we won't have to touch RageSound again for a very long time (unless it's being replaced by a different audio I/O library).

<details>

# Context

The builds made from the branch in this PR are confirmed to be stable on sync, so I'm urgently recommending merging, because 1.1.0 player experience has been negative from what I've been seeing on Twitch, including on public setups.

# Why this is necessary

@teejusb if you remember the recently merged RagesoundReader_Merge bugfix,  that actually ended up being a significant regression in sync stability. Afterwards, i applied the same change to an identical instance of that code appearing in RageSoundReader_Chain and distributed that build, which turned out to be unusable.

**What went wrong?  We followed the comments, because we believed they were correct and accurately represented the code they accompanied.**

What I found out is that what is happening in the code does **not** match what is happening in the comments, and the code which I repaired and @teejusb merged is actively detrimental and unwanted in game.

Because of the realization that RageSound's comments can't be trusted, I urge putting it back to the way it was for the hardcoded 48000 build that so many people had a very good experience with. It should then be left in its working/stable state. 

This implementation is safe because Windows prefers 48khz by default, ALSA/OSS prefer 48khz and often negotiate it directly with the hardware. Additionally, Mac and ALSA can handle real-time resampling without timing related issues (which can't be said for Windows)

# Explanation of PR changes

On the surface, this undoes the `kFallbackSampleRate` changes so that the values are hardcoded.  That **shouldn't** make any difference, but this diff is what prevents the game from falling apart. That is how fragile our audio backend is.

As stated in the above comment, this reverts commit c80da544f1a5def3acdf9dae12f8e89dfcf203cb, because sync was reported to be better when this code block was non-functional. 

(It's probably safe to delete this nonfunctional code, here and `RageSoundReader_Chain`, rather than restore the old code, but I'd prefer to put it back how it was, to ensure original behavior is maintained, rather than tinker further with RageSoundReader. It should be left alone after this, as it's in a very stable place in this branch. There are probably some remaining small optimizations, but likely not much compared to the current state of stability.)

Players have confirmed that the build this branch produces is as stable as the original "48000 exe" (based on 1.0.2). I have rolled back affected files to the commit af127ca23b32aaf53df9cd177da0d5200a34e0ee. _Note that I don't know if the pulseaudio driver changes in this PR are wanted, but I'll let someone who is more familiar with that code speak to that._ 

</details>