### PR TITLE
Force the GetFrame function into a loop until it finds a good frame to display

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -181,7 +181,7 @@ float MovieDecoder_FFMpeg::GetTimestamp() const
 	}
 
 	std::lock_guard<std::mutex> lock(packet->lock);
-	return packet->frame_timestamp;
+	return packet->frame_timestamp - timestamp_offset_;
 }
 
 bool MovieDecoder_FFMpeg::IsCurrentFrameReady() {
@@ -416,6 +416,10 @@ int MovieDecoder_FFMpeg::DecodePacketToFrame() {
 			else {
 				packet->frame_timestamp = 0;
 			}
+		}
+		// Some movies start at a non-zero point in time (audio before video?)
+		if (packet_buffer_position_ == 0 && packet->frame_timestamp != 0) {
+			timestamp_offset_ = packet->frame_timestamp;
 		}
 
 		// Length of this frame, only used as a fallback for getting the frame

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -161,6 +161,7 @@ private:
 	std::vector<std::unique_ptr<FrameHolder>> frame_buffer_;
 	std::size_t frame_buffer_position_ = 0;
 	std::size_t packet_buffer_position_ = 0;
+	float timestamp_offset_ = 0.0;
 
 	// Offset for the frame_buffer_ when a looping movie goes back to
 	// the zeroeth frame. next_offset_ is written when the zeroeth frame

--- a/src/arch/MovieTexture/MovieTexture_Generic.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Generic.cpp
@@ -340,18 +340,30 @@ void MovieTexture_Generic::UpdateFrame()
 		texture_lock_->Lock(iHandle, surface_);
 	}
 
-	int frame_ret = decoder_->GetFrame(surface_);
+	int frame_ret = -1;
+	// Our frame buffer should (almost) always be 50 ahead of our current frame to display, which is when
+	// IsCurrentFrameReady will evaluate to false. This loop will continue attempting to find a displayable
+	// frame until we hit that limit. If we really can't find a frame after that, then the currently
+	// displayed frame will appear stuck.
+    while (frame_ret < 0 && decoder_->IsCurrentFrameReady()) {
+        frame_ret = decoder_->GetFrame(surface_);
 
-	// Are we looping?
-	if (decoder_->EndOfMovie() && loop_) {
-		LOG->Info("File \"%s\" looping", GetID().filename.c_str());
-		decoder_->Rollover();
-		clock_ = 0.0;
-	}
-	else if (decoder_->EndOfMovie()) {
-		// At the end of the movie, and not looping.
-		finished_ = true;
-	}
+        // Are we looping?
+        if (decoder_->EndOfMovie() && loop_) {
+			LOG->Info("File \"%s\" looping", GetID().filename.c_str());
+			decoder_->Rollover();
+			clock_ = 0.0;
+        } else if (decoder_->EndOfMovie()) {
+        // At the end of the movie, and not looping.
+			finished_ = true;
+        }
+
+        // If we failed to display the frame, it's getting skipped, advance the
+        // clock.
+        if (frame_ret < 0) {
+          clock_ += (decoder_->GetTimestamp() - clock_);
+        }
+    }
 
 	// There's an issue with the frame, make sure it does not get
 	// uploaded.


### PR DESCRIPTION
Also add an offset for some movies that seem to begin after zero seconds.

This is to address #964 