### PR TITLE
All My Remaining RageSound Fixes (for now)

### DIFF
--- a/src/CMakeData-rage.cmake
+++ b/src/CMakeData-rage.cmake
@@ -184,6 +184,7 @@ list(APPEND SMDATA_RAGE_SOUND_SRC
 
 list(APPEND SMDATA_RAGE_SOUND_HPP
             "RageSound.h"
+            "RageSoundConstants.h"
             "RageSoundManager.h"
             "RageSoundMixBuffer.h"
             "RageSoundPosMap.h"

--- a/src/RageSound.cpp
+++ b/src/RageSound.cpp
@@ -147,7 +147,7 @@ public:
 	int SetPosition( int iFrame )  { return 1; }
 	int Read( float *pBuf, int iFrames ) { return RageSoundReader::END_OF_FILE; }
 	RageSoundReader *Copy() const { return new RageSoundReader_Silence; }
-	int GetSampleRate() const { return kFallbackSampleRate; }
+	int GetSampleRate() const { return FALLBACK_SAMPLE_RATE; }
 	unsigned GetNumChannels() const { return 1; }
 	int GetNextSourceFrame() const { return 0; }
 	float GetStreamToSourceRatio() const { return 1.0f; }

--- a/src/RageSound.h
+++ b/src/RageSound.h
@@ -6,10 +6,9 @@
 #include "RageThreads.h"
 #include "RageTimer.h"
 #include "RageSoundPosMap.h"
+#include "RageSoundConstants.h"
 
 #include <cstdint>
-
-constexpr int kFallbackSampleRate = 44100;
 
 class RageSoundReader;
 struct lua_State;

--- a/src/RageSoundConstants.h
+++ b/src/RageSoundConstants.h
@@ -1,0 +1,11 @@
+#ifndef RAGE_SOUND_CONSTANTS_H
+#define RAGE_SOUND_CONSTANTS_H
+
+// Fallback sample rate used when no other sample rate is available.
+// I use a macro here to ensure the constant does not affect
+// how the legacy RageSound code is compiled. Users notice enough to
+// complain when a constexpr / const int is used here. I haven't yet
+// found the root of that issue within RageSound.
+#define FALLBACK_SAMPLE_RATE 44100
+
+#endif // RAGE_SOUND_CONSTANTS_H

--- a/src/RageSoundManager.cpp
+++ b/src/RageSoundManager.cpp
@@ -133,7 +133,7 @@ float RageSoundManager::GetPlayLatency() const
 int RageSoundManager::GetDriverSampleRate() const
 {
 	if( m_pDriver == nullptr )
-		return kFallbackSampleRate;
+		return FALLBACK_SAMPLE_RATE;
 
 	// Returns the *actual* operating rate of the loaded driver
 	return m_pDriver->GetSampleRate();

--- a/src/RageSoundManager.h
+++ b/src/RageSoundManager.h
@@ -9,6 +9,8 @@
 #include <map>
 #include <set>
 
+#include "RageSoundConstants.h"
+
 class RageSound;
 class RageSoundBase;
 class RageSoundDriver;

--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -10,6 +10,7 @@
 #include "RageSound.h"
 #include "RageSoundMixBuffer.h"
 #include "RageSoundUtil.h"
+#include "RageSoundConstants.h"
 
 #include <cmath>
 #include <vector>
@@ -25,13 +26,13 @@
  */
 RageSoundReader_Chain::RageSoundReader_Chain()
 {
-	m_iPreferredSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
-	if (m_iPreferredSampleRate == 0)
-	{
-		m_iPreferredSampleRate = kFallbackSampleRate;
-	}
-	
+	// The preferred sample rate for resampling when sounds have different rates.
+	m_iPreferredSampleRate = FALLBACK_SAMPLE_RATE;
+
+	// The actual sample rate of the audio after resampling.
+	// Used for timing calculations, such as sound offsets or frame positioning.
 	m_iActualSampleRate = -1;
+
 	m_iChannels = 0;
 	m_iCurrentFrame = 0;
 	m_iNextSound = 0;
@@ -129,6 +130,15 @@ int RageSoundReader_Chain::GetSampleRateInternal() const
 			return -1;
 	}
 	return iRate;
+}
+
+int RageSoundReader_Chain::GetSampleRate() const
+{
+	if (m_iActualSampleRate == -1)
+	{
+		return m_iPreferredSampleRate;
+	}
+	return m_iActualSampleRate;
 }
 
 void RageSoundReader_Chain::Finish()

--- a/src/RageSoundReader_Chain.h
+++ b/src/RageSoundReader_Chain.h
@@ -38,7 +38,7 @@ public:
 	int GetLength_Fast() const;
 	int SetPosition( int iFrame );
 	int Read( float *pBuf, int iFrames );
-	int GetSampleRate() const { return m_iActualSampleRate; }
+	int GetSampleRate() const;
 	unsigned GetNumChannels() const { return m_iChannels; }
 	bool SetProperty( const RString &sProperty, float fValue );
 	int GetNextSourceFrame() const;

--- a/src/arch/Sound/ALSA9Helpers.cpp
+++ b/src/arch/Sound/ALSA9Helpers.cpp
@@ -231,7 +231,7 @@ RString Alsa9Buf::Init( int channels_,
 	preferred_chunksize = iChunkSize;
 	if( iSampleRate == 0 )
 	{
-		samplerate = kFallbackSampleRate;
+		samplerate = FALLBACK_SAMPLE_RATE;
 	}
 	else
 	{

--- a/src/arch/Sound/DSoundHelpers.cpp
+++ b/src/arch/Sound/DSoundHelpers.cpp
@@ -67,7 +67,7 @@ void DSound::SetPrimaryBufferMode()
 	int preferredSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
 	if (preferredSampleRate == 0)
 	{
-		preferredSampleRate = kFallbackSampleRate;
+		preferredSampleRate = FALLBACK_SAMPLE_RATE;
 	}
 	waveformat.nSamplesPerSec = preferredSampleRate;
 	waveformat.nBlockAlign = (waveformat.nChannels * waveformat.wBitsPerSample) / 8;
@@ -223,7 +223,7 @@ RString DSoundBuf::Init( DSound &ds, DSoundBuf::hw hardware,
 	// DYNAMIC_SAMPLERATE is usually 0 or some special value
 	if( m_iSampleRate == DYNAMIC_SAMPLERATE )
 	{
-		m_iSampleRate = kFallbackSampleRate;
+		m_iSampleRate = FALLBACK_SAMPLE_RATE;
 		bNeedCtrlFrequency = true;
 	}
 

--- a/src/arch/Sound/RageSoundDriver.h
+++ b/src/arch/Sound/RageSoundDriver.h
@@ -6,7 +6,7 @@
 #include "RageThreads.h"
 #include "RageTimer.h"
 #include "RageUtil_CircularBuffer.h"
-#include "RageSound.h"
+#include "RageSoundConstants.h"
 
 #include <cstdint>
 
@@ -67,7 +67,7 @@ public:
 	 * hearing it.  (This isn't necessarily the same as the buffer latency.) */
 	virtual float GetPlayLatency() const { return 0.0f; }
 
-	virtual int GetSampleRate() const { return kFallbackSampleRate; }
+	virtual int GetSampleRate() const { return FALLBACK_SAMPLE_RATE; }
 
 protected:
 	/* Start the decoding.  This should be called once the hardware is set up and

--- a/src/arch/Sound/RageSoundDriver_AU.mm
+++ b/src/arch/Sound/RageSoundDriver_AU.mm
@@ -3,6 +3,7 @@
 #include "RageLog.h"
 #include "PrefsManager.h"
 #include "archutils/Darwin/DarwinThreadHelpers.h"
+#include "RageSoundConstants.h"
 
 #include <cstdint>
 
@@ -152,7 +153,7 @@ RString RageSoundDriver_AU::Init()
 
 	if( streamFormat.mSampleRate <= 0.0 )
 	{
-		streamFormat.mSampleRate = kFallbackSampleRate;
+		streamFormat.mSampleRate = FALLBACK_SAMPLE_RATE;
 	}
 	m_iSampleRate = int( streamFormat.mSampleRate );
 	m_TimeScale = streamFormat.mSampleRate / AudioGetHostClockFrequency();

--- a/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
@@ -98,7 +98,7 @@ RString RageSoundDriver_DSound_Software::Init()
 	m_iSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
 	if( m_iSampleRate == 0 )
 	{
-		m_iSampleRate = kFallbackSampleRate;
+		m_iSampleRate = FALLBACK_SAMPLE_RATE;
 	}
 	// This m_iSampleRate (driver's) is then passed as the iSampleRate parameter to DSoundBuf::Init()
 	sError = m_pPCM->Init( ds, DSoundBuf::HW_DONT_CARE, channels, m_iSampleRate, 16, g_iMaxWriteahead );

--- a/src/arch/Sound/RageSoundDriver_Null.cpp
+++ b/src/arch/Sound/RageSoundDriver_Null.cpp
@@ -3,6 +3,7 @@
 #include "RageLog.h"
 #include "RageUtil.h"
 #include "PrefsManager.h"
+#include "RageSoundConstants.h"
 
 #include <cstdint>
 
@@ -32,7 +33,7 @@ RageSoundDriver_Null::RageSoundDriver_Null()
 {
 	m_iSampleRate = PREFSMAN->m_iSoundPreferredSampleRate;
 	{
-    	m_iSampleRate = kFallbackSampleRate;
+    	m_iSampleRate = FALLBACK_SAMPLE_RATE;
 	}
 	m_iLastCursorPos = GetPosition();
 	StartDecodeThread();

--- a/src/arch/Sound/RageSoundDriver_PulseAudio.cpp
+++ b/src/arch/Sound/RageSoundDriver_PulseAudio.cpp
@@ -30,7 +30,7 @@ m_PulseMainLoop(nullptr), m_PulseCtx(nullptr), m_PulseStream(nullptr)
 	m_ss.rate = PREFSMAN->m_iSoundPreferredSampleRate;
 	if( m_ss.rate == 0 )
 	{
-		m_ss.rate = kFallbackSampleRate;
+		m_ss.rate = FALLBACK_SAMPLE_RATE;
 	}
 }
 

--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -141,7 +141,7 @@ RString RageSoundDriver_WaveOut::Init()
 	wo_samplerate_ = PREFSMAN->m_iSoundPreferredSampleRate;
 	if( wo_samplerate_ == 0 )
 	{
-		wo_samplerate_ = kFallbackSampleRate;
+		wo_samplerate_ = FALLBACK_SAMPLE_RATE;
 	}
 
 	wo_num_blocks_ = CalculateNumBlocks( wo_samplerate_ );


### PR DESCRIPTION
Making this in case it's easier to visualize what I'm trying to do here if it's all in one place....?


Here's what is going on in these commits:

1.  Move the fallback sample rate into its own header instead of `RageSound.h` or `global.h`.

2.  Change `kFallbackSampleRate` from a constexpr to a macro, so the code is still compiled the same way it was with the hardcoded value. I haven't got to the bottom of **why** this code behaves differently with a `const int` used for the 44100 value, but we know for many months now that any time this is a `const int` or `constexpr` value, players complain about sync.

3.  Make the fixes in RageSoundReader_Chain discussed in #985 .

4.  Make another fix to prevent the possibility of the uninitialized value `-1` being returned in a `GetSampleRate()` call.