### PR TITLE
Consolidate directory mounting logic in ArchHooks.cpp

### DIFF
--- a/src/arch/ArchHooks/ArchHooks.cpp
+++ b/src/arch/ArchHooks/ArchHooks.cpp
@@ -4,12 +4,33 @@
 #include "RageLog.h"
 #include "RageThreads.h"
 #include "arch/arch_default.h"
+#include "RageFileManager.h"
 
 bool ArchHooks::g_bQuitting = false;
 bool ArchHooks::g_bToggleWindowed = false;
 // Keep from pulling RageThreads.h into ArchHooks.h
 static RageMutex g_Mutex( "ArchHooks" );
 ArchHooks *HOOKS = nullptr; // global and accessible from anywhere in our program
+
+const std::vector<RString> ArchHooks::g_DirectoryStructureITGM = {
+	"/Announcers",
+	"/BGAnimations",
+	"/BackgroundEffects",
+	"/BackgroundTransitions",
+	"/Cache",
+	"/CDTitles",
+	"/Characters",
+	"/Courses",
+	"/Downloads",
+	"/Logs",
+	"/NoteSkins",
+	"/Packages",
+	"/Save",
+	"/Screenshots",
+	"/Songs",
+	"/RandomMovies",
+	"/Themes"
+};
 
 ArchHooks::ArchHooks(): m_bHasFocus(true), m_bFocusChanged(false)
 {
@@ -60,6 +81,12 @@ RString ArchHooks::GetClipboard()
 {
 	LOG->Warn("ArchHooks: GetClipboard() NOT IMPLEMENTED");
 	return "";
+}
+
+void ArchHooks::MountDirectories(const RString& baseDir) {
+	for (const RString& dir : g_DirectoryStructureITGM) {
+		FILEMAN->Mount("dir", baseDir + dir, dir);
+	}
 }
 
 /* XXX: Most singletons register with lua in their constructor.  ArchHooks is

--- a/src/arch/ArchHooks/ArchHooks.h
+++ b/src/arch/ArchHooks/ArchHooks.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <ctime>
+#include <vector>
 
 struct lua_State;
 class ArchHooks
@@ -98,6 +99,10 @@ public:
 	 * Add file search paths for user-writable directories.
 	 */
 	static void MountUserFilesystems( const RString &sDirOfExecutable );
+
+	static void MountDirectories(const RString& baseDir);
+
+	static const std::vector<RString> g_DirectoryStructureITGM;
 
 	/*
 	 * Platform-specific code calls this to indicate focus changes.

--- a/src/arch/ArchHooks/ArchHooks_MacOSX.mm
+++ b/src/arch/ArchHooks/ArchHooks_MacOSX.mm
@@ -267,32 +267,6 @@ int64_t ArchHooks::GetSystemTimeInMicroseconds()
 
 #include "RageFileManager.h"
 
-void MountDirectories(const RString& baseDir) {
-	const std::vector<RString> macDirectoryStructureITGm = {
-		"/Announcers",
-		"/BGAnimations",
-		"/BackgroundEffects",
-		"/BackgroundTransitions",
-		"/Cache",
-		"/CDTitles",
-		"/Characters",
-		"/Courses",
-		"/Downloads",
-		"/Logs",
-		"/NoteSkins",
-		"/Packages",
-		"/Save",
-		"/Screenshots",
-		"/Songs",
-		"/RandomMovies",
-		"/Themes"
-	};
-
-	for (const RString& dir : macDirectoryStructureITGm) {
-		FILEMAN->Mount("dir", baseDir + dir, dir);
-	}
-}
-
 void ArchHooks::MountInitialFilesystems( const RString &sDirOfExecutable )
 {
 	FILEMAN->Mount("dirro", sDirOfExecutable, "/");
@@ -334,7 +308,7 @@ void ArchHooks::MountInitialFilesystems( const RString &sDirOfExecutable )
 
 	if (portable)
 	{
-		MountDirectories(sDirOfExecutable);
+		ArchHooks::MountDirectories(sDirOfExecutable);
 	}
 }
 
@@ -353,7 +327,7 @@ void ArchHooks::MountUserFilesystems( const RString &sDirOfExecutable )
 	std::string appSupportDir = PathForDirectory(NSApplicationSupportDirectory);
 	RString appSupportPath = ssprintf("%s/" PRODUCT_ID, appSupportDir.c_str());
 
-	MountDirectories(appSupportPath);
+	ArchHooks::MountDirectories(appSupportPath);
 }
 
 static inline int GetIntValue( CFTypeRef r )

--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -358,23 +358,7 @@ void ArchHooks::MountInitialFilesystems( const RString &sDirOfExecutable )
 	bool portable = DoesFileExist("/Portable.ini");
 	if (portable)
 	{
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Announcers", "/Announcers");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/BGAnimations", "/BGAnimations");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/BackgroundEffects", "/BackgroundEffects");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/BackgroundTransitions", "/BackgroundTransitions");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Cache", "/Cache");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/CDTitles", "/CDTitles");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Characters", "/Characters");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Courses", "/Courses");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Downloads", "/Downloads");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Logs", "/Logs");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/NoteSkins", "/NoteSkins");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Packages", "/Packages");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Save", "/Save");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Screenshots", "/Screenshots");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Songs", "/Songs");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/RandomMovies", "/RandomMovies");
-		FILEMAN->Mount("dir", sDirOfExecutable + "/Themes", "/Themes");
+		ArchHooks::MountDirectories(sDirOfExecutable);
 	}
 }
 
@@ -385,23 +369,7 @@ void ArchHooks::MountUserFilesystems( const RString &sDirOfExecutable )
 	 */
 	const char *szHome = getenv( "HOME" );
 	RString sUserDataPath = ssprintf( "%s/.%s", szHome? szHome:".", "itgmania" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Announcers", "/Announcers" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/BGAnimations", "/BGAnimations" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/BackgroundEffects", "/BackgroundEffects" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/BackgroundTransitions", "/BackgroundTransitions" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Cache", "/Cache" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/CDTitles", "/CDTitles" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Characters", "/Characters" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Courses", "/Courses" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Downloads", "/Downloads" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Logs", "/Logs" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/NoteSkins", "/NoteSkins" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Packages", "/Packages" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Save", "/Save" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Screenshots", "/Screenshots" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Songs", "/Songs" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/RandomMovies", "/RandomMovies" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Themes", "/Themes" );
+	ArchHooks::MountDirectories(sUserDataPath);
 }
 
 /*

--- a/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
@@ -61,44 +61,18 @@ static RString GetMountDir( const RString &sDirOfExecutable )
 	return sDir;
 }
 
-void MountDirectories(const RString& baseDir) {
-	const std::vector<RString> winDirectoryStructureITGm = {
-		"/Announcers",
-		"/BGAnimations",
-		"/BackgroundEffects",
-		"/BackgroundTransitions",
-		"/Cache",
-		"/CDTitles",
-		"/Characters",
-		"/Courses",
-		"/Downloads",
-		"/Logs",
-		"/NoteSkins",
-		"/Packages",
-		"/Save",
-		"/Screenshots",
-		"/Songs",
-		"/RandomMovies",
-		"/Themes"
-	};
-
-	for (const RString& dir : winDirectoryStructureITGm) {
-		FILEMAN->Mount("dir", baseDir + dir, dir);
-	}
-}
-
 void ArchHooks::MountInitialFilesystems(const RString& sDirOfExecutable) {
 	RString sDir = GetMountDir(sDirOfExecutable);
 	FILEMAN->Mount("dirro", sDir, "/");
 
 	if (DoesFileExist("/Portable.ini")) {
-		MountDirectories(sDir);
+		ArchHooks::MountDirectories(sDir);
 	}
 }
 
 void ArchHooks::MountUserFilesystems(const RString& sDirOfExecutable) {
 	RString sAppDataDir = SpecialDirs::GetAppDataDir() + PRODUCT_ID;
-	MountDirectories(sAppDataDir);
+	ArchHooks::MountDirectories(sAppDataDir);
 }
 
 static RString LangIdToString( LANGID l )


### PR DESCRIPTION
Moved directory mounting logic into ArchHooks base class to consolidate platform-specific duplicates, now that all platforms share an identical directory structure.