### PR TITLE
RageSound: optimize mutex locking (RageSound refactor PR #2 of 4)

### DIFF
--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -300,11 +300,12 @@ int RageSound::GetDataToPlay( float *pBuffer, int iFrames, int64_t &iStreamFrame
 				break;
 		}
 
-		m_Mutex.Lock();
-		m_StreamToSourceMap.Insert( m_iStreamFrame, iGotFrames, iSourceFrame, fRate );
-		m_Mutex.Unlock();
-
-		m_iStreamFrame += iGotFrames;
+		// Scoped global audio mutex lock while updating the position maps.
+		{
+			LockMut(m_Mutex); 
+			m_StreamToSourceMap.Insert( m_iStreamFrame, iGotFrames, iSourceFrame, fRate );
+			m_iStreamFrame += iGotFrames;
+		}
 
 		iFramesStored += iGotFrames;
 		iFrames -= iGotFrames;


### PR DESCRIPTION
## _For an overview of these four refactor PR's please see_ #993 


Replaces manual mutex lock/unlock with scoped global sound system LockMut for safer synchronization around stream-to-source map insertion and frame update.