### PR TITLE
PumpHID (LXIO) Support

### DIFF
--- a/src/CMakeData-arch.cmake
+++ b/src/CMakeData-arch.cmake
@@ -251,8 +251,10 @@ source_group("Arch Specific\\\\Lights"
              ${SMDATA_ARCH_LIGHTS_HPP})
 
 list(APPEND SMDATA_ARCH_INPUT_SRC "arch/InputHandler/InputHandler.cpp"
+            "arch/InputHandler/InputHandler_PumpHID.cpp"
             "arch/InputHandler/InputHandler_MonkeyKeyboard.cpp")
 list(APPEND SMDATA_ARCH_INPUT_HPP "arch/InputHandler/InputHandler.h"
+            "arch/InputHandler/InputHandler_PumpHID.h"
             "arch/InputHandler/InputHandler_MonkeyKeyboard.h")
 
 if(WIN32)

--- a/src/RageInputDevice.cpp
+++ b/src/RageInputDevice.cpp
@@ -235,6 +235,7 @@ static const char *InputDeviceNames[] = {
 	"Midi",
 	"Mouse",
 	"PIUIO",
+	"PumpHID",
 };
 XToString( InputDevice );
 StringToX( InputDevice );

--- a/src/RageInputDevice.h
+++ b/src/RageInputDevice.h
@@ -51,6 +51,7 @@ enum InputDevice
 	DEVICE_MIDI,
 	DEVICE_MOUSE,
 	DEVICE_PIUIO,
+	DEVICE_PUMPHID,
 	NUM_InputDevice,		// leave this at the end
 	InputDevice_Invalid		// means this is nullptr
 };

--- a/src/arch/InputHandler/InputHandler_PumpHID.cpp
+++ b/src/arch/InputHandler/InputHandler_PumpHID.cpp
@@ -1,0 +1,268 @@
+// do NOT let clang reposition these includes, because it will mess up the
+// compile
+
+// clang-format off
+#include "global.h"
+#include "InputHandler_PumpHID.h"
+#include "PrefsManager.h"
+#include "RageLog.h"
+#include "RageUtil.h"
+#include "arch/Lights/LightsDriver_Export.h"
+#include "GameState.h"
+#include "Game.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <set>
+#include <vector>
+
+#if defined(HAVE_UNISTD_H)
+#include <unistd.h>
+#endif
+#if defined(HAVE_FCNTL_H)
+#include <fcntl.h>
+#endif
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include "hidapi.h"
+// clang-format on
+
+const std::vector<int> InputHandler_PumpHID::devPIDS = {
+    PUMPHID_PID_V1, PUMPHID_PID_V2};
+
+REGISTER_INPUT_HANDLER_CLASS(PumpHID);
+
+InputHandler_PumpHID::InputHandler_PumpHID() {
+  // clear buffers etc.
+
+  dev = new HidDevice(PUMPHID_VID, devPIDS, 0);
+
+  memset(msg_to_device.raw_buff, PUMPHID_DEF_LIGHTS, sizeof(msg_to_device));
+  memset(msg_from_device.raw_buff, PUMPHID_DEF_INPUT, sizeof(msg_from_device));
+
+  m_bShutdown = false;
+
+  if (IsConnected() && PREFSMAN->m_bThreadedInput) {
+    InputThread.SetName("PumpHID thread");
+    InputThread.Create(InputThread_Start, this);
+  }
+}
+
+InputHandler_PumpHID::~InputHandler_PumpHID() {
+  // disconnect cleanup etc
+  if (InputThread.IsCreated()) {
+    m_bShutdown = true;
+    LOG->Trace("Shutting down PumpHID thread ...");
+    InputThread.Wait();
+    LOG->Trace("PumpHID thread shut down.");
+
+    // turn off all of the lights manually.
+    memset(msg_to_device.raw_buff, PUMPHID_DEF_LIGHTS, sizeof(msg_to_device));
+    dev->Write(msg_to_device.raw_buff, PUMPHID_PAYLOADSIZE_TODEV);
+  }
+}
+
+RString InputHandler_PumpHID::GetDeviceSpecificInputString(
+    const DeviceInput& di) {
+  return InputHandler::GetDeviceSpecificInputString(di);
+}
+
+void InputHandler_PumpHID::GetDevicesAndDescriptions(
+    std::vector<InputDeviceInfo>& vDevicesOut) {
+  // We use a joystick device so we can get automatic input mapping
+  vDevicesOut.push_back(
+      InputDeviceInfo(InputDevice(PUMPHID_DEVICEID), "PumpHID"));
+}
+
+int InputHandler_PumpHID::InputThread_Start(void* p) {
+  ((InputHandler_PumpHID*)p)->InputThreadMain();
+  return 0;
+}
+
+void InputHandler_PumpHID::InputThreadMain() {
+  uint32_t newInput = 0;
+  LightsState newLS;
+
+  uint32_t prevInput = 0;
+  LightsState prevLS;
+
+  while (!m_bShutdown) {
+    newLS = LightsDriver_Export::GetState();
+
+    // even though we need to write to the PumpHID every cycle (otherwise it
+    // will lock up) we don't need to make a new message every time because you
+    // know it hasn't changed.
+    if (IsLightChange(prevLS, newLS)) {
+      CreateLightingMessage(newLS);
+    }
+
+    // hidapi always wants a report id for the device
+    // yet the PumpHID device doesn't have one, so make sure it's always zero
+    msg_to_device.report_id_pad = 0;
+
+    // push lighting state
+    dev->Write(msg_to_device.raw_buff, PUMPHID_PAYLOADSIZE_TODEV);
+
+    // pull input state
+    int rtn = dev->Read(msg_from_device.raw_buff, PUMPHID_PAYLOADSIZE_FROMDEV);
+    newInput = PumpHIDToLocalState();
+
+    // debugging pay no attention
+    // LOG->Info("%d | %08x", rtn, newInput);
+
+    // don't flood the engine with states that are not different.
+    if (prevInput != newInput) {
+      PushInputStateToEngine(newInput);
+    }
+
+    prevLS = newLS;
+    prevInput = newInput;
+  }
+}
+
+void InputHandler_PumpHID::CreateLightingMessage(LightsState newLS) {
+  // clear the state and recreate.
+  memset(msg_to_device.raw_buff, PUMPHID_DEF_LIGHTS, sizeof(msg_to_device));
+
+  // lights are active high, so we can just set them as booleans.
+
+  // check to see which game we are running as it can change during gameplay.
+  const InputScheme* pInput = &GAMESTATE->GetCurrentGame()->m_InputScheme;
+  RString sInputName = pInput->m_szName;
+
+  if (EqualsNoCase(sInputName, "dance")) {
+    msg_to_device.lamp_p1_ul =
+        newLS.m_bGameButtonLights[GameController_1][DANCE_BUTTON_UP];
+    msg_to_device.lamp_p1_ur =
+        newLS.m_bGameButtonLights[GameController_1][DANCE_BUTTON_DOWN];
+    msg_to_device.lamp_p1_c =
+        newLS.m_bGameButtonLights[GameController_1][DANCE_BUTTON_LEFT];
+    msg_to_device.lamp_p1_ll =
+        newLS.m_bGameButtonLights[GameController_1][DANCE_BUTTON_RIGHT];
+
+    msg_to_device.lamp_p2_ul =
+        newLS.m_bGameButtonLights[GameController_2][DANCE_BUTTON_UP];
+    msg_to_device.lamp_p2_ur =
+        newLS.m_bGameButtonLights[GameController_2][DANCE_BUTTON_DOWN];
+    msg_to_device.lamp_p2_c =
+        newLS.m_bGameButtonLights[GameController_2][DANCE_BUTTON_LEFT];
+    msg_to_device.lamp_p2_ll =
+        newLS.m_bGameButtonLights[GameController_2][DANCE_BUTTON_RIGHT];
+  } else if (EqualsNoCase(sInputName, "pump")) {
+    msg_to_device.lamp_p1_ul =
+        newLS.m_bGameButtonLights[GameController_1][PUMP_BUTTON_UPLEFT];
+    msg_to_device.lamp_p1_ur =
+        newLS.m_bGameButtonLights[GameController_1][PUMP_BUTTON_UPRIGHT];
+    msg_to_device.lamp_p1_c =
+        newLS.m_bGameButtonLights[GameController_1][PUMP_BUTTON_CENTER];
+    msg_to_device.lamp_p1_ll =
+        newLS.m_bGameButtonLights[GameController_1][PUMP_BUTTON_DOWNLEFT];
+    msg_to_device.lamp_p1_lr =
+        newLS.m_bGameButtonLights[GameController_1][PUMP_BUTTON_DOWNRIGHT];
+
+    msg_to_device.lamp_p2_ul =
+        newLS.m_bGameButtonLights[GameController_2][PUMP_BUTTON_UPLEFT];
+    msg_to_device.lamp_p2_ur =
+        newLS.m_bGameButtonLights[GameController_2][PUMP_BUTTON_UPRIGHT];
+    msg_to_device.lamp_p2_c =
+        newLS.m_bGameButtonLights[GameController_2][PUMP_BUTTON_CENTER];
+    msg_to_device.lamp_p2_ll =
+        newLS.m_bGameButtonLights[GameController_2][PUMP_BUTTON_DOWNLEFT];
+    msg_to_device.lamp_p2_lr =
+        newLS.m_bGameButtonLights[GameController_2][PUMP_BUTTON_DOWNRIGHT];
+  }
+
+  // TODO how to handle Menu U/D/L/R vs lx cabs UR/UL/C etc
+  // menu buttons.
+  msg_to_device.menu_p1_cn =
+      newLS.m_bGameButtonLights[GameController_1][GAME_BUTTON_START];
+
+  msg_to_device.menu_p2_cn =
+      newLS.m_bGameButtonLights[GameController_1][GAME_BUTTON_START];
+
+  // cabinet lights
+  msg_to_device.lamp_mar_ul = newLS.m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT];
+  msg_to_device.lamp_maq_ur = newLS.m_bCabinetLights[LIGHT_MARQUEE_UP_RIGHT];
+  msg_to_device.lamp_maq_ll = newLS.m_bCabinetLights[LIGHT_MARQUEE_LR_LEFT];
+  msg_to_device.lamp_maq_lr = newLS.m_bCabinetLights[LIGHT_MARQUEE_LR_RIGHT];
+
+  msg_to_device.lamp_neon = newLS.m_bCabinetLights[LIGHT_BASS_LEFT] ||
+                            newLS.m_bCabinetLights[LIGHT_BASS_RIGHT];
+
+  msg_to_device.lamp_coin_pulse = newLS.m_bCoinCounter;
+
+  // static values to match.
+  msg_to_device.lamp_alwayson0 = true;
+  msg_to_device.lamp_alwayson1 = true;
+  msg_to_device.lamp_alwaysoff0 = false;
+}
+
+uint32_t InputHandler_PumpHID::PumpHIDToLocalState() {
+  // device is active low, but stepmania is active high.
+  for (int i = 0; i < PUMPHID_PAYLOADSIZE_FROMDEV; i++) {
+    msg_from_device.raw_buff[i] = ~msg_from_device.raw_buff[i];
+  }
+
+  // TODO: expose the raw individual sensor values to lua to allow someone to
+  // write a nice test input screen for debugging. See ITG3's theme and oITG for
+  // inspiration.
+  uint8_t p1 = msg_from_device.p1_sensor0.raw | msg_from_device.p1_sensor1.raw |
+               msg_from_device.p1_sensor2.raw | msg_from_device.p1_sensor3.raw;
+
+  uint8_t p2 = msg_from_device.p2_sensor0.raw | msg_from_device.p2_sensor1.raw |
+               msg_from_device.p2_sensor2.raw | msg_from_device.p2_sensor3.raw;
+
+  // newer firmwares of the pump hid are WEIRD about this, so just pull out the
+  // bits we want test, coin, service, and clear from p1, and just coin from p2.
+  uint8_t cab = 0;
+  cab |= msg_from_device.cab0.btn_TEST << 0;
+  cab |= msg_from_device.cab0.btn_SERVICE << 1;
+  cab |= msg_from_device.cab0.btn_CLR << 2;
+  cab |= msg_from_device.cab0.btn_COIN << 3;
+  cab |= msg_from_device.cab1.btn_COIN << 4;
+
+  // we should now have a clean active high message,
+  // so let's concat it into a
+  // local message.
+  // squish it into bit packs of five.
+  return (p1 << 0) | (p2 << (5)) | (msg_from_device.p1_menu.raw << (10)) |
+         (msg_from_device.p2_menu.raw << (15)) | (cab << (20));
+}
+
+void InputHandler_PumpHID::PushInputStateToEngine(std::uint32_t newInput) {
+  for (int i = 0; i < 32; i++) {
+    bool pressed = (newInput & (1 << i));
+
+    DeviceInput di(PUMPHID_DEVICEID, enum_add2(JOY_BUTTON_1, i), pressed);
+
+    // If we're in a thread, our timestamp is accurate.
+    if (InputThread.IsCreated()) {
+      di.ts.Touch();
+    }
+
+    ButtonPressed(di);
+  }
+}
+
+bool InputHandler_PumpHID::IsLightChange(
+    LightsState prevLS, LightsState newLS) {
+  FOREACH_CabinetLight(light) {
+    if (prevLS.m_bCabinetLights[light] != newLS.m_bCabinetLights[light]) {
+      return true;
+    }
+  }
+
+  for (int gc = 0; gc < NUM_GameController; gc++) {
+    FOREACH_ENUM(GameButton, gb) {
+      if (prevLS.m_bGameButtonLights[gc][gb] !=
+          newLS.m_bGameButtonLights[gc][gb]) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}

--- a/src/arch/InputHandler/InputHandler_PumpHID.cpp
+++ b/src/arch/InputHandler/InputHandler_PumpHID.cpp
@@ -131,7 +131,7 @@ void InputHandler_PumpHID::InputThreadMain() {
       PushInputStateToEngine(newInput);
 
       // debugging pay no attention
-      // LOG->Info("%d | %08x", rtn, newInput);
+      // LOG->Info("%d | %08x", readRtn, newInput);
     }
 
     prevLS = newLS;

--- a/src/arch/InputHandler/InputHandler_PumpHID.cpp
+++ b/src/arch/InputHandler/InputHandler_PumpHID.cpp
@@ -89,7 +89,7 @@ void InputHandler_PumpHID::InputThreadMain() {
   LightsState newLS;
 
   uint32_t prevInput = 0;
-  LightsState prevLS;
+  LightsState prevLS = {};
 
   while (!m_bShutdown) {
     newLS = LightsDriver_Export::GetState();

--- a/src/arch/InputHandler/InputHandler_PumpHID.cpp
+++ b/src/arch/InputHandler/InputHandler_PumpHID.cpp
@@ -111,7 +111,7 @@ void InputHandler_PumpHID::InputThreadMain() {
         dev->Write(msg_to_device.raw_buff, PUMPHID_PAYLOADSIZE_TODEV);
 
     if (writeRtn != HidResults::Success) {
-      LOG->Warn("PumpHID write read fail %d", writeRtn);
+      LOG->Warn("PumpHID write fail %d", writeRtn);
       continue;
     }
 

--- a/src/arch/InputHandler/InputHandler_PumpHID.cpp
+++ b/src/arch/InputHandler/InputHandler_PumpHID.cpp
@@ -75,9 +75,8 @@ RString InputHandler_PumpHID::GetDeviceSpecificInputString(
 
 void InputHandler_PumpHID::GetDevicesAndDescriptions(
     std::vector<InputDeviceInfo>& vDevicesOut) {
-  // We use a joystick device so we can get automatic input mapping
   vDevicesOut.push_back(
-      InputDeviceInfo(InputDevice(PUMPHID_DEVICEID), "PumpHID"));
+      InputDeviceInfo(InputDevice(DEVICE_PUMPHID), "PumpHID"));
 }
 
 int InputHandler_PumpHID::InputThread_Start(void* p) {
@@ -125,7 +124,7 @@ void InputHandler_PumpHID::InputThreadMain() {
     }
 
     // convert it to a local value.
-    newInput = PumpHIDToLocalState();
+    newInput = PumpHIDToLocalState(msg_from_device);
 
     // don't flood the engine with states that are not different.
     if (prevInput != newInput) {
@@ -217,49 +216,58 @@ void InputHandler_PumpHID::CreateLightingMessage(LightsState newLS) {
   msg_to_device.lamp_alwaysoff0 = false;
 }
 
-uint32_t InputHandler_PumpHID::PumpHIDToLocalState() {
-  // device is active low, but stepmania is active high.
-  // so bit flip them.
+uint32_t InputHandler_PumpHID::PumpHIDToLocalState(
+    pumphid_output_state_t from_dev) {
+  // active low state to stepmania
+  pumphid_to_stepmania_t state;
+  state.raw = 0;
+
+  // the device is active low, but active high easier to understand.
+  // bit flip to make the message active high.
   for (int i = 0; i < PUMPHID_PAYLOADSIZE_FROMDEV; i++) {
-    msg_from_device.raw_buff[i] = ~msg_from_device.raw_buff[i];
+    from_dev.raw_buff[i] = ~from_dev.raw_buff[i];
   }
 
   // TODO: expose the raw individual sensor values to lua to allow someone to
   // write a nice test input screen for debugging. See ITG3's theme and oITG for
   // inspiration.
-  uint8_t p1 = msg_from_device.p1_sensor0.raw | msg_from_device.p1_sensor1.raw |
-               msg_from_device.p1_sensor2.raw | msg_from_device.p1_sensor3.raw;
+  uint8_t p1 = from_dev.p1_sensor0.raw | from_dev.p1_sensor1.raw |
+               from_dev.p1_sensor2.raw | from_dev.p1_sensor3.raw;
 
-  uint8_t p2 = msg_from_device.p2_sensor0.raw | msg_from_device.p2_sensor1.raw |
-               msg_from_device.p2_sensor2.raw | msg_from_device.p2_sensor3.raw;
+  uint8_t p2 = from_dev.p2_sensor0.raw | from_dev.p2_sensor1.raw |
+               from_dev.p2_sensor2.raw | from_dev.p2_sensor3.raw;
 
   // newer firmwares of the pump hid are WEIRD about this, so just pull out the
   // bits we want test, coin, service, and clear from p1, and just coin from p2.
   uint8_t cab = 0;
-  cab |= msg_from_device.cab0.btn_TEST << 0;
-  cab |= msg_from_device.cab0.btn_SERVICE << 1;
-  cab |= msg_from_device.cab0.btn_CLR << 2;
-  cab |= msg_from_device.cab0.btn_COIN << 3;
-  cab |= msg_from_device.cab1.btn_COIN << 4;
+  cab |= from_dev.cab0.btn_TEST << 0;
+  cab |= from_dev.cab0.btn_SERVICE << 1;
+  cab |= from_dev.cab0.btn_CLR << 2;
+  cab |= from_dev.cab0.btn_COIN << 3;
+  cab |= from_dev.cab1.btn_COIN << 4;
 
-  // we should now have a clean active high message,
-  // so let's concat it into a local message.
-  // squish it into bit packs of five.
-  uint32_t final_state = 0;
-  final_state |= ((p1 & 0x1F) << 0);
-  final_state |= ((p2 & 0x1F) << 5);
-  final_state |= ((msg_from_device.p1_menu.raw & 0x1F) << 10);
-  final_state |= ((msg_from_device.p2_menu.raw & 0x1F) << 15);
-  final_state |= ((cab & 0x1F) << 20);
+  // so let's jam this all of this info into 32bits.
+  // we are reserving 8bits per player (which covers an itg cab with pumphid
+  // upgrade, since buttons are in there.) five bits per menu (matches the lx
+  // cab) and five for the cab state (test/service/clear/coin1/coin2)
 
-  return final_state;
+  state.p1 = p1;
+  state.p2 = p2;
+  state.p1_menu = (from_dev.p1_menu.raw & 0x1F);
+  state.p2_menu = (from_dev.p2_menu.raw & 0x1F);
+  state.cab = (cab & 0x1F);
+
+  // we have exactly one bit left over in this 32bit word.
+  // don't spend it all in one place.
+
+  return state.raw;
 }
 
 void InputHandler_PumpHID::PushInputStateToEngine(std::uint32_t newInput) {
   for (int i = 0; i < 32; i++) {
     bool pressed = (newInput & (1 << i));
 
-    DeviceInput di(PUMPHID_DEVICEID, enum_add2(JOY_BUTTON_1, i), pressed);
+    DeviceInput di(DEVICE_PUMPHID, enum_add2(JOY_BUTTON_1, i), pressed);
 
     // If we're in a thread, our timestamp is accurate.
     if (InputThread.IsCreated()) {

--- a/src/arch/InputHandler/InputHandler_PumpHID.cpp
+++ b/src/arch/InputHandler/InputHandler_PumpHID.cpp
@@ -107,18 +107,32 @@ void InputHandler_PumpHID::InputThreadMain() {
     msg_to_device.report_id_pad = 0;
 
     // push lighting state
-    dev->Write(msg_to_device.raw_buff, PUMPHID_PAYLOADSIZE_TODEV);
+    HidResults writeRtn =
+        dev->Write(msg_to_device.raw_buff, PUMPHID_PAYLOADSIZE_TODEV);
+
+    if (writeRtn != HidResults::Success) {
+      LOG->Warn("PumpHID write read fail %d", writeRtn);
+      continue;
+    }
 
     // pull input state
-    int rtn = dev->Read(msg_from_device.raw_buff, PUMPHID_PAYLOADSIZE_FROMDEV);
-    newInput = PumpHIDToLocalState();
+    int readRtn =
+        dev->Read(msg_from_device.raw_buff, PUMPHID_PAYLOADSIZE_FROMDEV);
 
-    // debugging pay no attention
-    // LOG->Info("%d | %08x", rtn, newInput);
+    if (readRtn != PUMPHID_PAYLOADSIZE_FROMDEV) {
+      LOG->Warn("PumpHID read fail %d", readRtn);
+      continue;
+    }
+
+    // convert it to a local value.
+    newInput = PumpHIDToLocalState();
 
     // don't flood the engine with states that are not different.
     if (prevInput != newInput) {
       PushInputStateToEngine(newInput);
+
+      // debugging pay no attention
+      // LOG->Info("%d | %08x", rtn, newInput);
     }
 
     prevLS = newLS;

--- a/src/arch/InputHandler/InputHandler_PumpHID.cpp
+++ b/src/arch/InputHandler/InputHandler_PumpHID.cpp
@@ -30,6 +30,7 @@
 #include "hidapi.h"
 // clang-format on
 
+// all of the known device pid's that use this communication protocol.
 const std::vector<int> InputHandler_PumpHID::devPIDS = {
     PUMPHID_PID_V1, PUMPHID_PID_V2};
 
@@ -38,12 +39,14 @@ REGISTER_INPUT_HANDLER_CLASS(PumpHID);
 InputHandler_PumpHID::InputHandler_PumpHID() {
   // clear buffers etc.
 
-  dev = new HidDevice(PUMPHID_VID, devPIDS, 0);
-
   memset(msg_to_device.raw_buff, PUMPHID_DEF_LIGHTS, sizeof(msg_to_device));
   memset(msg_from_device.raw_buff, PUMPHID_DEF_INPUT, sizeof(msg_from_device));
 
   m_bShutdown = false;
+
+  // ensure auto reconnect and blocking reads (since the device wants write/read
+  // cycles properly.)
+  dev = new HidDevice(PUMPHID_VID, devPIDS, PUMPHID_INTERFACE_NUM, true, false);
 
   if (IsConnected() && PREFSMAN->m_bThreadedInput) {
     InputThread.SetName("PumpHID thread");
@@ -138,7 +141,7 @@ void InputHandler_PumpHID::CreateLightingMessage(LightsState newLS) {
         newLS.m_bGameButtonLights[GameController_1][DANCE_BUTTON_UP];
     msg_to_device.lamp_p1_ur =
         newLS.m_bGameButtonLights[GameController_1][DANCE_BUTTON_DOWN];
-    msg_to_device.lamp_p1_c =
+    msg_to_device.lamp_p1_cn =
         newLS.m_bGameButtonLights[GameController_1][DANCE_BUTTON_LEFT];
     msg_to_device.lamp_p1_ll =
         newLS.m_bGameButtonLights[GameController_1][DANCE_BUTTON_RIGHT];
@@ -147,7 +150,7 @@ void InputHandler_PumpHID::CreateLightingMessage(LightsState newLS) {
         newLS.m_bGameButtonLights[GameController_2][DANCE_BUTTON_UP];
     msg_to_device.lamp_p2_ur =
         newLS.m_bGameButtonLights[GameController_2][DANCE_BUTTON_DOWN];
-    msg_to_device.lamp_p2_c =
+    msg_to_device.lamp_p2_cn =
         newLS.m_bGameButtonLights[GameController_2][DANCE_BUTTON_LEFT];
     msg_to_device.lamp_p2_ll =
         newLS.m_bGameButtonLights[GameController_2][DANCE_BUTTON_RIGHT];
@@ -156,7 +159,7 @@ void InputHandler_PumpHID::CreateLightingMessage(LightsState newLS) {
         newLS.m_bGameButtonLights[GameController_1][PUMP_BUTTON_UPLEFT];
     msg_to_device.lamp_p1_ur =
         newLS.m_bGameButtonLights[GameController_1][PUMP_BUTTON_UPRIGHT];
-    msg_to_device.lamp_p1_c =
+    msg_to_device.lamp_p1_cn =
         newLS.m_bGameButtonLights[GameController_1][PUMP_BUTTON_CENTER];
     msg_to_device.lamp_p1_ll =
         newLS.m_bGameButtonLights[GameController_1][PUMP_BUTTON_DOWNLEFT];
@@ -167,7 +170,7 @@ void InputHandler_PumpHID::CreateLightingMessage(LightsState newLS) {
         newLS.m_bGameButtonLights[GameController_2][PUMP_BUTTON_UPLEFT];
     msg_to_device.lamp_p2_ur =
         newLS.m_bGameButtonLights[GameController_2][PUMP_BUTTON_UPRIGHT];
-    msg_to_device.lamp_p2_c =
+    msg_to_device.lamp_p2_cn =
         newLS.m_bGameButtonLights[GameController_2][PUMP_BUTTON_CENTER];
     msg_to_device.lamp_p2_ll =
         newLS.m_bGameButtonLights[GameController_2][PUMP_BUTTON_DOWNLEFT];
@@ -202,6 +205,7 @@ void InputHandler_PumpHID::CreateLightingMessage(LightsState newLS) {
 
 uint32_t InputHandler_PumpHID::PumpHIDToLocalState() {
   // device is active low, but stepmania is active high.
+  // so bit flip them.
   for (int i = 0; i < PUMPHID_PAYLOADSIZE_FROMDEV; i++) {
     msg_from_device.raw_buff[i] = ~msg_from_device.raw_buff[i];
   }
@@ -225,11 +229,16 @@ uint32_t InputHandler_PumpHID::PumpHIDToLocalState() {
   cab |= msg_from_device.cab1.btn_COIN << 4;
 
   // we should now have a clean active high message,
-  // so let's concat it into a
-  // local message.
+  // so let's concat it into a local message.
   // squish it into bit packs of five.
-  return (p1 << 0) | (p2 << (5)) | (msg_from_device.p1_menu.raw << (10)) |
-         (msg_from_device.p2_menu.raw << (15)) | (cab << (20));
+  uint32_t final_state = 0;
+  final_state |= ((p1 & 0x1F) << 0);
+  final_state |= ((p2 & 0x1F) << 5);
+  final_state |= ((msg_from_device.p1_menu.raw & 0x1F) << 10);
+  final_state |= ((msg_from_device.p2_menu.raw & 0x1F) << 15);
+  final_state |= ((cab & 0x1F) << 20);
+
+  return final_state;
 }
 
 void InputHandler_PumpHID::PushInputStateToEngine(std::uint32_t newInput) {

--- a/src/arch/InputHandler/InputHandler_PumpHID.h
+++ b/src/arch/InputHandler/InputHandler_PumpHID.h
@@ -7,12 +7,12 @@
  * This driver needs user read/write access the device.
  * This can be achieved by using a udev rule like this:
  *
- * SUBSYSTEMS=="usb", ATTRS{idVendor}=="0D2F", ATTRS{idProduct}=="1040",
+ * SUBSYSTEMS=="usb", ATTRS{idVendor}=="0d2f", ATTRS{idProduct}=="1020",
  * OWNER="dance", GROUP="dance", MODE="0660"
  *
  * or
  *
- * KERNEL=="hidraw*", ATTRS{idVendor}=="0D2F", ATTRS{idProduct}=="1020",
+ * KERNEL=="hidraw*", ATTRS{idVendor}=="0d2f", ATTRS{idProduct}=="1020",
  * OWNER="dance", GROUP="dance", MODE="0660"
  *
  * Refer to your distribution's documentation on how to properly apply a udev

--- a/src/arch/InputHandler/InputHandler_PumpHID.h
+++ b/src/arch/InputHandler/InputHandler_PumpHID.h
@@ -1,0 +1,217 @@
+#ifndef INPUT_HANDLER_PUMPHID
+#define INPUT_HANDLER_PUMPHID
+
+#include <vector>
+
+#include "InputHandler.h"
+#include "RageThreads.h"
+#include "arch/Lights/LightsDriver_Export.h"
+#include "archutils/Common/HidDevice.h"
+
+#define PUMPHID_DEVICEID DEVICE_JOY1
+#define PUMPHID_PAYLOADSIZE_FROMDEV 16
+
+// hidapi wants a blank report ID, but since this device doesn't use that
+// we have to add a byte just to compensate.
+#define PUMPHID_PAYLOADSIZE_TODEV (16 + 1)
+
+// active high lights, active low input.
+#define PUMPHID_DEF_LIGHTS 0x00
+#define PUMPHID_DEF_INPUT 0xFF
+
+// two known device IDs that have shipped.
+#define PUMPHID_VID 0x0D2F
+#define PUMPHID_PID_V1 0x1020
+#define PUMPHID_PID_V2 0x1040
+
+#pragma pack(push, 1)
+
+typedef union {
+  struct {
+    bool btn_UL_U : 1;
+    bool btn_UR_D : 1;
+    bool btn_CN_L : 1;
+    bool btn_LL_R : 1;
+    bool btn_LR_START : 1;
+    bool btn_SELECT : 1;
+    bool btn_MENU_LEFT : 1;
+    bool btn_MENU_RIGHT : 1;
+  };
+  uint8_t raw;
+} pumphid_player_byte_t;
+
+typedef union {
+  struct {
+    bool pad0 : 1;
+    bool btn_TEST : 1;
+    bool btn_COIN : 1;
+    bool pad3 : 1;
+    bool pad4 : 1;
+    bool pad5 : 1;
+    bool btn_SERVICE : 1;
+    bool btn_CLR : 1;
+  };
+  uint8_t raw;
+} pumphid_cabinet_byte_t;
+
+typedef union {
+  struct {
+    bool btn_MENU_UL : 1;
+    bool btn_MENU_UR : 1;
+    bool btn_MENU_CN : 1;
+    bool btn_MENU_LL : 1;
+    bool btn_MENU_LR : 1;
+    bool pad5 : 1;
+    bool pad6 : 1;
+    bool pad7 : 1;
+  };
+  uint8_t raw;
+} pumphid_menu_byte_t;
+
+typedef union {
+  struct {
+    pumphid_player_byte_t p1_sensor0;
+    pumphid_player_byte_t p1_sensor1;
+    pumphid_player_byte_t p1_sensor2;
+    pumphid_player_byte_t p1_sensor3;
+
+    pumphid_player_byte_t p2_sensor0;
+    pumphid_player_byte_t p2_sensor1;
+    pumphid_player_byte_t p2_sensor2;
+    pumphid_player_byte_t p2_sensor3;
+
+    pumphid_cabinet_byte_t cab0;
+    pumphid_cabinet_byte_t cab1;
+
+    pumphid_menu_byte_t p1_menu;
+    pumphid_menu_byte_t p2_menu;
+
+    uint8_t byte12;
+    uint8_t byte13;
+    // TODO: Figure out what this counter does. Increments on every packet?
+    uint16_t counter;
+  };
+  uint8_t raw_buff[PUMPHID_PAYLOADSIZE_FROMDEV];
+} pumphid_output_state_t;
+
+typedef union {
+  struct {
+    // fake padding byte for hidapi
+    uint8_t report_id_pad = 0;
+
+    // Byte 0: P1 lamps
+    uint8_t mux_setting_p1 : 2;
+    bool lamp_p1_ul : 1;
+    bool lamp_p1_ur : 1;
+    bool lamp_p1_c : 1;
+    bool lamp_p1_ll : 1;
+    bool lamp_p1_lr : 1;
+    bool lamp_pad0 : 1;
+
+    // Byte 1: Neon lights
+    bool pad0 : 1;
+    bool pad1 : 1;
+    bool lamp_neon : 1;
+    bool pad3 : 1;
+    bool pad4 : 1;
+    bool pad5 : 1;
+    bool lamp_led : 1;
+    bool pad7 : 1;
+
+    // Byte 2: P2 lamps
+    uint8_t mux_setting_p2 : 2;
+    bool lamp_p2_ul : 1;
+    bool lamp_p2_ur : 1;
+    bool lamp_p2_c : 1;
+    bool lamp_p2_ll : 1;
+    bool lamp_p2_lr : 1;
+    bool lamp_mar_ul : 1;
+
+    // Byte 3: Cabinet lamps
+    bool lamp_maq_lr : 1;
+    bool lamp_maq_ll : 1;
+    bool lamp_maq_ur : 1;
+    bool lamp_coin_pulse : 1;
+    bool lamp_usb_en : 1;
+    bool lamp_alwayson0 : 1;
+    bool lamp_alwayson1 : 1;
+    bool lamp_alwaysoff0 : 1;
+
+    // Byte 4: P1 menu lamps
+    bool menu_p1_ul : 1;
+    bool menu_p1_ur : 1;
+    bool menu_p1_cn : 1;
+    bool menu_p1_ll : 1;
+    bool menu_p1_lr : 1;
+    bool pad5_p1 : 1;
+    bool pad6_p1 : 1;
+    bool pad7_p1 : 1;
+
+    // Byte 5: P2 menu lamps
+    bool menu_p2_ul : 1;
+    bool menu_p2_ur : 1;
+    bool menu_p2_cn : 1;
+    bool menu_p2_ll : 1;
+    bool menu_p2_lr : 1;
+    bool pad5_p2 : 1;
+    bool pad6_p2 : 1;
+    bool pad7_p2 : 1;
+
+    // Byte 6–15: Reserved/Raw
+    uint8_t byte6;
+    uint8_t byte7;
+    uint8_t byte8;
+    uint8_t byte9;
+    uint8_t byte10;
+    uint8_t byte11;
+    uint8_t byte12;
+    uint8_t byte13;
+    uint8_t byte14;
+    uint8_t byte15;
+  };
+  uint8_t raw_buff[PUMPHID_PAYLOADSIZE_TODEV];
+} pumphid_input_state_t;
+
+#pragma pack(pop)
+
+// ensure the sizes are correct
+static_assert(
+    sizeof(pumphid_input_state_t) == PUMPHID_PAYLOADSIZE_TODEV,
+    "pumphid_input_state_t != PUMPHID_PAYLOADSIZE_TODEV");
+
+static_assert(
+    sizeof(pumphid_output_state_t) == PUMPHID_PAYLOADSIZE_FROMDEV,
+    "pumphid_output_state_t != PUMPHID_PAYLOADSIZE_FROMDEV");
+
+class InputHandler_PumpHID : public InputHandler {
+ public:
+  InputHandler_PumpHID();
+  ~InputHandler_PumpHID();
+
+  RString GetDeviceSpecificInputString(const DeviceInput& di);
+  void GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut);
+
+  bool IsConnected() { return dev != nullptr && dev->IsConnected(); }
+
+ private:
+  HidDevice* dev;
+  static const std::vector<int> devPIDS;
+
+  pumphid_output_state_t msg_from_device;
+  pumphid_input_state_t msg_to_device;
+
+  bool m_bShutdown;
+  RageThread InputThread;
+
+  uint32_t PumpHIDToLocalState();
+
+  void PushInputStateToEngine(std::uint32_t newInput);
+
+  static int InputThread_Start(void* p);
+  void InputThreadMain();
+
+  bool IsLightChange(LightsState prevLS, LightsState newLS);
+  void CreateLightingMessage(LightsState newLS);
+};
+
+#endif

--- a/src/arch/InputHandler/InputHandler_PumpHID.h
+++ b/src/arch/InputHandler/InputHandler_PumpHID.h
@@ -28,7 +28,6 @@
 #include "arch/Lights/LightsDriver_Export.h"
 #include "archutils/Common/HidDevice.h"
 
-#define PUMPHID_DEVICEID DEVICE_JOY1
 #define PUMPHID_PAYLOADSIZE_FROMDEV 16
 
 // hidapi wants a blank report ID, but since this device doesn't use that
@@ -196,6 +195,23 @@ typedef union {
   uint8_t raw_buff[PUMPHID_PAYLOADSIZE_TODEV];
 } pumphid_input_state_t;
 
+// used to convert all of this info to 31 buttons for stepmania.
+typedef union {
+  struct {
+    uint8_t p1 : 8;
+    uint8_t p2 : 8;
+
+    uint8_t p1_menu : 5;
+    uint8_t p2_menu : 5;
+
+    uint8_t cab : 5;
+
+    // one extra bit in question.
+    uint8_t padding : 1;
+  };
+  uint32_t raw;
+} pumphid_to_stepmania_t;
+
 #pragma pack(pop)
 
 // ensure the sizes are correct
@@ -206,6 +222,10 @@ static_assert(
 static_assert(
     sizeof(pumphid_output_state_t) == PUMPHID_PAYLOADSIZE_FROMDEV,
     "pumphid_output_state_t != PUMPHID_PAYLOADSIZE_FROMDEV");
+
+// ensure that we are making a 32bit word for stepmania, 32=8*4
+static_assert(
+    sizeof(pumphid_to_stepmania_t) == 4, "pumphid_to_stepmania_t != 4");
 
 class InputHandler_PumpHID : public InputHandler {
  public:
@@ -227,7 +247,7 @@ class InputHandler_PumpHID : public InputHandler {
   bool m_bShutdown;
   RageThread InputThread;
 
-  uint32_t PumpHIDToLocalState();
+  uint32_t PumpHIDToLocalState(pumphid_output_state_t from_dev);
 
   void PushInputStateToEngine(std::uint32_t newInput);
 

--- a/src/arch/InputHandler/InputHandler_PumpHID.h
+++ b/src/arch/InputHandler/InputHandler_PumpHID.h
@@ -1,6 +1,26 @@
 #ifndef INPUT_HANDLER_PUMPHID
 #define INPUT_HANDLER_PUMPHID
 
+/*
+ * -------------------------- NOTE --------------------------
+ *
+ * This driver needs user read/write access the device.
+ * This can be achieved by using a udev rule like this:
+ *
+ * SUBSYSTEMS=="usb", ATTRS{idVendor}=="0D2F", ATTRS{idProduct}=="1040",
+ * OWNER="dance", GROUP="dance", MODE="0660"
+ *
+ * or
+ *
+ * KERNEL=="hidraw*", ATTRS{idVendor}=="0D2F", ATTRS{idProduct}=="1020",
+ * OWNER="dance", GROUP="dance", MODE="0660"
+ *
+ * Refer to your distribution's documentation on how to properly apply a udev
+ * rule.
+ *
+ * -------------------------- NOTE --------------------------
+ */
+
 #include <vector>
 
 #include "InputHandler.h"
@@ -23,6 +43,8 @@
 #define PUMPHID_VID 0x0D2F
 #define PUMPHID_PID_V1 0x1020
 #define PUMPHID_PID_V2 0x1040
+
+#define PUMPHID_INTERFACE_NUM 0
 
 #pragma pack(push, 1)
 
@@ -103,10 +125,10 @@ typedef union {
     uint8_t mux_setting_p1 : 2;
     bool lamp_p1_ul : 1;
     bool lamp_p1_ur : 1;
-    bool lamp_p1_c : 1;
+    bool lamp_p1_cn : 1;
     bool lamp_p1_ll : 1;
     bool lamp_p1_lr : 1;
-    bool lamp_pad0 : 1;
+    bool lamp_p1_pad7 : 1;
 
     // Byte 1: Neon lights
     bool pad0 : 1;
@@ -115,16 +137,18 @@ typedef union {
     bool pad3 : 1;
     bool pad4 : 1;
     bool pad5 : 1;
-    bool lamp_led : 1;
+    bool pad6 : 1;
     bool pad7 : 1;
 
     // Byte 2: P2 lamps
     uint8_t mux_setting_p2 : 2;
     bool lamp_p2_ul : 1;
     bool lamp_p2_ur : 1;
-    bool lamp_p2_c : 1;
+    bool lamp_p2_cn : 1;
     bool lamp_p2_ll : 1;
     bool lamp_p2_lr : 1;
+    // yes this is a cab lamp in a player byte... not a mistake, it's the
+    // hardware.
     bool lamp_mar_ul : 1;
 
     // Byte 3: Cabinet lamps
@@ -143,9 +167,9 @@ typedef union {
     bool menu_p1_cn : 1;
     bool menu_p1_ll : 1;
     bool menu_p1_lr : 1;
-    bool pad5_p1 : 1;
-    bool pad6_p1 : 1;
-    bool pad7_p1 : 1;
+    bool menu_p1_pad5 : 1;
+    bool menu_p1_pad6 : 1;
+    bool menu_p1_pad7 : 1;
 
     // Byte 5: P2 menu lamps
     bool menu_p2_ul : 1;
@@ -153,9 +177,9 @@ typedef union {
     bool menu_p2_cn : 1;
     bool menu_p2_ll : 1;
     bool menu_p2_lr : 1;
-    bool pad5_p2 : 1;
-    bool pad6_p2 : 1;
-    bool pad7_p2 : 1;
+    bool menu_p2_pad5 : 1;
+    bool menu_p2_pad6 : 1;
+    bool menu_p2_pad7 : 1;
 
     // Byte 6–15: Reserved/Raw
     uint8_t byte6;
@@ -215,3 +239,28 @@ class InputHandler_PumpHID : public InputHandler {
 };
 
 #endif
+
+/*
+ * (c) 2025 din
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */

--- a/src/arch/InputHandler/InputHandler_PumpHID.h
+++ b/src/arch/InputHandler/InputHandler_PumpHID.h
@@ -118,7 +118,7 @@ typedef union {
 typedef union {
   struct {
     // fake padding byte for hidapi
-    uint8_t report_id_pad = 0;
+    uint8_t report_id_pad;
 
     // Byte 0: P1 lamps
     uint8_t mux_setting_p1 : 2;
@@ -198,16 +198,16 @@ typedef union {
 // used to convert all of this info to 31 buttons for stepmania.
 typedef union {
   struct {
-    uint8_t p1 : 8;
-    uint8_t p2 : 8;
+    uint16_t p1 : 8;
+    uint16_t p2 : 8;
 
-    uint8_t p1_menu : 5;
-    uint8_t p2_menu : 5;
+    uint16_t p1_menu : 5;
+    uint16_t p2_menu : 5;
 
-    uint8_t cab : 5;
+    uint16_t cab : 5;
 
     // one extra bit in question.
-    uint8_t padding : 1;
+    uint16_t padding : 1;
   };
   uint32_t raw;
 } pumphid_to_stepmania_t;


### PR DESCRIPTION
leverages hidapi to poll an PumpHID/ATMegaPump/NuvotonPump or "LXIO" device. As this is using hidapi, it is cross platform and driver less, tested on linux and windows.

enable by adding it to your InputDrivers list. `InputDrivers=X11,PumpHID`

Notes
- supports pump and dance modes. bits are reserved for using one in an upgraded itg dedicab for example
- lights for both modes included
- proper 1khz polling etc

future
- make a new issue ticket for "discovering" devices like this rather than manually defining them.
- work on automapping/button names as I've had trouble getting that to be reliable in the past
- work on how we want the lights to map for the menu buttons (Pump mirrors the corners of the stage to the cabinet, which doesn't map 1:1 with our lights for MENU_*). For now I have just wired up the start light to center for example.
- if someone wants to have the individual sensors printed out in the service menu, the data is in the engine you just have to route it up. openitg did this by giving a lua hook with `MK6_GetSensors` for example and a theme can then pick it up.