### PR TITLE
Add a generic Unix backtrace method for use with arm64 platforms.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -191,10 +191,19 @@ if(WIN32)
   endif()
 elseif(APPLE)
   # TODO should we set CRASH_HANDLER and other things like LINUX does below? Why is that logic specfic to LINUX?
-  target_compile_definitions("${SM_EXE_NAME}" PRIVATE BACKTRACE_METHOD_X86_DARWIN)
+  # Use generic Unix backtrace for all Apple architectures
+  target_compile_definitions("${SM_EXE_NAME}" PRIVATE BACKTRACE_METHOD_GENERIC_UNIX)
+  target_compile_definitions("${SM_EXE_NAME}" PRIVATE BACKTRACE_METHOD_TEXT="generic unix backtrace")
   target_compile_definitions("${SM_EXE_NAME}" PRIVATE BACKTRACE_LOOKUP_METHOD_TEXT="dladdr")
   target_compile_definitions("${SM_EXE_NAME}" PRIVATE BACKTRACE_LOOKUP_METHOD_DLADDR)
   target_compile_definitions("${SM_EXE_NAME}" PRIVATE MACOSX)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+    target_compile_definitions("${SM_EXE_NAME}" PRIVATE CPU_X86_64)
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86" OR CMAKE_SYSTEM_PROCESSOR MATCHES "i686")
+    target_compile_definitions("${SM_EXE_NAME}" PRIVATE CPU_X86)
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+    target_compile_definitions("${SM_EXE_NAME}" PRIVATE CPU_AARCH64)
+  endif()
   set_target_properties(
     "${SM_EXE_NAME}"
     PROPERTIES
@@ -268,6 +277,10 @@ else() # Linux
         target_compile_definitions("${SM_EXE_NAME}" PRIVATE BACKTRACE_METHOD_X86_LINUX)
         target_compile_definitions("${SM_EXE_NAME}" PRIVATE
                                    BACKTRACE_METHOD_TEXT="x86 custom backtrace")
+      elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+        target_compile_definitions("${SM_EXE_NAME}" PRIVATE BACKTRACE_METHOD_GENERIC_UNIX)
+        target_compile_definitions("${SM_EXE_NAME}" PRIVATE
+                                   BACKTRACE_METHOD_TEXT="generic unix backtrace")
       else()
         target_compile_definitions("${SM_EXE_NAME}" PRIVATE
                                    BACKTRACE_METHOD_TEXT="no backtrace")

--- a/src/archutils/Darwin/arch_setup.h
+++ b/src/archutils/Darwin/arch_setup.h
@@ -16,12 +16,6 @@ extern "C" int sm_main( int argc, char *argv[] );
 // CGFlushDrawable() performs a glFlush() and the docs say not to call glFlush()
 #define NO_GL_FLUSH
 
-#define CPU_X86
-#ifndef BACKTRACE_METHOD_X86_DARWIN
-#define BACKTRACE_METHOD_X86_DARWIN
-#endif
-#define BACKTRACE_LOOKUP_METHOD_DLADDR
-
 #ifndef MACOSX
 # define MACOSX
 #endif

--- a/src/archutils/Unix/Backtrace.cpp
+++ b/src/archutils/Unix/Backtrace.cpp
@@ -752,6 +752,35 @@ void GetBacktrace( const void **buf, size_t size, const BacktraceContext *ctx )
 	buf[i] = nullptr;
 }
 
+#elif defined(BACKTRACE_METHOD_GENERIC_UNIX)
+#include <vector>
+#include <execinfo.h>
+
+void GetSignalBacktraceContext( BacktraceContext *ctx, const ucontext_t *uc ) { }
+
+void InitializeBacktrace() { }
+
+void GetBacktrace( const void **buf, size_t size, const BacktraceContext *ctx )
+{
+	if (!buf || size == 0) return;
+
+	// Ensure we can place a terminator.
+	if (size == 1) { buf[0] = nullptr; return; }
+
+	const size_t capacity = size - 1;
+	std::vector<void*> frames(capacity);
+
+	int n = backtrace(frames.data(), static_cast<int>(capacity));
+	if (n < 0) n = 0;
+
+	for (int i = 0; i < n; ++i)
+	{
+		buf[i] = frames[i];
+	}
+
+	buf[n] = nullptr;
+}
+
 #else
 
 #warning Undefined BACKTRACE_METHOD_*

--- a/src/archutils/Unix/Backtrace.cpp
+++ b/src/archutils/Unix/Backtrace.cpp
@@ -403,7 +403,16 @@ void GetSignalBacktraceContext( BacktraceContext *ctx, const ucontext_t *uc )
 #elif defined(CPU_AARCH64)
 void GetSignalBacktraceContext( BacktraceContext *ctx, const ucontext_t *uc )
 {
-	// NYI
+#if defined(MACOSX)
+	ctx->ip = (void *) uc->uc_mcontext->__ss.__pc;
+	ctx->bp = (void *) uc->uc_mcontext->__ss.__fp;
+	ctx->sp = (void *) uc->uc_mcontext->__ss.__sp;
+#elif defined(LINUX)
+	ctx->ip = (void *) uc->uc_mcontext.pc;
+	ctx->bp = (void *) uc->uc_mcontext.regs[29]; // x29 is frame pointer
+	ctx->sp = (void *) uc->uc_mcontext.sp;
+#endif
+	ctx->pid = GetCurrentThreadId();
 }
 
 #else

--- a/src/archutils/Unix/Backtrace.h
+++ b/src/archutils/Unix/Backtrace.h
@@ -16,7 +16,7 @@ struct BacktraceContext
 	const void *ip, *bp, *sp;
 #endif
 
-#if defined(UNIX)
+#if defined(UNIX) || defined(MACOSX)
 	pid_t pid;
 #endif
 


### PR DESCRIPTION
tl;dr  with this change, ARM64 Linux and ARM64 macOS both get a valid backtrace method. As it stands, they either don't get a backtrace method or are forced into building with an X86 backtrace method.

<details>

following the merging of #1043, it exposed an pre-existing issue in the macOS port.

This warning floods the log now on just about every file compiled:

```
/Users/runner/work/itgmania/itgmania/src/archutils/Darwin/arch_setup.h:23:9: warning: 'BACKTRACE_LOOKUP_METHOD_DLADDR' macro redefined [-Wmacro-redefined]

   23 | #define BACKTRACE_LOOKUP_METHOD_DLADDR

      |         ^

<command line>:1:9: note: previous definition is here

    1 | #define BACKTRACE_LOOKUP_METHOD_DLADDR 1

      |         ^
```

We only have backtrace methods for X86 Darwin, X86 Linux and PPC Linux. ARM64 seems to be forced into using a X86 backtrace method currently.

This PR adds a generic Unix backtrace method which can be used by non-X86 / non-PPC platforms, and makes it default for ARM64. `backtrace()` handles pretty much everything, so this is super light weight.

I'm attaching a crash log generated with this backtrace method used, so you can see it works: 
[crashinfo.txt](https://github.com/user-attachments/files/23336711/crashinfo.txt)


</details>

Even though it's not many lines added or removed, I've taken care to separate every part of how this PR came to be into individual commits so it is easier to visualize why this is how I've implemented this change.