### PR TITLE
Detect and handle audio buffer misalignment (improves AI generated commit)

### DIFF
--- a/src/RageSoundReader_ChannelSplit.cpp
+++ b/src/RageSoundReader_ChannelSplit.cpp
@@ -196,7 +196,15 @@ int RageSoundSplitterImpl::ReadBuffer()
 	{
 		int iEraseFrames = iMinFrameRequested - m_iBufferPositionFrames;
 		iEraseFrames = std::min( iEraseFrames, (int) m_sBuffer.size() );
-		m_sBuffer.erase( m_sBuffer.begin(), m_sBuffer.begin() + static_cast<size_t>(iEraseFrames) * m_pSource->GetNumChannels() );
+
+		// Prevent buffer misalignment
+		if (iEraseFrames % m_pSource->GetNumChannels() != 0 || iEraseFrames < 0)
+		{
+			LOG->Warn("RageSoundSplitterImpl::ReadBuffer: Buffer misalignment or negative erase frames detected (iEraseFrames=%d, channels=%d)", iEraseFrames, m_pSource->GetNumChannels());
+			return -1;
+		}
+
+		m_sBuffer.erase( m_sBuffer.begin(), m_sBuffer.begin() + iEraseFrames * m_pSource->GetNumChannels() );
 		m_iBufferPositionFrames += iEraseFrames;
 	}
 


### PR DESCRIPTION
Improves AI generated commit 6cdf64afc822c2729e1d47a8faec2326a3847b44.  

The AI commit only static casted so that the number could not be negative, but that would hide the bug if any existed.

This commit adds a check for buffer misalignment and negative erase frames before erasing from the buffer. I considered putting an assert here but did not think crashing on failure was appropriate. 

Removing the static cast from within the buffer erase command ensures behavior is consistent with older versions of ITGm / SM 5.1. 