### PR TITLE
Revise macOS directory structure

### DIFF
--- a/src/arch/ArchHooks/ArchHooks_MacOSX.mm
+++ b/src/arch/ArchHooks/ArchHooks_MacOSX.mm
@@ -5,9 +5,11 @@
 #include "archutils/Unix/CrashHandler.h"
 #include "archutils/Unix/SignalHandler.h"
 #include "ProductInfo.h"
+#include "SpecialFiles.h"
 
 #include <cstddef>
 #include <cstdint>
+#include <vector>
 
 #include <CoreServices/CoreServices.h>
 #include <ApplicationServices/ApplicationServices.h>
@@ -265,6 +267,32 @@ int64_t ArchHooks::GetSystemTimeInMicroseconds()
 
 #include "RageFileManager.h"
 
+void MountDirectories(const RString& baseDir) {
+	const std::vector<RString> macDirectoryStructureITGm = {
+		"/Announcers",
+		"/BGAnimations",
+		"/BackgroundEffects",
+		"/BackgroundTransitions",
+		"/Cache",
+		"/CDTitles",
+		"/Characters",
+		"/Courses",
+		"/Downloads",
+		"/Logs",
+		"/NoteSkins",
+		"/Packages",
+		"/Save",
+		"/Screenshots",
+		"/Songs",
+		"/RandomMovies",
+		"/Themes"
+	};
+
+	for (const RString& dir : macDirectoryStructureITGm) {
+		FILEMAN->Mount("dir", baseDir + dir, dir);
+	}
+}
+
 void ArchHooks::MountInitialFilesystems( const RString &sDirOfExecutable )
 {
 	FILEMAN->Mount("dirro", sDirOfExecutable, "/");
@@ -306,23 +334,7 @@ void ArchHooks::MountInitialFilesystems( const RString &sDirOfExecutable )
 
 	if (portable)
 	{
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Announcers", "/Announcers");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/BGAnimations", "/BGAnimations");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/BackgroundEffects", "/BackgroundEffects");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/BackgroundTransitions", "/BackgroundTransitions");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Cache", "/Cache");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/CDTitles", "/CDTitles");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Characters", "/Characters");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Courses", "/Courses");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Downloads", "/Downloads");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Logs", "/Logs");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/NoteSkins", "/NoteSkins");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Packages", "/Packages");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Save", "/Save");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Screenshots", "/Screenshots");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Songs", "/Songs");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/RandomMovies", "/RandomMovies");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Themes", "/Themes");
+		MountDirectories(sDirOfExecutable);
 	}
 }
 
@@ -338,36 +350,10 @@ static std::string PathForDirectory( NSSearchPathDirectory directory )
 
 void ArchHooks::MountUserFilesystems( const RString &sDirOfExecutable )
 {
-	// /Save -> ~/Library/Preferences/PRODUCT_ID
-	std::string libraryDir = PathForDirectory(NSLibraryDirectory);
-	FILEMAN->Mount( "dir", libraryDir + "/Preferences/" PRODUCT_ID, "/Save" );
-
-	// Other stuff -> ~/Library/Application Support/PRODUCT_ID/*
 	std::string appSupportDir = PathForDirectory(NSApplicationSupportDirectory);
-	FILEMAN->Mount( "dir", appSupportDir + "/" PRODUCT_ID "/Announcers", "/Announcers" );
-	FILEMAN->Mount( "dir", appSupportDir + "/" PRODUCT_ID "/BGAnimations", "/BGAnimations" );
-	FILEMAN->Mount( "dir", appSupportDir + "/" PRODUCT_ID "/BackgroundEffects", "/BackgroundEffects" );
-	FILEMAN->Mount( "dir", appSupportDir + "/" PRODUCT_ID "/BackgroundTransitions", "/BackgroundTransitions" );
-	FILEMAN->Mount( "dir", appSupportDir + "/" PRODUCT_ID "/CDTitles", "/CDTitles" );
-	FILEMAN->Mount( "dir", appSupportDir + "/" PRODUCT_ID "/Characters", "/Characters" );
-	FILEMAN->Mount( "dir", appSupportDir + "/" PRODUCT_ID "/Courses", "/Courses" );
-	FILEMAN->Mount( "dir", appSupportDir + "/" PRODUCT_ID "/Downloads", "/Downloads" );
-	FILEMAN->Mount( "dir", appSupportDir + "/" PRODUCT_ID "/NoteSkins", "/NoteSkins" );
-	FILEMAN->Mount( "dir", appSupportDir + "/" PRODUCT_ID "/Packages", "/Packages" );
-	FILEMAN->Mount( "dir", appSupportDir + "/" PRODUCT_ID "/Songs", "/Songs" );
-	FILEMAN->Mount( "dir", appSupportDir + "/" PRODUCT_ID "/RandomMovies", "/RandomMovies" );
-	FILEMAN->Mount( "dir", appSupportDir + "/" PRODUCT_ID "/Themes", "/Themes" );
+	RString appSupportPath = ssprintf("%s/" PRODUCT_ID, appSupportDir.c_str());
 
-	// /Screenshots -> ~/Pictures/PRODUCT_ID Screenshots
-	std::string picturesDir = PathForDirectory(NSCachesDirectory);
-	FILEMAN->Mount( "dir", picturesDir + "/" PRODUCT_ID " Screenshots", "/Screenshots" );
-
-	// /Cache -> ~/Library/Caches/PRODUCT_ID
-	std::string cachesDir = PathForDirectory(NSCachesDirectory);
-	FILEMAN->Mount( "dir", cachesDir + "/" PRODUCT_ID, "/Cache" );
-
-	// /Logs -> ~/Library/Logs/PRODUCT_ID
-	FILEMAN->Mount( "dir", libraryDir + "/Logs/" PRODUCT_ID, "/Logs" );
+	MountDirectories(appSupportPath);
 }
 
 static inline int GetIntValue( CFTypeRef r )


### PR DESCRIPTION
Resolves #1055. macOS now matches Unix and Windows single-folder behavior, same as `.itgmania` on Linux or `%APPDATA%/ITGmania` on Windows. Thus, all files would now be kept in `~/Library/Application Support/ITGmania` for parity with other ITGmania's behavior on other OS's.

```
$ ls -lha ~/Library/Application\ Support/ITGmania/
total 16
drwxr-xr-x  20 itg  staff   640B Nov  5 22:22 .
drwx------+ 60 itg  staff   1.9K Nov  5 22:05 ..
-rw-r--r--@  1 itg  staff   6.0K Nov  5 22:23 .DS_Store
drwxr-xr-x   2 itg  staff    64B Nov  5 22:22 Announcers
drwxr-xr-x   2 itg  staff    64B Nov  5 22:22 BackgroundEffects
drwxr-xr-x   2 itg  staff    64B Nov  5 22:22 BackgroundTransitions
drwxr-xr-x   2 itg  staff    64B Nov  5 22:22 BGAnimations
drwxr-xr-x   7 itg  staff   224B Nov  5 23:52 Cache
drwxr-xr-x   2 itg  staff    64B Nov  5 22:22 CDTitles
drwxr-xr-x   2 itg  staff    64B Nov  5 22:22 Characters
drwxr-xr-x   2 itg  staff    64B Nov  5 22:22 Courses
drwxr-xr-x   2 itg  staff    64B Nov  5 22:22 Downloads
drwxr-xr-x   5 itg  staff   160B Nov  5 22:22 Logs
drwxr-xr-x   2 itg  staff    64B Nov  5 22:22 NoteSkins
drwxr-xr-x   2 itg  staff    64B Nov  5 22:22 Packages
drwxr-xr-x   2 itg  staff    64B Nov  5 22:22 RandomMovies
drwxr-xr-x   8 itg  staff   256B Nov  5 23:52 Save
drwxr-xr-x   2 itg  staff    64B Nov  5 22:22 Screenshots
drwxr-xr-x   3 itg  staff    96B Nov  5 22:55 Songs
drwxr-xr-x   3 itg  staff    96B Nov  5 22:23 Themes
```