### PR TITLE
RageSound: reduce time spent in mutex lock (RageSound refactor PR #4 of 4)

### DIFF
--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -494,22 +494,18 @@ float RageSound::GetPositionSeconds( RageTimer *pTimestamp ) const
 	// Get our current hardware position.
 	int64_t iCurrentHardwareFrame = SOUNDMAN->GetPosition(pTimestamp);
 
-	// Lock the mutex after calling SOUNDMAN->GetPosition().
-	LockMut(m_Mutex);
-
 	// cast the sample rate to be used for the remainder of the function.
 	float fSampleRate = static_cast<float>(m_pSource->GetSampleRate());
 
-	/* If we're not playing, just report the static position. */
+	// Quick check without lock
 	if( !IsPlaying() )
 		return static_cast<float>(m_iStoppedSourceFrame) / fSampleRate;
 
-	/* If we don't yet have any position data, CommitPlayingPosition hasn't yet been called at all,
-	 * so guess what we think the real time is. */
+	// If we don't have position information, CommitPlayingPosition hasn't been called yet
+	LockMut(m_Mutex);
+    
 	if( m_HardwareToStreamMap.IsEmpty() || m_StreamToSourceMap.IsEmpty() )
-	{
 		return static_cast<float>(m_iStoppedSourceFrame) / fSampleRate;
-	}
 
 	int iSourceFrame = GetSourceFrameFromHardwareFrame( iCurrentHardwareFrame );
 	return static_cast<float>(iSourceFrame) / fSampleRate;

--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -505,7 +505,9 @@ float RageSound::GetPositionSeconds( RageTimer *pTimestamp ) const
 	LockMut(m_Mutex);
     
 	if( m_HardwareToStreamMap.IsEmpty() || m_StreamToSourceMap.IsEmpty() )
+	{
 		return static_cast<float>(m_iStoppedSourceFrame) / fSampleRate;
+	}
 
 	int iSourceFrame = GetSourceFrameFromHardwareFrame( iCurrentHardwareFrame );
 	return static_cast<float>(iSourceFrame) / fSampleRate;


### PR DESCRIPTION
```mermaid
flowchart TD


    subgraph "Core Sound Classes"
        RSnd["RageSound<br>Main sound object<br>- Load sounds<br>- Play/Stop/Pause<br>- Get position"]
        RReader["RageSoundReader<br>Audio decoder<br>- Read PCM data<br>- Handle formats"]
        RManager["RageSoundManager (SOUNDMAN)<br>Global sound manager<br>- Driver interface<br>- Preload cache<br>- Volume control"]
        RPosMap["RageSoundPosMap<br>Position mapper<br>- Hardware ↔ Source frames<br>- Search mappings"]
        RMix["RageSoundMixBuffer<br>Mixing buffer<br>- Mix PCM data<br>- Convert to int16"]
    end

    subgraph "System"
        Driver["Audio Driver<br>(Hardware Output)"]
    end

    %% User starts with RageSound
    ITGmania -->|"Create RageSound<br>Call Load(), Play()"| RSnd

    %% RageSound interacts with SOUNDMAN for global operations
    RSnd -->|"Load/Play signals"| RManager
    RManager -->|"GetLoadedSound()"| RSnd
    RManager -->|"StartMixing()<br>(Register with driver)"| Driver

    %% Decoding and mixing flow
    RSnd -->|"GetDataToPlay():<br>Decode PCM via Read()"| RReader
    RReader -->|"Read():<br>Return decoded frames"| RSnd
    RSnd -->|"write():<br>Mix into buffer"| RMix
    RMix -->|"read():<br>Supply mixed frames"| Driver

    %% Position tracking - key interaction
    RSnd -->|"Insert position map"| RPosMap
    RPosMap -->|"Store position maps"| RSnd
    RSnd -->|"GetPositionSeconds()"| RPosMap
    RPosMap -->|"Search()"| RSnd

    %% SOUNDMAN manages preloading
    RManager -->|"AddLoadedSound():<br>Cache preloaded readers"| RReader
    RReader -->|"Copy():<br>Refcounted copy for reuse"| RManager

    %% Driver feedback
    Driver -->|"GetDriverSampleRate()<br>Hardware info"| RManager

    %% Notes for clarity
    classDef note fill:#f9f,stroke:#333,stroke-width:2px;
    classDef core fill:#e1f5fe,stroke:#01579b,stroke-width:2px;
    classDef user fill:#fff3e0,stroke:#e65100,stroke-width:2px;
    classDef system fill:#f3e5f5,stroke:#4a148c,stroke-width:2px;

    class RSnd,RReader,RManager,RPosMap,RMix core;
    class Driver system;
```

Above is a general overview of RageSound structure.  This is oversimplified (RageSoundReader is about a dozen different source files which handle everything from splitting channels to resampling, or handling individual file types such as MP3 / OGG / WAV)

The general theory of the RageSound refactor PR's is resolving bottlenecks. The bottlenecks are a result of excessive heap activity or lock contention. It is split up into four changes, so four PR's.

These changes, combined with #985 provided a build on top of the current state of `beta` which users said was more stable than the 1.0.2 48khz build.

The first PR, #989 stops excessive heap allocations by replacing `list` with `deque`, because `deque` is more ideal for this purpose than `vector` or `list`.

The other three refactor RageSound mutexing to improve thread safety and reduce the amount of time spent inside mutex locks.

#991  refactors `RageSound::GetDataToPlay` has a more finely scoped mutex lock and ensures proper synchronization between adding a position to the map and updating the position of the active frame. 

#992  refactors `RageSound::SoundIsFinishedPlaying` refactors the logic flow so that any object deletion is handled outside of the scope of the mutex lock, and so the mutex lock is held for as little time as possible.

This PR moves two operations outside of the lock scope to prevent unwanted mutex lock effects if we don't need to lock.