### PR TITLE
Fix duplicated attacks when saving

### DIFF
--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -402,8 +402,18 @@ static RString GetSSCNoteData( const Song &song, const Steps &in, bool bSavingCa
 	}
 
 	// todo: get this to output similar to course mods -aj
-	if (song.GetAttackString() != in.GetAttackString())
-		lines.push_back( ssprintf("#ATTACKS:%s;", in.GetAttackString().c_str()));
+	RString songAttacks = song.GetAttackString();
+	RString stepAttacks = in.GetAttackString();
+	if( stepAttacks != songAttacks )
+	{
+		// When loading, Steps::m_Attacks are set to the song attacks followed
+		// by the step attacks. We need to omit the song attacks when saving.
+		// Otherwise, a second copy of the song attacks would be added on the
+		// next load.
+		if( Left(stepAttacks, songAttacks.size() + 1) == songAttacks + ":" )
+			stepAttacks = Right(stepAttacks, stepAttacks.size() - songAttacks.size() - 1);
+		lines.push_back( ssprintf("#ATTACKS:%s;", stepAttacks.c_str()));
+	}
 
 	switch( in.GetDisplayBPM() )
 	{


### PR DESCRIPTION
Fixes a copy of the song-level attacks being added to the step-level attacks when saving a song that had attacks at both the song level and the step level.

It would be cleaner to not merge song and step attacks, but some existing charts might rely on that. Songs "Feral" and "Throne of Skulls" from 9guys1pack have both song-level and step-level attacks, but the step attacks already contain multiple copies of the song attacks (maybe because of this bug).