### PR TITLE
macOS AudioUnit/JACK drivers: Apply volume limiting to prevent clipping

### DIFF
--- a/src/RageSoundMixBuffer.cpp
+++ b/src/RageSoundMixBuffer.cpp
@@ -61,7 +61,9 @@ void RageSoundMixBuffer::read( int16_t *pBuf )
 
 void RageSoundMixBuffer::read( float *pBuf )
 {
-	std::copy(m_pMixbuf.begin(), m_pMixbuf.end(), pBuf);
+	// ensure volume is within expected levels to prevent clipping
+	std::transform(m_pMixbuf.begin(), m_pMixbuf.end(), pBuf,
+		[](float s) { return std::clamp(s, -1.0f, +1.0f); });
 	m_pMixbuf.clear();
 }
 


### PR DESCRIPTION
Clamping that was applied to the int16_t mix buffer read function also needed to be applied to the float mix buffer read function, which is used by macOS AudioUnit and JACK audio drivers. This was resulting in audio clipping which was only perceptible when using either of these drivers.