### PR TITLE
Threaded Song Loading-  Replace a `std::map` with a `std::unordered_map` in SongManager

### DIFF
--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -45,6 +45,15 @@
 #include <tuple>
 #include <vector>
 
+#include <unordered_map>
+namespace std {
+    template <>
+    struct hash<RString> {
+        size_t operator()(const RString& s) const {
+            return hash<std::string>()(static_cast<const std::string&>(s));
+        }
+    };
+}
 
 SongManager*	SONGMAN = nullptr;	// global and accessible from anywhere in our program
 
@@ -382,7 +391,7 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 	StripCvsAndSvn( arrayGroupDirs );
 	StripMacResourceForks( arrayGroupDirs );
 
-	std::map<RString, std::vector<RString>> mapGroupSongDirs;
+	std::unordered_map<RString, std::vector<RString>> mapGroupSongDirs;
 	int groupIndex, songCount, songIndex;
 
 	groupIndex = 0;


### PR DESCRIPTION
For **Experiment Loading Songs In Parallel Threads**.


Slightly improves load time on its own.