### PR TITLE
Avoid unnecessary Group allocations in LoadSongDir

### DIFF
--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -432,16 +432,21 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 
 		SongPointerVector& index_entry = m_mapSongGroupIndex[sGroupDirName];
 		RString group_base_name= Basename(sGroupDirName);
-		Group* group = new Group(sDir, sGroupDirName);
 		
 		// We need to keep track of previously loaded groups so we don't delete them if we're only loading additions
 		bool groupAlreadyLoaded = false;
-		// Add the group to the group mapping
-		if (m_mapNameToGroup.find(sGroupDirName) == m_mapNameToGroup.end())
+		const auto groupIter = m_mapNameToGroup.find(sGroupDirName);
+		Group* group = nullptr;
+		
+		if (groupIter != m_mapNameToGroup.end())
 		{
-			m_mapNameToGroup[sGroupDirName] = group;
-		} else {
+			group = groupIter->second;
 			groupAlreadyLoaded = true;
+		}
+		else
+		{
+			group = new Group(sDir, sGroupDirName);
+			m_mapNameToGroup[sGroupDirName] = group;
 		}
 
 		for( unsigned j=0; j< arraySongDirs.size(); ++j )	// for each song dir


### PR DESCRIPTION
Refactored LoadSongDir to check if a Group already exists before allocating a new one, preventing redundant memory allocations and ensuring proper reuse of loaded groups.