### PR TITLE
add lua binding for ScreenOptions.SetOptionRowIndex

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -1740,6 +1740,7 @@
 			<Function name='GetCurrentRowIndex'/>
 			<Function name='GetNumRows'/>
 			<Function name='GetOptionRow'/>
+			<Function name='SetOptionRowIndex'/>
 		</Class>
 		<Class base='ScreenOptions' name='ScreenPlayerOptions'>
 			<Function name='GetGoToOptions'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -3423,7 +3423,7 @@ end
 		If this is not set in the <code>Pack.ini</code>, the <code>sGroupDirName</code> is used instead.
 	</Function>
 	<Function name='GetDisplayTitle' return='string' arguments='' since='ITGmania 1.0.0'>
-		Returns the display title of the group as its displayed to the user in the MusicWheel 
+		Returns the display title of the group as its displayed to the user in the MusicWheel
 		If this is not set in the <code>Pack.ini</code>, the <code>sGroupDirName</code> is used instead.
 	</Function>
 	<Function name='GetTranslitTitle' return='string' arguments='' since='ITGmania 1.0.0'>
@@ -5471,19 +5471,22 @@ Details of the <code>event</code> table:
 </Class>
 <Class name='ScreenOptions' grouping='Screen'>
 	<Function name='AllAreOnLastRow' return='bool'  arguments=''>
-		Returns <code>true</code> if all active players are on the last options row.
+		Returns <code>true</code> if all active players are on the last OptionRow.
 	</Function>
 	<Function name='FocusedItemEndsScreen' return='bool'  arguments='PlayerNumber pn'>
 		Returns <code>true</code> if the specified player is on an items that ends the screen.
 	</Function>
 	<Function name='GetCurrentRowIndex' return='int' arguments='PlayerNumber pn'>
-		Returns the current row that player <code>pn</code> is on. (Was previously <code>GetCurrentRow</code>.)
+		Returns the 0-based index of the current row that player <code>pn</code> is on.
 	</Function>
 	<Function name='GetNumRows' return='int' arguments=''>
 		Returns the number of rows on the screen.
 	</Function>
 	<Function name='GetOptionRow' return='OptionRow' arguments='int iRow'>
-		Returns the specified OptionRow.
+		Returns the specified <Link class='OptionRow' />.  The first row has index <code>0</code>.
+	</Function>
+	<Function name='SetOptionRowIndex' return='' arguments='PlayerNumber pn, int iRow' since='ITGmania 1.2.0'>
+		Sets OptionRow <code>iRow</code> as the active row for player <code>pn</code>.  The first row has index <code>0</code>.
 	</Function>
 </Class>
 <Class name='ScreenPlayerOptions' grouping='Screen'>

--- a/src/ScreenOptions.cpp
+++ b/src/ScreenOptions.cpp
@@ -1342,19 +1342,6 @@ void ScreenOptions::MenuUpDown( const InputEventPlus &input, int iDir )
 	}
 }
 
-/*
-void ScreenOptions::SetOptionRowFromName( const RString& nombre )
-	{
-		FOREACH_PlayerNumber( pn )
-		{
-			for( unsigned i=0; i<m_pRows.size(); i++ )
-			{
-				if( m_pRows[i]->GetRowTitle() == nombre) && m_pRows[i]->GetRowDef().IsEnabledForPlayer(p) )
-					MoveRowAbsolute(pn,i)
-			}
-		}
-	}
-*/
 // lua start
 #include "LuaBinding.h"
 
@@ -1367,8 +1354,6 @@ public:
 	static int GetCurrentRowIndex( T* p, lua_State *L ) { lua_pushnumber( L, p->GetCurrentRow(Enum::Check<PlayerNumber>(L, 1)) ); return 1; }
 	static int GetOptionRow( T* p, lua_State *L ) {
 		int row_index= IArg(1);
-		// TODO:  Change row indices to be 1-indexed when breaking compatibility
-		// is allowed. -Kyz
 		if(row_index < 0 || row_index >= p->GetNumRows())
 		{
 			luaL_error(L, "Row index %d is invalid.", row_index);
@@ -1381,7 +1366,16 @@ public:
 		return 1;
 	}
 	DEFINE_METHOD(GetNumRows, GetNumRows());
-   //static int SetOptionRowFromName( T* p, lua_State *L ) { p->SetOptionRowFromName( SArg(1) ); return 0; }
+
+	static int SetOptionRowIndex( T* p, lua_State *L ) {
+		PlayerNumber pn = Enum::Check<PlayerNumber>(L, 1);
+		int row_index = IArg(2);
+		if (row_index < 0 || row_index >= p->GetNumRows()) {
+			luaL_error(L, "Row index %d is invalid.", row_index);
+		}
+		p->MoveRowAbsolute(pn, row_index);
+		COMMON_RETURN_SELF;
+	}
 
 	LunaScreenOptions()
 	{
@@ -1390,7 +1384,7 @@ public:
 		ADD_METHOD( GetCurrentRowIndex );
 		ADD_METHOD( GetOptionRow );
 		ADD_METHOD( GetNumRows );
-        //ADD_METHOD( SetOptionRowFromName );
+		ADD_METHOD( SetOptionRowIndex );
 	}
 };
 


### PR DESCRIPTION
# New Lua Binding

I exposed a new Lua method under `ScreenOptions` that acts as a wrapper for `MoveRowAbsolute()` which ScreenOptions was already using internally to change the active row.

Exposing it to Lua should allow themes to programmatically set the active OptionRow on any screen that inherits from ScreenOptions, e.g. ScreenOptionsService

# Motivation
I wanted to improve UX in Simply-Love's Operator Menu by "remembering" what OptionRow you were previously on when going in-and-out of its many screens and sub-screens, like this:

https://github.com/user-attachments/assets/0717e594-8705-4efa-8885-5e6f284a4fc7

(The current behavior is to always initialize the screen's **first** OptionRow as active.)

If this PR is merged, I'll follow up with a PR to Simply-Love-SM5 that uses `SetOptionRowFromIndex()` as demonstrated in the video.

# Help Wanted
I could use some help adding safeguards to this new method.  ITGm crashes if the theme passes a negative int or an int larger than the number of rows available.  What's the best way to do this in ITGm?

I've marked this PR as _draft_ until then.