### PR TITLE
RageSoundReader_ThreadedBuffer: Shorten the ThreadedBuffer thread name

### DIFF
--- a/src/RageSoundReader_ThreadedBuffer.cpp
+++ b/src/RageSoundReader_ThreadedBuffer.cpp
@@ -44,7 +44,7 @@ RageSoundReader_ThreadedBuffer::RageSoundReader_ThreadedBuffer( RageSoundReader 
 	m_StreamPosition.back().iPositionOfFirstFrame = pSource->GetNextSourceFrame();
 	m_StreamPosition.back().fRate = pSource->GetStreamToSourceRatio();
 
-	m_Thread.SetName( "Streaming sound buffering" );
+	m_Thread.SetName( "Sound buffering" );
 	m_Thread.Create( StartBufferingThread, this );
 }
 


### PR DESCRIPTION
Some compilers don't want this to be longer than 16 characters, so this shortens the name so that we don't spam the log file with thread name truncation warnings.