### PR TITLE
ScreenSelect: Replace an assert with a warning

### DIFF
--- a/src/ScreenSelect.cpp
+++ b/src/ScreenSelect.cpp
@@ -227,8 +227,17 @@ void ScreenSelect::HandleScreenMessage( const ScreenMessage SM )
 
 		SCREENMAN->RefreshCreditsMessages();
 
-		ASSERT( !IsTransitioning() );
-		StartTransitioningScreen( SM_GoToNextScreen );
+		if( IsTransitioning() )
+		{
+			// If the player pressed Start and Back on the same frame, the
+			// Cancel transition can have started after the
+			// SM_BeginFadingOut message was queued.
+			LOG->Warn("Still transitioning when playing SM_GoToNextScreen");
+		}
+		else
+		{
+			StartTransitioningScreen( SM_GoToNextScreen );
+		}
 	}
 
 	ScreenWithMenuElements::HandleScreenMessage( SM );


### PR DESCRIPTION
ScreenTitleMenu can be in the Cancel transition when the SM_BeginFadingOut message is handled if the players press the Back and Start buttons with the right timing. It seems fine to just continue with even if IsTransitioning() is true.

This seems to happen more easily on weaker machines, but I was able to trigger it on my PC too after spamming Back and Start for a minute or so.