### PR TITLE
Revert 3 Win32/GraphicsWindow commits

### DIFF
--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -448,6 +448,8 @@ void GraphicsWindow::DestroyGraphicsWindow()
 		g_HDC = nullptr;
 	}
 
+	CHECKPOINT;
+
 	if( g_hWndMain != nullptr )
 	{
 		DestroyWindow( g_hWndMain );
@@ -455,11 +457,15 @@ void GraphicsWindow::DestroyGraphicsWindow()
 		CrashHandler::SetForegroundWindow( g_hWndMain );
 	}
 
+	CHECKPOINT;
+
 	if( g_hIcon != nullptr )
 	{
 		DestroyIcon( g_hIcon );
 		g_hIcon = nullptr;
 	}
+
+	CHECKPOINT;
 
 	MSG msg;
 	while( PeekMessage( &msg, nullptr, 0, 0, PM_NOREMOVE ) )
@@ -469,6 +475,8 @@ void GraphicsWindow::DestroyGraphicsWindow()
 		CHECKPOINT;
 		DispatchMessage( &msg );
 	}
+
+	CHECKPOINT;
 }
 
 void GraphicsWindow::Initialize( bool bD3D )

--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -436,12 +436,6 @@ void GraphicsWindow::CreateGraphicsWindow( const VideoModeParams &p, bool bForce
 /** @brief Shut down the window, but don't reset the video mode. */
 void GraphicsWindow::DestroyGraphicsWindow()
 {
-	// If we were in fullscreen, release the display mode before destroying the window
-	if( g_hWndMain && !g_CurrentParams.windowed )
-	{
-		ChangeDisplaySettingsEx(g_CurrentParams.sDisplayId, nullptr, nullptr, 0, nullptr);
-	}
-	
 	if( g_HDC != nullptr )
 	{
 		ReleaseDC( g_hWndMain, g_HDC );
@@ -531,6 +525,12 @@ void GraphicsWindow::Initialize( bool bD3D )
 void GraphicsWindow::Shutdown()
 {
 	DestroyGraphicsWindow();
+
+	/* Return to the desktop resolution, if needed.
+	 * It'd be nice to not do this: Windows will do it when we quit, and if
+	 * we're shutting down OpenGL to try D3D, this will cause extra mode
+	 * switches. However, we need to do this before displaying dialogs. */
+	ChangeDisplaySettingsEx( g_CurrentParams.sDisplayId.c_str(), nullptr, nullptr, 0, nullptr );
 
 	AppInstance inst;
 	UnregisterClass( g_sClassName.c_str(), inst );

--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -232,12 +232,10 @@ static void AdjustVideoModeParams( VideoModeParams &p )
  * The refresh setting may be ignored. */
 RString GraphicsWindow::SetScreenMode( const VideoModeParams &p )
 {
-	const DWORD displaySettingsFlag = p.windowed ? CDS_RESET : CDS_FULLSCREEN;
-	
 	if( p.windowed )
 	{
 		// We're going windowed. If we were previously fullscreen, reset.
-		ChangeDisplaySettingsEx( p.sDisplayId.c_str(), nullptr, nullptr, displaySettingsFlag, nullptr );
+		ChangeDisplaySettingsEx( p.sDisplayId.c_str(), nullptr, nullptr, 0, nullptr );
 
 		return RString();
 	}
@@ -245,14 +243,6 @@ RString GraphicsWindow::SetScreenMode( const VideoModeParams &p )
 	DEVMODE DevMode;
 	ZERO( DevMode );
 	DevMode.dmSize = sizeof(DEVMODE);
-
-	// Run DevMode thru EnumDisplaySettings to ensure we only provide modes supported by the display driver.
-	if( !EnumDisplaySettings(p.sDisplayId.c_str(), ENUM_CURRENT_SETTINGS, &DevMode) )
-	{
-		LOG->Warn("EnumDisplaySettings failed for display: %s", p.sDisplayId.c_str());
-		return "Failed to retrieve current display settings.";
-	}
-	
 	DevMode.dmPelsWidth = p.width;
 	DevMode.dmPelsHeight = p.height;
 	DevMode.dmBitsPerPel = p.bpp;
@@ -263,12 +253,13 @@ RString GraphicsWindow::SetScreenMode( const VideoModeParams &p )
 		DevMode.dmDisplayFrequency = p.rate;
 		DevMode.dmFields |= DM_DISPLAYFREQUENCY;
 	}
+	ChangeDisplaySettingsEx(p.sDisplayId.c_str(), nullptr, nullptr, 0, nullptr);
 
-	int ret = ChangeDisplaySettingsEx( p.sDisplayId.c_str(), &DevMode, nullptr, displaySettingsFlag, nullptr );
+	int ret = ChangeDisplaySettingsEx( p.sDisplayId.c_str(), &DevMode, nullptr, CDS_FULLSCREEN, nullptr );
 	if( ret != DISP_CHANGE_SUCCESSFUL && (DevMode.dmFields & DM_DISPLAYFREQUENCY) )
 	{
 		DevMode.dmFields &= ~DM_DISPLAYFREQUENCY;
-		ret = ChangeDisplaySettingsEx( p.sDisplayId.c_str(), &DevMode, nullptr, displaySettingsFlag, nullptr );
+		ret = ChangeDisplaySettingsEx( p.sDisplayId.c_str(), &DevMode, nullptr, CDS_FULLSCREEN, nullptr );
 	}
 
 	// XXX: append error


### PR DESCRIPTION
These commits improved support of multi-monitor setups on Windows 11, but caused a reproducible regression older/noncompliant display drivers, such as Pre-Ryzen AMD APU.