### PR TITLE
Duplicate of #930

### DIFF
--- a/src/RageFile.cpp
+++ b/src/RageFile.cpp
@@ -78,6 +78,9 @@ bool RageFile::Open( const RString& path, int mode )
 		return false;
 	}
 
+	// If we're reading the file, be sure the Enable CRC32 flag is set
+	m_File->EnableCRC32( !!(m_Mode & READ) );
+	
 	return true;
 }
 


### PR DESCRIPTION
Each RageFile already has an [associated uint32_t member variable](https://github.com/itgmania/itgmania/blob/159391b8a244cffdde9366b97e6a2d03f9cfb6b8/src/RageFileBasic.h#L155-L159) to store the CRC32 which is currently left unused.  All this PR does is fill that value.
