### PR TITLE
LightsMan Threading

### DIFF
--- a/src/GameInput.h
+++ b/src/GameInput.h
@@ -62,6 +62,9 @@ GameButton StringToGameButton( const InputScheme* pInputs, const RString& s );
 /** @brief A special way to loop through each game button. */
 #define FOREACH_GameButton_Custom( gb ) for( GameButton gb=GAME_BUTTON_CUSTOM_01; gb<NUM_GameButton; enum_add(gb, +1) )
 
+/** @brief A special way to loop through each menu button. */
+#define FOREACH_GameButton_Menu( gb ) for( GameButton gb=GAME_BUTTON_MENULEFT; gb<=GAME_BUTTON_BACK; enum_add(gb, +1) )
+
 #define GAME_BUTTON_NEXT		GAME_BUTTON_CUSTOM_01
 
 // dance
@@ -225,7 +228,7 @@ struct GameInput
  * @author Chris Danford (c) 2001-2004
  * @section LICENSE
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -235,7 +238,7 @@ struct GameInput
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF

--- a/src/LightsManager.cpp
+++ b/src/LightsManager.cpp
@@ -4,6 +4,7 @@
 #include "RageTimer.h"
 #include "arch/Lights/LightsDriver.h"
 #include "RageUtil.h"
+#include "RageUtil/ConvertValue.h"
 #include "GameInput.h"	// for GameController
 #include "InputMapper.h"
 #include "Game.h"

--- a/src/LightsManager.cpp
+++ b/src/LightsManager.cpp
@@ -111,13 +111,59 @@ LightsManager::LightsManager() {
   LightsDriver::Create(sDriver, m_vpDrivers);
 
   SetLightsMode(LIGHTSMODE_ATTRACT);
+
+  m_LightsMutex = new RageEvent("LightsMutex");
+  m_LightsThreadShutdown = false;
+  m_LightsThread.SetName("LightsManager thread");
+  m_LightsThread.Create(LightsManThread_Start, this);
 }
 
 LightsManager::~LightsManager() {
+  // tell the thread to quit.
+  if (m_LightsMutex != nullptr) {
+    m_LightsMutex->Lock();
+    m_LightsThreadShutdown = true;
+    m_LightsMutex->Broadcast();
+    m_LightsMutex->Unlock();
+    m_LightsThread.Wait();
+  }
+
   for (LightsDriver* iter : m_vpDrivers) {
     RageUtil::SafeDelete(iter);
   }
   m_vpDrivers.clear();
+}
+
+int LightsManager::LightsManThreadMain() {
+  while (!m_LightsThreadShutdown) {
+    m_LightsMutex->Lock();
+
+    // spin here until we get a light to push out.
+    while (m_LightsQueue.empty() && !m_LightsThreadShutdown) {
+      m_LightsMutex->Wait();
+    }
+
+    m_LightsMutex->Unlock();
+
+    // push every state on the queue to all of the devices.
+    while (!m_LightsQueue.empty()) {
+      m_LightsMutex->Lock();
+
+      // pop the first in first state out from the queue
+      LightsState push = m_LightsQueue.front();
+      m_LightsQueue.pop();
+
+      m_LightsMutex->Unlock();
+
+      // push to all of the devices
+      // could take time, it's why we are in at thread
+      for (LightsDriver* iter : m_vpDrivers) {
+        iter->Set(&push);
+      }
+    }
+  }
+
+  return 0;
 }
 
 // XXX: Allow themer to change these. (rewritten; who wrote original? -aj)
@@ -470,12 +516,16 @@ void LightsManager::Update(float fDeltaTime) {
   }
 
   // apply new light values we set above
-  for (LightsDriver* iter : m_vpDrivers) {
-    if (memcmp(&m_LightsState, &m_PrevLightsState, sizeof(m_LightsState)) !=
-        0) {
-      iter->Set(&m_LightsState);
-	  memcpy(&m_PrevLightsState, &m_LightsState, sizeof(m_LightsState));
-    }
+
+  // only push to thread on changes.
+  if (memcmp(&m_LightsState, &m_PrevLightsState, sizeof(m_LightsState)) != 0) {
+    // add lights state to queue.
+    m_LightsMutex->Lock();
+    m_LightsQueue.push(m_LightsState);
+    m_LightsMutex->Broadcast();
+    m_LightsMutex->Unlock();
+
+    memcpy(&m_PrevLightsState, &m_LightsState, sizeof(m_LightsState));
   }
 }
 

--- a/src/LightsManager.cpp
+++ b/src/LightsManager.cpp
@@ -527,14 +527,14 @@ void LightsManager::Update(float fDeltaTime) {
   // apply new light values we set above
 
   // only push to thread on changes.
-  if (memcmp(&m_LightsState, &m_PrevLightsState, sizeof(m_LightsState)) != 0) {
+  if (m_LightsState != m_PrevLightsState) {
     // add lights state to queue.
     m_LightsMutex->Lock();
     m_LightsQueue.push(m_LightsState);
     m_LightsMutex->Signal();
     m_LightsMutex->Unlock();
 
-    memcpy(&m_PrevLightsState, &m_LightsState, sizeof(m_LightsState));
+    m_PrevLightsState = std::move(m_LightsState);
   }
 }
 

--- a/src/LightsManager.cpp
+++ b/src/LightsManager.cpp
@@ -1,582 +1,547 @@
-#include "global.h"
 #include "LightsManager.h"
-#include "GameState.h"
-#include "RageTimer.h"
-#include "arch/Lights/LightsDriver.h"
-#include "RageUtil.h"
-#include "RageUtil/ConvertValue.h"
-#include "GameInput.h"	// for GameController
-#include "InputMapper.h"
-#include "Game.h"
-#include "PrefsManager.h"
-#include "Actor.h"
-#include "Preference.h"
-#include "GameManager.h"
-#include "PlayerState.h"
-#include "GameState.h"
-#include "CommonMetrics.h"
-#include "Style.h"
 
 #include <cmath>
 #include <cstddef>
 #include <vector>
 
+#include "Actor.h"
+#include "CommonMetrics.h"
+#include "Game.h"
+#include "GameInput.h"  // for GameController
+#include "GameManager.h"
+#include "GameState.h"
+#include "InputMapper.h"
+#include "PlayerState.h"
+#include "Preference.h"
+#include "PrefsManager.h"
+#include "RageTimer.h"
+#include "RageUtil.h"
+#include "RageUtil/ConvertValue.h"
+#include "Style.h"
+#include "arch/Lights/LightsDriver.h"
+#include "global.h"
 
 const RString DEFAULT_LIGHTS_DRIVER = "SystemMessage,Export";
-static Preference<RString> g_sLightsDriver( "LightsDriver", "" ); // "" == DEFAULT_LIGHTS_DRIVER
-Preference<float>	g_fLightsFalloffSeconds( "LightsFalloffSeconds", 0.1f );
-Preference<float>	g_fLightsAheadSeconds( "LightsAheadSeconds", 0.05f );
-static Preference<bool>	g_bBlinkGameplayButtonLightsOnNote( "BlinkGameplayButtonLightsOnNote", false );
+static Preference<RString> g_sLightsDriver(
+    "LightsDriver", "");  // "" == DEFAULT_LIGHTS_DRIVER
+Preference<float> g_fLightsFalloffSeconds("LightsFalloffSeconds", 0.1f);
+Preference<float> g_fLightsAheadSeconds("LightsAheadSeconds", 0.05f);
+static Preference<bool> g_bBlinkGameplayButtonLightsOnNote(
+    "BlinkGameplayButtonLightsOnNote", false);
 
-static ThemeMetric<RString> GAME_BUTTONS_TO_SHOW( "LightsManager", "GameButtonsToShow" );
+static ThemeMetric<RString> GAME_BUTTONS_TO_SHOW(
+    "LightsManager", "GameButtonsToShow");
 
-static const char *CabinetLightNames[] = {
-	"MarqueeUpLeft",
-	"MarqueeUpRight",
-	"MarqueeLrLeft",
-	"MarqueeLrRight",
-	"BassLeft",
-	"BassRight",
+static const char* CabinetLightNames[] = {
+    "MarqueeUpLeft",  "MarqueeUpRight", "MarqueeLrLeft",
+    "MarqueeLrRight", "BassLeft",       "BassRight",
 };
-XToString( CabinetLight );
-StringToX( CabinetLight );
+XToString(CabinetLight);
+StringToX(CabinetLight);
 
-static const char *LightsModeNames[] = {
-	"Attract",
-	"Joining",
-	"MenuStartOnly",
-	"MenuStartAndDirections",
-	"Demonstration",
-	"Gameplay",
-	"Stage",
-	"Cleared",
-	"TestAutoCycle",
-	"TestManualCycle",
+static const char* LightsModeNames[] = {
+    "Attract",       "Joining",
+    "MenuStartOnly", "MenuStartAndDirections",
+    "Demonstration", "Gameplay",
+    "Stage",         "Cleared",
+    "TestAutoCycle", "TestManualCycle",
 };
-XToString( LightsMode );
-LuaXType( LightsMode );
+XToString(LightsMode);
+LuaXType(LightsMode);
 
-static void GetUsedGameInputs( std::vector<GameInput> &vGameInputsOut )
-{
-	vGameInputsOut.clear();
+static void GetUsedGameInputs(std::vector<GameInput>& vGameInputsOut) {
+  vGameInputsOut.clear();
 
-	std::vector<RString> asGameButtons;
-	split( GAME_BUTTONS_TO_SHOW.GetValue(), ",", asGameButtons );
-	FOREACH_ENUM( GameController,  gc )
-	{
-		for (RString const &button : asGameButtons)
-		{
-			GameButton gb = StringToGameButton( INPUTMAPPER->GetInputScheme(), button );
-			if( gb != GameButton_Invalid )
-			{
-				GameInput gi = GameInput( gc, gb );
-				vGameInputsOut.push_back( gi );
-			}
-		}
-	}
+  std::vector<RString> asGameButtons;
+  split(GAME_BUTTONS_TO_SHOW.GetValue(), ",", asGameButtons);
+  FOREACH_ENUM(GameController, gc) {
+    for (const RString& button : asGameButtons) {
+      GameButton gb = StringToGameButton(INPUTMAPPER->GetInputScheme(), button);
+      if (gb != GameButton_Invalid) {
+        GameInput gi = GameInput(gc, gb);
+        vGameInputsOut.push_back(gi);
+      }
+    }
+  }
 
-	std::set<GameInput> vGIs;
-	std::vector<const Style*> vStyles;
-	GAMEMAN->GetStylesForGame( GAMESTATE->m_pCurGame, vStyles );
-	auto const &value = CommonMetrics::STEPS_TYPES_TO_SHOW.GetValue();
-	for (Style const *style : vStyles)
-	{
-		bool bFound = find( value.begin(), value.end(), style->m_StepsType ) != value.end();
-		if( !bFound )
-			continue;
-		FOREACH_PlayerNumber( pn )
-		{
-			for( int iCol=0; iCol < style->m_iColsPerPlayer; ++iCol )
-			{
-				std::vector<GameInput> gi;
-				style->StyleInputToGameInput( iCol, pn, gi );
-				for(size_t i= 0; i < gi.size(); ++i)
-				{
-					if(gi[i].IsValid())
-					{
-						vGIs.insert(gi[i]);
-					}
-				}
-			}
-		}
-	}
+  std::set<GameInput> vGIs;
+  std::vector<const Style*> vStyles;
+  GAMEMAN->GetStylesForGame(GAMESTATE->m_pCurGame, vStyles);
+  const auto& value = CommonMetrics::STEPS_TYPES_TO_SHOW.GetValue();
+  for (const Style* style : vStyles) {
+    bool bFound =
+        find(value.begin(), value.end(), style->m_StepsType) != value.end();
+    if (!bFound) {
+      continue;
+    }
+    FOREACH_PlayerNumber(pn) {
+      for (int iCol = 0; iCol < style->m_iColsPerPlayer; ++iCol) {
+        std::vector<GameInput> gi;
+        style->StyleInputToGameInput(iCol, pn, gi);
+        for (size_t i = 0; i < gi.size(); ++i) {
+          if (gi[i].IsValid()) {
+            vGIs.insert(gi[i]);
+          }
+        }
+      }
+    }
+  }
 
-	for (GameInput const &input : vGIs)
-		vGameInputsOut.push_back( input );
+  for (const GameInput& input : vGIs) {
+    vGameInputsOut.push_back(input);
+  }
 }
 
-LightsManager*	LIGHTSMAN = nullptr;	// global and accessible from anywhere in our program
+LightsManager* LIGHTSMAN =
+    nullptr;  // global and accessible from anywhere in our program
 
-LightsManager::LightsManager()
-{
-	ZERO( m_fSecsLeftInCabinetLightBlink );
-	ZERO( m_fSecsLeftInGameButtonBlink );
-	ZERO( m_fActorLights );
-	ZERO( m_fSecsLeftInActorLightBlink );
-	m_iQueuedCoinCounterPulses = 0;
-	m_CoinCounterTimer.SetZero();
+LightsManager::LightsManager() {
+  ZERO(m_fSecsLeftInCabinetLightBlink);
+  ZERO(m_fSecsLeftInGameButtonBlink);
+  ZERO(m_fActorLights);
+  ZERO(m_fSecsLeftInActorLightBlink);
+  m_iQueuedCoinCounterPulses = 0;
+  m_CoinCounterTimer.SetZero();
 
-	m_LightsMode = LIGHTSMODE_JOINING;
-	RString sDriver = g_sLightsDriver.Get();
-	if( sDriver.empty() )
-		sDriver = DEFAULT_LIGHTS_DRIVER;
-	LightsDriver::Create( sDriver, m_vpDrivers );
+  m_LightsMode = LIGHTSMODE_JOINING;
+  RString sDriver = g_sLightsDriver.Get();
+  if (sDriver.empty()) {
+    sDriver = DEFAULT_LIGHTS_DRIVER;
+  }
+  LightsDriver::Create(sDriver, m_vpDrivers);
 
-	SetLightsMode( LIGHTSMODE_ATTRACT );
+  SetLightsMode(LIGHTSMODE_ATTRACT);
 }
 
-LightsManager::~LightsManager()
-{
-	for (LightsDriver *iter : m_vpDrivers)
-	{
-		RageUtil::SafeDelete( iter );
-	}
-	m_vpDrivers.clear();
+LightsManager::~LightsManager() {
+  for (LightsDriver* iter : m_vpDrivers) {
+    RageUtil::SafeDelete(iter);
+  }
+  m_vpDrivers.clear();
 }
 
 // XXX: Allow themer to change these. (rewritten; who wrote original? -aj)
 static const float g_fLightEffectRiseSeconds = 0.075f;
 static const float g_fLightEffectFalloffSeconds = 0.35f;
 static const float g_fCoinPulseTime = 0.100f;
-void LightsManager::BlinkActorLight( CabinetLight cl )
-{
-	m_fSecsLeftInActorLightBlink[cl] = g_fLightEffectRiseSeconds;
+void LightsManager::BlinkActorLight(CabinetLight cl) {
+  m_fSecsLeftInActorLightBlink[cl] = g_fLightEffectRiseSeconds;
 }
 
-float LightsManager::GetActorLightLatencySeconds() const
-{
-	return g_fLightEffectRiseSeconds;
+float LightsManager::GetActorLightLatencySeconds() const {
+  return g_fLightEffectRiseSeconds;
 }
 
-void LightsManager::Update( float fDeltaTime )
-{
-	// Update actor effect lights.
-	FOREACH_CabinetLight( cl )
-	{
-		float fTime = fDeltaTime;
-		float &fDuration = m_fSecsLeftInActorLightBlink[cl];
-		if( fDuration > 0 )
-		{
-			// The light has power left.  Brighten it.
-			float fSeconds = std::min( fDuration, fTime );
-			fDuration -= fSeconds;
-			fTime -= fSeconds;
-			fapproach( m_fActorLights[cl], 1, fSeconds / g_fLightEffectRiseSeconds );
-		}
+void LightsManager::Update(float fDeltaTime) {
+  // Update actor effect lights.
+  FOREACH_CabinetLight(cl) {
+    float fTime = fDeltaTime;
+    float& fDuration = m_fSecsLeftInActorLightBlink[cl];
+    if (fDuration > 0) {
+      // The light has power left.  Brighten it.
+      float fSeconds = std::min(fDuration, fTime);
+      fDuration -= fSeconds;
+      fTime -= fSeconds;
+      fapproach(m_fActorLights[cl], 1, fSeconds / g_fLightEffectRiseSeconds);
+    }
 
-		if( fTime > 0 )
-		{
-			// The light is out of power.  Dim it.
-			fapproach( m_fActorLights[cl], 0, fTime / g_fLightEffectFalloffSeconds );
-		}
+    if (fTime > 0) {
+      // The light is out of power.  Dim it.
+      fapproach(m_fActorLights[cl], 0, fTime / g_fLightEffectFalloffSeconds);
+    }
 
-		Actor::SetBGMLight( cl, m_fActorLights[cl] );
-	}
+    Actor::SetBGMLight(cl, m_fActorLights[cl]);
+  }
 
-	if( !IsEnabled() )
-		return;
+  if (!IsEnabled()) {
+    return;
+  }
 
-	// update lights falloff
-	{
-		FOREACH_CabinetLight( cl )
-			fapproach( m_fSecsLeftInCabinetLightBlink[cl], 0, fDeltaTime );
-		FOREACH_ENUM( GameController,  gc )
-			FOREACH_ENUM( GameButton,  gb )
-				fapproach( m_fSecsLeftInGameButtonBlink[gc][gb], 0, fDeltaTime );
-	}
+  // update lights falloff
+  {
+    FOREACH_CabinetLight(cl)
+        fapproach(m_fSecsLeftInCabinetLightBlink[cl], 0, fDeltaTime);
+    FOREACH_ENUM(GameController, gc)
+    FOREACH_ENUM(GameButton, gb)
+    fapproach(m_fSecsLeftInGameButtonBlink[gc][gb], 0, fDeltaTime);
+  }
 
-	// Set new lights state cabinet lights
-	{
-		ZERO( m_LightsState.m_bCabinetLights );
-		ZERO( m_LightsState.m_bGameButtonLights );
-	}
+  // Set new lights state cabinet lights
+  {
+    ZERO(m_LightsState.m_bCabinetLights);
+    ZERO(m_LightsState.m_bGameButtonLights);
+  }
 
-	{
-		m_LightsState.m_bCoinCounter = false;
-		if( !m_CoinCounterTimer.IsZero() )
-		{
-			float fAgo = m_CoinCounterTimer.Ago();
-			if( fAgo < g_fCoinPulseTime )
-				m_LightsState.m_bCoinCounter = true;
-			else if( fAgo >= g_fCoinPulseTime * 2 )
-				m_CoinCounterTimer.SetZero();
-		}
-		else if( m_iQueuedCoinCounterPulses )
-		{
-			m_CoinCounterTimer.Touch();
-			--m_iQueuedCoinCounterPulses;
-		}
-	}
+  {
+    m_LightsState.m_bCoinCounter = false;
+    if (!m_CoinCounterTimer.IsZero()) {
+      float fAgo = m_CoinCounterTimer.Ago();
+      if (fAgo < g_fCoinPulseTime) {
+        m_LightsState.m_bCoinCounter = true;
+      } else if (fAgo >= g_fCoinPulseTime * 2) {
+        m_CoinCounterTimer.SetZero();
+      }
+    } else if (m_iQueuedCoinCounterPulses) {
+      m_CoinCounterTimer.Touch();
+      --m_iQueuedCoinCounterPulses;
+    }
+  }
 
-	if( m_LightsMode == LIGHTSMODE_TEST_AUTO_CYCLE )
-	{
-		m_fTestAutoCycleCurrentIndex += fDeltaTime;
-		m_fTestAutoCycleCurrentIndex = std::fmod( m_fTestAutoCycleCurrentIndex, NUM_CabinetLight*100 );
-	}
+  if (m_LightsMode == LIGHTSMODE_TEST_AUTO_CYCLE) {
+    m_fTestAutoCycleCurrentIndex += fDeltaTime;
+    m_fTestAutoCycleCurrentIndex =
+        std::fmod(m_fTestAutoCycleCurrentIndex, NUM_CabinetLight * 100);
+  }
 
-	switch( m_LightsMode )
-	{
-		DEFAULT_FAIL( m_LightsMode );
+  switch (m_LightsMode) {
+    DEFAULT_FAIL(m_LightsMode);
 
-		case LIGHTSMODE_ATTRACT:
-		{
-			int iSec = RageTimer::GetTimeSinceStartSeconds();
-			int iTopIndex = iSec % 4;
+    case LIGHTSMODE_ATTRACT: {
+      int iSec = RageTimer::GetTimeSinceStartSeconds();
+      int iTopIndex = iSec % 4;
 
-			// Aldo: Disabled this line, apparently it was a forgotten initialization
-			//CabinetLight cl = CabinetLight_Invalid;
+      // Aldo: Disabled this line, apparently it was a forgotten initialization
+      // CabinetLight cl = CabinetLight_Invalid;
 
-			switch( iTopIndex )
-			{
-				DEFAULT_FAIL( iTopIndex );
-				case 0:	m_LightsState.m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT]  = true;	break;
-				case 1:	m_LightsState.m_bCabinetLights[LIGHT_MARQUEE_LR_RIGHT] = true;	break;
-				case 2:	m_LightsState.m_bCabinetLights[LIGHT_MARQUEE_UP_RIGHT] = true;	break;
-				case 3:	m_LightsState.m_bCabinetLights[LIGHT_MARQUEE_LR_LEFT]  = true;	break;
-			}
+      switch (iTopIndex) {
+        DEFAULT_FAIL(iTopIndex);
+        case 0:
+          m_LightsState.m_bCabinetLights[LIGHT_MARQUEE_UP_LEFT] = true;
+          break;
+        case 1:
+          m_LightsState.m_bCabinetLights[LIGHT_MARQUEE_LR_RIGHT] = true;
+          break;
+        case 2:
+          m_LightsState.m_bCabinetLights[LIGHT_MARQUEE_UP_RIGHT] = true;
+          break;
+        case 3:
+          m_LightsState.m_bCabinetLights[LIGHT_MARQUEE_LR_LEFT] = true;
+          break;
+      }
 
-			if( iTopIndex == 0 )
-			{
-				m_LightsState.m_bCabinetLights[LIGHT_BASS_LEFT] = true;
-				m_LightsState.m_bCabinetLights[LIGHT_BASS_RIGHT] = true;
-			}
+      if (iTopIndex == 0) {
+        m_LightsState.m_bCabinetLights[LIGHT_BASS_LEFT] = true;
+        m_LightsState.m_bCabinetLights[LIGHT_BASS_RIGHT] = true;
+      }
 
-			break;
-		}
-		case LIGHTSMODE_MENU_START_ONLY:
-		case LIGHTSMODE_MENU_START_AND_DIRECTIONS:
-		case LIGHTSMODE_JOINING:
-		{
-			static int iLight;
+      break;
+    }
+    case LIGHTSMODE_MENU_START_ONLY:
+    case LIGHTSMODE_MENU_START_AND_DIRECTIONS:
+    case LIGHTSMODE_JOINING: {
+      static int iLight;
 
-			// if we've crossed a beat boundary, advance the light index
-			{
-				static float fLastBeat;
-				float fLightSongBeat = GAMESTATE->m_Position.m_fLightSongBeat;
+      // if we've crossed a beat boundary, advance the light index
+      {
+        static float fLastBeat;
+        float fLightSongBeat = GAMESTATE->m_Position.m_fLightSongBeat;
 
-				if( fracf(fLightSongBeat) < fracf(fLastBeat) )
-				{
-					++iLight;
-					wrap( iLight, 4 );
-				}
+        if (fracf(fLightSongBeat) < fracf(fLastBeat)) {
+          ++iLight;
+          wrap(iLight, 4);
+        }
 
-				fLastBeat = fLightSongBeat;
-			}
+        fLastBeat = fLightSongBeat;
+      }
 
-			CabinetLight cl = CabinetLight_Invalid;
+      CabinetLight cl = CabinetLight_Invalid;
 
-			switch( iLight )
-			{
-				DEFAULT_FAIL( iLight );
-				case 0:	cl = LIGHT_MARQUEE_UP_LEFT;	break;
-				case 1:	cl = LIGHT_MARQUEE_LR_RIGHT;	break;
-				case 2:	cl = LIGHT_MARQUEE_UP_RIGHT;	break;
-				case 3:	cl = LIGHT_MARQUEE_LR_LEFT;	break;
-			}
+      switch (iLight) {
+        DEFAULT_FAIL(iLight);
+        case 0:
+          cl = LIGHT_MARQUEE_UP_LEFT;
+          break;
+        case 1:
+          cl = LIGHT_MARQUEE_LR_RIGHT;
+          break;
+        case 2:
+          cl = LIGHT_MARQUEE_UP_RIGHT;
+          break;
+        case 3:
+          cl = LIGHT_MARQUEE_LR_LEFT;
+          break;
+      }
 
-			m_LightsState.m_bCabinetLights[cl] = true;
+      m_LightsState.m_bCabinetLights[cl] = true;
 
-			break;
-		}
+      break;
+    }
 
-		case LIGHTSMODE_DEMONSTRATION:
-		case LIGHTSMODE_GAMEPLAY:
-		{
-			FOREACH_CabinetLight(cl)
-			{
-				int currLightPlayerNumber = (cl & 1) == 1 ? 1 : 0;
-				bool skipLightActivation = false;
+    case LIGHTSMODE_DEMONSTRATION:
+    case LIGHTSMODE_GAMEPLAY: {
+      FOREACH_CabinetLight(cl) {
+        int currLightPlayerNumber = (cl & 1) == 1 ? 1 : 0;
+        bool skipLightActivation = false;
 
-				auto playerOptions = GAMESTATE->m_pPlayerState[currLightPlayerNumber]->m_PlayerOptions.GetCurrent();
+        auto playerOptions = GAMESTATE->m_pPlayerState[currLightPlayerNumber]
+                                 ->m_PlayerOptions.GetCurrent();
 
-				if (cl == LIGHT_MARQUEE_UP_LEFT ||
-					cl == LIGHT_MARQUEE_UP_RIGHT ||
-					cl == LIGHT_MARQUEE_LR_LEFT ||
-					cl == LIGHT_MARQUEE_LR_RIGHT)
-				{
-					if (GAMESTATE->IsHumanPlayer((PlayerNumber)currLightPlayerNumber))
-					{
-						skipLightActivation = playerOptions.m_HideLightType == HideLightType::HideLightType_HideMarqueeLights ||
-							playerOptions.m_HideLightType == HideLightType::HideLightType_HideAllLights;
-					}
-				}
-				else
-				{
-					bool lightsBassParallel = PREFSMAN->m_bLightsBassParallel;
+        if (cl == LIGHT_MARQUEE_UP_LEFT || cl == LIGHT_MARQUEE_UP_RIGHT ||
+            cl == LIGHT_MARQUEE_LR_LEFT || cl == LIGHT_MARQUEE_LR_RIGHT) {
+          if (GAMESTATE->IsHumanPlayer((PlayerNumber)currLightPlayerNumber)) {
+            skipLightActivation =
+                playerOptions.m_HideLightType ==
+                    HideLightType::HideLightType_HideMarqueeLights ||
+                playerOptions.m_HideLightType ==
+                    HideLightType::HideLightType_HideAllLights;
+          }
+        } else {
+          bool lightsBassParallel = PREFSMAN->m_bLightsBassParallel;
 
-					int otherPn = currLightPlayerNumber == 0 ? 1 : 0;
-					auto otherPlayerOptions = GAMESTATE->m_pPlayerState[otherPn]->m_PlayerOptions.GetCurrent();
+          int otherPn = currLightPlayerNumber == 0 ? 1 : 0;
+          auto otherPlayerOptions =
+              GAMESTATE->m_pPlayerState[otherPn]->m_PlayerOptions.GetCurrent();
 
-					if (GAMESTATE->IsHumanPlayer((PlayerNumber)currLightPlayerNumber))
-					{
-						skipLightActivation = playerOptions.m_HideLightType == HideLightType::HideLightType_HideBassLights ||
-												playerOptions.m_HideLightType == HideLightType::HideLightType_HideAllLights ||
-							(lightsBassParallel &&
-								(otherPlayerOptions.m_HideLightType == HideLightType::HideLightType_HideBassLights ||
-									otherPlayerOptions.m_HideLightType == HideLightType::HideLightType_HideAllLights));
-					}
-					else
-					{
-						skipLightActivation = lightsBassParallel &&
-							(otherPlayerOptions.m_HideLightType == HideLightType::HideLightType_HideBassLights ||
-								otherPlayerOptions.m_HideLightType == HideLightType::HideLightType_HideAllLights);
-					}
-				}
+          if (GAMESTATE->IsHumanPlayer((PlayerNumber)currLightPlayerNumber)) {
+            skipLightActivation =
+                playerOptions.m_HideLightType ==
+                    HideLightType::HideLightType_HideBassLights ||
+                playerOptions.m_HideLightType ==
+                    HideLightType::HideLightType_HideAllLights ||
+                (lightsBassParallel &&
+                 (otherPlayerOptions.m_HideLightType ==
+                      HideLightType::HideLightType_HideBassLights ||
+                  otherPlayerOptions.m_HideLightType ==
+                      HideLightType::HideLightType_HideAllLights));
+          } else {
+            skipLightActivation =
+                lightsBassParallel &&
+                (otherPlayerOptions.m_HideLightType ==
+                     HideLightType::HideLightType_HideBassLights ||
+                 otherPlayerOptions.m_HideLightType ==
+                     HideLightType::HideLightType_HideAllLights);
+          }
+        }
 
-				if (!skipLightActivation)
-					m_LightsState.m_bCabinetLights[cl] = m_fSecsLeftInCabinetLightBlink[cl] > 0;
-			}
-			break;
-		}
+        if (!skipLightActivation) {
+          m_LightsState.m_bCabinetLights[cl] =
+              m_fSecsLeftInCabinetLightBlink[cl] > 0;
+        }
+      }
+      break;
+    }
 
-		case LIGHTSMODE_STAGE:
-		case LIGHTSMODE_ALL_CLEARED:
-		{
-			FOREACH_CabinetLight( cl )
-				m_LightsState.m_bCabinetLights[cl] = true;
+    case LIGHTSMODE_STAGE:
+    case LIGHTSMODE_ALL_CLEARED: {
+      FOREACH_CabinetLight(cl) m_LightsState.m_bCabinetLights[cl] = true;
 
-			break;
-		}
+      break;
+    }
 
-		case LIGHTSMODE_TEST_AUTO_CYCLE:
-		{
-			int iSec = GetTestAutoCycleCurrentIndex();
+    case LIGHTSMODE_TEST_AUTO_CYCLE: {
+      int iSec = GetTestAutoCycleCurrentIndex();
 
-			CabinetLight cl = CabinetLight(iSec % NUM_CabinetLight);
-			m_LightsState.m_bCabinetLights[cl] = true;
+      CabinetLight cl = CabinetLight(iSec % NUM_CabinetLight);
+      m_LightsState.m_bCabinetLights[cl] = true;
 
-			break;
-		}
+      break;
+    }
 
-		case LIGHTSMODE_TEST_MANUAL_CYCLE:
-		{
-			CabinetLight cl = m_clTestManualCycleCurrent;
-			m_LightsState.m_bCabinetLights[cl] = true;
+    case LIGHTSMODE_TEST_MANUAL_CYCLE: {
+      CabinetLight cl = m_clTestManualCycleCurrent;
+      m_LightsState.m_bCabinetLights[cl] = true;
 
-			break;
-		}
-	}
+      break;
+    }
+  }
 
+  // Update game controller lights
+  switch (m_LightsMode) {
+    DEFAULT_FAIL(m_LightsMode);
 
-	// Update game controller lights
-	switch( m_LightsMode )
-	{
-		DEFAULT_FAIL( m_LightsMode );
+    case LIGHTSMODE_ALL_CLEARED:
+    case LIGHTSMODE_STAGE:
+    case LIGHTSMODE_JOINING: {
+      FOREACH_ENUM(GameController, gc) {
+        if (GAMESTATE->m_bSideIsJoined[gc]) {
+          FOREACH_ENUM(GameButton, gb)
+          m_LightsState.m_bGameButtonLights[gc][gb] = true;
+        }
+      }
 
-		case LIGHTSMODE_ALL_CLEARED:
-		case LIGHTSMODE_STAGE:
-		case LIGHTSMODE_JOINING:
-		{
-			FOREACH_ENUM( GameController, gc )
-			{
-				if( GAMESTATE->m_bSideIsJoined[gc] )
-				{
-					FOREACH_ENUM( GameButton, gb )
-						m_LightsState.m_bGameButtonLights[gc][gb] = true;
-				}
-			}
+      break;
+    }
 
-			break;
-		}
+    case LIGHTSMODE_MENU_START_ONLY:
+    case LIGHTSMODE_MENU_START_AND_DIRECTIONS: {
+      float fLightSongBeat = GAMESTATE->m_Position.m_fLightSongBeat;
 
-		case LIGHTSMODE_MENU_START_ONLY:
-		case LIGHTSMODE_MENU_START_AND_DIRECTIONS:
-		{
-			float fLightSongBeat = GAMESTATE->m_Position.m_fLightSongBeat;
+      /* Blink menu lights on the first half of the beat */
+      if (fracf(fLightSongBeat) <= 0.5f) {
+        FOREACH_PlayerNumber(pn) {
+          if (!GAMESTATE->m_bSideIsJoined[pn]) {
+            continue;
+          }
 
-			/* Blink menu lights on the first half of the beat */
-			if( fracf(fLightSongBeat) <= 0.5f )
-			{
-				FOREACH_PlayerNumber( pn )
-				{
-					if( !GAMESTATE->m_bSideIsJoined[pn] )
-						continue;
+          m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_START] = true;
 
-					m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_START] = true;
+          if (m_LightsMode == LIGHTSMODE_MENU_START_AND_DIRECTIONS) {
+            m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_MENULEFT] = true;
+            m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_MENURIGHT] = true;
+            m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_MENUUP] = true;
+            m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_MENUDOWN] = true;
+          } else {
+            // flash select during evaluation screen to indicate
+            // that the button can be used for screenshots etc.
+            m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_SELECT] = true;
+          }
+        }
+      }
 
-					if( m_LightsMode == LIGHTSMODE_MENU_START_AND_DIRECTIONS )
-					{
-						m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_MENULEFT] = true;
-						m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_MENURIGHT] = true;
-						m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_MENUUP] = true;
-						m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_MENUDOWN] = true;
-					}
-					else
-					{
-						//flash select during evaluation screen to indicate
-						//that the button can be used for screenshots etc.
-						m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_SELECT] = true;
-					}
-				}
-			}
+      // fall through to blink on button presses
+      [[fallthrough]];
+    }
 
-			// fall through to blink on button presses
-			[[fallthrough]];
-		}
+    case LIGHTSMODE_DEMONSTRATION:
+    case LIGHTSMODE_GAMEPLAY: {
+      bool bGameplay = (m_LightsMode == LIGHTSMODE_DEMONSTRATION) ||
+                       (m_LightsMode == LIGHTSMODE_GAMEPLAY);
 
-		case LIGHTSMODE_DEMONSTRATION:
-		case LIGHTSMODE_GAMEPLAY:
-		{
-			bool bGameplay = (m_LightsMode == LIGHTSMODE_DEMONSTRATION) || (m_LightsMode == LIGHTSMODE_GAMEPLAY);
+      // Blink on notes during gameplay.
+      if (bGameplay && g_bBlinkGameplayButtonLightsOnNote) {
+        FOREACH_ENUM(GameController, gc) {
+          FOREACH_ENUM(GameButton, gb) {
+            m_LightsState.m_bGameButtonLights[gc][gb] =
+                m_fSecsLeftInGameButtonBlink[gc][gb] > 0;
+          }
+        }
+        break;
+      }
 
-			// Blink on notes during gameplay.
-			if( bGameplay && g_bBlinkGameplayButtonLightsOnNote )
-			{
-				FOREACH_ENUM( GameController,  gc )
-				{
-					FOREACH_ENUM( GameButton,  gb )
-					{
-						m_LightsState.m_bGameButtonLights[gc][gb] = m_fSecsLeftInGameButtonBlink[gc][gb] > 0 ;
-					}
-				}
-				break;
-			}
+      // fall through to blink on button presses
+      [[fallthrough]];
+    }
 
-			// fall through to blink on button presses
-			[[fallthrough]];
-		}
+    case LIGHTSMODE_ATTRACT: {
+      // Blink on button presses.
+      FOREACH_ENUM(GameController, gc) {
+        FOREACH_GameButton_Custom(gb) {
+          bool bOn = INPUTMAPPER->IsBeingPressed(GameInput(gc, gb));
+          m_LightsState.m_bGameButtonLights[gc][gb] = bOn;
+        }
+      }
 
-		case LIGHTSMODE_ATTRACT:
-		{
-			// Blink on button presses.
-			FOREACH_ENUM( GameController,  gc )
-			{
-				FOREACH_GameButton_Custom( gb )
-				{
-					bool bOn = INPUTMAPPER->IsBeingPressed( GameInput(gc,gb) );
-					m_LightsState.m_bGameButtonLights[gc][gb] = bOn;
-				}
-			}
+      break;
+    }
 
-			break;
-		}
+    case LIGHTSMODE_TEST_AUTO_CYCLE: {
+      int index = GetTestAutoCycleCurrentIndex();
 
-		case LIGHTSMODE_TEST_AUTO_CYCLE:
-		{
-			int index = GetTestAutoCycleCurrentIndex();
+      std::vector<GameInput> vGI;
+      GetUsedGameInputs(vGI);
+      wrap(index, vGI.size());
 
-			std::vector<GameInput> vGI;
-			GetUsedGameInputs( vGI );
-			wrap( index, vGI.size() );
+      ZERO(m_LightsState.m_bGameButtonLights);
 
-			ZERO( m_LightsState.m_bGameButtonLights );
+      GameController gc = vGI[index].controller;
+      GameButton gb = vGI[index].button;
+      m_LightsState.m_bGameButtonLights[gc][gb] = true;
 
-			GameController gc = vGI[index].controller;
-			GameButton gb = vGI[index].button;
-			m_LightsState.m_bGameButtonLights[gc][gb] = true;
+      break;
+    }
 
-			break;
-		}
+    case LIGHTSMODE_TEST_MANUAL_CYCLE: {
+      ZERO(m_LightsState.m_bGameButtonLights);
 
-		case LIGHTSMODE_TEST_MANUAL_CYCLE:
-		{
-			ZERO( m_LightsState.m_bGameButtonLights );
+      std::vector<GameInput> vGI;
+      GetUsedGameInputs(vGI);
 
-			std::vector<GameInput> vGI;
-			GetUsedGameInputs( vGI );
+      if (m_iControllerTestManualCycleCurrent != -1) {
+        GameController gc = vGI[m_iControllerTestManualCycleCurrent].controller;
+        GameButton gb = vGI[m_iControllerTestManualCycleCurrent].button;
+        m_LightsState.m_bGameButtonLights[gc][gb] = true;
+      }
 
-			if( m_iControllerTestManualCycleCurrent != -1 )
-			{
-				GameController gc = vGI[m_iControllerTestManualCycleCurrent].controller;
-				GameButton gb = vGI[m_iControllerTestManualCycleCurrent].button;
-				m_LightsState.m_bGameButtonLights[gc][gb] = true;
-			}
+      break;
+    }
+  }
 
-			break;
-		}
-	}
+  // If not joined, has enough credits, and not too late to join, then
+  // blink the menu buttons rapidly so they'll press Start
+  {
+    int iBeat = (int)(GAMESTATE->m_Position.m_fLightSongBeat * 4);
+    bool bBlinkOn = (iBeat % 2) == 0;
+    FOREACH_PlayerNumber(pn) {
+      if (!GAMESTATE->m_bSideIsJoined[pn] && GAMESTATE->PlayersCanJoin() &&
+          GAMESTATE->EnoughCreditsToJoin()) {
+        m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_START] = bBlinkOn;
+      }
+    }
+  }
 
-	// If not joined, has enough credits, and not too late to join, then
-	// blink the menu buttons rapidly so they'll press Start
-	{
-		int iBeat = (int)(GAMESTATE->m_Position.m_fLightSongBeat*4);
-		bool bBlinkOn = (iBeat%2)==0;
-		FOREACH_PlayerNumber( pn )
-		{
-			if( !GAMESTATE->m_bSideIsJoined[pn] && GAMESTATE->PlayersCanJoin() && GAMESTATE->EnoughCreditsToJoin() )
-				m_LightsState.m_bGameButtonLights[pn][GAME_BUTTON_START] = bBlinkOn;
-		}
-	}
-
-	// apply new light values we set above
-	for (LightsDriver *iter : m_vpDrivers)
-		iter->Set( &m_LightsState );
+  // apply new light values we set above
+  for (LightsDriver* iter : m_vpDrivers) {
+    if (memcmp(&m_LightsState, &m_PrevLightsState, sizeof(m_LightsState)) !=
+        0) {
+      iter->Set(&m_LightsState);
+	  memcpy(&m_PrevLightsState, &m_LightsState, sizeof(m_LightsState));
+    }
+  }
 }
 
-void LightsManager::BlinkCabinetLight( CabinetLight cl )
-{
-	m_fSecsLeftInCabinetLightBlink[cl] = g_fLightsFalloffSeconds;
+void LightsManager::BlinkCabinetLight(CabinetLight cl) {
+  m_fSecsLeftInCabinetLightBlink[cl] = g_fLightsFalloffSeconds;
 }
 
-void LightsManager::BlinkGameButton( GameInput gi )
-{
-	m_fSecsLeftInGameButtonBlink[gi.controller][gi.button] = g_fLightsFalloffSeconds;
+void LightsManager::BlinkGameButton(GameInput gi) {
+  m_fSecsLeftInGameButtonBlink[gi.controller][gi.button] =
+      g_fLightsFalloffSeconds;
 }
 
-void LightsManager::SetLightsMode( LightsMode lm )
-{
-	m_LightsMode = lm;
-	m_fTestAutoCycleCurrentIndex = 0;
-	m_clTestManualCycleCurrent = CabinetLight_Invalid;
-	m_iControllerTestManualCycleCurrent = -1;
+void LightsManager::SetLightsMode(LightsMode lm) {
+  m_LightsMode = lm;
+  m_fTestAutoCycleCurrentIndex = 0;
+  m_clTestManualCycleCurrent = CabinetLight_Invalid;
+  m_iControllerTestManualCycleCurrent = -1;
 }
 
-LightsMode LightsManager::GetLightsMode()
-{
-	return m_LightsMode;
+LightsMode LightsManager::GetLightsMode() { return m_LightsMode; }
+
+void LightsManager::ChangeTestCabinetLight(int iDir) {
+  m_iControllerTestManualCycleCurrent = -1;
+
+  enum_add(m_clTestManualCycleCurrent, iDir);
+  wrap(*ConvertValue<int>(&m_clTestManualCycleCurrent), NUM_CabinetLight);
 }
 
-void LightsManager::ChangeTestCabinetLight( int iDir )
-{
-	m_iControllerTestManualCycleCurrent = -1;
+void LightsManager::ChangeTestGameButtonLight(int iDir) {
+  m_clTestManualCycleCurrent = CabinetLight_Invalid;
 
-	enum_add( m_clTestManualCycleCurrent, iDir );
-	wrap( *ConvertValue<int>(&m_clTestManualCycleCurrent), NUM_CabinetLight );
+  std::vector<GameInput> vGI;
+  GetUsedGameInputs(vGI);
+
+  m_iControllerTestManualCycleCurrent += iDir;
+  wrap(m_iControllerTestManualCycleCurrent, vGI.size());
 }
 
-void LightsManager::ChangeTestGameButtonLight( int iDir )
-{
-	m_clTestManualCycleCurrent = CabinetLight_Invalid;
-
-	std::vector<GameInput> vGI;
-	GetUsedGameInputs( vGI );
-
-	m_iControllerTestManualCycleCurrent += iDir;
-	wrap( m_iControllerTestManualCycleCurrent, vGI.size() );
+CabinetLight LightsManager::GetFirstLitCabinetLight() {
+  FOREACH_CabinetLight(cl) {
+    if (m_LightsState.m_bCabinetLights[cl]) {
+      return cl;
+    }
+  }
+  return CabinetLight_Invalid;
 }
 
-CabinetLight LightsManager::GetFirstLitCabinetLight()
-{
-	FOREACH_CabinetLight( cl )
-	{
-		if( m_LightsState.m_bCabinetLights[cl] )
-			return cl;
-	}
-	return CabinetLight_Invalid;
+GameInput LightsManager::GetFirstLitGameButtonLight() {
+  FOREACH_ENUM(GameController, gc) {
+    FOREACH_ENUM(GameButton, gb) {
+      if (m_LightsState.m_bGameButtonLights[gc][gb]) {
+        return GameInput(gc, gb);
+      }
+    }
+  }
+  return GameInput();
 }
 
-GameInput LightsManager::GetFirstLitGameButtonLight()
-{
-	FOREACH_ENUM( GameController, gc )
-	{
-		FOREACH_ENUM( GameButton, gb )
-		{
-			if( m_LightsState.m_bGameButtonLights[gc][gb] )
-				return GameInput( gc, gb );
-		}
-	}
-	return GameInput();
+bool LightsManager::IsEnabled() const {
+  return m_vpDrivers.size() >= 1 || PREFSMAN->m_bDebugLights;
 }
 
-bool LightsManager::IsEnabled() const
-{
-	return m_vpDrivers.size() >= 1 || PREFSMAN->m_bDebugLights;
-}
-
-void LightsManager::TurnOffAllLights()
-{
-	for(LightsDriver *iter : m_vpDrivers)
-		iter->Reset();
+void LightsManager::TurnOffAllLights() {
+  for (LightsDriver* iter : m_vpDrivers) {
+    iter->Reset();
+  }
 }
 
 /*

--- a/src/LightsManager.cpp
+++ b/src/LightsManager.cpp
@@ -123,7 +123,7 @@ LightsManager::~LightsManager() {
   if (m_LightsMutex != nullptr) {
     m_LightsMutex->Lock();
     m_LightsThreadShutdown = true;
-    m_LightsMutex->Broadcast();
+    m_LightsMutex->Signal();
     m_LightsMutex->Unlock();
     m_LightsThread.Wait();
   }
@@ -143,23 +143,21 @@ int LightsManager::LightsManThreadMain() {
       m_LightsMutex->Wait();
     }
 
+    if (m_LightsThreadShutdown) {
+      m_LightsMutex->Unlock();
+      break;
+    }
+
+    // pop the first in first state out from the queue
+    LightsState push = m_LightsQueue.front();
+    m_LightsQueue.pop();
+
     m_LightsMutex->Unlock();
 
-    // push every state on the queue to all of the devices.
-    while (!m_LightsQueue.empty()) {
-      m_LightsMutex->Lock();
-
-      // pop the first in first state out from the queue
-      LightsState push = m_LightsQueue.front();
-      m_LightsQueue.pop();
-
-      m_LightsMutex->Unlock();
-
-      // push to all of the devices
-      // could take time, it's why we are in at thread
-      for (LightsDriver* iter : m_vpDrivers) {
-        iter->Set(&push);
-      }
+    // push to all of the devices
+    // could take time, it's why we are in at thread
+    for (LightsDriver* iter : m_vpDrivers) {
+      iter->Set(&push);
     }
   }
 
@@ -533,7 +531,7 @@ void LightsManager::Update(float fDeltaTime) {
     // add lights state to queue.
     m_LightsMutex->Lock();
     m_LightsQueue.push(m_LightsState);
-    m_LightsMutex->Broadcast();
+    m_LightsMutex->Signal();
     m_LightsMutex->Unlock();
 
     memcpy(&m_PrevLightsState, &m_LightsState, sizeof(m_LightsState));

--- a/src/LightsManager.cpp
+++ b/src/LightsManager.cpp
@@ -1,25 +1,24 @@
+#include "global.h"
 #include "LightsManager.h"
+#include "GameState.h"
+#include "RageTimer.h"
+#include "arch/Lights/LightsDriver.h"
+#include "RageUtil.h"
+#include "GameInput.h"	// for GameController
+#include "InputMapper.h"
+#include "Game.h"
+#include "PrefsManager.h"
+#include "Actor.h"
+#include "Preference.h"
+#include "GameManager.h"
+#include "PlayerState.h"
+#include "GameState.h"
+#include "CommonMetrics.h"
+#include "Style.h"
 
 #include <cmath>
 #include <cstddef>
 #include <vector>
-
-#include "Actor.h"
-#include "CommonMetrics.h"
-#include "Game.h"
-#include "GameInput.h"  // for GameController
-#include "GameManager.h"
-#include "GameState.h"
-#include "InputMapper.h"
-#include "PlayerState.h"
-#include "Preference.h"
-#include "PrefsManager.h"
-#include "RageTimer.h"
-#include "RageUtil.h"
-#include "RageUtil/ConvertValue.h"
-#include "Style.h"
-#include "arch/Lights/LightsDriver.h"
-#include "global.h"
 
 const RString DEFAULT_LIGHTS_DRIVER = "SystemMessage,Export";
 static Preference<RString> g_sLightsDriver(

--- a/src/LightsManager.cpp
+++ b/src/LightsManager.cpp
@@ -459,9 +459,20 @@ void LightsManager::Update(float fDeltaTime) {
     }
 
     case LIGHTSMODE_ATTRACT: {
-      // Blink on button presses.
+      // Blink on game button presses.
+      // GAME_BUTTON_CUSTOM_01 -> NUM_GameButton
       FOREACH_ENUM(GameController, gc) {
         FOREACH_GameButton_Custom(gb) {
+          bool bOn = INPUTMAPPER->IsBeingPressed(GameInput(gc, gb));
+          m_LightsState.m_bGameButtonLights[gc][gb] = bOn;
+        }
+      }
+
+      // Blink on each menu button press
+      // GAME_BUTTON_MENULEFT -> GAME_BUTTON_BACK
+      // left, right, up, down, start, select, and back.
+      FOREACH_ENUM(GameController, gc) {
+        FOREACH_GameButton_Menu(gb) {
           bool bOn = INPUTMAPPER->IsBeingPressed(GameInput(gc, gb));
           m_LightsState.m_bGameButtonLights[gc][gb] = bOn;
         }

--- a/src/LightsManager.h
+++ b/src/LightsManager.h
@@ -2,11 +2,13 @@
 #define LightsManager_H
 
 #include <vector>
+#include <queue>
 
 #include "EnumHelper.h"
 #include "GameInput.h"
 #include "PlayerNumber.h"
 #include "Preference.h"
+#include "RageThreads.h"
 #include "RageTimer.h"
 
 extern Preference<float> g_fLightsFalloffSeconds;
@@ -100,6 +102,18 @@ class LightsManager {
 
   int m_iQueuedCoinCounterPulses;
   RageTimer m_CoinCounterTimer;
+
+  bool m_LightsThreadShutdown;
+  RageThread m_LightsThread;
+  RageEvent* m_LightsMutex;
+  std::queue<LightsState> m_LightsQueue;
+
+  int LightsManThreadMain();
+
+  static int LightsManThread_Start(void* p) {
+    ((LightsManager*)p)->LightsManThreadMain();
+    return 0;
+  }
 
   int GetTestAutoCycleCurrentIndex() {
     return (int)m_fTestAutoCycleCurrentIndex;

--- a/src/LightsManager.h
+++ b/src/LightsManager.h
@@ -53,6 +53,36 @@ struct LightsState {
   // This isn't actually a light, but it's typically implemented in the same
   // way.
   bool m_bCoinCounter;
+
+  // equality operator
+  bool operator==(const LightsState& rhs) const {
+    // compare cabinet lights
+    for (int i = 0; i < NUM_CabinetLight; ++i) {
+      if (m_bCabinetLights[i] != rhs.m_bCabinetLights[i]) {
+        return false;
+      }
+    }
+
+    // compare game button lights
+    for (int c = 0; c < NUM_GameController; ++c) {
+      for (int b = 0; b < NUM_GameButton; ++b) {
+        if (m_bGameButtonLights[c][b] != rhs.m_bGameButtonLights[c][b]) {
+          return false;
+        }
+      }
+    }
+
+    // compare coin counter
+    if (m_bCoinCounter != rhs.m_bCoinCounter) {
+      return false;
+    }
+
+    // all fields match
+    return true;
+  }
+
+  // inequality operator
+  bool operator!=(const LightsState& rhs) const { return !(*this == rhs); }
 };
 
 class LightsDriver;

--- a/src/LightsManager.h
+++ b/src/LightsManager.h
@@ -1,114 +1,117 @@
 #ifndef LightsManager_H
 #define LightsManager_H
 
-#include "PlayerNumber.h"
-#include "GameInput.h"
+#include <vector>
+
 #include "EnumHelper.h"
+#include "GameInput.h"
+#include "PlayerNumber.h"
 #include "Preference.h"
 #include "RageTimer.h"
 
-#include <vector>
+extern Preference<float> g_fLightsFalloffSeconds;
+extern Preference<float> g_fLightsAheadSeconds;
 
-
-extern Preference<float>	g_fLightsFalloffSeconds;
-extern Preference<float>	g_fLightsAheadSeconds;
-
-enum CabinetLight
-{
-	LIGHT_MARQUEE_UP_LEFT,
-	LIGHT_MARQUEE_UP_RIGHT,
-	LIGHT_MARQUEE_LR_LEFT,
-	LIGHT_MARQUEE_LR_RIGHT,
-	LIGHT_BASS_LEFT,
-	LIGHT_BASS_RIGHT,
-	NUM_CabinetLight,
-	CabinetLight_Invalid
+enum CabinetLight {
+  LIGHT_MARQUEE_UP_LEFT,
+  LIGHT_MARQUEE_UP_RIGHT,
+  LIGHT_MARQUEE_LR_LEFT,
+  LIGHT_MARQUEE_LR_RIGHT,
+  LIGHT_BASS_LEFT,
+  LIGHT_BASS_RIGHT,
+  NUM_CabinetLight,
+  CabinetLight_Invalid
 };
 /** @brief Loop through each CabinetLight on the machine. */
-#define FOREACH_CabinetLight( i ) FOREACH_ENUM( CabinetLight, i )
-const RString& CabinetLightToString( CabinetLight cl );
-CabinetLight StringToCabinetLight( const RString& s);
+#define FOREACH_CabinetLight(i) FOREACH_ENUM(CabinetLight, i)
+const RString& CabinetLightToString(CabinetLight cl);
+CabinetLight StringToCabinetLight(const RString& s);
 
-enum LightsMode
-{
-	LIGHTSMODE_ATTRACT,
-	LIGHTSMODE_JOINING,
-	LIGHTSMODE_MENU_START_ONLY,
-	LIGHTSMODE_MENU_START_AND_DIRECTIONS,
-	LIGHTSMODE_DEMONSTRATION,
-	LIGHTSMODE_GAMEPLAY,
-	LIGHTSMODE_STAGE,
-	LIGHTSMODE_ALL_CLEARED,
-	LIGHTSMODE_TEST_AUTO_CYCLE,
-	LIGHTSMODE_TEST_MANUAL_CYCLE,
-	NUM_LightsMode,
-	LightsMode_Invalid
+enum LightsMode {
+  LIGHTSMODE_ATTRACT,
+  LIGHTSMODE_JOINING,
+  LIGHTSMODE_MENU_START_ONLY,
+  LIGHTSMODE_MENU_START_AND_DIRECTIONS,
+  LIGHTSMODE_DEMONSTRATION,
+  LIGHTSMODE_GAMEPLAY,
+  LIGHTSMODE_STAGE,
+  LIGHTSMODE_ALL_CLEARED,
+  LIGHTSMODE_TEST_AUTO_CYCLE,
+  LIGHTSMODE_TEST_MANUAL_CYCLE,
+  NUM_LightsMode,
+  LightsMode_Invalid
 };
-const RString& LightsModeToString( LightsMode lm );
-LuaDeclareType( LightsMode );
+const RString& LightsModeToString(LightsMode lm);
+LuaDeclareType(LightsMode);
 
-struct LightsState
-{
-	bool m_bCabinetLights[NUM_CabinetLight];
-	bool m_bGameButtonLights[NUM_GameController][NUM_GameButton];
+struct LightsState {
+  bool m_bCabinetLights[NUM_CabinetLight];
+  bool m_bGameButtonLights[NUM_GameController][NUM_GameButton];
 
-	// This isn't actually a light, but it's typically implemented in the same way.
-	bool m_bCoinCounter;
+  // This isn't actually a light, but it's typically implemented in the same
+  // way.
+  bool m_bCoinCounter;
 };
 
 class LightsDriver;
 /** @brief Control lights. */
-class LightsManager
-{
-public:
-	LightsManager();
-	~LightsManager();
+class LightsManager {
+ public:
+  LightsManager();
+  ~LightsManager();
 
-	void Update( float fDeltaTime );
-	bool IsEnabled() const;
+  void Update(float fDeltaTime);
+  bool IsEnabled() const;
 
-	void BlinkCabinetLight( CabinetLight cl );
-	void BlinkGameButton( GameInput gi );
-	void BlinkActorLight( CabinetLight cl );
-	void TurnOffAllLights();
-	void PulseCoinCounter() { ++m_iQueuedCoinCounterPulses; }
-	float GetActorLightLatencySeconds() const;
+  void BlinkCabinetLight(CabinetLight cl);
+  void BlinkGameButton(GameInput gi);
+  void BlinkActorLight(CabinetLight cl);
+  void TurnOffAllLights();
+  void PulseCoinCounter() { ++m_iQueuedCoinCounterPulses; }
+  float GetActorLightLatencySeconds() const;
 
-	void SetLightsMode( LightsMode lm );
-	LightsMode GetLightsMode();
+  void SetLightsMode(LightsMode lm);
+  LightsMode GetLightsMode();
 
-	void PrevTestCabinetLight()		{ ChangeTestCabinetLight(-1); }
-	void NextTestCabinetLight()		{ ChangeTestCabinetLight(+1); }
-	void PrevTestGameButtonLight()	{ ChangeTestGameButtonLight(-1); }
-	void NextTestGameButtonLight()	{ ChangeTestGameButtonLight(+1); }
+  void PrevTestCabinetLight() { ChangeTestCabinetLight(-1); }
+  void NextTestCabinetLight() { ChangeTestCabinetLight(+1); }
+  void PrevTestGameButtonLight() { ChangeTestGameButtonLight(-1); }
+  void NextTestGameButtonLight() { ChangeTestGameButtonLight(+1); }
 
-	CabinetLight	GetFirstLitCabinetLight();
-	GameInput	GetFirstLitGameButtonLight();
+  CabinetLight GetFirstLitCabinetLight();
+  GameInput GetFirstLitGameButtonLight();
 
-private:
-	void ChangeTestCabinetLight( int iDir );
-	void ChangeTestGameButtonLight( int iDir );
+ private:
+  void ChangeTestCabinetLight(int iDir);
+  void ChangeTestGameButtonLight(int iDir);
 
-	float m_fSecsLeftInCabinetLightBlink[NUM_CabinetLight];
-	float m_fSecsLeftInGameButtonBlink[NUM_GameController][NUM_GameButton];
-	float m_fActorLights[NUM_CabinetLight];	// current "power" of each actor light
-	float m_fSecsLeftInActorLightBlink[NUM_CabinetLight];	// duration to "power" an actor light
+  float m_fSecsLeftInCabinetLightBlink[NUM_CabinetLight];
+  float m_fSecsLeftInGameButtonBlink[NUM_GameController][NUM_GameButton];
+  float
+      m_fActorLights[NUM_CabinetLight];  // current "power" of each actor light
+  float m_fSecsLeftInActorLightBlink[NUM_CabinetLight];  // duration to "power"
+                                                         // an actor light
 
-	std::vector<LightsDriver*> m_vpDrivers;
-	LightsMode m_LightsMode;
-	LightsState m_LightsState;
+  std::vector<LightsDriver*> m_vpDrivers;
+  LightsMode m_LightsMode;
 
-	int m_iQueuedCoinCounterPulses;
-	RageTimer m_CoinCounterTimer;
+  LightsState m_LightsState;
+  LightsState m_PrevLightsState;
 
-	int GetTestAutoCycleCurrentIndex() { return (int)m_fTestAutoCycleCurrentIndex; }
+  int m_iQueuedCoinCounterPulses;
+  RageTimer m_CoinCounterTimer;
 
-	float			m_fTestAutoCycleCurrentIndex;
-	CabinetLight	m_clTestManualCycleCurrent;
-	int				m_iControllerTestManualCycleCurrent;
+  int GetTestAutoCycleCurrentIndex() {
+    return (int)m_fTestAutoCycleCurrentIndex;
+  }
+
+  float m_fTestAutoCycleCurrentIndex;
+  CabinetLight m_clTestManualCycleCurrent;
+  int m_iControllerTestManualCycleCurrent;
 };
 
-extern LightsManager*	LIGHTSMAN;	// global and accessible from anywhere in our program
+extern LightsManager*
+    LIGHTSMAN;  // global and accessible from anywhere in our program
 
 #endif
 


### PR DESCRIPTION
Moves the Set commands in LightsManager to their own thread as some of the LightsDrivers can take longer than expected.

...and in the gameloop `LIGHTSMAN->Update(fDeltaTime);` is a blocking call.

Tasks:
- Creates a LightsMan thread that will fire and forget the state to all of the LightsDrivers
- Queue for creating a list of lights to the threads to consume
- only adds items to the queue if and only if the state has changed (yes this was not the case before)
- formats lightsmanager cpp to clang (sorry the diff looks terrible, you can better look at it in my git history)
- makes the `MENU_` lights reactive now (user pressing will light them up)

Tagging for review/visibility as these users expressed interest in these features:
@pogof
@LucaSilva-r
@dando92 

