### PR TITLE
RageSound: Replace list with deque for audio position map (RageSound refactor PR #1 of 4)

### DIFF
--- a/src/RageSoundPosMap.cpp
+++ b/src/RageSoundPosMap.cpp
@@ -8,7 +8,7 @@
 #include <climits>
 #include <cmath>
 #include <cstdint>
-#include <list>
+#include <deque>
 
 // NOTE(sukibaby): The number of frames we should keep pos_map data for.
 // File bitrate, metadata, etc will factor in here. 80k is a safe value
@@ -29,7 +29,7 @@ struct pos_map_t
 
 struct pos_map_impl
 {
-	std::list<pos_map_t> m_Queue;
+	std::deque<pos_map_t> m_Queue;
 	void Cleanup();
 };
 
@@ -82,7 +82,7 @@ void pos_map_queue::Insert(int64_t iSourceFrame, int64_t iFrames, int64_t iDestF
 
 	if (!merged)
 	{
-		m_pImpl->m_Queue.push_back(pos_map_t());
+		m_pImpl->m_Queue.emplace_back();
 		pos_map_t& m = m_pImpl->m_Queue.back();
 		m.m_iSourceFrame = iSourceFrame;
 		m.m_iDestFrame = iDestFrame;
@@ -95,7 +95,7 @@ void pos_map_queue::Insert(int64_t iSourceFrame, int64_t iFrames, int64_t iDestF
 
 void pos_map_impl::Cleanup()
 {
-	std::list<pos_map_t>::iterator it = m_Queue.end();
+	auto it = m_Queue.end();
 	int64_t iTotalFrames = 0;
 	// Scan backwards until we have at least pos_map_backlog_frames.
 	while (iTotalFrames < pos_map_backlog_frames)


### PR DESCRIPTION
## _For an overview of these four refactor PR's please see_ #993 


We know that RageSoundPosMap benefits directly from reduced overhead, as we have previously determined; after more closely considering our append-only usage of pos_map_queue, deque should be a nice improvement over list here.

list is not ideal for this application because it has heavy on allocations. It gives good iterator/reference stability, but is not appealing for this use case otherwise. This is not a case where the node based structure of list is beneficial.

Likewise, vector would be good for performance, but it has poor iterator/reference stability, so vector is not appealing. 

Since deque gives adequate reference stability, as well as improved cache locality and reduced heap activity compared to list, I determined deque seems ideal here.

In a play test I felt sync was especially stable.