### PR TITLE
Cleanup unnecessary use of GAMESTATE->SetProcessedTimingData in file loading

### DIFF
--- a/src/ColumnCues.cpp
+++ b/src/ColumnCues.cpp
@@ -1,11 +1,9 @@
 #include "global.h"
 #include "ColumnCues.h"
 #include "GameState.h"
-#include "TimingData.h"
 
-void ColumnCue::CalculateColumnCues(const NoteData &in, std::vector<ColumnCue> &out, float minDuration)
+void ColumnCue::CalculateColumnCues(const NoteData &in, TimingData * timing, std::vector<ColumnCue> &out, float minDuration)
 {
-	TimingData *timing = GAMESTATE->GetProcessedTimingData();
 	NoteData::all_tracks_const_iterator curr_note = in.GetTapNoteRangeAllTracks(0, MAX_NOTE_ROW);
 	int curr_row = -1;
 

--- a/src/ColumnCues.h
+++ b/src/ColumnCues.h
@@ -4,6 +4,7 @@
 #include "GameConstantsAndTypes.h"
 #include "NoteTypes.h"
 #include "NoteData.h"
+#include "TimingData.h"
 
 /* ColumnCues are used to indicate to the player which column the next note will occur
  after a long gap in the stepchart.
@@ -46,7 +47,7 @@ struct ColumnCue
 	/** @brief Calculates the set of ColumnCues for the given NoteData. Each "cue" is for any note that has a
 	 * minimum of minDuration seconds between it and the previous note on that same column.
 	*/
-	static void CalculateColumnCues(const NoteData &in, std::vector<ColumnCue> &out, float minDuration);
+	static void CalculateColumnCues(const NoteData &in, TimingData * timing, std::vector<ColumnCue> &out, float minDuration);
 };
 
 #endif

--- a/src/MeasureInfo.cpp
+++ b/src/MeasureInfo.cpp
@@ -4,7 +4,6 @@
 #include "RageLog.h"
 #include "LocalizedString.h"
 #include "LuaBinding.h"
-#include "TimingData.h"
 #include "GameState.h"
 
 
@@ -48,13 +47,12 @@ void MeasureInfo::FromString(const RString& sValues)
 	peakNps = peak_nps;
 }
 
-void MeasureInfo::CalculateMeasureInfo(const NoteData &in, MeasureInfo &out)
+void MeasureInfo::CalculateMeasureInfo(const NoteData &in, TimingData * timing, MeasureInfo &out)
 {
 	int lastRow = in.GetLastRow();
 	int lastRowMeasureIndex = 0;
 	int lastRowBeatIndex = 0;
 	int lastRowRemainder = 0;
-	TimingData *timing = GAMESTATE->GetProcessedTimingData();
 	timing->NoteRowToMeasureAndBeat(lastRow, lastRowMeasureIndex, lastRowBeatIndex, lastRowRemainder);
 
 	int totalMeasureCount = lastRowMeasureIndex + 1;

--- a/src/MeasureInfo.h
+++ b/src/MeasureInfo.h
@@ -3,6 +3,7 @@
 
 #include "GameConstantsAndTypes.h"
 #include "NoteData.h"
+#include "TimingData.h"
 
 struct MeasureInfo
 {
@@ -26,7 +27,7 @@ struct MeasureInfo
 
 	RString ToString() const;
 	void FromString(const RString& sValues );
-	static void CalculateMeasureInfo(const NoteData &in, MeasureInfo &out);
+	static void CalculateMeasureInfo(const NoteData &in, TimingData * timing, MeasureInfo &out);
 };
 
 #endif

--- a/src/NoteDataUtil.cpp
+++ b/src/NoteDataUtil.cpp
@@ -1030,6 +1030,12 @@ static void DoRowEndRadarCalc(crv_state& state, RadarValues& out)
 
 void NoteDataUtil::CalculateRadarValues( const NoteData &in, float fSongSeconds, RadarValues& out )
 {
+	TimingData* timing= GAMESTATE->GetProcessedTimingData();
+	CalculateRadarValues(in, fSongSeconds, timing, out);
+}
+
+void NoteDataUtil::CalculateRadarValues( const NoteData &in, float fSongSeconds, const TimingData * timing, RadarValues& out )
+{
 	// Anybody editing this function should also examine
 	// NoteDataWithScoring::GetActualRadarValues to make sure it handles things
 	// the same way.
@@ -1042,7 +1048,7 @@ void NoteDataUtil::CalculateRadarValues( const NoteData &in, float fSongSeconds,
 	std::vector<recent_note> recent_notes;
 	NoteData::all_tracks_const_iterator curr_note=
 		in.GetTapNoteRangeAllTracks(0, MAX_NOTE_ROW);
-	TimingData* timing= GAMESTATE->GetProcessedTimingData();
+
 	// total_taps exists because the stream calculation needs GetNumTapNotes,
 	// but TapsAndHolds + Jumps + Hands would be inaccurate. -Kyz
 	float total_taps= 0;

--- a/src/NoteDataUtil.h
+++ b/src/NoteDataUtil.h
@@ -58,6 +58,7 @@ namespace NoteDataUtil
 	void AutogenKickbox(const NoteData& in, NoteData& out, const TimingData& timing, StepsType out_type, int nonrandom_seed);
 
 	void CalculateRadarValues( const NoteData &in, float fSongSeconds, RadarValues& out );
+	void CalculateRadarValues( const NoteData &in, float fSongSeconds, const TimingData * timing, RadarValues& out );
 
 	/**
 	 * @brief Remove all of the Hold notes.

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -415,7 +415,6 @@ std::vector<int> StepParityGenerator::computeCheapestPath()
 void StepParityGenerator::CreateIntermediateNoteData(
 		const NoteData &in, std::vector<IntermediateNoteData> &out)
 {
-	TimingData *timing = GAMESTATE->GetProcessedTimingData();
 	int columnCount = in.GetNumTracks();
 
 	NoteData::all_tracks_const_iterator curr_note = in.GetTapNoteRangeAllTracks(0, MAX_NOTE_ROW);
@@ -451,8 +450,7 @@ void StepParityGenerator::CreateIntermediateNoteData(
 }
 
 void StepParityGenerator::CreateRows(const NoteData &in)
-{	
-	TimingData *timing = GAMESTATE->GetProcessedTimingData();
+{
 	int columnCount = in.GetNumTracks();
 
 	RowCounter counter = RowCounter(columnCount);

--- a/src/StepParityGenerator.h
+++ b/src/StepParityGenerator.h
@@ -7,6 +7,7 @@
 #include <queue>
 #include <unordered_map>
 #include "json/json.h"
+#include "TimingData.h"
 
 namespace StepParity {
 	
@@ -35,6 +36,7 @@ namespace StepParity {
 	{
 	private:
 		StageLayout layout;
+		TimingData * timing;
 		std::unordered_map < int, std::vector<std::vector<StepParity::Foot>>> permuteCache;
 		
 		StepParity::State * beginningState = nullptr;
@@ -49,8 +51,8 @@ namespace StepParity {
 		std::vector<int> nodes_for_rows;
 		int columnCount_;
 		
-		StepParityGenerator(const StageLayout & l) : layout(l) {
-			
+		StepParityGenerator(const StageLayout & l, TimingData * t) : layout(l) {
+			timing = t;
 		}
 		
 		~StepParityGenerator()

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -399,13 +399,11 @@ void Steps::CalculateTechCounts()
 		return;
 	}
 	StepParity::StageLayout layout = StepParity::Layouts.at(this->m_StepsType);
-	GAMESTATE->SetProcessedTimingData(this->GetTimingData());
-	StepParity::StepParityGenerator gen = StepParity::StepParityGenerator(layout);
+	TimingData * timing = this->GetTimingData();
+	StepParity::StepParityGenerator gen = StepParity::StepParityGenerator(layout, timing);
 	gen.analyzeNoteData(tempNoteData);
 	TechCounts::CalculateTechCountsFromRows(gen.rows, layout, m_CachedTechCounts[0]);
 	std::fill_n( m_CachedTechCounts + 1, NUM_PLAYERS-1, m_CachedTechCounts[0] );
-
-	GAMESTATE->SetProcessedTimingData(nullptr);
 }
 
 void Steps::CalculateMeasureInfo()
@@ -426,8 +424,7 @@ void Steps::CalculateMeasureInfo()
 
 	std::vector<MeasureInfo> measureInfoPerPlayer;
 	
-	GAMESTATE->SetProcessedTimingData(this->GetTimingData());
-
+	TimingData * timing = this->GetTimingData();
 	if( tempNoteData.IsComposite() )
 	{
 		measureInfoPerPlayer.resize(NUM_PLAYERS);
@@ -435,7 +432,7 @@ void Steps::CalculateMeasureInfo()
 		NoteDataUtil::SplitCompositeNoteData( tempNoteData, vParts );
 		for( std::size_t pn = 0; pn < std::min(vParts.size(), std::size_t(NUM_PLAYERS)); ++pn )
 		{
-			MeasureInfo::CalculateMeasureInfo(vParts[pn], measureInfoPerPlayer[pn]);
+			MeasureInfo::CalculateMeasureInfo(vParts[pn], timing, measureInfoPerPlayer[pn]);
 		}
 	}
 	else if (GAMEMAN->GetStepsTypeInfo(this->m_StepsType).m_StepsTypeCategory == StepsTypeCategory_Couple)
@@ -445,15 +442,15 @@ void Steps::CalculateMeasureInfo()
 		// XXX: Assumption that couple will always have an even number of notes.
 		const int tracks = tempNoteData.GetNumTracks() / 2;
 		p1.SetNumTracks(tracks);
-		MeasureInfo::CalculateMeasureInfo(tempNoteData, measureInfoPerPlayer[PLAYER_1]);
+		MeasureInfo::CalculateMeasureInfo(tempNoteData, timing, measureInfoPerPlayer[PLAYER_1]);
 		NoteDataUtil::ShiftTracks(tempNoteData, tracks);
 		tempNoteData.SetNumTracks(tracks);
-		MeasureInfo::CalculateMeasureInfo(tempNoteData, measureInfoPerPlayer[PLAYER_2]);
+		MeasureInfo::CalculateMeasureInfo(tempNoteData, timing, measureInfoPerPlayer[PLAYER_2]);
 	}
 	else
 	{
 		measureInfoPerPlayer.resize(1);
-		MeasureInfo::CalculateMeasureInfo(tempNoteData, measureInfoPerPlayer[0]);
+		MeasureInfo::CalculateMeasureInfo(tempNoteData, timing, measureInfoPerPlayer[0]);
 	}
 	
 	m_CachedNotesPerMeasure.clear();
@@ -466,8 +463,6 @@ void Steps::CalculateMeasureInfo()
 		m_CachedNpsPerMeasure.push_back(mi.npsPerMeasure);
 		m_PeakNps.push_back(mi.peakNps);
 	}
-	
-	GAMESTATE->SetProcessedTimingData(nullptr);
 }
 
 void Steps::ChangeFilenamesForCustomSong()
@@ -1016,9 +1011,8 @@ std::vector<ColumnCue> Steps::GetColumnCues(float minDuration)
 	std::vector<ColumnCue> cues;
 	NoteData noteData;
 	this->GetNoteData( noteData );
-	GAMESTATE->SetProcessedTimingData(this->GetTimingData());
-	ColumnCue::CalculateColumnCues(noteData, cues, minDuration);
-	GAMESTATE->SetProcessedTimingData(nullptr);
+	TimingData * timing = this->GetTimingData();
+	ColumnCue::CalculateColumnCues(noteData, timing, cues, minDuration);
 	return cues;
 }
 

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -338,7 +338,7 @@ void Steps::CalculateRadarValues( float fMusicLengthSeconds )
 	FOREACH_PlayerNumber(pn)
 		m_CachedRadarValues[pn].Zero();
 
-	GAMESTATE->SetProcessedTimingData(this->GetTimingData());
+	TimingData * timing = this->GetTimingData();
 	if( tempNoteData.IsComposite() )
 	{
 		std::vector<NoteData> vParts;
@@ -346,7 +346,7 @@ void Steps::CalculateRadarValues( float fMusicLengthSeconds )
 		NoteDataUtil::SplitCompositeNoteData( tempNoteData, vParts );
 		for( size_t pn = 0; pn < std::min(vParts.size(), size_t(NUM_PLAYERS)); ++pn )
 		{
-			NoteDataUtil::CalculateRadarValues( vParts[pn], fMusicLengthSeconds, m_CachedRadarValues[pn] );
+			NoteDataUtil::CalculateRadarValues( vParts[pn], fMusicLengthSeconds, timing, m_CachedRadarValues[pn] );
 		}
 	}
 	else if (GAMEMAN->GetStepsTypeInfo(this->m_StepsType).m_StepsTypeCategory == StepsTypeCategory_Couple)
@@ -357,21 +357,21 @@ void Steps::CalculateRadarValues( float fMusicLengthSeconds )
 		p1.SetNumTracks(tracks);
 		NoteDataUtil::CalculateRadarValues(p1,
 										   fMusicLengthSeconds,
+										   timing,
 										   m_CachedRadarValues[PLAYER_1]);
 		// at this point, p2 is tempNoteData.
 		NoteDataUtil::ShiftTracks(tempNoteData, tracks);
 		tempNoteData.SetNumTracks(tracks);
 		NoteDataUtil::CalculateRadarValues(tempNoteData,
 										   fMusicLengthSeconds,
+										   timing,
 										   m_CachedRadarValues[PLAYER_2]);
 	}
 	else
 	{
-		NoteDataUtil::CalculateRadarValues( tempNoteData, fMusicLengthSeconds, m_CachedRadarValues[0] );
+		NoteDataUtil::CalculateRadarValues( tempNoteData, fMusicLengthSeconds, timing, m_CachedRadarValues[0] );
 		std::fill_n( m_CachedRadarValues + 1, NUM_PLAYERS-1, m_CachedRadarValues[0] );
 	}
-
-	GAMESTATE->SetProcessedTimingData(nullptr);
 }
 
 void Steps::CalculateTechCounts()

--- a/src/Trail.cpp
+++ b/src/Trail.cpp
@@ -119,8 +119,8 @@ const RadarValues &Trail::GetRadarValues() const
 				NoteData nd;
 				pSteps->GetNoteData( nd );
 				RadarValues rv_orig;
-				GAMESTATE->SetProcessedTimingData(const_cast<TimingData *>(pSteps->GetTimingData()));
-				NoteDataUtil::CalculateRadarValues( nd, e.pSong->m_fMusicLengthSeconds, rv_orig );
+				TimingData * timing = const_cast<TimingData *>(pSteps->GetTimingData());
+				NoteDataUtil::CalculateRadarValues( nd, e.pSong->m_fMusicLengthSeconds, timing, rv_orig );
 				PlayerOptions po;
 				po.FromString( e.Modifiers );
 				if( po.ContainsTransformOrTurn() )
@@ -129,8 +129,7 @@ const RadarValues &Trail::GetRadarValues() const
 				}
 				NoteDataUtil::TransformNoteData(nd, *(pSteps->GetTimingData()), e.Attacks, pSteps->m_StepsType, e.pSong);
 				RadarValues transformed_rv;
-				NoteDataUtil::CalculateRadarValues( nd, e.pSong->m_fMusicLengthSeconds, transformed_rv );
-				GAMESTATE->SetProcessedTimingData(nullptr);
+				NoteDataUtil::CalculateRadarValues( nd, e.pSong->m_fMusicLengthSeconds, timing, transformed_rv );
 				rv += transformed_rv;
 			}
 			else


### PR DESCRIPTION
As mentioned in #995, the use of `GAMESTATE->SetProcessedTimingData()` and `GAMESTATE->GetProcessedTimingData()` while loading chart data is not thread safe.

Other than code that's executing during the game loop, there's really not any reason to use those functions. It's just a convenient way to make the TimingData of the currently loaded song available to whatever parts of the engine that need it.
A lot of it's usage in Steps was just from me aping the general structure of `Steps::CalculateRadarValues` when I was adding tech counts, measure info, and column cues.

This is _most_ of the changes from the patch I made on 9-18-25. I don't want to touch anything in the game loop if I can avoid it, because I don't want to accidentally break something that's relying on the TimingData getting set in an unexpected place.

Aside from `NoteDataUtill::CalculateRadarValues` and `NoteDataWithScoring::GetActualRadarValues`, the only other place that uses `GAMESTATE->GetProcessedTimingData()` is the `NoteData` class. There it's used in a number of methods to check whether a given row is judgable. 

These NoteData methods, and how they rely on game state values to be set correctly ahead of time,  feels like a foot-gun to me. The fact that they're not used by, for instance, the StepParity classes, or to calculate radar values, is probably an accident. If we were really inclined, we could probably figure out a way to get rid of `GAMESTATE->SetProcessedTimingData()` and `GAMESTATE->GetProcessedTimingData()` altogether. But that's way outside the scope of this PR of course.