### PR TITLE
macOS: Fix the "Input Monitoring" issue (Add NSEvent-based keyboard input)

### DIFF
--- a/src/CMakeData-arch.cmake
+++ b/src/CMakeData-arch.cmake
@@ -276,9 +276,11 @@ if(WIN32)
   endif()
 elseif(APPLE)
   list(APPEND SMDATA_ARCH_INPUT_SRC
-              "arch/InputHandler/InputHandler_MacOSX_HID.mm")
+              "arch/InputHandler/InputHandler_MacOSX_HID.mm"
+              "arch/InputHandler/InputHandler_NSEvent.mm")
   list(APPEND SMDATA_ARCH_INPUT_HPP
-              "arch/InputHandler/InputHandler_MacOSX_HID.h")
+              "arch/InputHandler/InputHandler_MacOSX_HID.h"
+              "arch/InputHandler/InputHandler_NSEvent.hpp")
 else() # Unix/Linux
   if(LINUX)
     list(APPEND SMDATA_ARCH_INPUT_SRC

--- a/src/CMakeData-os.cmake
+++ b/src/CMakeData-os.cmake
@@ -4,6 +4,7 @@ list(APPEND SMDATA_OS_HPP "archutils/Common/HidDevice.h")
 if(APPLE)
   list(APPEND SMDATA_OS_DARWIN_SRC
               "archutils/Darwin/Crash.mm"
+              "archutils/Darwin/CocoaEventDispatcher.mm"
               "archutils/Darwin/DarwinThreadHelpers.cpp"
               "archutils/Darwin/HIDDevice.cpp"
               "archutils/Darwin/JoystickDevice.cpp"
@@ -14,6 +15,7 @@ if(APPLE)
               "archutils/Darwin/SpecialDirs.mm")
   list(APPEND SMDATA_OS_DARWIN_HPP
               "archutils/Darwin/arch_setup.h"
+              "archutils/Darwin/CocoaEventDispatcher.h"
               "archutils/Darwin/Crash.h"
               "archutils/Darwin/DarwinThreadHelpers.h"
               "archutils/Darwin/HIDDevice.h"

--- a/src/arch/InputHandler/InputHandler_MacOSX_HID.mm
+++ b/src/arch/InputHandler/InputHandler_MacOSX_HID.mm
@@ -169,8 +169,9 @@ static CFDictionaryRef GetMatchingDictionary( int usagePage, int usage )
 // Factor this out because nothing else in IH_C::AddDevices() needs to know the type of the device.
 static HIDDevice *MakeDevice( InputDevice id )
 {
-	if( id == DEVICE_KEYBOARD )
-		return new KeyboardDevice;
+	// Keyboard input is now handled by NSEvent handler to avoid Input Monitoring permission requirements
+	// if( id == DEVICE_KEYBOARD )
+	//	return new KeyboardDevice;
 	/*
 	if( id == DEVICE_MOUSE )
 		return new MouseDevice;
@@ -243,11 +244,13 @@ InputHandler_MacOSX_HID::InputHandler_MacOSX_HID() : m_Sem( "Input thread starte
 	m_NotifyPort = IONotificationPortCreate( kIOMasterPortDefault );
 
 	// Add devices.
+#if !OSX_KEYBOARD_USE_NSEVENT
 	LOG->Trace( "Finding keyboards" );
 	AddDevices( kHIDPage_GenericDesktop, kHIDUsage_GD_Keyboard, id );
 
 	LOG->Trace( "Finding mice" );
 	AddDevices( kHIDPage_GenericDesktop, kHIDUsage_GD_Mouse, id );
+#endif // !OSX_KEYBOARD_USE_NSEVENT
 
 	LOG->Trace( "Finding joysticks" );
 	id = DEVICE_JOY1;

--- a/src/arch/InputHandler/InputHandler_NSEvent.hpp
+++ b/src/arch/InputHandler/InputHandler_NSEvent.hpp
@@ -8,11 +8,16 @@
 #ifndef InputHandler_NSEvent_hpp
 #define InputHandler_NSEvent_hpp
 
+#include <cstdint>
+#include <cstdio>
 #include "InputHandler.h"
 
-#include <cstdio>
-#include <vector>
-
+#if __OBJC__
+#   import <Cocoa/Cocoa.h>
+#   define EVENT_TYPE NSEvent *
+#else
+#   define EVENT_TYPE void *
+#endif
 
 class InputHandler_NSEvent : public InputHandler
 {
@@ -21,6 +26,14 @@ public:
     ~InputHandler_NSEvent();
 
     void GetDevicesAndDescriptions( std::vector<InputDeviceInfo>& vDevicesOut );
+    
+protected:
+    void HandleEvent( EVENT_TYPE e );
+    void InitKeyCodeMap();
+        
+private:
+    DeviceButton m_NSKeyCodeMap[0x100];
+    unsigned     m_ResponderID;
 };
 
 #endif /* InputHandler_NSEvent_hpp */

--- a/src/arch/InputHandler/InputHandler_NSEvent.mm
+++ b/src/arch/InputHandler/InputHandler_NSEvent.mm
@@ -1,199 +1,208 @@
 //
-//  InputHandler_NSEvent.cpp
+//  InputHandler_NSEvent.mm
 //  StepMania
 //
 //  Created by heshuimu on 12/22/19.
 //
 
+#include "global.h"
 #include "InputHandler_NSEvent.hpp"
-
-#include <vector>
+#include "archutils/Darwin/CocoaEventDispatcher.h"
 
 #import <AppKit/AppKit.h>
 #import <Carbon/Carbon.h>
 
+#if OSX_KEYBOARD_USE_NSEVENT
+REGISTER_INPUT_HANDLER_CLASS2( NSEvent, NSEvent );
+#endif
 
-DeviceButton NSKeyCodeMap[0x100];
-
-float DownOrUp(bool down)
+static float DownOrUp( bool down )
 {
     return down ? 1 : 0;
 }
 
-void InitKeyCodeMap()
-{
-    NSKeyCodeMap[kVK_ANSI_A] = KEY_Ca;
-    NSKeyCodeMap[kVK_ANSI_B] = KEY_Cb;
-    NSKeyCodeMap[kVK_ANSI_C] = KEY_Cc;
-    NSKeyCodeMap[kVK_ANSI_D] = KEY_Cd;
-    NSKeyCodeMap[kVK_ANSI_E] = KEY_Ce;
-    NSKeyCodeMap[kVK_ANSI_F] = KEY_Cf;
-    NSKeyCodeMap[kVK_ANSI_G] = KEY_Cg;
-    NSKeyCodeMap[kVK_ANSI_H] = KEY_Ch;
-    NSKeyCodeMap[kVK_ANSI_I] = KEY_Ci;
-    NSKeyCodeMap[kVK_ANSI_J] = KEY_Cj;
-    NSKeyCodeMap[kVK_ANSI_K] = KEY_Ck;
-    NSKeyCodeMap[kVK_ANSI_L] = KEY_Cl;
-    NSKeyCodeMap[kVK_ANSI_M] = KEY_Cm;
-    NSKeyCodeMap[kVK_ANSI_N] = KEY_Cn;
-    NSKeyCodeMap[kVK_ANSI_O] = KEY_Co;
-    NSKeyCodeMap[kVK_ANSI_P] = KEY_Cp;
-    NSKeyCodeMap[kVK_ANSI_Q] = KEY_Cq;
-    NSKeyCodeMap[kVK_ANSI_R] = KEY_Cr;
-    NSKeyCodeMap[kVK_ANSI_S] = KEY_Cs;
-    NSKeyCodeMap[kVK_ANSI_T] = KEY_Ct;
-    NSKeyCodeMap[kVK_ANSI_U] = KEY_Cu;
-    NSKeyCodeMap[kVK_ANSI_V] = KEY_Cv;
-    NSKeyCodeMap[kVK_ANSI_W] = KEY_Cw;
-    NSKeyCodeMap[kVK_ANSI_X] = KEY_Cx;
-    NSKeyCodeMap[kVK_ANSI_Y] = KEY_Cy;
-    NSKeyCodeMap[kVK_ANSI_Z] = KEY_Cz;
-
-    NSKeyCodeMap[kVK_ANSI_0] = KEY_C0;
-    NSKeyCodeMap[kVK_ANSI_1] = KEY_C1;
-    NSKeyCodeMap[kVK_ANSI_2] = KEY_C2;
-    NSKeyCodeMap[kVK_ANSI_3] = KEY_C3;
-    NSKeyCodeMap[kVK_ANSI_4] = KEY_C4;
-    NSKeyCodeMap[kVK_ANSI_5] = KEY_C5;
-    NSKeyCodeMap[kVK_ANSI_6] = KEY_C6;
-    NSKeyCodeMap[kVK_ANSI_7] = KEY_C7;
-    NSKeyCodeMap[kVK_ANSI_8] = KEY_C8;
-    NSKeyCodeMap[kVK_ANSI_9] = KEY_C9;
-
-    NSKeyCodeMap[kVK_ANSI_Keypad0] = KEY_KP_C0;
-    NSKeyCodeMap[kVK_ANSI_Keypad1] = KEY_KP_C1;
-    NSKeyCodeMap[kVK_ANSI_Keypad2] = KEY_KP_C2;
-    NSKeyCodeMap[kVK_ANSI_Keypad3] = KEY_KP_C3;
-    NSKeyCodeMap[kVK_ANSI_Keypad4] = KEY_KP_C4;
-    NSKeyCodeMap[kVK_ANSI_Keypad5] = KEY_KP_C5;
-    NSKeyCodeMap[kVK_ANSI_Keypad6] = KEY_KP_C6;
-    NSKeyCodeMap[kVK_ANSI_Keypad7] = KEY_KP_C7;
-    NSKeyCodeMap[kVK_ANSI_Keypad8] = KEY_KP_C8;
-    NSKeyCodeMap[kVK_ANSI_Keypad9] = KEY_KP_C9;
-
-    NSKeyCodeMap[kVK_ANSI_KeypadDivide] = KEY_KP_SLASH;
-    NSKeyCodeMap[kVK_ANSI_KeypadMultiply] = KEY_KP_ASTERISK;
-    NSKeyCodeMap[kVK_ANSI_KeypadEnter] = KEY_KP_ENTER;
-    NSKeyCodeMap[kVK_ANSI_KeypadEquals] = KEY_KP_EQUAL;
-    NSKeyCodeMap[kVK_ANSI_KeypadMinus] = KEY_KP_HYPHEN;
-    NSKeyCodeMap[kVK_ANSI_KeypadPlus] = KEY_KP_PLUS;
-    NSKeyCodeMap[kVK_ANSI_KeypadDecimal] = KEY_KP_PERIOD;
-
-    NSKeyCodeMap[kVK_Home] = KEY_HOME;
-    NSKeyCodeMap[kVK_End] = KEY_END;
-    NSKeyCodeMap[kVK_PageDown] = KEY_PGDN;
-    NSKeyCodeMap[kVK_PageUp] = KEY_PGUP;
-
-    NSKeyCodeMap[kVK_F1] = KEY_F1;
-    NSKeyCodeMap[kVK_F2] = KEY_F2;
-    NSKeyCodeMap[kVK_F3] = KEY_F3;
-    NSKeyCodeMap[kVK_F4] = KEY_F4;
-    NSKeyCodeMap[kVK_F5] = KEY_F5;
-    NSKeyCodeMap[kVK_F6] = KEY_F6;
-    NSKeyCodeMap[kVK_F7] = KEY_F7;
-    NSKeyCodeMap[kVK_F8] = KEY_F8;
-    NSKeyCodeMap[kVK_F9] = KEY_F9;
-    NSKeyCodeMap[kVK_F10] = KEY_F10;
-    NSKeyCodeMap[kVK_F11] = KEY_F11;
-    NSKeyCodeMap[kVK_F12] = KEY_F12;
-    NSKeyCodeMap[kVK_F13] = KEY_F13;
-    NSKeyCodeMap[kVK_F14] = KEY_F14;
-    NSKeyCodeMap[kVK_F15] = KEY_F15;
-    NSKeyCodeMap[kVK_F16] = KEY_F16;
-
-    NSKeyCodeMap[kVK_ANSI_Quote] = KEY_QUOTE;
-    NSKeyCodeMap[kVK_ANSI_Backslash] = KEY_BACKSLASH;
-    NSKeyCodeMap[kVK_CapsLock] = KEY_CAPSLOCK;
-    NSKeyCodeMap[kVK_ANSI_Comma] = KEY_COMMA;
-    NSKeyCodeMap[kVK_ForwardDelete] = KEY_DEL;
-    NSKeyCodeMap[kVK_Delete] = KEY_BACK;
-    NSKeyCodeMap[kVK_ANSI_Equal] = KEY_EQUAL;
-
-    NSKeyCodeMap[kVK_Escape] = KEY_ESC;
-    NSKeyCodeMap[kVK_ANSI_LeftBracket] = KEY_LBRACKET;
-    NSKeyCodeMap[kVK_ANSI_Minus] = KEY_HYPHEN;
-    NSKeyCodeMap[kVK_ANSI_Period] = KEY_PERIOD;
-    NSKeyCodeMap[kVK_Return] = KEY_ENTER;
-    NSKeyCodeMap[kVK_ANSI_RightBracket] = KEY_RBRACKET;
-    NSKeyCodeMap[kVK_ANSI_Semicolon] = KEY_SEMICOLON;
-    NSKeyCodeMap[kVK_Space] = KEY_SPACE;
-    NSKeyCodeMap[kVK_Tab] = KEY_TAB;
-
-    NSKeyCodeMap[kVK_Command] = KEY_LMETA;
-    NSKeyCodeMap[kVK_RightCommand] = KEY_RMETA;
-    NSKeyCodeMap[kVK_Control] = KEY_LCTRL;
-    NSKeyCodeMap[kVK_RightControl] = KEY_RCTRL;
-    NSKeyCodeMap[kVK_Function] = KEY_FN;
-    NSKeyCodeMap[kVK_Option] = KEY_LALT;
-    NSKeyCodeMap[kVK_RightOption] = KEY_RALT;
-    NSKeyCodeMap[kVK_Shift] = KEY_LSHIFT;
-    NSKeyCodeMap[kVK_RightShift] = KEY_RSHIFT;
-
-    NSKeyCodeMap[kVK_DownArrow] = KEY_DOWN;
-    NSKeyCodeMap[kVK_LeftArrow] = KEY_LEFT;
-    NSKeyCodeMap[kVK_RightArrow] = KEY_RIGHT;
-    NSKeyCodeMap[kVK_UpArrow] = KEY_UP;
-}
-
-//static let backApostrophe = UInt16(kVK_ANSI_Grave)
-//static let keypadClear = UInt16(kVK_ANSI_KeypadClear)
-//static let mute = UInt16(kVK_Mute)
-//static let volumeDown = UInt16(kVK_VolumeDown)
-//static let volumeUp = UInt16(kVK_VolumeUp)
-//
-//static let downArrow = UInt16(kVK_DownArrow)
-//static let leftArrow = UInt16(kVK_LeftArrow)
-//static let rightArrow = UInt16(kVK_RightArrow)
-//static let upArrow = UInt16(kVK_UpArrow)
-
 InputHandler_NSEvent::InputHandler_NSEvent()
 {
     InitKeyCodeMap();
-
-    [NSEvent addLocalMonitorForEventsMatchingMask:(NSEventMaskKeyDown | NSEventMaskKeyUp | NSEventMaskFlagsChanged) handler:^(NSEvent* e) {
-        unsigned short keyCode = [e keyCode];
-
-        if([e type] == NSEventTypeKeyUp)
-        {
-            ButtonPressed(DeviceInput(DEVICE_KEYBOARD, NSKeyCodeMap[keyCode], 1));
-            ButtonPressed(DeviceInput(DEVICE_KEYBOARD, NSKeyCodeMap[keyCode], 0));
-        }
-        else if([e type] == NSEventTypeFlagsChanged)
-        {
-            NSEventModifierFlags flags = [e modifierFlags];
-            switch(keyCode)
-            {
-            case kVK_CapsLock:
-                ButtonPressed(DeviceInput(DEVICE_KEYBOARD, NSKeyCodeMap[keyCode], DownOrUp(flags & NSEventModifierFlagCapsLock)));
-                break;
-            case kVK_Shift:
-            case kVK_RightShift:
-                ButtonPressed(DeviceInput(DEVICE_KEYBOARD, NSKeyCodeMap[keyCode], DownOrUp(flags & NSEventModifierFlagShift)));
-                break;
-            case kVK_Control:
-            case kVK_RightControl:
-                ButtonPressed(DeviceInput(DEVICE_KEYBOARD, NSKeyCodeMap[keyCode], DownOrUp(flags & NSEventModifierFlagControl)));
-                break;
-            case kVK_Option:
-            case kVK_RightOption:
-                ButtonPressed(DeviceInput(DEVICE_KEYBOARD, NSKeyCodeMap[keyCode], DownOrUp(flags & NSEventModifierFlagOption)));
-                break;
-            case kVK_Command:
-            case kVK_RightCommand:
-                ButtonPressed(DeviceInput(DEVICE_KEYBOARD, NSKeyCodeMap[keyCode], DownOrUp(flags & NSEventModifierFlagCommand)));
-                break;
-            case kVK_Function:
-                ButtonPressed(DeviceInput(DEVICE_KEYBOARD, NSKeyCodeMap[keyCode], DownOrUp(flags & NSEventModifierFlagFunction)));
-                break;
-            }
-        }
-
-        return e;
-    }];
+    
+    auto &dispatcher = CocoaEventDispatcher::sharedDispatcher;
+    m_ResponderID = dispatcher.AddResponder(std::bind(&InputHandler_NSEvent::HandleEvent, this, std::placeholders::_1));
 }
 
 InputHandler_NSEvent::~InputHandler_NSEvent()
 {
+    auto &dispatcher = CocoaEventDispatcher::sharedDispatcher;
+    dispatcher.RemoveResponder( m_ResponderID );
+}
+
+void InputHandler_NSEvent::InitKeyCodeMap()
+{
+    m_NSKeyCodeMap[kVK_ANSI_A] = KEY_Ca;
+    m_NSKeyCodeMap[kVK_ANSI_B] = KEY_Cb;
+    m_NSKeyCodeMap[kVK_ANSI_C] = KEY_Cc;
+    m_NSKeyCodeMap[kVK_ANSI_D] = KEY_Cd;
+    m_NSKeyCodeMap[kVK_ANSI_E] = KEY_Ce;
+    m_NSKeyCodeMap[kVK_ANSI_F] = KEY_Cf;
+    m_NSKeyCodeMap[kVK_ANSI_G] = KEY_Cg;
+    m_NSKeyCodeMap[kVK_ANSI_H] = KEY_Ch;
+    m_NSKeyCodeMap[kVK_ANSI_I] = KEY_Ci;
+    m_NSKeyCodeMap[kVK_ANSI_J] = KEY_Cj;
+    m_NSKeyCodeMap[kVK_ANSI_K] = KEY_Ck;
+    m_NSKeyCodeMap[kVK_ANSI_L] = KEY_Cl;
+    m_NSKeyCodeMap[kVK_ANSI_M] = KEY_Cm;
+    m_NSKeyCodeMap[kVK_ANSI_N] = KEY_Cn;
+    m_NSKeyCodeMap[kVK_ANSI_O] = KEY_Co;
+    m_NSKeyCodeMap[kVK_ANSI_P] = KEY_Cp;
+    m_NSKeyCodeMap[kVK_ANSI_Q] = KEY_Cq;
+    m_NSKeyCodeMap[kVK_ANSI_R] = KEY_Cr;
+    m_NSKeyCodeMap[kVK_ANSI_S] = KEY_Cs;
+    m_NSKeyCodeMap[kVK_ANSI_T] = KEY_Ct;
+    m_NSKeyCodeMap[kVK_ANSI_U] = KEY_Cu;
+    m_NSKeyCodeMap[kVK_ANSI_V] = KEY_Cv;
+    m_NSKeyCodeMap[kVK_ANSI_W] = KEY_Cw;
+    m_NSKeyCodeMap[kVK_ANSI_X] = KEY_Cx;
+    m_NSKeyCodeMap[kVK_ANSI_Y] = KEY_Cy;
+    m_NSKeyCodeMap[kVK_ANSI_Z] = KEY_Cz;
+    
+    m_NSKeyCodeMap[kVK_ANSI_0] = KEY_C0;
+    m_NSKeyCodeMap[kVK_ANSI_1] = KEY_C1;
+    m_NSKeyCodeMap[kVK_ANSI_2] = KEY_C2;
+    m_NSKeyCodeMap[kVK_ANSI_3] = KEY_C3;
+    m_NSKeyCodeMap[kVK_ANSI_4] = KEY_C4;
+    m_NSKeyCodeMap[kVK_ANSI_5] = KEY_C5;
+    m_NSKeyCodeMap[kVK_ANSI_6] = KEY_C6;
+    m_NSKeyCodeMap[kVK_ANSI_7] = KEY_C7;
+    m_NSKeyCodeMap[kVK_ANSI_8] = KEY_C8;
+    m_NSKeyCodeMap[kVK_ANSI_9] = KEY_C9;
+    
+    m_NSKeyCodeMap[kVK_ANSI_Keypad0] = KEY_KP_C0;
+    m_NSKeyCodeMap[kVK_ANSI_Keypad1] = KEY_KP_C1;
+    m_NSKeyCodeMap[kVK_ANSI_Keypad2] = KEY_KP_C2;
+    m_NSKeyCodeMap[kVK_ANSI_Keypad3] = KEY_KP_C3;
+    m_NSKeyCodeMap[kVK_ANSI_Keypad4] = KEY_KP_C4;
+    m_NSKeyCodeMap[kVK_ANSI_Keypad5] = KEY_KP_C5;
+    m_NSKeyCodeMap[kVK_ANSI_Keypad6] = KEY_KP_C6;
+    m_NSKeyCodeMap[kVK_ANSI_Keypad7] = KEY_KP_C7;
+    m_NSKeyCodeMap[kVK_ANSI_Keypad8] = KEY_KP_C8;
+    m_NSKeyCodeMap[kVK_ANSI_Keypad9] = KEY_KP_C9;
+    
+    m_NSKeyCodeMap[kVK_ANSI_KeypadDivide] = KEY_KP_SLASH;
+    m_NSKeyCodeMap[kVK_ANSI_KeypadMultiply] = KEY_KP_ASTERISK;
+    m_NSKeyCodeMap[kVK_ANSI_KeypadEnter] = KEY_KP_ENTER;
+    m_NSKeyCodeMap[kVK_ANSI_KeypadEquals] = KEY_KP_EQUAL;
+    m_NSKeyCodeMap[kVK_ANSI_KeypadMinus] = KEY_KP_HYPHEN;
+    m_NSKeyCodeMap[kVK_ANSI_KeypadPlus] = KEY_KP_PLUS;
+    m_NSKeyCodeMap[kVK_ANSI_KeypadDecimal] = KEY_KP_PERIOD;
+    
+    m_NSKeyCodeMap[kVK_Home] = KEY_HOME;
+    m_NSKeyCodeMap[kVK_End] = KEY_END;
+    m_NSKeyCodeMap[kVK_PageDown] = KEY_PGDN;
+    m_NSKeyCodeMap[kVK_PageUp] = KEY_PGUP;
+
+    m_NSKeyCodeMap[kVK_F1] = KEY_F1;
+    m_NSKeyCodeMap[kVK_F2] = KEY_F2;
+    m_NSKeyCodeMap[kVK_F3] = KEY_F3;
+    m_NSKeyCodeMap[kVK_F4] = KEY_F4;
+    m_NSKeyCodeMap[kVK_F5] = KEY_F5;
+    m_NSKeyCodeMap[kVK_F6] = KEY_F6;
+    m_NSKeyCodeMap[kVK_F7] = KEY_F7;
+    m_NSKeyCodeMap[kVK_F8] = KEY_F8;
+    m_NSKeyCodeMap[kVK_F9] = KEY_F9;
+    m_NSKeyCodeMap[kVK_F10] = KEY_F10;
+    m_NSKeyCodeMap[kVK_F11] = KEY_F11;
+    m_NSKeyCodeMap[kVK_F12] = KEY_F12;
+    m_NSKeyCodeMap[kVK_F13] = KEY_F13;
+    m_NSKeyCodeMap[kVK_F14] = KEY_F14;
+    m_NSKeyCodeMap[kVK_F15] = KEY_F15;
+    m_NSKeyCodeMap[kVK_F16] = KEY_F16;
+    
+    m_NSKeyCodeMap[kVK_ANSI_Quote] = KEY_QUOTE;
+    m_NSKeyCodeMap[kVK_ANSI_Backslash] = KEY_BACKSLASH;
+    m_NSKeyCodeMap[kVK_CapsLock] = KEY_CAPSLOCK;
+    m_NSKeyCodeMap[kVK_ANSI_Comma] = KEY_COMMA;
+    m_NSKeyCodeMap[kVK_ForwardDelete] = KEY_DEL;
+    m_NSKeyCodeMap[kVK_Delete] = KEY_BACK;
+    m_NSKeyCodeMap[kVK_ANSI_Equal] = KEY_EQUAL;
+    
+    m_NSKeyCodeMap[kVK_Escape] = KEY_ESC;
+    m_NSKeyCodeMap[kVK_ANSI_LeftBracket] = KEY_LBRACKET;
+    m_NSKeyCodeMap[kVK_ANSI_Minus] = KEY_HYPHEN;
+    m_NSKeyCodeMap[kVK_ANSI_Period] = KEY_PERIOD;
+    m_NSKeyCodeMap[kVK_Return] = KEY_ENTER;
+    m_NSKeyCodeMap[kVK_ANSI_RightBracket] = KEY_RBRACKET;
+    m_NSKeyCodeMap[kVK_ANSI_Semicolon] = KEY_SEMICOLON;
+    m_NSKeyCodeMap[kVK_Space] = KEY_SPACE;
+    m_NSKeyCodeMap[kVK_Tab] = KEY_TAB;
+    
+    m_NSKeyCodeMap[kVK_Command] = KEY_LMETA;
+    m_NSKeyCodeMap[kVK_RightCommand] = KEY_RMETA;
+    m_NSKeyCodeMap[kVK_Control] = KEY_LCTRL;
+    m_NSKeyCodeMap[kVK_RightControl] = KEY_RCTRL;
+    m_NSKeyCodeMap[kVK_Function] = KEY_FN;
+    m_NSKeyCodeMap[kVK_Option] = KEY_LALT;
+    m_NSKeyCodeMap[kVK_RightOption] = KEY_RALT;
+    m_NSKeyCodeMap[kVK_Shift] = KEY_LSHIFT;
+    m_NSKeyCodeMap[kVK_RightShift] = KEY_RSHIFT;
+    
+    m_NSKeyCodeMap[kVK_DownArrow] = KEY_DOWN;
+    m_NSKeyCodeMap[kVK_LeftArrow] = KEY_LEFT;
+    m_NSKeyCodeMap[kVK_RightArrow] = KEY_RIGHT;
+    m_NSKeyCodeMap[kVK_UpArrow] = KEY_UP;
+}
+
+void InputHandler_NSEvent::HandleEvent( NSEvent *e )
+{
+    NSEventType type = [e type];
+    if ( type != NSEventTypeKeyDown && type != NSEventTypeKeyUp && type != NSEventTypeFlagsChanged ) {
+        return;
+    }
+    
+    if( type != NSEventTypeFlagsChanged && [e isARepeat] ) {
+        return;
+    }
+    
+    RageTimer now;
+    unsigned short keyCode = [e keyCode];
+    float zval = ( type == NSEventTypeKeyDown ? 1.0 : 0.0 );
+    
+    switch(type)
+    {
+    case NSEventTypeKeyUp:
+    case NSEventTypeKeyDown:
+        ButtonPressed( DeviceInput( DEVICE_KEYBOARD, m_NSKeyCodeMap[keyCode], zval, now ) );
+        break;
+        
+    case NSEventTypeFlagsChanged: {
+        NSEventModifierFlags flags = [e modifierFlags];
+        switch(keyCode)
+        {
+        case kVK_CapsLock:
+            ButtonPressed( DeviceInput( DEVICE_KEYBOARD, m_NSKeyCodeMap[keyCode], DownOrUp( flags & NSEventModifierFlagCapsLock ), now ) );
+            break;
+        case kVK_Shift:
+        case kVK_RightShift:
+            ButtonPressed( DeviceInput( DEVICE_KEYBOARD, m_NSKeyCodeMap[keyCode], DownOrUp( flags & NSEventModifierFlagShift ), now ) );
+            break;
+        case kVK_Control:
+        case kVK_RightControl:
+            ButtonPressed( DeviceInput( DEVICE_KEYBOARD, m_NSKeyCodeMap[keyCode], DownOrUp( flags & NSEventModifierFlagControl ), now ) );
+            break;
+        case kVK_Option:
+        case kVK_RightOption:
+            ButtonPressed( DeviceInput( DEVICE_KEYBOARD, m_NSKeyCodeMap[keyCode], DownOrUp( flags & NSEventModifierFlagOption ), now ) );
+            break;
+        case kVK_Command:
+        case kVK_RightCommand:
+            ButtonPressed( DeviceInput( DEVICE_KEYBOARD, m_NSKeyCodeMap[keyCode], DownOrUp( flags & NSEventModifierFlagCommand ), now ) );
+            break;
+        case kVK_Function:
+            ButtonPressed( DeviceInput( DEVICE_KEYBOARD, m_NSKeyCodeMap[keyCode], DownOrUp( flags & NSEventModifierFlagFunction ), now ) );
+            break;
+        }} break;
+    
+    default:
+        break;
+    }
 }
 
 void InputHandler_NSEvent::GetDevicesAndDescriptions( std::vector<InputDeviceInfo>& vDevicesOut )

--- a/src/arch/arch_default.h
+++ b/src/arch/arch_default.h
@@ -32,7 +32,7 @@ inline const std::vector<RString>& GetDefaultSoundDriverList() {
 #include "MemoryCard/MemoryCardDriverThreaded_MacOSX.h"
 
 inline const std::vector<RString>& GetDefaultInputDriverList() {
-	static const std::vector<RString> inputDriverList = { "HID" };
+	static const std::vector<RString> inputDriverList = { "HID", "NSEvent" };
 	return inputDriverList;
 }
 

--- a/src/archutils/Darwin/CocoaEventDispatcher.h
+++ b/src/archutils/Darwin/CocoaEventDispatcher.h
@@ -1,0 +1,40 @@
+#ifndef COCOA_EVENT_DISPATCHER_H
+#define COCOA_EVENT_DISPATCHER_H
+
+#include <functional>
+#include <vector>
+#include "RageThreads.h"
+
+#if __OBJC__
+#   import <Cocoa/Cocoa.h>
+#   define EVENT_TYPE NSEvent *
+#else
+#   define EVENT_TYPE void *
+#endif
+
+class CocoaEventDispatcher
+{
+public:
+    static CocoaEventDispatcher sharedDispatcher;
+
+    CocoaEventDispatcher();
+    CocoaEventDispatcher(const CocoaEventDispatcher& ) = delete;
+    CocoaEventDispatcher(CocoaEventDispatcher&& ) = delete;
+
+    unsigned AddResponder(const std::function<void(EVENT_TYPE)> &resp);
+    void RemoveResponder(unsigned respID);
+    void DispatchEvent(EVENT_TYPE e);
+
+private:
+    struct Responder
+    {
+        unsigned ID;
+        std::function<void(EVENT_TYPE)> Function;
+    };
+
+    RageMutex m_Mutex;
+    std::vector<Responder> m_Responders;
+    unsigned m_NextResponderID;
+};
+
+#endif // COCOA_EVENT_DISPATCHER_H

--- a/src/archutils/Darwin/CocoaEventDispatcher.mm
+++ b/src/archutils/Darwin/CocoaEventDispatcher.mm
@@ -1,0 +1,43 @@
+#include "global.h"
+#include "CocoaEventDispatcher.h"
+
+CocoaEventDispatcher CocoaEventDispatcher::sharedDispatcher;
+
+CocoaEventDispatcher::CocoaEventDispatcher()
+    : m_Mutex("Cocoa Event Dispatcher")
+    , m_NextResponderID(1)
+{
+}
+
+unsigned CocoaEventDispatcher::AddResponder(const std::function<void(EVENT_TYPE)> &resp)
+{
+    LockMut(m_Mutex);
+
+    const unsigned respID = m_NextResponderID++;
+    m_Responders.push_back(CocoaEventDispatcher::Responder
+    {
+        respID,
+        resp
+    });
+
+    return respID;
+}
+
+void CocoaEventDispatcher::RemoveResponder(unsigned respID)
+{
+    LockMut(m_Mutex);
+    m_Responders.erase(find_if(m_Responders.begin(), m_Responders.end(), [=](const auto &resp)
+    {
+        return resp.ID == respID;
+    }));
+}
+
+void CocoaEventDispatcher::DispatchEvent(EVENT_TYPE e)
+{
+    LockMut(m_Mutex);
+
+    for (const auto &responder : m_Responders)
+    {
+        responder.Function(e);
+    }
+}

--- a/src/archutils/Darwin/SMMain.mm
+++ b/src/archutils/Darwin/SMMain.mm
@@ -7,7 +7,10 @@
 #import <Cocoa/Cocoa.h>
 #include "ProductInfo.h"
 #include "arch/ArchHooks/ArchHooks.h"
+#include "arch/InputHandler/InputHandler_NSEvent.hpp"
+#include "archutils/Darwin/CocoaEventDispatcher.h"
 #include "StepMania.h"
+#include "RageInput.h"
 
 @interface NSApplication (PrivateShutUpWarning)
 - (void) setAppleMenu:(NSMenu *)menu;
@@ -30,6 +33,11 @@
 
 - (void)sendEvent:(NSEvent *)event
 {
+	if( INPUTMAN ) {
+		auto &dispatcher = CocoaEventDispatcher::sharedDispatcher;
+		dispatcher.DispatchEvent( event );
+	}
+	
 	if( [event type] == NSEventTypeKeyDown )
 		[[self mainMenu] performKeyEquivalent:event];
 	else

--- a/src/archutils/Darwin/arch_setup.h
+++ b/src/archutils/Darwin/arch_setup.h
@@ -29,6 +29,8 @@ extern "C" int sm_main( int argc, char *argv[] );
 # define __MACOSX__
 #endif
 
+#define OSX_KEYBOARD_USE_NSEVENT 1
+
 #endif
 
 /*

--- a/src/global.h
+++ b/src/global.h
@@ -15,7 +15,7 @@
 /* Platform-specific fixes. */
 #if defined(_WIN32)
 #include "archutils/Win32/arch_setup.h"
-#elif defined(PBBUILD)
+#elif defined(PBBUILD) || defined(MACOSX)
 #include "archutils/Darwin/arch_setup.h"
 #elif defined(UNIX)
 #include "archutils/Unix/arch_setup.h"


### PR DESCRIPTION
Resolves #87 

I have ported over the macOS improvements from the Club Fantastic build of StepMania, so that there is no more need to add ITGmania to Input Monitoring on modern macOS.  (https://github.com/ClubFantastic/stepmania/pull/1/files)

Some users have been using this build for years, so this input driver is well tested.

Here is a video taken on my own machine, running an identical setup to the Mac M1 GitHub CI runner (M1, macOS 15, Xcode 16.4). Here you can see ITGmania is not added to Input Monitoring, and the inputs are working as expected.


https://github.com/user-attachments/assets/87d125d9-ecee-46cd-8324-5499885a995a

