### PR TITLE
Allow selecting a SoundDevice in Graphics/Sound Options

### DIFF
--- a/src/GameSoundManager.cpp
+++ b/src/GameSoundManager.cpp
@@ -925,6 +925,37 @@ int LuaFunc_get_sound_driver_list(lua_State* L)
 }
 LUAFUNC_REGISTER_COMMON(get_sound_driver_list);
 
+int LuaFunc_get_sound_device_list(lua_State* L);
+int LuaFunc_get_sound_device_list(lua_State* L)
+{
+	//std::vector<RString> audio_devices = SOUNDMAN->GetDriverAudioDevices();
+	std::vector<DriverAudioDevice> audio_devices = SOUNDMAN->GetDriverAudioDevices();
+
+	lua_createtable(L, audio_devices.size(), 0);
+	// User .c_str() if using RString
+	lua_newtable(L);
+	int tableIndex = 1;
+
+	for(size_t n= 0; n < audio_devices.size(); ++n)
+	{
+		// New added table element
+		lua_newtable(L);
+		// Add  readable name
+		lua_pushstring(L, audio_devices[n].readableName);
+		lua_setfield(L, -2, "readable_name");
+
+		//Add system name
+		lua_pushstring(L, audio_devices[n].id);
+		lua_setfield(L, -2, "system_name");
+
+		// Go to next table item
+		lua_rawseti(L, -2, tableIndex++);
+	}
+
+	return 1;
+}
+LUAFUNC_REGISTER_COMMON(get_sound_device_list);
+
 
 /*
  * Copyright (c) 2003-2005 Glenn Maynard

--- a/src/GameSoundManager.cpp
+++ b/src/GameSoundManager.cpp
@@ -928,11 +928,9 @@ LUAFUNC_REGISTER_COMMON(get_sound_driver_list);
 int LuaFunc_get_sound_device_list(lua_State* L);
 int LuaFunc_get_sound_device_list(lua_State* L)
 {
-	//std::vector<RString> audio_devices = SOUNDMAN->GetDriverAudioDevices();
 	std::vector<DriverAudioDevice> audio_devices = SOUNDMAN->GetDriverAudioDevices();
 
 	lua_createtable(L, audio_devices.size(), 0);
-	// User .c_str() if using RString
 	lua_newtable(L);
 	int tableIndex = 1;
 

--- a/src/GameSoundManager.cpp
+++ b/src/GameSoundManager.cpp
@@ -925,35 +925,6 @@ int LuaFunc_get_sound_driver_list(lua_State* L)
 }
 LUAFUNC_REGISTER_COMMON(get_sound_driver_list);
 
-int LuaFunc_get_sound_device_list(lua_State* L);
-int LuaFunc_get_sound_device_list(lua_State* L)
-{
-	std::vector<DriverAudioDevice> audio_devices = SOUNDMAN->GetDriverAudioDevices();
-
-	lua_createtable(L, audio_devices.size(), 0);
-	lua_newtable(L);
-	int tableIndex = 1;
-
-	for(size_t n= 0; n < audio_devices.size(); ++n)
-	{
-		// New added table element
-		lua_newtable(L);
-		// Add  readable name
-		lua_pushstring(L, audio_devices[n].readableName);
-		lua_setfield(L, -2, "readable_name");
-
-		//Add system name
-		lua_pushstring(L, audio_devices[n].id);
-		lua_setfield(L, -2, "system_name");
-
-		// Go to next table item
-		lua_rawseti(L, -2, tableIndex++);
-	}
-
-	return 1;
-}
-LUAFUNC_REGISTER_COMMON(get_sound_device_list);
-
 
 /*
  * Copyright (c) 2003-2005 Glenn Maynard

--- a/src/RageSoundManager.cpp
+++ b/src/RageSoundManager.cpp
@@ -139,6 +139,16 @@ int RageSoundManager::GetDriverSampleRate() const
 	return m_pDriver->GetSampleRate();
 }
 
+std::vector<DriverAudioDevice> RageSoundManager::GetDriverAudioDevices() const
+{
+	if( m_pDriver == nullptr ) {
+		LOG->Info("No audio driver");
+		return { {"", ""} };
+	}
+
+	return m_pDriver->GetAudioDevices();
+}
+
 /* If the given path is loaded, return a copy; otherwise return nullptr.
  * It's the caller's responsibility to delete the result. */
 RageSoundReader *RageSoundManager::GetLoadedSound( const RString &sPath_ )

--- a/src/RageSoundManager.cpp
+++ b/src/RageSoundManager.cpp
@@ -44,8 +44,10 @@ static LocalizedString COULDNT_FIND_SOUND_DRIVER( "RageSoundManager", "Couldn't 
 void RageSoundManager::Init()
 {
 	m_pDriver = RageSoundDriver::Create( g_sSoundDrivers );
-	if( m_pDriver == nullptr )
-		RageException::Throw( "%s", COULDNT_FIND_SOUND_DRIVER.GetValue().c_str() );
+	if( m_pDriver == nullptr ) {
+		LOG->Warn(" %s", COULDNT_FIND_SOUND_DRIVER.GetValue().c_str() );
+		m_pDriver = RageSoundDriver::Create( "Null" );
+	}
 }
 
 RageSoundManager::~RageSoundManager()

--- a/src/RageSoundManager.cpp
+++ b/src/RageSoundManager.cpp
@@ -139,14 +139,14 @@ int RageSoundManager::GetDriverSampleRate() const
 	return m_pDriver->GetSampleRate();
 }
 
-std::vector<DriverAudioDevice> RageSoundManager::GetDriverAudioDevices() const
+std::vector<DriverSoundDevice> RageSoundManager::GetDriverSoundDevices() const
 {
 	if( m_pDriver == nullptr ) {
 		LOG->Info("No audio driver");
 		return { {"", ""} };
 	}
 
-	return m_pDriver->GetAudioDevices();
+	return m_pDriver->GetSoundDevices();
 }
 
 /* If the given path is loaded, return a copy; otherwise return nullptr.

--- a/src/RageSoundManager.cpp
+++ b/src/RageSoundManager.cpp
@@ -145,7 +145,7 @@ std::vector<DriverSoundDevice> RageSoundManager::GetDriverSoundDevices() const
 {
 	if( m_pDriver == nullptr ) {
 		LOG->Info("No audio driver");
-		return { {"", ""} };
+		return { {"", "No driver"} };
 	}
 
 	return m_pDriver->GetSoundDevices();

--- a/src/RageSoundManager.h
+++ b/src/RageSoundManager.h
@@ -18,7 +18,7 @@ class RageSoundReader;
 class RageSoundReader_Preload;
 class RageTimer;
 
-struct DriverAudioDevice {
+struct DriverSoundDevice {
 	RString id;
 	RString readableName;
 };
@@ -48,7 +48,7 @@ public:
 	int64_t GetPosition( RageTimer *pTimer ) const;	/* used by RageSound */
 	float GetPlayLatency() const;
 	int GetDriverSampleRate() const;
-	std::vector<DriverAudioDevice> GetDriverAudioDevices() const;
+	std::vector<DriverSoundDevice> GetDriverSoundDevices() const;
 
 	RageSoundReader *GetLoadedSound( const RString &sPath );
 	void AddLoadedSound( const RString &sPath, RageSoundReader_Preload *pSound );

--- a/src/RageSoundManager.h
+++ b/src/RageSoundManager.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <map>
 #include <set>
+#include <vector>
 
 class RageSound;
 class RageSoundBase;
@@ -16,6 +17,11 @@ struct RageSoundParams;
 class RageSoundReader;
 class RageSoundReader_Preload;
 class RageTimer;
+
+struct DriverAudioDevice {
+	RString id;
+	RString readableName;
+};
 
 class RageSoundManager
 {
@@ -42,6 +48,7 @@ public:
 	int64_t GetPosition( RageTimer *pTimer ) const;	/* used by RageSound */
 	float GetPlayLatency() const;
 	int GetDriverSampleRate() const;
+	std::vector<DriverAudioDevice> GetDriverAudioDevices() const;
 
 	RageSoundReader *GetLoadedSound( const RString &sPath );
 	void AddLoadedSound( const RString &sPath, RageSoundReader_Preload *pSound );

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -8,6 +8,7 @@
 #include "SongOptions.h"
 #include "RageDisplay.h"
 #include "RageUtil.h"
+#include "RageSoundManager.h"
 #include "GameManager.h"
 #include "GameState.h"
 #include "StepMania.h"
@@ -20,6 +21,7 @@
 #include "RageUtil/LanguageInfo.h"
 
 #include <vector>
+
 
 
 using namespace StringConversion;
@@ -702,6 +704,43 @@ static void PreferredSampleRate( int &sel, bool ToSel, const ConfOption *pConfOp
 	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
 }
 
+static void SoundDeviceChoices( std::vector<RString> &out )
+{
+	std::vector<DriverAudioDevice> soundDevices = SOUNDMAN->GetDriverAudioDevices();
+	for( const DriverAudioDevice &device : soundDevices )
+	{
+		out.push_back( device.readableName );
+	}
+}
+
+static void SoundDevice( int &sel, bool ToSel, const ConfOption *pConfOption )
+{
+	// Get choices from the sound driver
+	std::vector<DriverAudioDevice> soundDevices = SOUNDMAN->GetDriverAudioDevices();
+
+	IPreference *pSoundDevicePref = IPreference::GetPreferenceByName( pConfOption->m_sPrefName );
+
+	// Given a value in "SoundDevice=", find its position in the vector
+	if( ToSel )
+	{
+		RString currentDeviceId = pSoundDevicePref->ToString();
+		sel = 0;
+		for( uint16_t i = 0; i < soundDevices.size(); ++i )
+		{
+			if( soundDevices[i].id == currentDeviceId )
+			{
+				sel = i;
+				break;
+			}
+		}
+	}
+	else
+	{
+		// Provide the system ID for a SoundDevice in position "sel"
+		pSoundDevicePref->FromString( soundDevices[sel].id );
+	}
+}
+
 static void VisualDelaySeconds( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	const float mapping[] = { -0.125f,-0.1f,-0.075f,-0.05f,-0.025f,0.0f,0.025f,0.05f,0.075f,0.1f,0.125f };
@@ -957,6 +996,9 @@ static void InitializeConfOptions()
 	ADD( ConfOption( "EnableAttackSounds",		MovePref<bool>,		"No","Yes" ) );
 	ADD( ConfOption( "EnableMineHitSound",		MovePref<bool>,		"No","Yes" ) );
 	ADD( ConfOption( "RateModPreservesPitch",		MovePref<bool>,		"No","Yes") );
+	ADD( ConfOption( "SoundDevice", SoundDevice, SoundDeviceChoices ) );  
+	g_ConfOptions.back().m_sPrefName = "SoundDevice";
+	g_ConfOptions.back().m_iEffects = OPT_APPLY_SOUND;
 
 	// Editor options
 	ADD( ConfOption( "EditorShowBGChangesPlay",	MovePref<bool>,		"Hide","Show") );

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -23,7 +23,6 @@
 #include <vector>
 
 
-
 using namespace StringConversion;
 
 static void GetPrefsDefaultModifiers( PlayerOptions &po, SongOptions &so )
@@ -706,8 +705,8 @@ static void PreferredSampleRate( int &sel, bool ToSel, const ConfOption *pConfOp
 
 static void SoundDeviceChoices( std::vector<RString> &out )
 {
-	std::vector<DriverAudioDevice> soundDevices = SOUNDMAN->GetDriverAudioDevices();
-	for( const DriverAudioDevice &device : soundDevices )
+	std::vector<DriverSoundDevice> soundDevices = SOUNDMAN->GetDriverSoundDevices();
+	for( const DriverSoundDevice &device : soundDevices )
 	{
 		out.push_back( device.readableName );
 	}
@@ -716,7 +715,7 @@ static void SoundDeviceChoices( std::vector<RString> &out )
 static void SoundDevice( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
 	// Get choices from the sound driver
-	std::vector<DriverAudioDevice> soundDevices = SOUNDMAN->GetDriverAudioDevices();
+	std::vector<DriverSoundDevice> soundDevices = SOUNDMAN->GetDriverSoundDevices();
 
 	IPreference *pSoundDevicePref = IPreference::GetPreferenceByName( pConfOption->m_sPrefName );
 

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -724,7 +724,7 @@ static void SoundDevice( int &sel, bool ToSel, const ConfOption *pConfOption )
 	{
 		RString currentDeviceId = pSoundDevicePref->ToString();
 		sel = 0;
-		for( uint16_t i = 0; i < soundDevices.size(); ++i )
+		for( unsigned int i = 0; i < soundDevices.size(); ++i )
 		{
 			if( soundDevices[i].id == currentDeviceId )
 			{

--- a/src/arch/Sound/RageSoundDriver.h
+++ b/src/arch/Sound/RageSoundDriver.h
@@ -72,7 +72,7 @@ public:
 
 	virtual int GetSampleRate() const { return kFallbackSampleRate; }
 
-	virtual std::vector<DriverAudioDevice> GetAudioDevices() const { return { DriverAudioDevice{"", "default"} }; }
+	virtual std::vector<DriverSoundDevice> GetSoundDevices() const { return { DriverSoundDevice{"", "default"} }; }
 
 protected:
 	/* Start the decoding.  This should be called once the hardware is set up and

--- a/src/arch/Sound/RageSoundDriver.h
+++ b/src/arch/Sound/RageSoundDriver.h
@@ -8,6 +8,9 @@
 #include "RageUtil_CircularBuffer.h"
 #include "RageSound.h"
 
+// Just to include DriverSoundDevice - this might not be ideal
+#include "RageSoundManager.h"
+
 #include <cstdint>
 
 class RageSoundBase;
@@ -68,6 +71,8 @@ public:
 	virtual float GetPlayLatency() const { return 0.0f; }
 
 	virtual int GetSampleRate() const { return kFallbackSampleRate; }
+
+	virtual std::vector<DriverAudioDevice> GetAudioDevices() const { return { DriverAudioDevice{"", "default"} }; }
 
 protected:
 	/* Start the decoding.  This should be called once the hardware is set up and

--- a/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
@@ -151,9 +151,9 @@ float RageSoundDriver_ALSA9_Software::GetPlayLatency() const
 }
 
 // NOTE: This is using ALSA9Helpers.cpp code here - There might be a better option to re-use the code
-std::vector<DriverAudioDevice> RageSoundDriver_ALSA9_Software::GetAudioDevices() const
+std::vector<DriverSoundDevice> RageSoundDriver_ALSA9_Software::GetSoundDevices() const
 {
-	std::vector<DriverAudioDevice> devices;
+	std::vector<DriverSoundDevice> devices;
 	// Add default device
 	devices.push_back({ "", "Default" });
 
@@ -195,7 +195,7 @@ std::vector<DriverAudioDevice> RageSoundDriver_ALSA9_Software::GetAudioDevices()
                                         LOG->Info("dsnd_ctl_pcm_info(%i) (%s) failed: %s", card, id.c_str(), dsnd_strerror(err));
                                 continue;
                         }
-			DriverAudioDevice device;
+			DriverSoundDevice device;
 			device.id = ssprintf("hw:%i,%i", card, dev);
 			device.readableName = dsnd_pcm_info_get_name(pcminfo);
 			devices.push_back(device);

--- a/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
@@ -150,14 +150,70 @@ float RageSoundDriver_ALSA9_Software::GetPlayLatency() const
 	return float(g_iMaxWriteahead) / m_iSampleRate;
 }
 
+// NOTE: This is using ALSA9Helpers.cpp code here - There might be a better option to re-use the code
 std::vector<DriverAudioDevice> RageSoundDriver_ALSA9_Software::GetAudioDevices() const
 {
 	std::vector<DriverAudioDevice> devices;
 	// Add default device
-	DriverAudioDevice defaultDevice;
-	defaultDevice.id = "";
-	defaultDevice.readableName = "Default (ALSA Placeholder for PR)";
-	devices.push_back(defaultDevice);
+	devices.push_back({ "", "Default" });
+
+        int card = -1;
+        while( dsnd_card_next( &card ) >= 0 && card >= 0 )
+        {
+                const RString id = ssprintf( "hw:%d", card );
+                snd_ctl_t *handle;
+                int err;
+                err = dsnd_ctl_open( &handle, id.c_str(), 0 );
+                if ( err < 0 )
+                {
+                        LOG->Info( "Couldn't open card #%i (\"%s\") to probe: %s", card, id.c_str(), dsnd_strerror(err) );
+                        continue;
+                }
+
+                snd_ctl_card_info_t *info;
+                dsnd_ctl_card_info_alloca(&info);
+                err = dsnd_ctl_card_info( handle, info );
+                if ( err < 0 )
+                {
+                        LOG->Info( "Couldn't get card info for card #%i (\"%s\"): %s", card, id.c_str(), dsnd_strerror(err) );
+                        dsnd_ctl_close( handle );
+                        continue;
+                }
+
+                int dev = -1;
+                while ( dsnd_ctl_pcm_next_device( handle, &dev ) >= 0 && dev >= 0 )
+                {
+                        snd_pcm_info_t *pcminfo;
+                        dsnd_pcm_info_alloca(&pcminfo);
+                        dsnd_pcm_info_set_device(pcminfo, dev);
+                        dsnd_pcm_info_set_stream(pcminfo, SND_PCM_STREAM_PLAYBACK);
+
+                        err = dsnd_ctl_pcm_info(handle, pcminfo);
+                        if ( err < 0 )
+                        {
+                                if (err != -ENOENT)
+                                        LOG->Info("dsnd_ctl_pcm_info(%i) (%s) failed: %s", card, id.c_str(), dsnd_strerror(err));
+                                continue;
+                        }
+			DriverAudioDevice device;
+			device.id = ssprintf("hw:%i,%i", card, dev);
+			device.readableName = dsnd_pcm_info_get_name(pcminfo);
+			devices.push_back(device);
+
+                        LOG->Info( "ALSA Driver: %i: %s [%s], device %i: %s [%s], %i/%i subdevices avail",
+                                        card, dsnd_ctl_card_info_get_name(info), dsnd_ctl_card_info_get_id(info), dev,
+                                        dsnd_pcm_info_get_id(pcminfo), dsnd_pcm_info_get_name(pcminfo),
+                                        dsnd_pcm_info_get_subdevices_avail(pcminfo),
+                                        dsnd_pcm_info_get_subdevices_count(pcminfo) );
+
+                }
+                dsnd_ctl_close(handle);
+        }
+
+        if( card == 0 )
+                LOG->Info( "No ALSA sound cards were found.");
+
+
 	return devices;
 }
 

--- a/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
@@ -157,56 +157,37 @@ std::vector<DriverSoundDevice> RageSoundDriver_ALSA9_Software::GetSoundDevices()
 	// Add default device
 	devices.push_back({ "", "Default" });
 
-	int card = -1;
-	while( dsnd_card_next( &card ) >= 0 && card >= 0 )
-	{
-		const RString id = ssprintf( "hw:%d", card );
-		snd_ctl_t *handle;
-		int err;
-		err = dsnd_ctl_open( &handle, id.c_str(), 0 );
-		if ( err < 0 )
-		{
-			LOG->Info( "Couldn't open card #%i (\"%s\") to probe: %s", card, id.c_str(), dsnd_strerror(err) );
-			continue;
-		}
+	void **hints;
+	int err;
 
-		snd_ctl_card_info_t *info;
-		dsnd_ctl_card_info_alloca(&info);
-		err = dsnd_ctl_card_info( handle, info );
-		if ( err < 0 )
-		{
-			LOG->Info( "Couldn't get card info for card #%i (\"%s\"): %s", card, id.c_str(), dsnd_strerror(err) );
-			dsnd_ctl_close( handle );
-			continue;
-		}
+	// Get device hints for all PCM devices
+	if ((err = snd_device_name_hint(-1, "pcm", &hints)) < 0) {
+		LOG->Info( "ALSA: Could not get device list: %s",  dsnd_strerror(err) );
+	}
+	void **n = hints;
+	while (*n != NULL) {
+		char *name = snd_device_name_get_hint(*n, "NAME");
+		char *desc = snd_device_name_get_hint(*n, "DESC");
+		char *ioid = snd_device_name_get_hint(*n, "IOID");
 
-		int dev = -1;
-		while ( dsnd_ctl_pcm_next_device( handle, &dev ) >= 0 && dev >= 0 )
-		{
-			snd_pcm_info_t *pcminfo;
-			dsnd_pcm_info_alloca(&pcminfo);
-			dsnd_pcm_info_set_device(pcminfo, dev);
-			dsnd_pcm_info_set_stream(pcminfo, SND_PCM_STREAM_PLAYBACK);
+		// Only consider real PCM hw devices
+		bool is_output = (!ioid || strcmp(ioid, "Output") == 0);
+		bool has_card_id = (strstr(name, "CARD=") != NULL );
+		bool has_default_name = (strstr(name, "default") != NULL );
 
-			err = dsnd_ctl_pcm_info(handle, pcminfo);
-			if ( err < 0 )
-			{
-				if (err != -ENOENT)
-					LOG->Info("dsnd_ctl_pcm_info(%i) (%s) failed: %s", card, id.c_str(), dsnd_strerror(err));
-				continue;
-			}
+		if (name && is_output && has_card_id && !has_default_name) {
+			snd_pcm_t *handle;
 			DriverSoundDevice device;
-			device.id = ssprintf("hw:%i,%i", card, dev);
-			device.readableName = dsnd_pcm_info_get_name(pcminfo);
+			device.id = name;
+			device.readableName = desc;
 			devices.push_back(device);
 		}
-		dsnd_ctl_close(handle);
+		if (desc) free(desc);
+		if (name) free(name);
+		if (ioid) free(ioid);
+		n++;
 	}
-
-	if( card == 0 )
-		LOG->Info( "No ALSA sound cards were found.");
-
-
+	snd_device_name_free_hint(hints);
 	return devices;
 }
 

--- a/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
@@ -157,54 +157,54 @@ std::vector<DriverSoundDevice> RageSoundDriver_ALSA9_Software::GetSoundDevices()
 	// Add default device
 	devices.push_back({ "", "Default" });
 
-        int card = -1;
-        while( dsnd_card_next( &card ) >= 0 && card >= 0 )
-        {
-                const RString id = ssprintf( "hw:%d", card );
-                snd_ctl_t *handle;
-                int err;
-                err = dsnd_ctl_open( &handle, id.c_str(), 0 );
-                if ( err < 0 )
-                {
-                        LOG->Info( "Couldn't open card #%i (\"%s\") to probe: %s", card, id.c_str(), dsnd_strerror(err) );
-                        continue;
-                }
+	int card = -1;
+	while( dsnd_card_next( &card ) >= 0 && card >= 0 )
+	{
+		const RString id = ssprintf( "hw:%d", card );
+		snd_ctl_t *handle;
+		int err;
+		err = dsnd_ctl_open( &handle, id.c_str(), 0 );
+		if ( err < 0 )
+		{
+			LOG->Info( "Couldn't open card #%i (\"%s\") to probe: %s", card, id.c_str(), dsnd_strerror(err) );
+			continue;
+		}
 
-                snd_ctl_card_info_t *info;
-                dsnd_ctl_card_info_alloca(&info);
-                err = dsnd_ctl_card_info( handle, info );
-                if ( err < 0 )
-                {
-                        LOG->Info( "Couldn't get card info for card #%i (\"%s\"): %s", card, id.c_str(), dsnd_strerror(err) );
-                        dsnd_ctl_close( handle );
-                        continue;
-                }
+		snd_ctl_card_info_t *info;
+		dsnd_ctl_card_info_alloca(&info);
+		err = dsnd_ctl_card_info( handle, info );
+		if ( err < 0 )
+		{
+			LOG->Info( "Couldn't get card info for card #%i (\"%s\"): %s", card, id.c_str(), dsnd_strerror(err) );
+			dsnd_ctl_close( handle );
+			continue;
+		}
 
-                int dev = -1;
-                while ( dsnd_ctl_pcm_next_device( handle, &dev ) >= 0 && dev >= 0 )
-                {
-                        snd_pcm_info_t *pcminfo;
-                        dsnd_pcm_info_alloca(&pcminfo);
-                        dsnd_pcm_info_set_device(pcminfo, dev);
-                        dsnd_pcm_info_set_stream(pcminfo, SND_PCM_STREAM_PLAYBACK);
+		int dev = -1;
+		while ( dsnd_ctl_pcm_next_device( handle, &dev ) >= 0 && dev >= 0 )
+		{
+			snd_pcm_info_t *pcminfo;
+			dsnd_pcm_info_alloca(&pcminfo);
+			dsnd_pcm_info_set_device(pcminfo, dev);
+			dsnd_pcm_info_set_stream(pcminfo, SND_PCM_STREAM_PLAYBACK);
 
-                        err = dsnd_ctl_pcm_info(handle, pcminfo);
-                        if ( err < 0 )
-                        {
-                                if (err != -ENOENT)
-                                        LOG->Info("dsnd_ctl_pcm_info(%i) (%s) failed: %s", card, id.c_str(), dsnd_strerror(err));
-                                continue;
-                        }
+			err = dsnd_ctl_pcm_info(handle, pcminfo);
+			if ( err < 0 )
+			{
+				if (err != -ENOENT)
+					LOG->Info("dsnd_ctl_pcm_info(%i) (%s) failed: %s", card, id.c_str(), dsnd_strerror(err));
+				continue;
+			}
 			DriverSoundDevice device;
 			device.id = ssprintf("hw:%i,%i", card, dev);
 			device.readableName = dsnd_pcm_info_get_name(pcminfo);
 			devices.push_back(device);
-                }
-                dsnd_ctl_close(handle);
-        }
+		}
+		dsnd_ctl_close(handle);
+	}
 
-        if( card == 0 )
-                LOG->Info( "No ALSA sound cards were found.");
+	if( card == 0 )
+		LOG->Info( "No ALSA sound cards were found.");
 
 
 	return devices;

--- a/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
@@ -199,13 +199,6 @@ std::vector<DriverSoundDevice> RageSoundDriver_ALSA9_Software::GetSoundDevices()
 			device.id = ssprintf("hw:%i,%i", card, dev);
 			device.readableName = dsnd_pcm_info_get_name(pcminfo);
 			devices.push_back(device);
-
-                        LOG->Info( "ALSA Driver: %i: %s [%s], device %i: %s [%s], %i/%i subdevices avail",
-                                        card, dsnd_ctl_card_info_get_name(info), dsnd_ctl_card_info_get_id(info), dev,
-                                        dsnd_pcm_info_get_id(pcminfo), dsnd_pcm_info_get_name(pcminfo),
-                                        dsnd_pcm_info_get_subdevices_avail(pcminfo),
-                                        dsnd_pcm_info_get_subdevices_count(pcminfo) );
-
                 }
                 dsnd_ctl_close(handle);
         }

--- a/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
@@ -150,6 +150,17 @@ float RageSoundDriver_ALSA9_Software::GetPlayLatency() const
 	return float(g_iMaxWriteahead) / m_iSampleRate;
 }
 
+std::vector<DriverAudioDevice> RageSoundDriver_ALSA9_Software::GetAudioDevices() const
+{
+	std::vector<DriverAudioDevice> devices;
+	// Add default device
+	DriverAudioDevice defaultDevice;
+	defaultDevice.id = "";
+	defaultDevice.readableName = "Default (ALSA Placeholder for PR)";
+	devices.push_back(defaultDevice);
+	return devices;
+}
+
 /*
  * (c) 2002-2004 Glenn Maynard, Aaron VonderHaar
  * All rights reserved.

--- a/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
@@ -150,7 +150,6 @@ float RageSoundDriver_ALSA9_Software::GetPlayLatency() const
 	return float(g_iMaxWriteahead) / m_iSampleRate;
 }
 
-// NOTE: This is using ALSA9Helpers.cpp code here - There might be a better option to re-use the code
 std::vector<DriverSoundDevice> RageSoundDriver_ALSA9_Software::GetSoundDevices() const
 {
 	std::vector<DriverSoundDevice> devices;
@@ -170,9 +169,9 @@ std::vector<DriverSoundDevice> RageSoundDriver_ALSA9_Software::GetSoundDevices()
 		char *desc = snd_device_name_get_hint(*n, "DESC");
 		char *ioid = snd_device_name_get_hint(*n, "IOID");
 
-		// Only consider real PCM hw devices
+		// Only consider direct hw devices
 		bool is_output = (!ioid || strcmp(ioid, "Output") == 0);
-		bool has_card_id = (strstr(name, "CARD=") != NULL );
+		bool has_card_id = (strncmp(name, "hw:", 3) == 0);
 		bool has_default_name = (strstr(name, "default") != NULL );
 
 		if (name && is_output && has_card_id && !has_default_name) {

--- a/src/arch/Sound/RageSoundDriver_ALSA9_Software.h
+++ b/src/arch/Sound/RageSoundDriver_ALSA9_Software.h
@@ -22,7 +22,7 @@ public:
 
 	void SetupDecodingThread();
 
-	std::vector<DriverAudioDevice> GetAudioDevices() const;
+	std::vector<DriverSoundDevice> GetSoundDevices() const;
 
 private:
 	static int MixerThread_start( void *p );

--- a/src/arch/Sound/RageSoundDriver_ALSA9_Software.h
+++ b/src/arch/Sound/RageSoundDriver_ALSA9_Software.h
@@ -22,6 +22,8 @@ public:
 
 	void SetupDecodingThread();
 
+	std::vector<DriverAudioDevice> GetAudioDevices() const;
+
 private:
 	static int MixerThread_start( void *p );
 	void MixerThread();

--- a/src/arch/Sound/RageSoundDriver_Null.cpp
+++ b/src/arch/Sound/RageSoundDriver_Null.cpp
@@ -43,6 +43,13 @@ int RageSoundDriver_Null::GetSampleRate() const
 	return m_iSampleRate;
 }
 
+std::vector<DriverSoundDevice> RageSoundDriver_Null::GetSoundDevices() const
+{
+	std::vector<DriverSoundDevice> devices;
+	devices.push_back({ "", "Null driver" });
+	return devices;
+}
+
 /*
  * (c) 2002-2004 Glenn Maynard, Aaron VonderHaar
  * All rights reserved.

--- a/src/arch/Sound/RageSoundDriver_Null.h
+++ b/src/arch/Sound/RageSoundDriver_Null.h
@@ -12,6 +12,7 @@ public:
 	int64_t GetPosition() const;
 	int GetSampleRate() const;
 	void Update();
+	std::vector<DriverSoundDevice> GetSoundDevices() const;
 
 private:
 	int64_t m_iLastCursorPos;


### PR DESCRIPTION
# Issue

When an user boots an ITGMania system image that only uses ALSA, they have no sound, unless the `default` audio device happens to be the right one.

Imagine, they want to use audio via their `USB-0` sound card, instead of `HDMI-0`

## Proposed solution

From `Graphics/Sound Options`, it would be possible to select the `Sound Device`, at least when the driver provides options.

At a first stage, I think it would be worth it to implement it to set the `SoundDevice`, adding a description that says that the game needs to be restarted to make the change happen.

## Structure

As there is already `SOUNDMAN->GetDriverSampleRate()`, I thought that it could be fine to implement it as `SOUNDMAN->GetDriverAudioDevices();`

`RageSoundDriver` would implement the function `GetAudioDevices()`, just returning the default device, and any driver that can offer a list of devices, as `ALSA` (or `WDMKS` if someone is up to it in another PR), would override the function, returning the list of available devices.

Maybe an extra point to discuss is, if the driver should maintain a list of audio devices in memory, or if this should just be generated while calling that function (I assume the second)

All feedback is very welcome :) Thanks to @sukibaby for the answer in the issue, and @dLobatog for an initial test PR

(Reference: #954 )

Simply Love PR: https://github.com/Simply-Love/Simply-Love-SM5/pull/664

How it looks like:
<img width="1268" height="877" alt="image" src="https://github.com/user-attachments/assets/f443ad8a-9d95-4dd6-9471-d35a3c21f7ce" />
