### PR TITLE
Pin workflow runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13, windows-latest]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, macos-15-intel, windows-2022]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             name: Ubuntu (x86_64)
             install: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
@@ -24,17 +24,17 @@ jobs:
             install: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
             build: cmake --build build --parallel "$(nproc)"
-          - os: macos-latest
+          - os: macos-15
             name: macOS (M1)
             install: brew install nasm
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
             build: cmake --build build --parallel "$(sysctl -n hw.logicalcpu)"
-          - os: macos-13
+          - os: macos-15-intel
             name: macOS (Intel)
             install: brew install nasm
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
             build: cmake --build build --parallel "$(sysctl -n hw.logicalcpu)"
-          - os: windows-latest
+          - os: windows-2022
             name: Windows
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
             build: cmake --build build --parallel "$env:NUMBER_OF_PROCESSORS"
@@ -53,10 +53,10 @@ jobs:
      #     restore-keys: |
      #       ${{ runner.os }}-${{ runner.arch }}-cmake-build-ci-
       - name: Install dependencies
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-2022'
         run: ${{ matrix.install }}
       - name: Add msbuild to PATH
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         uses: microsoft/setup-msbuild@v2
         with:
           msbuild-architecture: x64
@@ -67,7 +67,7 @@ jobs:
 
   validate-xml-docs:
     name: Validate Lua.xml, LuaDocumentation.xml
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - name: Install dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   analyze:
     name: Analyze C++
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest] # TODO: macos-13
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, windows-2022] # TODO: macos-15-intel
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             name: Ubuntu (x86_64)
             install: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
@@ -33,7 +33,7 @@ jobs:
             release-full: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DWITH_NIGHTLY_RELEASE=Off -DWITH_CLUB_FANTASTIC=Off
             package: cmake --build build --target package
             path: build/ITGmania-*.tar.gz
-          - os: macos-latest
+          - os: macos-15
             name: macOS (M1)
             install: brew install nasm
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
@@ -41,7 +41,7 @@ jobs:
             release-full: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DWITH_NIGHTLY_RELEASE=Off -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_CLUB_FANTASTIC=Off
             package: cmake --build build --target package
             path: build/ITGmania-*.dmg
-          - os: windows-latest
+          - os: windows-2022
             name: Windows
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
             release-nightly: cmake -B build -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
@@ -63,10 +63,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ github.ref_name }}-
       - name: Install dependencies
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-2022'
         run: ${{ matrix.install }}
       - name: Add msbuild to PATH
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         uses: microsoft/setup-msbuild@v2
         with:
           msbuild-architecture: x64


### PR DESCRIPTION
Following https://github.com/actions/runner-images/issues/12677 Windows release builds have been failing as the NSIS package is not present in the new image. This PR pins workflow runners to specific runner images, reference https://github.com/actions/runner-images?tab=readme-ov-file#available-images, with three notable changes-

1. The Windows runner is restored to previous working 2022 image
2. The 'macOS Intel' image is updated to macOS 15
3. Ubuntu image stays at 24.04, latest available