### PR TITLE
Revert "Centralize fallback sample rate with kFallbackSampleRate"

### DIFF
--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -132,6 +132,15 @@ int RageSoundReader_Chain::GetSampleRateInternal() const
 	return iRate;
 }
 
+int RageSoundReader_Chain::GetSampleRate() const
+{
+	if (m_iActualSampleRate == -1)
+	{
+		return m_iPreferredSampleRate;
+	}
+	return m_iActualSampleRate;
+}
+
 void RageSoundReader_Chain::Finish()
 {
 	/* Figure out how many channels we have.  All sounds must either have 1 or 2 channels,

--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -25,13 +25,14 @@
  */
 RageSoundReader_Chain::RageSoundReader_Chain()
 {
-	m_iPreferredSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
-	if (m_iPreferredSampleRate == 0)
-	{
-		m_iPreferredSampleRate = kFallbackSampleRate;
-	}
-	
+	// The preferred sample rate for resampling when sounds have different rates.
+	// Initialized to 44100 Hz, assuming most audio libraries use CD-standard rates.
+	m_iPreferredSampleRate = 44100;
+
+	// The actual sample rate of the audio after resampling.
+	// Used for timing calculations, such as sound offsets or frame positioning.
 	m_iActualSampleRate = -1;
+
 	m_iChannels = 0;
 	m_iCurrentFrame = 0;
 	m_iNextSound = 0;

--- a/src/RageSoundReader_Chain.h
+++ b/src/RageSoundReader_Chain.h
@@ -38,7 +38,7 @@ public:
 	int GetLength_Fast() const;
 	int SetPosition( int iFrame );
 	int Read( float *pBuf, int iFrames );
-	int GetSampleRate() const { return m_iActualSampleRate; }
+	int GetSampleRate() const;
 	unsigned GetNumChannels() const { return m_iChannels; }
 	bool SetProperty( const RString &sProperty, float fValue );
 	int GetNextSourceFrame() const;


### PR DESCRIPTION
Putting it back to the way it was, because this particular commit did introduce some regressions, most significantly in RageSoundReader_Chain