### PR TITLE
MovieTexture_FFMpeg: replace `usleep` with `std::this_thread::sleep_for`

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -341,7 +341,7 @@ int MovieDecoder_FFMpeg::DecodePacketToFrame() {
 	if (packet_buffer_.size() > frame_buffer_.size()) {
 		while (!frame->displayed) {
 			// Sleep so the CPU performance stays happy.
-			usleep(1000);  // 1ms
+			std::this_thread::sleep_for(std::chrono::milliseconds(1));
 			if (cancel_) {
 				return -2;
 			}


### PR DESCRIPTION
Updated sleep implementation in MovieDecoder_FFMpeg::DecodePacketToFrame to use std::this_thread::sleep_for for better portability and C++11 compliance. Cleaning out usleep calls to improve the arm64 experience.