### PR TITLE
fix: std::pair construction correctness in AdjustSync

### DIFF
--- a/src/AdjustSync.cpp
+++ b/src/AdjustSync.cpp
@@ -156,7 +156,7 @@ void AdjustSync::HandleAutosync( float fNoteOffBySeconds, float fStepTime )
 	case AutosyncType_Tempo:
 	{
 		// We collect all of the data and process it at the end
-		s_vAutosyncTempoData.push_back( std::make_pair(fStepTime, fNoteOffBySeconds) );
+		s_vAutosyncTempoData.emplace_back( fStepTime, fNoteOffBySeconds );
 		break;
 	}
 	case AutosyncType_Machine:


### PR DESCRIPTION
The existing method raises warnings on certain compilers, and doesn't have guaranteed consistent behavior across different versions of C++.  The replacement as implemented in this commit eliminates any potential variation in execution between different revisions of the C++ standard.

Resolves warning such as this:

```
[ 84%] Building CXX object src/CMakeFiles/ITGmania.dir/AdjustSync.cpp.o
In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
                 from /usr/include/c++/13/algorithm:60,
                 from /home/runner/work/itgmania-testing/itgmania-testing/src/global.h:25,
                 from /home/runner/work/itgmania-testing/itgmania-testing/src/AdjustSync.cpp:36:
/usr/include/c++/13/bits/stl_pair.h: In instantiation of ‘constexpr std::pair<typename std::__strip_reference_wrapper<typename std::decay<_Tp>::type>::__type, typename std::__strip_reference_wrapper<typename std::decay<_Tp2>::type>::__type> std::make_pair(_T1&&, _T2&&) [with _T1 = float&; _T2 = float&; typename __strip_reference_wrapper<typename decay<_Tp>::type>::__type = float; typename decay<_Tp>::type = float; typename __strip_reference_wrapper<typename decay<_Tp2>::type>::__type = float; typename decay<_Tp2>::type = float]’:
/home/runner/work/itgmania-testing/itgmania-testing/src/AdjustSync.cpp:159:49:   required from here
/usr/include/c++/13/bits/stl_pair.h:922:5: note: parameter passing for argument of type ‘std::pair<float, float>’ when C++17 is enabled changed to match C++14 in GCC 10.1
  922 |     make_pair(_T1&& __x, _T2&& __y)
      |     ^~~~~~~~~
```