### PR TITLE
Thread safety fixes for parallel loading

### DIFF
--- a/src/ImageCache.cpp
+++ b/src/ImageCache.cpp
@@ -11,6 +11,7 @@
 #include "RageDisplay.h"
 #include "RageTexture.h"
 #include "RageTextureManager.h"
+#include "RageThreads.h"
 #include "RageSurface.h"
 #include "RageSurfaceUtils.h"
 #include "RageSurfaceUtils_Palettize.h"
@@ -55,6 +56,9 @@ ImageCache *IMAGECACHE; // global and accessible from anywhere in our program
 static std::map<RString, RageSurface*> g_ImagePathToImage;
 static int g_iDemandRefcount = 0;
 
+/* Synchronizes access to g_ImagePathToImage and ImageCache::ImageData. */
+static RageMutex g_ImageCacheMutex("ImageCache");
+
 RString ImageCache::GetImageCachePath( RString sImageDir ,RString sImagePath )
 {
 	return SongCacheIndex::GetCacheFilePath( sImageDir, sImagePath );
@@ -72,6 +76,7 @@ void ImageCache::Demand( RString sImageDir )
 	if( PREFSMAN->m_ImageCache != IMGCACHE_LOW_RES_LOAD_ON_DEMAND )
 		return;
 
+	LockMut(g_ImageCacheMutex);
 	FOREACH_CONST_Child( &ImageData, p )
 	{
 		RString sImagePath = p->GetName();
@@ -120,8 +125,11 @@ void ImageCache::LoadImage( RString sImageDir, RString sImagePath )
 
 	for( int tries = 0; tries < 2; ++tries )
 	{
-		if( g_ImagePathToImage.find(sImagePath) != g_ImagePathToImage.end() )
-			return; /* already loaded */
+		{
+			LockMut(g_ImageCacheMutex);
+			if( g_ImagePathToImage.find(sImagePath) != g_ImagePathToImage.end() )
+				return; /* already loaded */
+		}
 
 		CHECKPOINT_M( ssprintf( "ImageCache::LoadImage: %s", sCachePath.c_str() ) );
 		RageSurface *pImage = RageSurfaceUtils::LoadSurface( sCachePath );
@@ -145,12 +153,24 @@ void ImageCache::LoadImage( RString sImageDir, RString sImagePath )
 			}
 		}
 
-		g_ImagePathToImage[sImagePath] = pImage;
+		{
+			LockMut(g_ImageCacheMutex);
+			if( g_ImagePathToImage.find(sImagePath) != g_ImagePathToImage.end() )
+			{
+				/* already loaded */
+				delete pImage;
+			}
+			else
+			{
+				g_ImagePathToImage[sImagePath] = pImage;
+			}
+		}
 	}
 }
 
 void ImageCache::OutputStats() const
 {
+	LockMut(g_ImageCacheMutex);
 	int iTotalSize = 0;
 	for (auto const &it : g_ImagePathToImage)
 	{
@@ -163,6 +183,7 @@ void ImageCache::OutputStats() const
 
 void ImageCache::UnloadAllImages()
 {
+	LockMut(g_ImageCacheMutex);
 	for (auto &it: g_ImagePathToImage)
 	{
 		delete it.second;
@@ -184,6 +205,7 @@ ImageCache::~ImageCache()
 
 void ImageCache::ReadFromDisk()
 {
+	LockMut(g_ImageCacheMutex);
 	ImageData.ReadFile( IMAGE_CACHE_INDEX );	// don't care if this fails
 }
 
@@ -287,6 +309,8 @@ RageTextureID ImageCache::LoadCachedImage( RString sImageDir, RString sImagePath
 
 	//LOG->Trace( "ImageCache::LoadCachedImage(%s): %s", sImagePath.c_str(), ID.filename.c_str() );
 
+	LockMut(g_ImageCacheMutex);
+
 	/* Hack: make sure Image::Load doesn't change our return value and end up
 	 * reloading. */
 	if(sImageDir == "Banner")
@@ -362,8 +386,11 @@ void ImageCache::CacheImage( RString sImageDir, RString sImagePath )
 		{
 			unsigned CurFullHash;
 			const unsigned FullHash = GetHashForFile( sImagePath );
-			if( ImageData.GetValue( sImagePath, "FullHash", CurFullHash ) && CurFullHash == FullHash )
-				bCacheUpToDate = true;
+			{
+				LockMut(g_ImageCacheMutex);
+				if( ImageData.GetValue( sImagePath, "FullHash", CurFullHash ) && CurFullHash == FullHash )
+					bCacheUpToDate = true;
+			}
 		}
 
 		if( bCacheUpToDate )
@@ -447,33 +474,39 @@ void ImageCache::CacheImageInternal( RString sImageDir, RString sImagePath )
 	const RString sCachePath = GetImageCachePath(sImageDir,sImagePath);
 	RageSurfaceUtils::SaveSurface( pImage, sCachePath );
 
-	/* If an old image is loaded, free it. */
-	if( g_ImagePathToImage.find(sImagePath) != g_ImagePathToImage.end() )
 	{
-		RageSurface *oldimg = g_ImagePathToImage[sImagePath];
-		delete oldimg;
-		g_ImagePathToImage.erase(sImagePath);
+		LockMut(g_ImageCacheMutex);
+
+		/* If an old image is loaded, free it. */
+		if( g_ImagePathToImage.find(sImagePath) != g_ImagePathToImage.end() )
+		{
+			RageSurface *oldimg = g_ImagePathToImage[sImagePath];
+			delete oldimg;
+			g_ImagePathToImage.erase(sImagePath);
+		}
+
+		if( PREFSMAN->m_ImageCache == IMGCACHE_LOW_RES_PRELOAD )
+		{
+			/* Keep it; we're just going to load it anyway. */
+			g_ImagePathToImage[sImagePath] = pImage;
+		}
+		else
+			delete pImage;
+
+		/* Remember the original size. */
+		ImageData.SetValue( sImagePath, "Path", sCachePath );
+		ImageData.SetValue( sImagePath, "Width", iSourceWidth );
+		ImageData.SetValue( sImagePath, "Height", iSourceHeight );
+		ImageData.SetValue( sImagePath, "FullHash", GetHashForFile( sImagePath ) );
 	}
 
-	if( PREFSMAN->m_ImageCache == IMGCACHE_LOW_RES_PRELOAD )
-	{
-		/* Keep it; we're just going to load it anyway. */
-		g_ImagePathToImage[sImagePath] = pImage;
-	}
-	else
-		delete pImage;
-
-	/* Remember the original size. */
-	ImageData.SetValue( sImagePath, "Path", sCachePath );
-	ImageData.SetValue( sImagePath, "Width", iSourceWidth );
-	ImageData.SetValue( sImagePath, "Height", iSourceHeight );
-	ImageData.SetValue( sImagePath, "FullHash", GetHashForFile( sImagePath ) );
 	if (!delay_save_cache)
 		WriteToDisk();
 }
 
 void ImageCache::WriteToDisk()
 {
+	LockMut(g_ImageCacheMutex);
 	ImageData.WriteFile(IMAGE_CACHE_INDEX);
 }
 

--- a/src/NotesLoaderDWI.cpp
+++ b/src/NotesLoaderDWI.cpp
@@ -19,8 +19,6 @@
 
 Difficulty DwiCompatibleStringToDifficulty( const RString& sDC );
 
-static std::map<int,int> g_mapDanceNoteToNoteDataColumn;
-
 /** @brief The different types of core DWI arrows and pads. */
 enum DanceNotes
 {
@@ -102,18 +100,18 @@ static void DWIcharToNote( char c, GameController i, int &note1Out, int &note2Ou
  * @param col2Out The second result based on the character.
  * @param sPath the path to the file.
  */
-static void DWIcharToNoteCol( char c, GameController i, int &col1Out, int &col2Out, const RString &sPath )
+static void DWIcharToNoteCol( char c, GameController i, int &col1Out, int &col2Out, const RString &sPath, const std::map<int,int> &mapDanceNoteToNoteDataColumn )
 {
 	int note1, note2;
 	DWIcharToNote( c, i, note1, note2, sPath );
 
 	if( note1 != DANCE_NOTE_NONE )
-		col1Out = g_mapDanceNoteToNoteDataColumn[note1];
+		col1Out = mapDanceNoteToNoteDataColumn.at(note1);
 	else
 		col1Out = -1;
 
 	if( note2 != DANCE_NOTE_NONE )
-		col2Out = g_mapDanceNoteToNoteDataColumn[note2];
+		col2Out = mapDanceNoteToNoteDataColumn.at(note2);
 	else
 		col2Out = -1;
 }
@@ -188,7 +186,7 @@ static StepsType GetTypeFromMode(const RString &mode)
 }
 
 static NoteData ParseNoteData(RString &step1, RString &step2,
-			      Steps &out, const RString &path)
+	Steps &out, const RString &path )
 {
 	if (step1.size() < 2 && step2.size() < 2)
 	{
@@ -196,39 +194,40 @@ static NoteData ParseNoteData(RString &step1, RString &step2,
 		// Handle the error by returning an empty NoteData object
 		return NoteData();
 	}
-	g_mapDanceNoteToNoteDataColumn.clear();
+
+	std::map<int, int> mapDanceNoteToNoteDataColumn;
 	switch( out.m_StepsType )
 	{
 		case StepsType_dance_single:
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_LEFT] = 0;
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_DOWN] = 1;
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_UP] = 2;
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_RIGHT] = 3;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_LEFT] = 0;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_DOWN] = 1;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_UP] = 2;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_RIGHT] = 3;
 			break;
 		case StepsType_dance_double:
 		case StepsType_dance_couple:
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_LEFT] = 0;
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_DOWN] = 1;
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_UP] = 2;
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_RIGHT] = 3;
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD2_LEFT] = 4;
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD2_DOWN] = 5;
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD2_UP] = 6;
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD2_RIGHT] = 7;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_LEFT] = 0;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_DOWN] = 1;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_UP] = 2;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_RIGHT] = 3;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD2_LEFT] = 4;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD2_DOWN] = 5;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD2_UP] = 6;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD2_RIGHT] = 7;
 			break;
 		case StepsType_dance_solo:
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_LEFT] = 0;
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_UPLEFT] = 1;
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_DOWN] = 2;
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_UP] = 3;
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_UPRIGHT] = 4;
-			g_mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_RIGHT] = 5;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_LEFT] = 0;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_UPLEFT] = 1;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_DOWN] = 2;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_UP] = 3;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_UPRIGHT] = 4;
+			mapDanceNoteToNoteDataColumn[DANCE_NOTE_PAD1_RIGHT] = 5;
 			break;
 			DEFAULT_FAIL( out.m_StepsType );
 	}
 
 	NoteData newNoteData;
-	newNoteData.SetNumTracks( g_mapDanceNoteToNoteDataColumn.size() );
+	newNoteData.SetNumTracks( mapDanceNoteToNoteDataColumn.size() );
 
 	for( int pad=0; pad<2; pad++ )		// foreach pad
 	{
@@ -319,11 +318,12 @@ static NoteData ParseNoteData(RString &step1, RString &step2,
 
 						int iCol1, iCol2;
 						DWIcharToNoteCol(
-								 c,
-								 (GameController)pad,
-								 iCol1,
-								 iCol2,
-								 path );
+								c,
+								(GameController)pad,
+								iCol1,
+								iCol2,
+								path,
+								mapDanceNoteToNoteDataColumn);
 
 						if( iCol1 != -1 )
 							newNoteData.SetTapNote(iCol1,
@@ -347,10 +347,11 @@ static NoteData ParseNoteData(RString &step1, RString &step2,
 							const char holdChar = sStepData[i++];
 
 							DWIcharToNoteCol(holdChar,
-									 (GameController)pad,
-									 iCol1,
-									 iCol2,
-									 path );
+									(GameController)pad,
+									iCol1,
+									iCol2,
+									path,
+									mapDanceNoteToNoteDataColumn);
 
 							if( iCol1 != -1 )
 								newNoteData.SetTapNote(iCol1,

--- a/src/RageSurfaceUtils_Dither.cpp
+++ b/src/RageSurfaceUtils_Dither.cpp
@@ -4,6 +4,7 @@
 #include "RageSurface.h"
 #include "RageSurfaceUtils.h"
 
+#include <atomic>
 #include <cstdint>
 
 #define DitherMatDim 4
@@ -48,8 +49,8 @@ static uint8_t DitherPixel(int x, int y, int intensity,  int conv)
 
 void RageSurfaceUtils::OrderedDither( const RageSurface *src, RageSurface *dst )
 {
-	static bool DitherMatCalc_initted = false;
-	if( !DitherMatCalc_initted )
+	static std::atomic<bool> DitherMatCalc_initted = false;
+	if( !DitherMatCalc_initted.load(std::memory_order_acquire) )
 	{
 		for( int i = 0; i < DitherMatDim; ++i )
 		{
@@ -62,7 +63,7 @@ void RageSurfaceUtils::OrderedDither( const RageSurface *src, RageSurface *dst )
 			}
 		}
 
-		DitherMatCalc_initted = true;
+		DitherMatCalc_initted.store(true, std::memory_order_release);
 	}
 
 	// We can't dither to paletted surfaces.

--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -144,6 +144,14 @@ static RageMutex &GetThreadSlotsLock()
 	return *pLock;
 }
 
+/* All unkown threads are put into the same slot in g_ThreadSlots. This
+ * mutex synchronizes access to that slot. */
+static RageMutex &GetUnknownThreadSlotLock()
+{
+	static RageMutex *pLock = new RageMutex( "UnknownThreadSlot" );
+	return *pLock;
+}
+
 static int FindEmptyThreadSlot()
 {
 	LockMut( GetThreadSlotsLock() );
@@ -387,17 +395,24 @@ void Checkpoints::SetCheckpoint( const char *file, int line, const RString& mess
 
 void Checkpoints::SetCheckpoint( const char *file, int line, const char *message )
 {
+	bool bUnknownThread = false;
 	ThreadSlot *slot = GetCurThreadSlot();
 	if( slot == nullptr )
+	{
+		bUnknownThread = true;
 		slot = GetUnknownThreadSlot();
-	/* We can't ASSERT here, since that uses checkpoints. */
-	if( slot == nullptr )
-		sm_crash( "GetUnknownThreadSlot() returned nullptr" );
+		/* We can't ASSERT here, since that uses checkpoints. */
+		if( slot == nullptr )
+			sm_crash( "GetUnknownThreadSlot() returned nullptr" );
+	}
 
 	/* Ignore everything up to and including the first "src/". */
 	const char *temp = strstr( file, "src/" );
 	if( temp )
 		file = temp + 4;
+
+	if( bUnknownThread ) GetUnknownThreadSlotLock().Lock();
+
 	slot->m_Checkpoints[slot->m_iCurCheckpoint].Set( file, line, message );
 
 	if( g_LogCheckpoints )
@@ -406,6 +421,8 @@ void Checkpoints::SetCheckpoint( const char *file, int line, const char *message
 	++slot->m_iCurCheckpoint;
 	slot->m_iNumCheckpoints = std::max( slot->m_iNumCheckpoints, slot->m_iCurCheckpoint );
 	slot->m_iCurCheckpoint %= CHECKPOINT_COUNT;
+
+	if( bUnknownThread ) GetUnknownThreadSlotLock().Unlock();
 }
 
 /* This is called under crash conditions.  Be careful. */

--- a/src/RageUtil.cpp
+++ b/src/RageUtil.cpp
@@ -13,6 +13,7 @@
 #include <json/json.h>
 #include <pcre.h>
 
+#include <atomic>
 #include <cfloat>
 #include <cinttypes>
 #include <cmath>
@@ -850,10 +851,9 @@ RString GetCwd()
 void CRC32( unsigned int &iCRC, const void *pVoidBuffer, size_t iSize )
 {
 	static unsigned tab[256];
-	static bool initted = false;
-	if( !initted )
+	static std::atomic<bool> initted = false;
+	if( !initted.load(std::memory_order_acquire) )
 	{
-		initted = true;
 		const unsigned POLY = 0xEDB88320;
 
 		for( int i = 0; i < 256; ++i )
@@ -867,6 +867,7 @@ void CRC32( unsigned int &iCRC, const void *pVoidBuffer, size_t iSize )
 					tab[i] >>= 1;
 			}
 		}
+		initted.store(true, std::memory_order_release);
 	}
 
 	iCRC ^= 0xFFFFFFFF;

--- a/src/RageUtil_FileDB.cpp
+++ b/src/RageUtil_FileDB.cpp
@@ -449,6 +449,14 @@ void FilenameDB::DelFileSet( std::map<RString, FileSet*>::iterator dir )
 	for( std::map<RString, FileSet*>::iterator it = dirs.begin(); it != dirs.end(); ++it )
 	{
 		FileSet *Clean = it->second;
+
+		if( !Clean->m_bFilled )
+		{
+			// This directory is still being filled. Don't access the files set
+			// while another thread is modifying it.
+			continue;
+		}
+
 		for( std::set<File>::iterator f = Clean->files.begin(); f != Clean->files.end(); ++f )
 		{
 			File &ff = (File &) *f;

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -273,11 +273,6 @@ const RString &Song::GetSongFilePath() const
 	return m_sSongFileName;
 }
 
-/* Hack: This should be a parameter to TidyUpData, but I don't want to pull in
- * <set> into Song.h, which is heavily used. */
-static std::set<RString> BlacklistedImages;
-
-
 /* If PREFSMAN->m_bFastLoad is true, always load from cache if possible.
  * Don't read the contents of sDir if we can avoid it. That means we can't call
  * HasMusic(), HasBanner() or GetHashForDirectory().
@@ -357,10 +352,12 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
 	}
 	else
 	{
+		std::set<RString> blacklistedImages;
+
 		// There was no entry in the cache for this song, or it was out of date.
 		// Let's load it from a file, then write a cache entry.
 
-		if(!NotesLoader::LoadFromDir(sDir, *this, BlacklistedImages, load_autosave))
+		if(!NotesLoader::LoadFromDir(sDir, *this, blacklistedImages, load_autosave))
 		{
 			LOG->UserLog( "Song", sDir, "has no SSC, SM, SMA, DWI, BMS, or KSF files." );
 
@@ -385,7 +382,7 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
 		// loading time. -Kyz
 		LoadEditsFromSongDir(sDir);
 
-		TidyUpData(false, true);
+		TidyUpData(false, true, blacklistedImages);
 		// Don't save a cache file if the autosave is being loaded, because the
 		// cache file would contain the autosave filename. -Kyz
 		// Songs loaded from removable profile are never cached, on the
@@ -431,7 +428,7 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
 	// Normally TidyUpData would handle setting the m_fBeat0GroupOffsetInSeconds.
 	// That is to keep the song start and end times become inaccurate in some cases.
 	// SInce there are cases where TidyUpData isn't called, we still want to guarantee the
-	// m_fBeat0GroupOffsetInSeconds is always set so we do that here. 
+	// m_fBeat0GroupOffsetInSeconds is always set so we do that here.
 	float fOffset = PREFSMAN->m_DefaultSyncOffset == SyncOffset_NULL ? 0 : -0.009;
 	if (SONGMAN->GetGroupFromName(m_sGroupName) != nullptr)
 	{
@@ -489,7 +486,7 @@ bool Song::ReloadFromSongDir( RString sDir )
 		return false;
 	copy.RemoveAutoGenNotes();
 	*this = copy;
-	
+
 	if (SONGMAN->GetGroup(this) != nullptr) {
 		m_SongTiming.m_fBeat0GroupOffsetInSeconds = SONGMAN->GetGroup(this)->GetSyncOffset();
 	} else {
@@ -661,8 +658,14 @@ void FixupPath( RString &path, const RString &sSongPath )
 	Trim( path );
 }
 
+
+void Song::TidyUpData(bool from_cache, bool duringCache)
+{
+	Song::TidyUpData(from_cache, duringCache, std::set<RString>());
+}
+
 // Songs in BlacklistImages will never be autodetected as song images.
-void Song::TidyUpData( bool from_cache, bool /* duringCache */ )
+void Song::TidyUpData( bool from_cache, bool /* duringCache */, const std::set<RString>& blacklistedImages )
 {
 	// We need to do this before calling any of HasMusic, HasHasCDTitle, etc.
 	ASSERT_M(Left(m_sSongDir, 3) != "../", m_sSongDir); // meaningless
@@ -1013,7 +1016,7 @@ void Song::TidyUpData( bool from_cache, bool /* duringCache */ )
 				// ignore DWI "-char" graphics
 				RString lower = image_list[i];
 				MakeLower(lower);
-				if(BlacklistedImages.find(lower) != BlacklistedImages.end())
+				if(blacklistedImages.find(lower) != blacklistedImages.end())
 				continue;	// skip
 
 				// Skip any image that we've already classified
@@ -1197,7 +1200,7 @@ void Song::ReCalculateStepStatsAndLastSecond(bool fromCache, bool duringCache)
 	{
 		Steps* pSteps = m_vpSteps[i];
 		pSteps->CalculateStepStats(m_fMusicLengthSeconds);
-		
+
 		// Must initialize before the gotos.
 		NoteData tempNoteData;
 		pSteps->GetNoteData( tempNoteData );

--- a/src/Song.h
+++ b/src/Song.h
@@ -350,6 +350,9 @@ private:
 	AutoPtrCopyOnWrite<VBackgroundChange>	m_ForegroundChanges;
 
 	std::vector<RString> GetChangesToVectorString(const std::vector<BackgroundChange> & changes) const;
+
+	void TidyUpData( bool fromCache, bool duringCache, const std::set<RString>& blacklistedImages );
+
 public:
 	const std::vector<BackgroundChange>	&GetBackgroundChanges( BackgroundLayer bl ) const;
 	std::vector<BackgroundChange>	&GetBackgroundChanges( BackgroundLayer bl );


### PR DESCRIPTION
Some thread-safety improvements to pave the way for parallel song loading.

This fixes the data races I mentioned in https://github.com/itgmania/itgmania/pull/995#issuecomment-3339038143, except the backtrace and the SongLoadResult::state ones.

v2: Rebased and added a commit to remove the global variable in NotesLoaderDWI.