### PR TITLE
Move checkpoint macros/declarations to RageThreads.h

### DIFF
--- a/src/RageThreads.h
+++ b/src/RageThreads.h
@@ -79,10 +79,12 @@ namespace Checkpoints
 {
 	void LogCheckpoints( bool yes=true );
 	void SetCheckpoint( const char *file, int line, const char *message );
+	void SetCheckpoint( const char *file, int line, const RString& message );
 	void GetLogs( char *pBuf, int iSize, const char *delim );
 };
 
 #define CHECKPOINT_M(m) (Checkpoints::SetCheckpoint(__FILE__, __LINE__, m))
+#define CHECKPOINT (Checkpoints::SetCheckpoint(__FILE__, __LINE__, nullptr))
 
 /* Mutex class that follows the behavior of Windows mutexes: if the same
  * thread locks the same mutex twice, we just increase a refcount; a mutex

--- a/src/global.h
+++ b/src/global.h
@@ -41,16 +41,6 @@
 /** @brief Use RStrings throughout the program. */
 typedef StdString::CStdString RString;
 
-/** @brief RageThreads defines (don't pull in all of RageThreads.h here) */
-namespace Checkpoints
-{
-	void SetCheckpoint( const char *file, int line, const char *message );
-	void SetCheckpoint( const char *file, int line, const RString& message );
-}
-/** @brief Set a checkpoint with no message. */
-#define CHECKPOINT (Checkpoints::SetCheckpoint(__FILE__, __LINE__, nullptr))
-/** @brief Set a checkpoint with a specified message. */
-#define CHECKPOINT_M(m) (Checkpoints::SetCheckpoint(__FILE__, __LINE__, m))
 
 
 /**

--- a/src/global.h
+++ b/src/global.h
@@ -42,6 +42,10 @@
 typedef StdString::CStdString RString;
 
 
+#include "RageThreads.h"
+
+
+
 
 /**
  * @brief A crash has occurred, and we're not getting out of it easily.


### PR DESCRIPTION
Slightly reduces compilation time.