### PR TITLE
Increase FFmpeg buffer size to 32kb (merged in with #1084 for now)

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -22,7 +22,7 @@ namespace avcodec
 	}
 };
 
-constexpr size_t kFFMpegBufferSize = 4096;
+constexpr size_t kFFMpegBufferSize = 32768;
 constexpr int kSwsFlags = SWS_BICUBIC; // XXX: Reasonable default?
 
 struct FrameHolder {


### PR DESCRIPTION
Currently the legacy value of 4kb hurts more than it helps. 32kb is safe, more likely to work smoothly, and tested to work well.