### PR TITLE
Parallelize song loading in LoadSongDir using futures

### DIFF
--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -44,6 +44,7 @@
 #include <cstddef>
 #include <tuple>
 #include <vector>
+#include <mutex>
 
 
 SongManager*	SONGMAN = nullptr;	// global and accessible from anywhere in our program
@@ -362,6 +363,7 @@ void SongManager::AddGroup( RString sDir, RString sGroupDirName, Group* group )
 static LocalizedString LOADING_SONGS ( "SongManager", "Loading songs..." );
 void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditions )
 {
+	static std::mutex songLoadMutex;
 	if( ld )
 		ld->SetText( LOADING_SONGS );
 

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -506,6 +506,16 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 			songIndex++;
 		}
 
+		{
+			std::lock_guard<std::mutex> lock(m_LoadMutex);
+			for (Song* song : loadedSongs)
+			{
+				AddSongToList(song);
+				index_entry.push_back(song);
+				loaded++;
+			}
+		}
+
 		LOG->Trace("Loaded %i songs from \"%s\"", loaded, (sDir+sGroupDirName).c_str() );
 
 		// If we're only loading additions, already loaded groups should neither be added nor deleted

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -451,10 +451,9 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 			m_mapNameToGroup[sGroupDirName] = group;
 		}
 
-		for( unsigned j=0; j< arraySongDirs.size(); ++j )	// for each song dir
+		std::vector<RString> dirsToLoad;
+		for( RString const &sSongDirName : arraySongDirs )
 		{
-			RString sSongDirName = arraySongDirs[j];
-
 			// Skip already loaded songs if onlyAdditions is set.
 			if (onlyAdditions)
 			{
@@ -465,6 +464,8 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 			}
 
 			// this is a song directory. Load a new song.
+			dirsToLoad.push_back(sSongDirName);
+		}
 			if(ld && loading_window_last_update_time.Ago() > next_loading_window_update)
 			{
 				loading_window_last_update_time.Touch();

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -45,6 +45,7 @@
 #include <tuple>
 #include <vector>
 #include <mutex>
+#include <future>
 
 
 SongManager*	SONGMAN = nullptr;	// global and accessible from anywhere in our program
@@ -466,6 +467,25 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 			// this is a song directory. Load a new song.
 			dirsToLoad.push_back(sSongDirName);
 		}
+
+		// We use a pair of future and directory name so we can display the
+		// current song being loaded in the loading window. The directory name
+		// is used to show progress with the specific song name.
+		std::vector<std::pair<std::future<Song*>, RString>> futures;
+		for (const RString& songDir : dirsToLoad)
+		{
+			futures.push_back({std::async(std::launch::async, [songDir]() {
+				Song* pNewSong = new Song;
+				std::lock_guard<std::mutex> lock(songLoadMutex); // TODO remove songLoadMutex entirely
+				return pNewSong->LoadFromSongDir(songDir) ? pNewSong : (delete pNewSong, nullptr);
+			}), songDir});
+		}
+
+		std::vector<Song*> loadedSongs;
+		for (auto& futurePair : futures)
+		{
+			auto& songFuture = futurePair.first;
+			auto& sSongDirName = futurePair.second;
 			if(ld && loading_window_last_update_time.Ago() > next_loading_window_update)
 			{
 				loading_window_last_update_time.Touch();

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -498,18 +498,11 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 				);
 			}
 
-			Song* pNewSong = new Song;
-			if( !pNewSong->LoadFromSongDir( sSongDirName) )
+			Song* song = songFuture.get();
+			if (song)
 			{
-				// The song failed to load.
-				delete pNewSong;
-				continue;
+				loadedSongs.push_back(song);
 			}
-
-			AddSongToList(pNewSong);
-
-			index_entry.push_back( pNewSong );
-			loaded++;
 			songIndex++;
 		}
 

--- a/src/SongManager.h
+++ b/src/SongManager.h
@@ -22,6 +22,7 @@ struct lua_State;
 #include <cstddef>
 #include <unordered_set>
 #include <vector>
+#include <mutex>
 
 RString SONG_GROUP_COLOR_NAME( size_t i );
 RString COURSE_GROUP_COLOR_NAME( size_t i );
@@ -277,6 +278,8 @@ protected:
 	ThemeMetric1D<RageColor>	COURSE_GROUP_COLOR;
 	ThemeMetric<int> num_profile_song_group_colors;
 	ThemeMetric1D<RageColor> profile_song_group_colors;
+private:
+	std::mutex m_LoadMutex;
 };
 
 extern SongManager*	SONGMAN;	// global and accessible from anywhere in our program


### PR DESCRIPTION
Lightweight implementation of loading songs in parallel using `std::async`, with needed mutexes for guaranteed stability. This PR is inspired by #995 of course.

This improves song loading performance a decent amount:

_Initial cache build for 2703 songs_
beta: 3 minutes 45 seconds
feature branch: 2 minutes 55 seconds

_Subsequent load time_
beta: 4 seconds
feature branch: 2 seconds