### PR TITLE
Linux: Add joystick exception for Cobalt Flux adapter 

### DIFF
--- a/src/arch/InputHandler/InputHandler_Linux_Event.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Event.cpp
@@ -134,16 +134,32 @@ bool EventDevice::Open( RString sFile, InputDevice dev )
 	if( ioctl(m_iFD, EVIOCGBIT(EV_ABS, sizeof(iABSMask)), iABSMask) < 0 )
 		LOG->Warn( "ioctl(EVIOCGBIT(EV_ABS)): %s", strerror(errno) );
 
+	// If more exceptions need to be added, please add them here.
+	// The code below will check the device name against this list
+	// and apply an exception if a match is found.
+	static const char* kJoystickExceptions[] = {
+		"RedOctane USB Pad",
+		"Cobalt Flux Controller"
+	};
+
 	if( !BitIsSet(iABSMask, ABS_X) && !BitIsSet(iABSMask, ABS_THROTTLE) && !BitIsSet(iABSMask, ABS_WHEEL) )
 	{
 		LOG->Info( "    Not a joystick; ignoring [%s]",m_sName.c_str() );
-		if(m_sName.compare("RedOctane USB Pad") == 0)
+		bool bIsException = false;
+		for( const char* sException : kJoystickExceptions )
 		{
-			LOG->Info("RedOctane USB Pad detected, making an exception.");
-		} else if(m_sName.compare("Cobalt Flux Controller") == 0) 
-		{ 
-			LOG->Info("Cobalt Flux Controller detected, making an exception.");
-		} else {
+			if( m_sName == sException )
+			{
+				bIsException = true;
+				break;
+			}
+		}
+		if( bIsException )
+		{
+			LOG->Info( "%s detected, making an exception.", m_sName.c_str() );
+		}
+		else
+		{
 			Close();
 			return false;
 		}

--- a/src/arch/InputHandler/InputHandler_Linux_Event.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Event.cpp
@@ -140,6 +140,9 @@ bool EventDevice::Open( RString sFile, InputDevice dev )
 		if(m_sName.compare("RedOctane USB Pad") == 0)
 		{
 			LOG->Info("RedOctane USB Pad detected, making an exception.");
+		} else if(m_sName.compare("Cobalt Flux Controller") == 0) 
+		{ 
+			LOG->Info("Cobalt Flux Controller detected, making an exception.");
 		} else {
 			Close();
 			return false;


### PR DESCRIPTION
Resolves #1071 

This PR is based on the suggested fix shared in that issue to allow the official Cobalt Flux USB control box to be used with ITGmania on Linux. The creator of the issue who proposed the fix has been credited in 3c1f5e769cb7a0be7d227073678888f128c87a05

The suggested fix (which was originally proposed in 2020 to the StepMania repository) appears identical.

I have slightly refactored the relevant function to replace the hardcoded if-else logic to instead check a list of exceptions, so the code is a bit cleaner and more easily maintainable.