### PR TITLE
RageDisplay_OGL: Resolve an uninitialized variable.

### DIFF
--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -826,10 +826,19 @@ RString RageDisplay_Legacy::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 	return RString();	// successfully set mode
 }
 
+// https://stackoverflow.com/q/6594214
+// Since glGetIntegerv won't initialize the variable if it fails, account for failure.
 int RageDisplay_Legacy::GetMaxTextureSize() const
 {
 	GLint size;
 	glGetIntegerv( GL_MAX_TEXTURE_SIZE, &size );
+
+	if (size <= 0)
+	{
+		LOG->Warn("OpenGL: glGetIntegerv failed when retrieving GL_MAX_TEXTURE_SIZE. Returning fallback value.");
+		return 2048; // fallback
+	}
+	
 	return size;
 }
 

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -828,15 +828,18 @@ RString RageDisplay_Legacy::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 
 // https://stackoverflow.com/q/6594214
 // Since glGetIntegerv won't initialize the variable if it fails, account for failure.
+// We initialize it to -1, so we know if it failed. Failure here is extremely uncommon,
+// but was first reported on a setup using an AMD RX 6600 series GPU & late 2024 driver.
 int RageDisplay_Legacy::GetMaxTextureSize() const
 {
-	GLint size;
+	GLint size = -1;
 	glGetIntegerv( GL_MAX_TEXTURE_SIZE, &size );
 
-	if (size <= 0)
+	if( size <= 0 )
 	{
-		LOG->Warn("OpenGL: glGetIntegerv failed when retrieving GL_MAX_TEXTURE_SIZE. Returning fallback value.");
-		return 2048; // fallback
+		LOG->Warn("RageDisplay_Legacy::GetMaxTextureSize: glGetIntegerv %s %d", 
+		          ( size == -1 ) ? "failed" : "returned invalid value", size);
+		return 2048;
 	}
 	
 	return size;


### PR DESCRIPTION
Closes #996.

Since `glGetIntegerv` won't initialize the variable if it fails, this function can possibly return an uninitialized value, as shown in #996. This PR would safely handle that failure by initializing the returned variable to `-1`, so that if we can detect if the variable wasn't filled by the OpenGL function.

For context, `RageBitmapTexture::Create()` will typically find this value to be larger than the maximum texture size as set in game preferences (of which the largest is 2048). `Create()` will pick the smaller of the two numbers. If this returns an uninitialized variable, which is likely represented as a negative integer, then the assertion in `Create()` that the texture size is not negative will fail and crash the game.

The first (and so far, only) known report of a failure here was on Windows, with an AMD RX 6600 series card, and a late 2024 driver. While I can't confirm personally, it seems from some research online that the AMD driver may artificially cap the value at 2048, even if the actual maximum texture size the hardware is capable of is higher. Thus the behavior of the request for `GL_MAX_TEXTURE_SIZE` may be non standard on this particular setup.