### PR TITLE
Update log message for audio frame mismatch

### DIFF
--- a/src/RageSoundPosMap.cpp
+++ b/src/RageSoundPosMap.cpp
@@ -161,7 +161,7 @@ int64_t pos_map_queue::Search( int64_t iSourceFrame ) const
 	if( last.Ago() >= 1.0f )
 	{
 		last.Touch();
-		LOG->Trace("Audio frame (%" PRId64 ") was out of range of the data sent - possible buffer underflow? This is not always an error, however if you see it frequently there could be sound buffer problems.", iSourceFrame);
+		LOG->Trace("Audio position mismatch: frame %" PRId64 " outside buffered range (normal during start/stop)", iSourceFrame);
 	}
 
 	return iClosestPosition;


### PR DESCRIPTION
The existing message is too wordy, not clear enough, and also too long (one of the few log messages that spans more than one line). The new log message is more concise, uses more precise terminology, and removes wording/punctuation which comes across as uncertain.