### PR TITLE
Cmake changes to fix building in Xcode

### DIFF
--- a/CMake/SetupFfmpeg.cmake
+++ b/CMake/SetupFfmpeg.cmake
@@ -52,7 +52,12 @@ if(NOT WITH_EXTERNAL_WARNINGS)
   list(APPEND FFMPEG_CONFIGURE "--extra-cflags=-w")
 endif()
 
-list(APPEND SM_FFMPEG_MAKE $(MAKE))
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+  list(APPEND SM_FFMPEG_MAKE "make")
+else()
+  list(APPEND SM_FFMPEG_MAKE $(MAKE))
+endif()
+
 if(WITH_FFMPEG_JOBS GREATER 0)
   list(APPEND SM_FFMPEG_MAKE "-j${WITH_FFMPEG_JOBS}")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,10 @@ if(WITH_NO_ROLC_TOMCRYPT)
   target_compile_definitions("${SM_EXE_NAME}" PRIVATE LTC_NO_ROLC)
 endif()
 
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+  target_compile_options(mbedcrypto PRIVATE -Wno-shorten-64-to-32)
+endif()
+
 # Compilation flags per project here.
 target_compile_definitions("${SM_EXE_NAME}" PRIVATE $<$<CONFIG:Debug>:DEBUG>)
 target_compile_definitions("${SM_EXE_NAME}" PRIVATE $<$<CONFIG:Release>:RELEASE>)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,10 @@ if(MSVC)
   endif()
 endif()
 
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+  set(CMAKE_XCODE_GENERATE_SCHEME ON)
+endif()
+
 # Keep the module path local for easier grabbing.
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 


### PR DESCRIPTION
This is a couple of small CMake changes to make it possible to actually build ITGmania as an Xcode project on more recent versions of Xcode. 

The first commit sets `-Wno-shorten-64-to-32` for the mbedcrypto target, to silence the 'Implicit conversion loses integer precision' warnings that get treated as errors. This problem was introduced when we [downgraded from mbedtls 3.6.0 to 3.5.2](https://github.com/itgmania/itgmania/pull/279). I'm not 100% sure _why_ this happens in Xcode and not when building through cmake, but it's something to do with using clang. This has been fixed in newer versions of mbedtls.
Another option might be to set the `MBEDTLS_FATAL_WARNINGS` flag to OFF (it's on by default).

The second fixes an issue where Xcode would fail to build ffmpeg. Xcode uses shell scripts to run build commands for external projects, where I guess most other setups generate makefiles. The problem was that `$(MAKE)` is a make variable, so it wasn't getting expanded into anything. 

And the third is mostly a convenience thing, which has cmake generate scheme files. Otherwise, Xcode will  _always_ ask to "Autocreate Schemes" every time you open the project.

I'm not super familiar with cmake, so if it makes more sense to put these changes elsewhere or something, let me know.