### PR TITLE
Trim extraneous whitespace in HttpAllowHosts string

### DIFF
--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -142,6 +142,11 @@ bool NetworkManager::IsUrlAllowed(const std::string& url)
 	std::vector<RString> allowedHosts;
 	split(allowedHostsStr, ",", allowedHosts);
 
+	for (auto& host : allowedHosts)
+	{
+		Trim(host);
+	}
+	
 	for (const auto& allowedHost : allowedHosts)
 	{
 		// subdomain wildcards; ".domain" doesn't match "*.domain", but "a.domain" does


### PR DESCRIPTION
Currently we have a mismatch of preferences being split by comma+space or just comma, this change would allow either style to be used for HttpAllowHosts.