### PR TITLE
RageSound: Refactor RageSound::SoundIsFinishedPlaying (RageSound refactor PR #3 of 4)

### DIFF
--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -370,13 +370,20 @@ void RageSound::SoundIsFinishedPlaying()
 	if( !m_bPlaying )
 		return;
 
-	/* Get our current hardware position. */
+	// Get current hardware position to update stopped source frame when sound finishes playing.
 	int64_t iCurrentHardwareFrame = SOUNDMAN->GetPosition(nullptr);
     
+	// Make the decision to delete while inside the lock.
+	// Do the actual deletion after releasing the mutex.
 	bool bDeleteThis = false;
 	{
+		// Global sound mutex
 		LockMut(m_Mutex);
         
+		// Update the stopped source frame using the current hardware frame,
+		// but only if the hardware-to-stream and stream-to-source maps are not empty.
+		// This branch handles normal cleanup when the sound is not scheduled for deletion.
+		// If the maps are empty, we leave m_iStoppedSourceFrame untouched.
 		if( m_bDeleteWhenFinished )
 		{
 			m_bDeleteWhenFinished = false;
@@ -386,6 +393,7 @@ void RageSound::SoundIsFinishedPlaying()
 		{
 			if( !m_HardwareToStreamMap.IsEmpty() && !m_StreamToSourceMap.IsEmpty() )
 			{
+				// Update stopped position only if maps are available; otherwise, preserve existing value.
 				m_iStoppedSourceFrame = static_cast<int>(GetSourceFrameFromHardwareFrame(iCurrentHardwareFrame));
 			}
 
@@ -400,10 +408,6 @@ void RageSound::SoundIsFinishedPlaying()
 		delete this;
 		return;
 	}
-	// Update the stopped source frame using the current hardware frame,
-	// but only if the hardware-to-stream and stream-to-source maps are not empty
-//	LOG->Trace("set playing false for %p (SoundIsFinishedPlaying) (%s)", this, this->GetLoadedFilePath().c_str());
-//	LOG->Trace("SoundIsFinishedPlaying %p finished (%s)", this, this->GetLoadedFilePath().c_str());
 }
 
 void RageSound::Play(bool is_action, const RageSoundParams *pParams)

--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -372,31 +372,38 @@ void RageSound::SoundIsFinishedPlaying()
 
 	/* Get our current hardware position. */
 	int64_t iCurrentHardwareFrame = SOUNDMAN->GetPosition(nullptr);
-
-	m_Mutex.Lock();
-
-	if( m_bDeleteWhenFinished )
+    
+	bool bDeleteThis = false;
 	{
-		m_bDeleteWhenFinished = false;
-		m_Mutex.Unlock();
+		LockMut(m_Mutex);
+        
+		if( m_bDeleteWhenFinished )
+		{
+			m_bDeleteWhenFinished = false;
+			bDeleteThis = true;
+		}
+		else
+		{
+			if( !m_HardwareToStreamMap.IsEmpty() && !m_StreamToSourceMap.IsEmpty() )
+			{
+				m_iStoppedSourceFrame = static_cast<int>(GetSourceFrameFromHardwareFrame(iCurrentHardwareFrame));
+			}
+
+			m_bPlaying = false;
+			m_HardwareToStreamMap.Clear();
+			m_StreamToSourceMap.Clear();
+		}
+	}
+
+	if( bDeleteThis )
+	{
 		delete this;
 		return;
 	}
-
 	// Update the stopped source frame using the current hardware frame,
 	// but only if the hardware-to-stream and stream-to-source maps are not empty
-	if (!m_HardwareToStreamMap.IsEmpty() && !m_StreamToSourceMap.IsEmpty())
-		m_iStoppedSourceFrame = static_cast<int>(GetSourceFrameFromHardwareFrame(iCurrentHardwareFrame));
-
 //	LOG->Trace("set playing false for %p (SoundIsFinishedPlaying) (%s)", this, this->GetLoadedFilePath().c_str());
-	m_bPlaying = false;
-
-	m_HardwareToStreamMap.Clear();
-	m_StreamToSourceMap.Clear();
-
 //	LOG->Trace("SoundIsFinishedPlaying %p finished (%s)", this, this->GetLoadedFilePath().c_str());
-
-	m_Mutex.Unlock();
 }
 
 void RageSound::Play(bool is_action, const RageSoundParams *pParams)


### PR DESCRIPTION
## _For an overview of these four refactor PR's please see_ #993 

This commit refactors the function to hold the mutex for a shorter amount of time, and also reorganize which tasks are performed while the mutex is held. We now only handle the essential operations with the mutex held.

LockMut(m_Mutex) is used instead of Lock and Unlock() as it's preferred for locking the sound system. 

We introduce a new boolean bDeleteThis to track whether or not we need to delete the object, and handle deletion after releasing the mutex.

With this commit, the original functionality is maintained, with increased thread safety and reduced mutex contention.