### PR TITLE
Refactor RageThreads to use smart pointers

### DIFF
--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -137,8 +137,8 @@ const char *ThreadSlot::GetFormattedCheckpoint( int lineno )
 	return m_Checkpoints[lineno].GetFormattedCheckpoint();
 }
 
-static ThreadSlot g_ThreadSlots[MAX_THREADS];
-struct ThreadSlot *g_pUnknownThreadSlot = nullptr;
+static std::array<ThreadSlot, MAX_THREADS> g_ThreadSlots;
+static ThreadSlot *g_pUnknownThreadSlot = nullptr;
 
 /* Lock this mutex before using or modifying m_pImpl.  Other values are just identifiers,
  * so possibly racing over them is harmless (simply using a stale thread ID, etc). */

--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -256,7 +256,7 @@ void RageThread::Create( int (*fn)(void *), void *data )
 	/* Start a thread using our own startup function.  We pass the id to fill in,
 	 * to make sure it's set before the thread actually starts.  (Otherwise, early
 	 * checkpoints might not have a completely set-up thread slot.) */
-	m_pSlot->m_pImpl = MakeThread( fn, data, &m_pSlot->m_iID );
+	m_pSlot->m_pImpl.reset(MakeThread( fn, data, &m_pSlot->m_iID ));
 }
 
 RageThreadRegister::RageThreadRegister( const RString &sName )
@@ -272,7 +272,7 @@ RageThreadRegister::RageThreadRegister( const RString &sName )
 	sprintf( m_pSlot->m_szThreadFormattedOutput, "Thread: %s", sName.c_str() );
 
 	m_pSlot->m_iID = GetThisThreadId();
-	m_pSlot->m_pImpl = MakeThisThread();
+	m_pSlot->m_pImpl.reset(MakeThisThread());
 
 }
 

--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -16,9 +16,13 @@
 #include "RageLog.h"
 #include "RageUtil.h"
 
+#include <algorithm>
+#include <array>
+#include <atomic>
 #include <cerrno>
 #include <cinttypes>
 #include <cstdint>
+#include <memory>
 #include <set>
 
 #include "arch/Threads/Threads.h"
@@ -49,7 +53,7 @@ struct ThreadSlot
 	bool m_bUsed;
 	uint64_t m_iID;
 
-	ThreadImpl *m_pImpl;
+	std::unique_ptr<ThreadImpl, decltype(&SafeDelete<ThreadImpl>)> m_pImpl;
 
 	#undef CHECKPOINT_COUNT
 	#define CHECKPOINT_COUNT 5
@@ -68,12 +72,12 @@ struct ThreadSlot
 	const char *GetFormattedCheckpoint( int lineno );
 
 	ThreadSlot(): m_bUsed(false), m_iID(GetInvalidThreadId()),
-		m_pImpl(nullptr), m_iCurCheckpoint(0), m_iNumCheckpoints(0) {}
+		m_pImpl(nullptr, &SafeDelete<ThreadImpl>), m_iCurCheckpoint(0), m_iNumCheckpoints(0) {}
 	void Init()
 	{
 		m_iID = GetInvalidThreadId();
 		m_iCurCheckpoint = m_iNumCheckpoints = 0;
-		m_pImpl = nullptr;
+		m_pImpl.reset();
 
 		/* Reset used last; otherwise, a thread creation might pick up the slot. */
 		m_bUsed = false;
@@ -81,7 +85,7 @@ struct ThreadSlot
 
 	void Release()
 	{
-		RageUtil::SafeDelete( m_pImpl );
+		m_pImpl.reset();
 		Init();
 	}
 
@@ -374,10 +378,10 @@ uint64_t RageThread::GetInvalidThreadID()
 
 /* Normally, checkpoints are only seen in crash logs.  It's occasionally useful
  * to see them in logs, but this outputs a huge amount of text. */
-static bool g_LogCheckpoints = false;
+static std::atomic<bool> g_LogCheckpoints{false};
 void Checkpoints::LogCheckpoints( bool on )
 {
-	g_LogCheckpoints = on;
+	g_LogCheckpoints.store(on);
 }
 
 void Checkpoints::SetCheckpoint( const char *file, int line, const RString& message )
@@ -400,7 +404,7 @@ void Checkpoints::SetCheckpoint( const char *file, int line, const char *message
 		file = temp + 4;
 	slot->m_Checkpoints[slot->m_iCurCheckpoint].Set( file, line, message );
 
-	if( g_LogCheckpoints )
+	if( g_LogCheckpoints.load() )
 		LOG->Trace( "%s", slot->m_Checkpoints[slot->m_iCurCheckpoint].m_szFormattedBuf );
 
 	++slot->m_iCurCheckpoint;
@@ -532,7 +536,7 @@ static std::set<int> *g_FreeMutexIDs = nullptr;
 #endif
 
 RageMutex::RageMutex( const RString &name ):
-	m_pMutex( MakeMutex (this ) ), m_sName(name),
+	m_pMutex(MakeMutex(this), &SafeDelete<MutexImpl>), m_sName(name),
 	m_LockedBy(GetInvalidThreadId()), m_LockCnt(0)
 {
 
@@ -570,7 +574,6 @@ RageMutex::RageMutex( const RString &name ):
 
 RageMutex::~RageMutex()
 {
-	delete m_pMutex;
 /*
 	std::vector<RageMutex*>::iterator it = find( g_MutexList->begin(), g_MutexList->end(), this );
 	ASSERT( it != g_MutexList->end() );
@@ -701,11 +704,10 @@ void LockMutex::Unlock()
 }
 
 RageEvent::RageEvent( RString name ):
-	RageMutex( name ), m_pEvent(MakeEvent(m_pMutex)) {}
+	RageMutex( name ), m_pEvent(MakeEvent(m_pMutex.get()), &SafeDelete<EventImpl>) {}
 
 RageEvent::~RageEvent()
 {
-	delete m_pEvent;
 }
 
 /* For each of these calls, the mutex must be locked, and must not be locked recursively. */
@@ -743,11 +745,10 @@ bool RageEvent::WaitTimeoutSupported() const
 }
 
 RageSemaphore::RageSemaphore( RString sName, int iInitialValue ):
-	m_pSema(MakeSemaphore( iInitialValue )), m_sName(sName) {}
+	m_pSema(MakeSemaphore( iInitialValue ), &SafeDelete<SemaImpl>), m_sName(sName) {}
 
 RageSemaphore::~RageSemaphore()
 {
-	delete m_pSema;
 }
 
 int RageSemaphore::GetValue() const

--- a/src/RageThreads.h
+++ b/src/RageThreads.h
@@ -3,6 +3,15 @@
 
 #include <cstdint>
 #include <limits>
+#include <memory>
+
+// Same as RageUtil::SafeDelete, but here to avoid including RageUtil
+template <typename T>
+inline void SafeDelete(T*& p) noexcept
+{
+	delete p;
+	p = nullptr;
+}
 
 struct ThreadSlot;
 class RageTimer;
@@ -104,7 +113,7 @@ public:
 	virtual ~RageMutex();
 
 protected:
-	MutexImpl *m_pMutex;
+	std::unique_ptr<MutexImpl, decltype(&SafeDelete<MutexImpl>)> m_pMutex;
 	RString m_sName;
 
 	int m_UniqueID;
@@ -172,7 +181,7 @@ public:
 	RageEvent(const RageEvent& rhs);
 
 private:
-	EventImpl *m_pEvent;
+	std::unique_ptr<EventImpl, decltype(&SafeDelete<EventImpl>)> m_pEvent;
 };
 
 class SemaImpl;
@@ -189,7 +198,7 @@ public:
 	bool TryWait();
 
 private:
-	SemaImpl *m_pSema;
+	std::unique_ptr<SemaImpl, decltype(&SafeDelete<SemaImpl>)> m_pSema;
 	RString m_sName;
 
 	// Swallow up warnings. If they must be used, define them.


### PR DESCRIPTION
There are no functional differences whatsoever here.  This is just bringing the existing code up to more modern C++ standards.

Fully tested and was not able to identify any changed behavior.

This PR does a few things, which are put together since they must coexist to provide a working PR:

1. Replace raw pointers with unique_ptr + custom deleters
3. Add the SafeDelete template from RageUtil into RageThreads.h to avoid including RageUtil
4. Updated all unique_ptr declarations and initializations
5. Made g_LogCheckpoints atomic for thread safety
6. Improved safety of ThreadSlot handling by using a std::array rather than C-style array