### PR TITLE
Suppress MSVC warnings in HID and lights driver headers

### DIFF
--- a/src/arch/Lights/LightsDriver_MinimaidHID.h
+++ b/src/arch/Lights/LightsDriver_MinimaidHID.h
@@ -43,6 +43,8 @@
 
 #pragma pack(push, 1)
 
+#pragma warning(push)
+#pragma warning(disable : 4201) // nonstandard extension used : nameless struct/union
 typedef union {
   struct {
     // byte 0
@@ -126,6 +128,7 @@ class LightsDriver_MinimaidHID : public LightsDriver {
   virtual void Set(const LightsState* ls);
 };
 
+#pragma warning(pop)
 #endif
 
 /*

--- a/src/arch/Lights/LightsDriver_PacDrive.h
+++ b/src/arch/Lights/LightsDriver_PacDrive.h
@@ -41,6 +41,8 @@
 
 #pragma pack(push, 1)
 
+#pragma warning(push)
+#pragma warning(disable: 4201) // nonstandard extension used : nameless struct/union
 typedef union
 {
 	struct
@@ -99,6 +101,7 @@ public:
 	virtual void Set(const LightsState *ls);
 };
 
+#pragma warning(pop)
 #endif
 
 /*

--- a/src/archutils/Common/HidDevice.h
+++ b/src/archutils/Common/HidDevice.h
@@ -10,6 +10,8 @@ enum HidResults {
 	Success = 0,
 };
 
+#pragma warning(push)
+#pragma warning(disable: 4505) // MSVC: unreferenced local function has been removed
 static std::vector<int> make_pids(int base_pid, int size)
 {
 	std::vector<int> vec(size);
@@ -19,6 +21,7 @@ static std::vector<int> make_pids(int base_pid, int size)
 
 	return vec;
 }
+#pragma warning(pop)
 
 struct HidDeviceInfo {
 	char* path{ nullptr };


### PR DESCRIPTION
Added pragma warning directives to disable specific MSVC warnings (4201 for nameless struct/union and 4505 for unreferenced local functions) in LightsDriver_MinimaidHID.h, LightsDriver_PacDrive.h, and HidDevice.h.

Idk if this is how we want to handle the unreferenced local function error though?

Due to these errors in the beta branch I wanted to suppress these warnings.
<img width="1085" height="492" alt="Screenshot 2025-10-07 024644" src="https://github.com/user-attachments/assets/8d5b806d-3ae0-4c90-af7d-8772dd24498c" />
