### PR TITLE
ScreenSelectMusic: Option to confirm before cancel

### DIFF
--- a/Themes/_fallback/Languages/de.ini
+++ b/Themes/_fallback/Languages/de.ini
@@ -1834,6 +1834,7 @@ ALL MUSIC=ALL MUSIC
 HeaderText=Musik Auswählen
 HeaderSubText=Du wirst ein cooles Lied auswählen!
 PermanentlyDelete='%s' ( %s ) dauerhauft von der Festplatte löschen?
+PromptBeforeExiting=Möchtest du das Spiel beenden?
 
 [ScreenSelectCourse]
 HeaderText=Kurs Auswählen

--- a/Themes/_fallback/Languages/en.ini
+++ b/Themes/_fallback/Languages/en.ini
@@ -1881,6 +1881,7 @@ ALL MUSIC=ALL MUSIC
 HeaderText=Select Music
 HeaderSubText=You will pick a cool song!
 PermanentlyDelete=Permanently delete '%s' ( %s ) from disk?
+PromptBeforeExiting=Do you want to exit this game?
 
 [ScreenSelectCourse]
 HeaderText=Select Course

--- a/Themes/_fallback/Languages/es.ini
+++ b/Themes/_fallback/Languages/es.ini
@@ -1796,6 +1796,7 @@ ALL MUSIC=TODA LA MÚSICA
 [ScreenSelectMusic]
 HeaderText=Seleccionar canción
 HeaderSubText=¡Escoge una canción chula!
+PromptBeforeExiting=Quieres abandonar el juego?
 
 [ScreenSelectCourse]
 HeaderText=Seleccionar curso

--- a/Themes/_fallback/Languages/ja.ini
+++ b/Themes/_fallback/Languages/ja.ini
@@ -1973,6 +1973,7 @@ ALL MUSIC=ALL MUSIC
 HeaderText=Select Music
 HeaderSubText=You will pick a cool song!
 PermanentlyDelete='%s' ( %s ) を削除しますか?\n一度削除すると復元できません。
+PromptBeforeExiting=本当に終了しますか？
 
 [ScreenSelectCourse]
 HeaderText=Select Course

--- a/Themes/_fallback/Languages/pl.ini
+++ b/Themes/_fallback/Languages/pl.ini
@@ -1783,6 +1783,7 @@ ALL MUSIC=CAŁA MUZYKA
 [ScreenSelectMusic]
 HeaderText=Wybierz Piosenkę
 HeaderSubText=Nie ma czego się bać. Wybierz to co Ci się podoba.
+PromptBeforeExiting=Czy chcesz wyjść z tej gry?
 
 [ScreenSelectCourse]
 HeaderText=Wybierz Maraton

--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -2122,6 +2122,7 @@ PrevScreen=Branch.TitleMenu()
 #
 MusicWheelType="MusicWheel"
 Codes=""
+ConfirmExit=false
 #
 TimerSeconds=120
 DoRouletteOnMenuTimer=true

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -56,6 +56,7 @@ AutoScreenMessage( SM_SortOrderChanging );
 AutoScreenMessage( SM_SortOrderChanged );
 AutoScreenMessage( SM_BackFromPlayerOptions );
 AutoScreenMessage( SM_ConfirmDeleteSong );
+AutoScreenMessage( SM_ConfirmExit );
 
 static RString g_sCDTitlePath;
 static bool g_bWantFallbackCdTitle;
@@ -68,6 +69,7 @@ static RageTimer g_ScreenStartedLoadingAt(RageZeroTimer);
 RageTimer g_CanOpenOptionsList(RageZeroTimer);
 
 static LocalizedString PERMANENTLY_DELETE("ScreenSelectMusic", "PermanentlyDelete");
+static LocalizedString PROMPT_BEFORE_EXITING("ScreenSelectMusic", "PromptBeforeExiting");
 
 REGISTER_SCREEN_CLASS( ScreenSelectMusic );
 void ScreenSelectMusic::Init()
@@ -109,6 +111,7 @@ void ScreenSelectMusic::Init()
 	// To allow changing steps with gamebuttons -DaisuMaster
 	CHANGE_STEPS_WITH_GAME_BUTTONS.Load( m_sName, "ChangeStepsWithGameButtons" );
 	CHANGE_GROUPS_WITH_GAME_BUTTONS.Load( m_sName, "ChangeGroupsWithGameButtons" );
+	CONFIRM_EXIT.Load( m_sName, "ConfirmExit" );
 
 	m_GameButtonPreviousSong = INPUTMAPPER->GetInputScheme()->ButtonNameToIndex( THEME->GetMetric(m_sName,"PreviousSongButton") );
 	m_GameButtonNextSong = INPUTMAPPER->GetInputScheme()->ButtonNameToIndex( THEME->GetMetric(m_sName,"NextSongButton") );
@@ -1225,6 +1228,11 @@ void ScreenSelectMusic::HandleScreenMessage( const ScreenMessage SM )
 			m_MusicWheel.ChangeMusic(0);
 		}
 	}
+	else if( SM == SM_ConfirmExit )
+	{
+		if( ScreenPrompt::s_LastAnswer == ANSWER_YES )
+			ConfirmedCancel( SM_GoToPrevScreen );
+	}
 
 	ScreenWithMenuElements::HandleScreenMessage( SM );
 }
@@ -1562,10 +1570,25 @@ bool ScreenSelectMusic::MenuBack( const InputEventPlus & /* input */ )
 	}
 	*/
 
-	m_BackgroundLoader.Abort();
-
 	Cancel( SM_GoToPrevScreen );
 	return true;
+}
+
+void ScreenSelectMusic::Cancel(ScreenMessage smSendWhenDone)
+{
+	if( CONFIRM_EXIT )
+	{
+        m_MusicWheel.Move( 0 );
+		ScreenPrompt::Prompt( SM_ConfirmExit, PROMPT_BEFORE_EXITING.GetValue().c_str(), PROMPT_YES_NO );
+	}
+	else
+		ConfirmedCancel( smSendWhenDone );
+}
+
+void ScreenSelectMusic::ConfirmedCancel(ScreenMessage smSendWhenDone)
+{
+	m_BackgroundLoader.Abort();
+	ScreenWithMenuElements::Cancel( smSendWhenDone );
 }
 
 void ScreenSelectMusic::AfterStepsOrTrailChange( const std::vector<PlayerNumber> &vpns )

--- a/src/ScreenSelectMusic.h
+++ b/src/ScreenSelectMusic.h
@@ -43,6 +43,8 @@ public:
 
 	virtual bool MenuStart( const InputEventPlus &input );
 	virtual bool MenuBack( const InputEventPlus &input );
+	virtual void Cancel( ScreenMessage smSendWhenDone );
+	virtual void ConfirmedCancel( ScreenMessage smSendWhenDone );
 
 	// ScreenWithMenuElements override: never play music here; we do it ourself.
 	virtual void StartPlayingMusic() { }
@@ -108,6 +110,7 @@ protected:
 	ThemeMetric<bool>		CHANGE_GROUPS_WITH_GAME_BUTTONS;
 	ThemeMetric<RString>	NULL_SCORE_STRING;
 	ThemeMetric<bool>		PLAY_SOUND_ON_ENTERING_OPTIONS_MENU;
+	ThemeMetric<bool>		CONFIRM_EXIT;
 
 	bool CanChangeSong() const { return m_SelectionState == SelectionState_SelectingSong; }
 	bool CanChangeSteps() const { return TWO_PART_SELECTION ? m_SelectionState == SelectionState_SelectingSteps : m_SelectionState == SelectionState_SelectingSong; }


### PR DESCRIPTION
Changes ScreenSelectMusic to display a confirmation prompt on Cancel if the "ConfirmExit" is set to true in metrics.

This is intended to replace the EscapeFromEventMode2 code in Simply Love and fix the exit confirmation appearing after closing the SortMenu with Back.