### PR TITLE
Code Modernization: Replace `usleep` with `std::this_thread::sleep_for`

### DIFF
--- a/src/RageSoundReader_ThreadedBuffer.cpp
+++ b/src/RageSoundReader_ThreadedBuffer.cpp
@@ -5,6 +5,8 @@
 #include "RageLog.h"
 
 #include <cmath>
+#include <thread>
+#include <chrono>
 
 /* Implement threaded read-ahead buffering.
  *
@@ -222,10 +224,7 @@ void RageSoundReader_ThreadedBuffer::BufferingThread()
 
 		/* Sleep proportionately to the amount of data we buffered, so we
 		 * fill at a reasonable pace. */
-		float fTimeFilled = float(g_iReadBlockSizeFrames) / m_iSampleRate;
-		float fTimeToSleep = fTimeFilled / 2;
-		if( fTimeToSleep == 0 )
-			fTimeToSleep = float(g_iReadBlockSizeFrames) / m_iSampleRate;
+		const float fTimeToSleep = static_cast<float>(g_iReadBlockSizeFrames) / (m_iSampleRate * 2.0f);
 
 		if( m_Event.WaitTimeoutSupported() )
 		{
@@ -237,7 +236,9 @@ void RageSoundReader_ThreadedBuffer::BufferingThread()
 		else
 		{
 			m_Event.Unlock();
-			usleep( static_cast<int>((fTimeToSleep * 1000000) + 0.5) );
+			const auto sleep_duration_us = std::chrono::duration_cast<std::chrono::microseconds>(
+				std::chrono::duration<float>(fTimeToSleep));
+			std::this_thread::sleep_for(sleep_duration_us);
 			m_Event.Lock();
 		}
 	}


### PR DESCRIPTION
Updated BufferingThread to use `std::this_thread::sleep_for` with `std::chrono` for sleeping, replacing the old `usleep` call. Safer code & better for modern hardware. The usleep call is especially clunky on arm64.