### PR TITLE
Refactor Club Fantastic cmake integration to avoid copying unwanted song packs into ITGmania.app when building on macOS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,17 @@ include(CMakeData-file-types.cmake)
 include(CMakeData-globals.cmake)
 include(CMakeData-singletons.cmake)
 
+if(WITH_CLUB_FANTASTIC)
+  include(FetchContent)
+  FetchContent_Declare(
+    ClubFantastic
+    URL https://download.clubfantastic.dance/club_fantastic_season2_songs_9ms.zip
+    URL_HASH SHA256=845b62da6bb2994fc2ba7871b35da02f6eb36ea1ae78c2b9a59a6ec046946787
+  )
+  FetchContent_MakeAvailable(ClubFantastic)
+  FetchContent_GetProperties(ClubFantastic SOURCE_DIR CLUB_FANTASTIC_DIR)
+endif()
+
 list(APPEND SMDATA_ALL_FILES_SRC
             ${SMDATA_GLOBAL_FILES_SRC}
             ${SMDATA_GLOBAL_SINGLETON_SRC}
@@ -238,12 +249,22 @@ elseif(APPLE)
     "${SM_ROOT_DIR}/Data"
     "${SM_ROOT_DIR}/NoteSkins"
     "${SM_ROOT_DIR}/Scripts"
-    "${SM_ROOT_DIR}/Songs"
     "${SM_ROOT_DIR}/Themes"
   )
 
-  target_sources("${SM_EXE_NAME}" PUBLIC ${APPLE_BUNDLE_RESOURCES})
   set_source_files_properties(${APPLE_BUNDLE_RESOURCES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
+
+  if(WITH_CLUB_FANTASTIC)
+    set(CLUB_FANTASTIC_BUNDLE_RESOURCES
+      "${CLUB_FANTASTIC_DIR}/Club Fantastic Season 1"
+      "${CLUB_FANTASTIC_DIR}/Club Fantastic Season 2"
+    )
+    list(APPEND APPLE_BUNDLE_RESOURCES ${CLUB_FANTASTIC_BUNDLE_RESOURCES})
+    set_source_files_properties(${CLUB_FANTASTIC_BUNDLE_RESOURCES}
+                                PROPERTIES MACOSX_PACKAGE_LOCATION "Resources/Songs")
+  endif()
+
+  target_sources("${SM_EXE_NAME}" PUBLIC ${APPLE_BUNDLE_RESOURCES})
 
   target_compile_definitions("${SM_EXE_NAME}" PRIVATE _XOPEN_SOURCE)
 
@@ -550,22 +571,17 @@ install(DIRECTORY "${SM_ROOT_DIR}/Docs"
         DESTINATION "${SM_INSTALL_DESTINATION}")
 install(DIRECTORY "${SM_ROOT_DIR}/NoteSkins"
         DESTINATION "${SM_INSTALL_DESTINATION}")
-install(FILES "${SM_ROOT_DIR}/Songs/instructions.txt"
-        DESTINATION "${SM_INSTALL_DESTINATION}/Songs")
 
-if(WITH_CLUB_FANTASTIC)
-  # Fetch ClubFantastic packs
-  include(FetchContent)
-  FetchContent_Declare(
-    ClubFantastic
-    URL https://download.clubfantastic.dance/club_fantastic_season2_songs_9ms.zip
-    URL_HASH SHA256=845b62da6bb2994fc2ba7871b35da02f6eb36ea1ae78c2b9a59a6ec046946787
-  )
-  FetchContent_MakeAvailable(ClubFantastic)
-  FetchContent_GetProperties(ClubFantastic SOURCE_DIR CLUB_FANTASTIC_DIR)
-
-  install(DIRECTORY "${CLUB_FANTASTIC_DIR}/Club Fantastic Season 1"
-          DESTINATION "${SM_INSTALL_DESTINATION}/Songs")
-  install(DIRECTORY "${CLUB_FANTASTIC_DIR}/Club Fantastic Season 2"
-          DESTINATION "${SM_INSTALL_DESTINATION}/Songs")
+# For macOS builds, we have already populated the Songs directory with Club
+# Fantastic earlier via APPLE_BUNDLE_RESOURCES (macOS builds containing
+# the Club Fantastic songs will store them within the .app's Resources directory).
+if(NOT APPLE)
+  install(FILES "${SM_ROOT_DIR}/Songs/instructions.txt"
+    DESTINATION "${SM_INSTALL_DESTINATION}/Songs")
+  if(WITH_CLUB_FANTASTIC)
+    install(DIRECTORY "${CLUB_FANTASTIC_DIR}/Club Fantastic Season 1"
+      DESTINATION "${SM_INSTALL_DESTINATION}/Songs")
+    install(DIRECTORY "${CLUB_FANTASTIC_DIR}/Club Fantastic Season 2"
+      DESTINATION "${SM_INSTALL_DESTINATION}/Songs")
+  endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -239,6 +239,11 @@ elseif(APPLE)
       MACOSX_BUNDLE_INFO_PLIST
       "${SM_XCODE_DIR}/Info.plist.in")
 
+# macOS NOTE: All content in any of the following directories will be copied into
+# the macOS .app bundle at build time. This behavior is exclusive to macOS.
+# This way you can bundle anything you want inside the .app bundle. If you do not
+# want any custom content to be included with the .app bundle, you can comment
+# or delete the following code block:
   set(APPLE_BUNDLE_RESOURCES
     "${SM_ROOT_DIR}/Announcers"
     "${SM_ROOT_DIR}/BackgroundEffects"


### PR DESCRIPTION
The current code copies the entire contents of the /Songs folder **within ITGmania.app itself**.  So, if you have 20GB of packs when you compile the game, you end up with a 20GB sized executable.

<img width="1214" height="801" alt="Screenshot 2025-11-03 at 7 18 06 PM" src="https://github.com/user-attachments/assets/294921dc-5d97-494e-a929-30dcc59f0cd2" />

It's hard to imagine this was intended to do any more than maybe bundle the three default StepMania 5 songs, so I've removed it from the CMake.
