### PR TITLE
Threaded Song Loading-  Move image caching logic out of song loading for thread safety

### DIFF
--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -1227,6 +1227,7 @@ void Profile::LoadSongsFromDir(RString const& dir, ProfileSlot prof_slot, bool i
 			else
 			{
 				new_song->SetEnabled(true);
+				new_song->LoadCachedImages();
 				m_songs.push_back(new_song);
 			}
 			if(song_load_start_time.Ago() > PREFSMAN->m_custom_songs_load_timeout)

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -445,15 +445,6 @@ bool Song::LoadFromSongDir(RString sDir, bool load_autosave, ProfileSlot from_pr
 		s->Compress();
 	}
 
-	// Load the cached Images, if it's not loaded already.
-	if( PREFSMAN->m_ImageCache == IMGCACHE_LOW_RES_PRELOAD )
-	{
-		for( RString Image : ImageDir )
-		{
-			IMAGECACHE->LoadImage( Image, GetCacheFile( Image ) );
-		}
-	}
-
 	// Add AutoGen pointers. (These aren't cached.)
 	AddAutoGenNotes();
 
@@ -641,6 +632,15 @@ bool Song::LoadAutosaveFile()
 	return false;
 }
 
+void Song::LoadCachedImages()
+{
+	if (PREFSMAN->m_ImageCache == IMGCACHE_LOW_RES_PRELOAD) {
+		for (RString Image : ImageDir) {
+			IMAGECACHE->LoadImage(Image, GetCacheFile(Image));
+		}
+	}
+}
+
 /* Fix up song paths. If there's a leading "./", be sure to keep it: it's
  * a signal that the path is from the root directory, not the song directory.
  * Other than a leading "./", song paths must never contain "." or "..". */
@@ -733,11 +733,6 @@ void Song::TidyUpData( bool from_cache, bool /* duringCache */, const std::set<R
 		m_bHasMusic = HasMusic();
 		m_bHasBanner = HasBanner();
 		m_bHasBackground = HasBackground();
-
-		for( RString Image : ImageDir )
-		{
-			IMAGECACHE->LoadImage( Image, GetCacheFile( Image ) );
-		}
 
 		// There are several things that need to find a file from the dir with a
 		// particular extension or type of extension.  So fetch a list of all

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -634,10 +634,11 @@ bool Song::LoadAutosaveFile()
 
 void Song::LoadCachedImages()
 {
-	if (PREFSMAN->m_ImageCache == IMGCACHE_LOW_RES_PRELOAD) {
-		for (RString Image : ImageDir) {
-			IMAGECACHE->LoadImage(Image, GetCacheFile(Image));
-		}
+	// Preferenece is not expected to change during runtime, so cache it.
+	static const bool bPreloadImages = PREFSMAN->m_ImageCache == IMGCACHE_LOW_RES_PRELOAD;
+	if (!bPreloadImages) return;
+	for (RString Image : ImageDir) {
+		IMAGECACHE->LoadImage(Image, GetCacheFile(Image));
 	}
 }
 

--- a/src/Song.h
+++ b/src/Song.h
@@ -104,6 +104,11 @@ public:
 	bool LoadAutosaveFile();
 
 	/**
+	 * @brief Load cached images for this song.
+	 */
+	void LoadCachedImages();
+
+	/**
 	 * @brief Call this after loading a song to clean up invalid data.
 	 * @param fromCache was this data loaded from the cache file?
 	 * @param duringCache was this data loaded during the cache process? */

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -485,6 +485,8 @@ void SongManager::LoadSongDir( RString sDir, LoadingWindow *ld, bool onlyAdditio
 
 			AddSongToList(pNewSong);
 
+			pNewSong->LoadCachedImages();
+
 			index_entry.push_back( pNewSong );
 			loaded++;
 			songIndex++;
@@ -553,6 +555,7 @@ void SongManager::LoadGroupSymLinks(RString sDir, RString sGroupFolder)
 
 			pNewSong->m_bIsSymLink = true;	// Very important so we don't double-parse later
 			pNewSong->m_sGroupName = sGroupFolder;
+			pNewSong->LoadCachedImages();
 			AddSongToList(pNewSong);
 			index_entry.push_back( pNewSong );
 		}


### PR DESCRIPTION
In order to call `Song::LoadFromSongDir` in parallel, I had to move the IMAGECACHE access out of the function. This then allowed me to consolidate all image preloading into one place, decoupling image caching from song loading.