### PR TITLE
check BMT_Tweens before index

### DIFF
--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -128,12 +128,18 @@ void BitmapText::SetCurrentTweenStart()
 
 void BitmapText::EraseHeadTween()
 {
+	if (BMT_Tweens.empty())
+        return;
+
 	BMT_current= BMT_Tweens[0];
 	BMT_Tweens.erase(BMT_Tweens.begin());
 }
 
 void BitmapText::UpdatePercentThroughTween(float between)
 {
+	if (BMT_Tweens.empty())
+        return;
+
 	BMT_TweenState::MakeWeightedAverage(BMT_current, BMT_start, BMT_Tweens[0],
 		between);
 }
@@ -706,12 +712,12 @@ void BitmapText::DrawPrimitives() noexcept
 
 			RageColor c = m_ShadowColor;
 			c.a *= m_pTempState->diffuse[0].a;
-			
+
 			for (RageSpriteVertex& vertex : m_aVertices)
 			{
 				vertex.c = c;
 			}
-			
+
 			DrawChars( false );
 
 			DISPLAY->PopMatrix();
@@ -803,7 +809,7 @@ void BitmapText::DrawPrimitives() noexcept
 			RandomGen rnd( iSeed );
 			for (size_t i = 0; i < m_aVertices.size(); i += 4)
 			{
-				
+
 				RageVector3 jitter( rnd()%2, rnd()%3, 0 );
 				vGlyphJitter.push_back( jitter );
 


### PR DESCRIPTION
ran into this while testing 

it's possible for `BMT_Tweens` to be empty during `UpdatePercentThroughTween` or `EraseHeadTween` 

And you can't index [0] of an empty vector, it's undefined.