### PR TITLE
Change ogg and vorbis submodule URLs from GitLab to GitHub

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,11 +24,11 @@
 	shallow = true
 [submodule "extern/ogg"]
 	path = extern/ogg
-	url = https://gitlab.xiph.org/xiph/ogg.git
+	url = https://github.com/xiph/ogg.git
 	shallow = true
 [submodule "extern/vorbis"]
 	path = extern/vorbis
-	url = https://gitlab.xiph.org/xiph/vorbis.git
+	url = https://github.com/xiph/vorbis.git
 	shallow = true
 [submodule "extern/libtommath"]
 	path = extern/libtommath


### PR DESCRIPTION
This should resolve CI failures caused by blocked connections from GitLab. GitLab seems to be running fine,  just opening this up in case problems persist.