### PR TITLE
Restore original RageSoundReader_Chain behavior

### DIFF
--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -25,12 +25,8 @@
  */
 RageSoundReader_Chain::RageSoundReader_Chain()
 {
-	m_iPreferredSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
-	if (m_iPreferredSampleRate == 0)
-	{
-		m_iPreferredSampleRate = kFallbackSampleRate;
-	}
-	
+	// Game audio should ideally be in the same sample rate as m_iPreferredSampleRate.
+	m_iPreferredSampleRate = 44100;
 	m_iActualSampleRate = -1;
 	m_iChannels = 0;
 	m_iCurrentFrame = 0;
@@ -455,3 +451,4 @@ int RageSoundReader_Chain::GetLength_Fast() const
  * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  * PERFORMANCE OF THIS SOFTWARE.
  */
+


### PR DESCRIPTION
This was a regression introduced by the commit which changed all hardcoded values of 44100 to a constant. Game audio should ideally be in the same sample rate as m_iPreferredSampleRate - therefore this value is unrelated to the other uses of 44100.