### PR TITLE
Ignore auto-keysound notes when creating Rows for calculating foot placements

### DIFF
--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -463,7 +463,7 @@ void StepParityGenerator::CreateRows(const NoteData &in)
 
 	for (IntermediateNoteData note : noteData)
 	{
-		if (note.type == TapNoteType_Empty)
+		if (note.type == TapNoteType_Empty || note.type == TapNoteType_AutoKeysound)
 		{
 			continue;
 		}


### PR DESCRIPTION
This is a super small change to fix an issue that was found after keysounds were fixed, where notes of type `TapNoteType_AutoKeysound` would get counted towards bracket counts. Auto-keysound data isn't needed for tech counts, so the easiest solution here is to just ignore those notes at the very beginning of the process, so that we don't have to check against them in a bunch of places.

The reason why they would get counted towards bracket counts is because `Row.noteCount` gets incremented for any note that isn't of type `TapNoteType_Empty` in [Row::setFootPlacement](https://github.com/itgmania/itgmania/blob/159391b8a244cffdde9366b97e6a2d03f9cfb6b8/src/StepParityDatastructs.cpp#L111).