### PR TITLE
macOS: Fix a bug which causes Vsync to always be enabled

### DIFF
--- a/src/arch/LowLevelWindow/LowLevelWindow_MacOSX.mm
+++ b/src/arch/LowLevelWindow/LowLevelWindow_MacOSX.mm
@@ -393,7 +393,13 @@ RString LowLevelWindow_MacOSX::TryVideoMode( const VideoModeParams& p, bool& new
         [m_Context makeCurrentContext];
 		m_CurrentParams.windowed = true;
 		SetActualParamsFromMode( CGDisplayCurrentMode(kCGDirectMainDisplay) );
-		m_CurrentParams.vsync = p.vsync; // hack
+		
+		if( bChangeVsync )
+		{
+			GLint swap = p.vsync ? 1 : 0;
+			CGLSetParameter([m_Context CGLContextObj], kCGLCPSwapInterval, &swap);
+			m_CurrentParams.vsync = p.vsync;
+		}
 
 		return RString();
 	}
@@ -436,7 +442,7 @@ RString LowLevelWindow_MacOSX::TryVideoMode( const VideoModeParams& p, bool& new
 	if( bChangeVsync )
 	{
 		GLint swap = p.vsync ? 1 : 0;
-		[m_Context setValues:&swap forParameter:NSOpenGLCPSwapInterval];
+		CGLSetParameter([m_Context CGLContextObj], kCGLCPSwapInterval, &swap);
 		m_CurrentParams.vsync = p.vsync;
 	}
 


### PR DESCRIPTION
In macOS, there is logic for windowed mode as well as fullscreen mode, but the fullscreen mode logic is never executing, it seems like the logic for the windowed mode always executes, even when you go full screen.

There is a bug in the macOS video mode setting logic for Windowed mode which returns early, resulting in Vsync always being applied.  It's labeled "hack" with no further explanation.

The hack was committed over 15 years ago - safe to say this is a fix for something in some old version of Mac OS X. This hack is also the reason vsync is permanently enabled. I have removed it and added the normal vsync handling logic.

With this change, I can achieve ~600 FPS in menus and ~800 FPS in game with Vsync disabled on a 8GB Mac Mini M1 at 1080p, whereas I was previously unable to achieve higher than 120 FPS.

<img width="1392" height="860" alt="Screenshot 2025-11-06 at 4 37 02 AM" src="https://github.com/user-attachments/assets/34a2ee38-3392-4537-a7f8-2fa7db27a0a9" />
