### PR TITLE
Let's Talk About Lifts...

### DIFF
--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -2457,7 +2457,14 @@ void Player::Step(
               const auto& disabledWindows =
                   m_pPlayerState->m_PlayerOptions.GetCurrent()
                       .m_twDisabledWindows;
-              if (fSecondsFromExact <= GetWindowSeconds(TW_W1) &&
+              // Lifts have a wider window, anything above W3 is a W1
+              if (pTN->type == TapNoteType_Lift) {
+                if (fSecondsFromExact <= GetWindowSeconds(TW_W3) &&
+                    !disabledWindows[TW_W3]) {
+                  score = TNS_W1;
+                }
+              } else if (
+                  fSecondsFromExact <= GetWindowSeconds(TW_W1) &&
                   !disabledWindows[TW_W1]) {
                 score = TNS_W1;
               } else if (


### PR DESCRIPTION
### What is a "Lift"?
Lifts are the inverse? opposite? of regular tap notes. For regular tap notes you hit the arrow as it moves towards the receptors, you're scored based on how accurate you did so. For mines you want to avoid being on the arrow when the note reaches the receptor. For lifts you want to **lift** your foot **off** the arrow when the note reaches the receptor. A prerequisite for doing this would then mean that prior to the Lift-note reaching the receptor your foot must already be on the arrow. You are then scored based on how accurate you lifted your foot (A Fantastic if you lifted your foot at the perfect time!). 

There are a few other definitions online that might convey this better than I just did: https://www.reddit.com/r/Stepmania/comments/50y6cd/question_what_are_lifts/
https://stepmania.fandom.com/wiki/Note#Lift_Note_(less_common)
https://www.facebook.com/groups/565890830137096/posts/24469219142710930/

### Where do I find Lifts?
Lifts are still relatively uncommon in 4-panel spaces. The most common place you'll find them are in the U.P.S/R.I.G.H.T.S/L.E.F.T.S tournament packs. While they're actively used in many meme/shitpost charts, there are a lot of 'serious' applications of lifts both in these packs and in some experimental tech packs like the Technical Proficiency Exams. Most of the time [they're commonly used on the sound of a bed squeak or faucet leak](https://discord.com/channels/292111865658474496/427491189126594560/903317793334755370). U.P.S/R.I.G.H.T.S, Technical Proficiency Exams, and Squeaky Beds and Leaky Faucets have some good examples of lift use:
- Quarantineが [Squeaky Beds and Leaky Faucets] [Live Gameplay](https://www.youtube.com/watch?v=_ytYr2noT5U) [Raw Chart](https://www.youtube.com/watch?v=b8NGioz9MYY)
- Sunny after Rain [U.P.S. 4] [Live Gameplay](https://youtu.be/AydjYkTz46Y?si=_ZxDHlZcqStR8vpK&t=19548) [Raw Chart](https://www.youtube.com/watch?v=Cxk9cX5QkBM)
- Only You [Technical Proficiency Exam 2]
- [Freezing Hot](https://youtu.be/ybQpwIh2ccI) [Kerpa's Simfile Playlist 2]
- Popover [Squeaky Beds and Leaky Faucets]


Lifts exist in SMX and are pretty common in those charts. In SMX, when there is a Lift, it will **alwaysI** be at the end of a hold. Lifts in SMX are pass-fail similar to you either held the hold or missed the hold as we're used to in itg. I don't know what the timing window is on them specifically, but it is pretty generous.  Here's an example of a chart with lifts in SMX https://youtu.be/dWJqLCX3n6w?si=at-Nx9f62iDIfxWE&t=51 
 
 ### What's the problem?
 As sort of alluded to above, lifts are notoriously difficult to time as you're timing release of the arrow panel. They're currently judged like tap notes so you can get a Fantastic, Excellent, Great, etc. on a lift. In my own personal experience I'm basically either getting Fantastic, Great, or Miss. This had made charts with a lot of lifts often charts that are notoriously really difficult to get good scores on (or pass depending on the chart) despite the implementation of Lifts resolving and what not.
 
 There's been plenty of discourse about this already:
 https://discord.com/channels/165133532199387136/661547371456495636/1327019203462430773
 You can search "LIFTS" in most itg centric discords to see more convo.
 
 I'm throwing up this PR to first kickstart the conversation about the current Lifts implementation so we can think about how they should be improved. This PR makes it so that Lifts are judged such that anything W3 (great) and above is counted as a Fantastic. This is more or less a simple solution but it might not be all encompassing and its just intended to be here to get the convo going. 
 
 Things to consider:
 - Should lifts be binary hit/miss (This can have cons depending on the window as what normally would've given you some score could now count as a miss)
 - Should lifts have their windows expanded? ( Should we make lifts effectively binary through this?)
 - What should the timing window be? ( I personally think it should be great+ for perfect/hit )
 - How will existing charts be affected ?
 