### PR TITLE
Rewrite a comparison involving differing datatypes which is not compliant in Clang

### DIFF
--- a/src/RageSurfaceUtils.cpp
+++ b/src/RageSurfaceUtils.cpp
@@ -809,7 +809,9 @@ RageSurface *RageSurfaceUtils::LoadSurface( RString file )
 		return nullptr;
 	}
 
-	if( f.Read( img->pixels, static_cast<size_t>(h.height) * h.pitch ) != static_cast<size_t>(h.height) * h.pitch )
+	const size_t expected_size = static_cast<size_t>( h.height ) * h.pitch;
+	const size_t bytes_read = static_cast<size_t>( f.Read( img->pixels, expected_size ) );
+	if( bytes_read != expected_size )
 	{
 		delete img;
 		return nullptr;


### PR DESCRIPTION
The CodeQL scanner on GitHub found this potential issue which is a valid concern where a multiplication result is converted to a larger type.

`if( f.Read( img->pixels, h.height * h.pitch ) != h.height * h.pitch )`

The AI generated suggestion, which was applied in fc2d5db, was

`if( f.Read( img->pixels, static_cast<size_t>(h.height) * h.pitch ) != static_cast<size_t>(h.height) * h.pitch )`

which is non compliant in Clang.


```
/Users/runner/work/itgmania/itgmania/src/RageSurfaceUtils.cpp:812:69: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
  812 |         if( f.Read( img->pixels, static_cast<size_t>(h.height) * h.pitch ) != static_cast<size_t>(h.height) * h.pitch )
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

A more preferable fix would have been

`if( static_cast<size_t>(f.Read( img->pixels, static_cast<size_t>(h.height) * h.pitch )) != static_cast<size_t>(h.height) * h.pitch )`

However I was sure there was a way to do this that could both improve const correctness, as well as remove the duplication multiplication, so I've rewritten this code snippet. I think it's much easier to quickly understand the intent of the code now.