### PR TITLE
Remove msbuild@v2 from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,6 @@ jobs:
       - name: Install dependencies
         if: matrix.os != 'windows-latest'
         run: ${{ matrix.install }}
-      - name: Add msbuild to PATH
-        if: matrix.os == 'windows-latest'
-        uses: microsoft/setup-msbuild@v2
-        with:
-          msbuild-architecture: x64
       - name: Configure
         run: ${{ matrix.configure }}
       - name: Build


### PR DESCRIPTION
We don't actually need this - this code, while well-written, is actually unused, since `vswhere` was originally a band-aid to get around some issue with the github runner at the time where it didn't reliably find the path to the Windows compiler. I do not remember more specific details on that issue, but I never proposed the removal of that `vswhere` before it got refactored into this code.