### PR TITLE
Fix some Vsync issues (Closed temporarily to prevent merge conflicts)

### DIFF
--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -928,43 +928,6 @@ void RageDisplay::DrawCircle( const RageSpriteVertex &v, float radius )
 	this->DrawCircleInternal( v, radius );
 }
 
-void RageDisplay::FrameLimitBeforeVsync( int iFPS )
-{
-	ASSERT( iFPS != 0 );
-
-	int iDelayMicroseconds = 0;
-	if( g_fFrameLimitPercent.Get() > 0.0f && !g_LastFrameEndedAt.IsZero() )
-	{
-		float fFrameTime = g_LastFrameEndedAt.GetDeltaTime();
-		float fExpectedTime = 1.0f / iFPS;
-
-		/* This is typically used to turn some of the delay that would normally
-		 * be waiting for vsync and turn it into a usleep, to make sure we give
-		 * up the CPU.  If we overshoot the sleep, then we'll miss the vsync,
-		 * so allow tweaking the amount of time we expect a frame to take.
-		 * Frame limiting is disabled by setting this to 0. */
-		fExpectedTime *= g_fFrameLimitPercent.Get();
-		float fExtraTime = fExpectedTime - fFrameTime;
-
-		iDelayMicroseconds = int(fExtraTime * 1000000);
-	}
-
-	if( !HOOKS->AppHasFocus() )
-		iDelayMicroseconds = std::max( iDelayMicroseconds, 10000 ); // give some time to other processes and threads
-
-	if( iDelayMicroseconds > 0 )
-		usleep( iDelayMicroseconds );
-}
-
-void RageDisplay::FrameLimitAfterVsync()
-{
-	if( g_fFrameLimitPercent.Get() == 0.0f )
-		return;
-
-	g_LastFrameEndedAt.Touch();
-}
-
-
 RageCompiledGeometry::~RageCompiledGeometry()
 {
 	m_bNeedsNormals = false;

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -928,6 +928,14 @@ void RageDisplay::DrawCircle( const RageSpriteVertex &v, float radius )
 	this->DrawCircleInternal( v, radius );
 }
 
+void RageDisplay::SleepIfFocusLost()
+{
+	if( !HOOKS->AppHasFocus() )
+	{
+		usleep( 20000 ); // 20ms
+	}
+}
+
 RageCompiledGeometry::~RageCompiledGeometry()
 {
 	m_bNeedsNormals = false;

--- a/src/RageDisplay.h
+++ b/src/RageDisplay.h
@@ -453,6 +453,8 @@ protected:
 	const RageMatrix* GetViewTop() const;
 	const RageMatrix* GetWorldTop() const;
 	const RageMatrix* GetTextureTop() const;
+
+	void SleepIfFocusLost();
 };
 
 

--- a/src/RageDisplay.h
+++ b/src/RageDisplay.h
@@ -453,11 +453,6 @@ protected:
 	const RageMatrix* GetViewTop() const;
 	const RageMatrix* GetWorldTop() const;
 	const RageMatrix* GetTextureTop() const;
-
-	// To limit the framerate, call FrameLimitBeforeVsync before waiting
-	// for vsync and FrameLimitAfterVsync after.
-	void FrameLimitBeforeVsync( int iFPS );
-	void FrameLimitAfterVsync();
 };
 
 

--- a/src/RageDisplay_D3D.cpp
+++ b/src/RageDisplay_D3D.cpp
@@ -603,6 +603,7 @@ void RageDisplay_D3D::EndFrame()
 {
 	g_pd3dDevice->EndScene();
 
+	SleepIfFocusLost();
 	g_pd3dDevice->Present( 0, 0, 0, 0 );
 
 	RageDisplay::EndFrame();

--- a/src/RageDisplay_D3D.cpp
+++ b/src/RageDisplay_D3D.cpp
@@ -603,9 +603,7 @@ void RageDisplay_D3D::EndFrame()
 {
 	g_pd3dDevice->EndScene();
 
-	FrameLimitBeforeVsync( GetActualVideoModeParams().rate );
 	g_pd3dDevice->Present( 0, 0, 0, 0 );
-	FrameLimitAfterVsync();
 
 	RageDisplay::EndFrame();
 }

--- a/src/RageDisplay_GLES2.cpp
+++ b/src/RageDisplay_GLES2.cpp
@@ -436,6 +436,7 @@ void RageDisplay_GLES2::EndFrame()
 
 	// XXX: This is broken on NVidia, as their xrandr sucks.
 	// (comment may be outdated?)
+	SleepIfFocusLost();
 	g_pWind->SwapBuffers();
 
 	g_pWind->Update();

--- a/src/RageDisplay_GLES2.cpp
+++ b/src/RageDisplay_GLES2.cpp
@@ -435,9 +435,8 @@ void RageDisplay_GLES2::EndFrame()
 	glFlush();
 
 	// XXX: This is broken on NVidia, as their xrandr sucks.
-	FrameLimitBeforeVsync( g_pWind->GetActualVideoModeParams().rate );
+	// (comment may be outdated?)
 	g_pWind->SwapBuffers();
-	FrameLimitAfterVsync();
 
 	g_pWind->Update();
 

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -894,6 +894,8 @@ void RageDisplay_Legacy::EndFrame()
 		CameraPopMatrix();
 	}
 
+	SleepIfFocusLost();
+
 	g_pWind->SwapBuffers();
 
 	// Some would advise against glFinish(), ever. Those people don't realize

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -30,6 +30,10 @@ using namespace RageDisplay_Legacy_Helpers;
 #include <GL/wglew.h>
 #endif
 
+#if defined(UNIX) && !defined(__APPLE__)
+#include <GL/glxew.h>
+#endif
+
 #if defined(_MSC_VER)
 #pragma comment(lib, "opengl32.lib")
 #pragma comment(lib, "glu32.lib")
@@ -787,6 +791,20 @@ RString RageDisplay_Legacy::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 	if (err != "")
 		return err;	// failed to set video mode
 
+	// Set swap interval (vsync) for frame rate limiting.
+	// macOS swap interval is handled by LowLevelWindow_MacOSX.
+#if defined(WINDOWS)
+	if (wglSwapIntervalEXT != nullptr)
+		wglSwapIntervalEXT( p.vsync ? 1 : 0 );
+#elif defined(UNIX) && !defined(__APPLE__)
+	if (GLXEW_EXT_swap_control && glXSwapIntervalEXT)
+		glXSwapIntervalEXT( glXGetCurrentDisplay(), glXGetCurrentDrawable(), p.vsync ? 1 : 0 );
+	else if (GLXEW_MESA_swap_control && glXSwapIntervalMESA)
+		glXSwapIntervalMESA( p.vsync ? 1 : 0 );
+	else if (GLXEW_SGI_swap_control && glXSwapIntervalSGI)
+		glXSwapIntervalSGI( p.vsync ? 1 : 0 );
+#endif
+
 	/* Now that we've initialized, we can search for extensions.  Do this before InvalidateObjects,
 	 * since AllocateBuffers needs it. */
 	SetupExtensions();
@@ -810,16 +828,6 @@ RString RageDisplay_Legacy::TryVideoMode( const VideoModeParams &p, bool &bNewDe
 
 		InitShaders();
 	}
-
-// I'm not sure this is correct -Colby
-#if defined(WINDOWS)
-	/* Set vsync the Windows way, if we can.  (What other extensions are there
-	 * to do this, for other archs?) */
-	if( wglewIsSupported("WGL_EXT_swap_control") )
-		wglSwapIntervalEXT(p.vsync);
-	else
-		return RString("The WGL_EXT_swap_control extension is not supported on your computer.");
-#endif
 
 	ResolutionChanged();
 

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -894,9 +894,7 @@ void RageDisplay_Legacy::EndFrame()
 		CameraPopMatrix();
 	}
 
-	FrameLimitBeforeVsync( g_pWind->GetActualVideoModeParams().rate );
 	g_pWind->SwapBuffers();
-	FrameLimitAfterVsync();
 
 	// Some would advise against glFinish(), ever. Those people don't realize
 	// the degree of freedom GL hosts are permitted in queueing commands.


### PR DESCRIPTION
I tested this in full screen and windowed modes with a 180Hz monitor, and got constant 180 FPS, without any frame skips, & did not need to manually configure my refresh rate to do so. I got a solid tri star on my first keyboard play with these commits, & gameplay feels good.

---------

To be clear, the SM5 coders were on the right path, but they doubted themselves enough to leave a note that the correct implementation may have been wrong.

I've moved the focus-checking aspect of `FrameLimitBeforeVsync` into its own function `SleepIfFocusLost`. The 20ms usleep when focus is lost provides a good balance of smooth response on transitions in and out of focus, and lowered resource consumption when out of focus. 