### PR TITLE
Fix KeySounds causing crashes - Reapply old commit

### DIFF
--- a/src/AutoKeysounds.cpp
+++ b/src/AutoKeysounds.cpp
@@ -237,18 +237,6 @@ void AutoKeysounds::LoadTracks( const Song *pSong, RageSoundReader *&pShared, Ra
 
 void AutoKeysounds::FinishLoading()
 {
-	// Doesn't attempt to load any keysounds.
-	m_sSound.Unload();
-	Song* pSong = GAMESTATE->m_pCurSong;
-	LoadTracks( pSong, m_pSharedSound, m_pPlayerSounds[0], m_pPlayerSounds[1] );
-	ASSERT_M( m_pSharedSound != nullptr, ssprintf("No sound was loaded for the song %s!", pSong->m_sMainTitle.c_str() ));
-	m_pSharedSound = new RageSoundReader_PitchChange( m_pSharedSound );
-	m_pSharedSound = new RageSoundReader_PostBuffering( m_pSharedSound );
-	m_pSharedSound = new RageSoundReader_Pan( m_pSharedSound );
-	m_pChain = m_pSharedSound;
-	m_sSound.LoadSoundReader( m_pChain );
-
-#if 0 // Below is the old keysound loading code, which is currently broken.
 	m_sSound.Unload();
 
 	Song* pSong = GAMESTATE->m_pCurSong;
@@ -321,7 +309,6 @@ void AutoKeysounds::FinishLoading()
 	}
 
 	m_sSound.LoadSoundReader( m_pChain );
-#endif
 }
 
 void AutoKeysounds::Update( float fDelta )

--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -186,7 +186,7 @@ void RageSoundReader_Chain::Finish()
 	m_iActualSampleRate = GetSampleRateInternal();
 	if( m_iActualSampleRate == -1 )
 	{
-		for (auto &pSound : m_apLoadedSounds)
+		for (RageSoundReader*& pSound : m_apLoadedSounds)
 		{
 			RageSoundReader_Resample_Good *pResample = new RageSoundReader_Resample_Good( pSound, m_iPreferredSampleRate );
 			pSound = pResample;
@@ -196,10 +196,11 @@ void RageSoundReader_Chain::Finish()
 	}
 
 	/* Attempt to preload all sounds. */
-	for (auto &pSound : m_apLoadedSounds)
+	for (RageSoundReader*& pSound : m_apLoadedSounds)
 	{
 		RageSoundReader_Preload::PreloadSound( pSound );
 	}
+
 
 	/* Sort the sounds by start time. */
 	sort( m_aSounds.begin(), m_aSounds.end() );

--- a/src/RageSoundReader_Chain.cpp
+++ b/src/RageSoundReader_Chain.cpp
@@ -186,19 +186,19 @@ void RageSoundReader_Chain::Finish()
 	m_iActualSampleRate = GetSampleRateInternal();
 	if( m_iActualSampleRate == -1 )
 	{
-		for (RageSoundReader *it : m_apLoadedSounds)
+		for (auto &pSound : m_apLoadedSounds)
 		{
-			RageSoundReader_Resample_Good *pResample = new RageSoundReader_Resample_Good( it, m_iPreferredSampleRate );
-			it = pResample;
+			RageSoundReader_Resample_Good *pResample = new RageSoundReader_Resample_Good( pSound, m_iPreferredSampleRate );
+			pSound = pResample;
 		}
 
 		m_iActualSampleRate = m_iPreferredSampleRate;
 	}
 
 	/* Attempt to preload all sounds. */
-	for (RageSoundReader *it : m_apLoadedSounds)
+	for (auto &pSound : m_apLoadedSounds)
 	{
-		RageSoundReader_Preload::PreloadSound( it );
+		RageSoundReader_Preload::PreloadSound( pSound );
 	}
 
 	/* Sort the sounds by start time. */


### PR DESCRIPTION
So I've been digging through commits for the last few hours trying to figure out where keysounds broke. A million builds later, I sorta gave up on trying to determine when it happened and tried to figure out what the actual bug was. Was digging into all the changes to files that involved keysounds and was preparing to load up a million print statements to start the long debugging process. Then out of the corner of my eye while scrolling through git history i saw "fix keysounds" lmao:

<img width="773" height="592" alt="image" src="https://github.com/user-attachments/assets/c501b148-e003-4dc9-af0a-0c1d3b6ca875" />
This is the actual PR https://github.com/stepmania/stepmania/pull/979

Checked to see if our code differed at all and looks like we would have the same issue that commit aimed to fix. The commit itself was not very informative nor was the PR lol so I'm not entirely sure what the origins and true cause are here. But I just know applying this change does in fact fix KeySounds. Seems like something that got broken, fixed, and unfixed. 

Maybe someone can shed some more light on what's happening here. Going to @sukibaby since we were chatting about keysounds earlier. 