### PR TITLE
FFmpeg: Optimizing conversion to RGB pixel format

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -654,14 +654,9 @@ RString MovieDecoder_FFMpeg::Open(RString file)
 
 	// Additional safeguard: if video is shorter than buffer, shrink to match.
 	if (total_frames_ < frame_buffer_.size()) {
-		LOG->Trace("Video shorter than frame buffer (%zu frames vs %zu slots), shrinking the buffer.",
-			total_frames_, frame_buffer_.size());
 		frame_buffer_.resize(total_frames_);
 	}
-	LOG->Trace("Frame buffer finalized: %zu slots for %dx%d video at %.1f MB per frame, ~%.1f MB total.",
-		frame_buffer_.size(), av_stream_codec_->width, av_stream_codec_->height,
-		(av_stream_codec_->width * av_stream_codec_->height * kBytesPerPixelBGRA) / (1024.0 * 1024.0),
-		(frame_buffer_.size() * av_stream_codec_->width * av_stream_codec_->height * kBytesPerPixelBGRA) / (1024.0 * 1024.0));
+
 	LOG->Trace("Number of frames detected: %zu", total_frames_);
 
 	return RString();

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -205,7 +205,7 @@ bool MovieDecoder_FFMpeg::IsCurrentFrameReady() {
 		return false;
 	}
 
-	FrameHolder* frame = frame_buffer_[(display_frame_num_ + offset_) % frame_buffer_.size()].get();
+	FrameHolder* frame = frame_buffer_[GetFrameBufferIndex(display_frame_num_)].get();
 	// To make sure the frame doesn't change from under us.
 	std::lock_guard<std::mutex> lock(frame->lock);
 
@@ -495,7 +495,7 @@ int MovieDecoder_FFMpeg::BlitFrameToSurface(FrameHolder* frame, RageSurface* sur
 
 int MovieDecoder_FFMpeg::GetFrame(RageSurface* surface_out)
 {
-	const std::size_t display_frame_in_buffer = (display_frame_num_ + offset_) % frame_buffer_.size();
+	const size_t display_frame_in_buffer = GetFrameBufferIndex(display_frame_num_);
 	std::lock_guard<std::mutex> lock(frame_buffer_[display_frame_in_buffer]->lock);
 
 	int scale_status = BlitFrameToSurface(frame_buffer_[display_frame_in_buffer].get(), surface_out);

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -640,13 +640,18 @@ RString MovieDecoder_FFMpeg::Open(RString file)
 
 	// Resize frame buffer based on video resolution and target memory budget.
 	size_t optimal_buffer_size = CalculateFrameBufferSize(av_stream_codec_->width, av_stream_codec_->height);
-	if (optimal_buffer_size < frame_buffer_.size()) {
+	if (optimal_buffer_size < frame_buffer_.size())
+	{
 		frame_buffer_.resize(optimal_buffer_size);
-	} else if (optimal_buffer_size > frame_buffer_.size()) {
-		while (frame_buffer_.size() < optimal_buffer_size) {
+	}
+	else if (optimal_buffer_size > frame_buffer_.size())
+	{
+		while (frame_buffer_.size() < optimal_buffer_size)
+		{
 			frame_buffer_.emplace_back(std::make_unique<FrameHolder>());
 		}
 	}
+
 	// Additional safeguard: if video is shorter than buffer, shrink to match.
 	if (total_frames_ < frame_buffer_.size()) {
 		LOG->Trace("Video shorter than frame buffer (%zu frames vs %zu slots), shrinking the buffer.",

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -118,11 +118,12 @@ MovieDecoder_FFMpeg::MovieDecoder_FFMpeg()
 
 	av_format_context_ = nullptr;
 	av_stream_ = nullptr;
-	av_pixel_format_ = avcodec::AV_PIX_FMT_BGRA; // Default RGB target; may be overwritten by surface setup.
+	av_pixel_format_ = avcodec::AV_PIX_FMT_BGRA; // Always default to RGB, even though this can be overwritten
 	total_frames_ = 0;
 	end_of_file_ = 0;
-	// Frame buffer size will be calculated dynamically when the video is opened.
-	// For now, initialize with minimum slots to avoid null dereferences.
+
+	// We calculate the actual needed buffer size when opening the file,
+	// so it's safe to start with the minimum number of slots for now. 
 	for (size_t i = 0; i < kFrameBufferMinSlots; i++) {
 		frame_buffer_.emplace_back(std::make_unique<FrameHolder>());
 	}

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -118,6 +118,7 @@ MovieDecoder_FFMpeg::MovieDecoder_FFMpeg()
 
 	av_format_context_ = nullptr;
 	av_stream_ = nullptr;
+	av_pixel_format_ = avcodec::AV_PIX_FMT_BGRA; // Default RGB target; may be overwritten by surface setup.
 	total_frames_ = 0;
 	end_of_file_ = 0;
 	// Hardcoded frame buffer size of 50. Roughly translates to 100mb of ram.
@@ -132,6 +133,9 @@ MovieDecoder_FFMpeg::~MovieDecoder_FFMpeg()
 	{
 		avcodec::sws_freeContext(av_sws_context_);
 		av_sws_context_ = nullptr;
+	}
+	if (rgb_frame_ != nullptr) {
+		avcodec::av_frame_free(&rgb_frame_);
 	}
 	if (av_io_context_ != nullptr)
 	{
@@ -161,6 +165,10 @@ void MovieDecoder_FFMpeg::Init()
 		avcodec::sws_freeContext(av_sws_context_);
 	}
 	av_sws_context_ = nullptr;
+	if (rgb_frame_ != nullptr) {
+		avcodec::av_frame_free(&rgb_frame_);
+	}
+	rgb_frame_ = nullptr;
 	sws_width_ = 0;
 	sws_height_ = 0;
 	av_io_context_ = nullptr;
@@ -464,9 +472,12 @@ bool MovieDecoder_FFMpeg::EnsureSwsContext()
 
 int MovieDecoder_FFMpeg::BlitFrameToSurface(FrameHolder* frame, RageSurface* surface_out)
 {
-	avcodec::AVFrame pict;
-	pict.data[0] = (unsigned char*)surface_out->pixels;
-	pict.linesize[0] = surface_out->pitch;
+	if (rgb_frame_ == nullptr) {
+		rgb_frame_ = avcodec::av_frame_alloc();
+	}
+
+	rgb_frame_->data[0] = static_cast<unsigned char*>(surface_out->pixels);
+	rgb_frame_->linesize[0] = surface_out->pitch;
 
 	if (!EnsureSwsContext()) {
 		return -1;

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -361,7 +361,7 @@ bool MovieDecoder_FFMpeg::PrepareFrameSlot(FrameHolder* frame) {
 void MovieDecoder_FFMpeg::UpdateFrameTiming(PacketHolder* packet, FrameHolder* frame) {
 	if (frame->frame->pkt_dts != AV_NOPTS_VALUE)
 	{
-		packet->frame_timestamp = (float)(frame->frame->pkt_dts * av_q2d(av_stream_->time_base));
+		packet->frame_timestamp = static_cast<float>(frame->frame->pkt_dts * av_q2d(av_stream_->time_base));
 	}
 	else
 	{
@@ -377,7 +377,7 @@ void MovieDecoder_FFMpeg::UpdateFrameTiming(PacketHolder* packet, FrameHolder* f
 		timestamp_offset_ = packet->frame_timestamp;
 	}
 
-	packet->frame_delay = (float)av_q2d(av_stream_->time_base);
+	packet->frame_delay = static_cast<float>(av_q2d(av_stream_->time_base));
 	packet->frame_delay += frame->frame->repeat_pict * (packet->frame_delay * 0.5f);
 }
 

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -661,6 +661,26 @@ void MovieDecoder_FFMpeg::Rollover()
 	next_offset_ = 0;
 }
 
+size_t MovieDecoder_FFMpeg::CalculateFrameBufferSize(int width, int height)
+{
+	if (width <= 0 || height <= 0) {
+		return kFrameBufferMinSlots;
+	}
+
+	size_t frame_size_bytes = static_cast<size_t>(width) * static_cast<size_t>(height) * kBytesPerPixelBGRA;
+
+	size_t optimal_slots = kFrameBufferTargetMemory / frame_size_bytes;
+
+	return std::max(optimal_slots, kFrameBufferMinSlots);
+}
+
+size_t MovieDecoder_FFMpeg::GetFrameBufferIndex(size_t logical_frame_num) const
+{
+	// Apply the offset (used for looping) and wrap around the buffer size
+	ASSERT(frame_buffer_.size() > 0);
+	return (logical_frame_num + offset_) % frame_buffer_.size();
+}
+
 RageSurface* MovieDecoder_FFMpeg::CreateCompatibleSurface(int iTextureWidth, int iTextureHeight, bool bPreferHighColor, MovieDecoderPixelFormatYCbCr& fmtout)
 {
 	return RageMovieTextureDriver_FFMpeg::AVCodecCreateCompatibleSurface(iTextureWidth, iTextureHeight, bPreferHighColor, *ConvertValue<int>(&av_pixel_format_), fmtout);

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -261,7 +261,7 @@ int MovieDecoder_FFMpeg::DecodeFrame()
 		return status;
 	}
 
-	status = DecodePacketToFrame();
+	status = ProcessFrameFromPacket();
 	frame_buffer_position_ = (frame_buffer_position_ + 1) % frame_buffer_.size();
 	packet_buffer_position_ = (packet_buffer_position_ + 1) % total_frames_;
 	return status;
@@ -388,7 +388,7 @@ void MovieDecoder_FFMpeg::UpdateFrameTiming(PacketHolder* packet, FrameHolder* f
 	packet->frame_delay += frame->frame->repeat_pict * (packet->frame_delay * 0.5f);
 }
 
-int MovieDecoder_FFMpeg::DecodePacketIntoFrame(PacketHolder* packet, FrameHolder* frame) {
+int MovieDecoder_FFMpeg::DecodePacketToFrame(PacketHolder* packet, FrameHolder* frame) {
 	std::lock_guard<std::mutex> frame_lock(frame->lock);
 	std::lock_guard<std::mutex> packet_lock(packet->lock);
 
@@ -448,7 +448,7 @@ int MovieDecoder_FFMpeg::DecodePacketIntoFrame(PacketHolder* packet, FrameHolder
 	return 0; /* packet done */
 }
 
-int MovieDecoder_FFMpeg::DecodePacketToFrame() {
+int MovieDecoder_FFMpeg::ProcessFrameFromPacket() {
 	if (cancel_) {
 		return -2;
 	}
@@ -462,7 +462,7 @@ int MovieDecoder_FFMpeg::DecodePacketToFrame() {
 		return cancel_ ? -2 : 0;
 	}
 
-	return DecodePacketIntoFrame(packet, frame);
+	return DecodePacketToFrame(packet, frame);
 }
 
 bool MovieDecoder_FFMpeg::EnsureSwsContext()

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -326,36 +326,51 @@ int MovieDecoder_FFMpeg::SendPacketToBuffer()
 	}
 }
 
-int MovieDecoder_FFMpeg::DecodePacketToFrame() {
-	if (cancel_) {
-		return -2;
+bool MovieDecoder_FFMpeg::PrepareFrameSlot(FrameHolder* frame) {
+	if (packet_buffer_.size() <= frame_buffer_.size()) {
+		return true;
 	}
 
-	frame_buffer_position_ %= frame_buffer_.size();
-	packet_buffer_position_ %= total_frames_;
-	FrameHolder* frame = frame_buffer_[frame_buffer_position_].get();
-	PacketHolder* packet = packet_buffer_[packet_buffer_position_].get();
-
-	// Packet buffer is bigger than the frame buffer, don't overwrite frames that
-	// haven't been displayed.
-	if (packet_buffer_.size() > frame_buffer_.size()) {
-		while (!frame->displayed) {
-			// Sleep so the CPU performance stays happy.
-			std::this_thread::sleep_for(std::chrono::milliseconds(1));
-			if (cancel_) {
-				return -2;
-			}
-			if (reset_) {
-				return 0;
-			}
+	while (!frame->displayed) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		if (cancel_) {
+			return false;
+		}
+		if (reset_) {
+			return false;
 		}
 	}
 
+	return true;
+}
+
+void MovieDecoder_FFMpeg::UpdateFrameTiming(PacketHolder* packet, FrameHolder* frame) {
+	if (frame->frame->pkt_dts != AV_NOPTS_VALUE)
+	{
+		packet->frame_timestamp = (float)(frame->frame->pkt_dts * av_q2d(av_stream_->time_base));
+	}
+	else
+	{
+		if (packet_buffer_position_ != 0) {
+			packet->frame_timestamp += packet_buffer_[packet_buffer_.size() - 2]->frame_delay;
+		}
+		else {
+			packet->frame_timestamp = 0;
+		}
+	}
+
+	if (packet_buffer_position_ == 0 && packet->frame_timestamp != 0) {
+		timestamp_offset_ = packet->frame_timestamp;
+	}
+
+	packet->frame_delay = (float)av_q2d(av_stream_->time_base);
+	packet->frame_delay += frame->frame->repeat_pict * (packet->frame_delay * 0.5f);
+}
+
+int MovieDecoder_FFMpeg::DecodePacketIntoFrame(PacketHolder* packet, FrameHolder* frame) {
 	std::lock_guard<std::mutex> frame_lock(frame->lock);
 	std::lock_guard<std::mutex> packet_lock(packet->lock);
 
-	// If the movie is looping naturally, next_offset_ is decided where
-	// packet_buffer_position_ zero is decoded.
 	if (packet->decoded && packet_buffer_position_ == 0) {
 		next_offset_ = frame_buffer_position_;
 	}
@@ -363,18 +378,12 @@ int MovieDecoder_FFMpeg::DecodePacketToFrame() {
 	int packet_offset = 0;
 	while (packet_offset <= packet->packet->size)
 	{
-		/* If we have no data on the first frame, just return EOF; passing an empty packet
-		 * to avcodec_decode_video in this case is crashing it.  However, passing an empty
-		 * packet is normal with B-frames, to flush.  This may be unnecessary in newer
-		 * versions of avcodec, but I'm waiting until a new stable release to upgrade. */
 		if (packet->packet->size == 0 && packet_buffer_position_ == 0) {
 			return 0; /* eof */
 		}
 
-		/* Hack: we need to send size = 0 to flush frames at the end, but we have
-		 * to give it a buffer to read from since it tries to read anyway. */
 		packet->packet->data = packet->packet->size ? packet->packet->data : nullptr;
-		int len = packet->packet->size;
+		const int len = packet->packet->size;
 		avcodec::avcodec_send_packet(av_stream_codec_, packet->packet);
 		int avcodec_return = avcodec::avcodec_receive_frame(av_stream_codec_, frame_buffer_[frame_buffer_position_]->frame);
 		frame->displayed = false;
@@ -395,37 +404,12 @@ int MovieDecoder_FFMpeg::DecodePacketToFrame() {
 				static_cast<int>(packet_buffer_.size() - 1),
 				avcodec_return);
 
-			// Not a fatal decoding error, and the FFMpeg code is robust enough to handle displaying
-			// somewhat mangled frames.
 			if (packet_offset <= packet->packet->size) {
 				continue;
 			}
 		}
 
-		if (frame->frame->pkt_dts != AV_NOPTS_VALUE)
-		{
-			packet->frame_timestamp = (float)(frame->frame->pkt_dts * av_q2d(av_stream_->time_base));
-		}
-		else
-		{
-			/* If the timestamp is zero, this frame is to be played at the
-			 * time of the last frame plus the length of the last frame. */
-			if (packet_buffer_position_ != 0) {
-				packet->frame_timestamp += packet_buffer_[packet_buffer_.size() - 2]->frame_delay;
-			}
-			else {
-				packet->frame_timestamp = 0;
-			}
-		}
-		// Some movies start at a non-zero point in time (audio before video?)
-		if (packet_buffer_position_ == 0 && packet->frame_timestamp != 0) {
-			timestamp_offset_ = packet->frame_timestamp;
-		}
-
-		// Length of this frame, only used as a fallback for getting the frame
-		// timestamp above.
-		packet->frame_delay = (float)av_q2d(av_stream_->time_base);
-		packet->frame_delay += frame_buffer_[frame_buffer_position_]->frame->repeat_pict * (packet->frame_delay * 0.5f);
+		UpdateFrameTiming(packet, frame);
 		packet->decoded = true;
 		return 1;
 	}
@@ -433,45 +417,68 @@ int MovieDecoder_FFMpeg::DecodePacketToFrame() {
 	return 0; /* packet done */
 }
 
-int MovieDecoder_FFMpeg::GetFrame(RageSurface* surface_out)
+int MovieDecoder_FFMpeg::DecodePacketToFrame() {
+	if (cancel_) {
+		return -2;
+	}
+
+	frame_buffer_position_ %= frame_buffer_.size();
+	packet_buffer_position_ %= total_frames_;
+	FrameHolder* frame = frame_buffer_[frame_buffer_position_].get();
+	PacketHolder* packet = packet_buffer_[packet_buffer_position_].get();
+
+	if (!PrepareFrameSlot(frame)) {
+		return cancel_ ? -2 : 0;
+	}
+
+	return DecodePacketIntoFrame(packet, frame);
+}
+
+bool MovieDecoder_FFMpeg::EnsureSwsContext()
+{
+	if (av_sws_context_ != nullptr) {
+		return true;
+	}
+
+	av_sws_context_ = avcodec::sws_getCachedContext(av_sws_context_,
+		GetWidth(), GetHeight(), av_stream_codec_->pix_fmt,
+		GetWidth(), GetHeight(), av_pixel_format_,
+		kSwsFlags, nullptr, nullptr, nullptr);
+	if (av_sws_context_ == nullptr)
+	{
+		LOG->Warn("Cannot initialize sws conversion context for (%d,%d) %d->%d", GetWidth(), GetHeight(), av_stream_codec_->pix_fmt, av_pixel_format_);
+		return false;
+	}
+
+	return true;
+}
+
+int MovieDecoder_FFMpeg::BlitFrameToSurface(FrameHolder* frame, RageSurface* surface_out)
 {
 	avcodec::AVFrame pict;
 	pict.data[0] = (unsigned char*)surface_out->pixels;
 	pict.linesize[0] = surface_out->pitch;
 
-	/* XXX 1: Do this in one of the Open() methods instead?
-	 * XXX 2: The problem of doing this in Open() is that m_AVTexfmt is not
-	 * already initialized with its correct value.
-	 */
-	if (av_sws_context_ == nullptr)
-	{
-		av_sws_context_ = avcodec::sws_getCachedContext(av_sws_context_,
-			GetWidth(), GetHeight(), av_stream_codec_->pix_fmt,
-			GetWidth(), GetHeight(), av_pixel_format_,
-			kSwsFlags, nullptr, nullptr, nullptr);
-		if (av_sws_context_ == nullptr)
-		{
-			LOG->Warn("Cannot initialize sws conversion context for (%d,%d) %d->%d", GetWidth(), GetHeight(), av_stream_codec_->pix_fmt, av_pixel_format_);
-			return -1;
-		}
+	if (!EnsureSwsContext()) {
+		return -1;
 	}
 
-	std::size_t display_frame_in_buffer = (display_frame_num_ + offset_) % frame_buffer_.size();
-	std::lock_guard<std::mutex> lock(frame_buffer_[display_frame_in_buffer]->lock);
-	int scale_status = 0;
-
-	// Sanity check.
-	if (frame_buffer_[display_frame_in_buffer]->packet_num == display_frame_num_) {
-		scale_status = avcodec::sws_scale(av_sws_context_,
-			frame_buffer_[display_frame_in_buffer]->frame->data, frame_buffer_[display_frame_in_buffer]->frame->linesize, 0, GetHeight(),
+	if (frame->packet_num == display_frame_num_) {
+		return avcodec::sws_scale(av_sws_context_,
+			frame->frame->data, frame->frame->linesize, 0, GetHeight(),
 			pict.data, pict.linesize);
 	}
-	else {
-		LOG->Warn("Unexpected frame trying to display! display_frame_num_ = %zu, packet_num = %zu", display_frame_num_, frame_buffer_[display_frame_in_buffer]->packet_num);
-	}
 
-	// Even if scale_status returns a failure, we mark displayed as true. The
-	// frame won't be displayed, but instead skipped over.
+	LOG->Warn("Unexpected frame trying to display! display_frame_num_ = %zu, packet_num = %zu", display_frame_num_, frame->packet_num);
+	return 0;
+}
+
+int MovieDecoder_FFMpeg::GetFrame(RageSurface* surface_out)
+{
+	const std::size_t display_frame_in_buffer = (display_frame_num_ + offset_) % frame_buffer_.size();
+	std::lock_guard<std::mutex> lock(frame_buffer_[display_frame_in_buffer]->lock);
+
+	int scale_status = BlitFrameToSurface(frame_buffer_[display_frame_in_buffer].get(), surface_out);
 	frame_buffer_[display_frame_in_buffer]->displayed = true;
 
 	if (LastFrame()) {

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -722,11 +722,10 @@ size_t MovieDecoder_FFMpeg::CalculateFrameBufferSize(int width, int height)
 		return kFrameBufferMinSlots;
 	}
 
-	size_t frame_size_bytes = static_cast<size_t>(width) * static_cast<size_t>(height) * kBytesPerPixelBGRA;
-
-	size_t optimal_slots = kFrameBufferTargetMemory / frame_size_bytes;
-
-	return std::max(optimal_slots, kFrameBufferMinSlots);
+	return std::max(
+	kFrameBufferTargetMemory /
+		(size_t(width) * size_t(height) * kBytesPerPixelBGRA),
+	kFrameBufferMinSlots);
 }
 
 size_t MovieDecoder_FFMpeg::GetFrameBufferIndex(size_t logical_frame_num) const

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -598,6 +598,15 @@ RString MovieDecoder_FFMpeg::Open(RString file)
 		total_frames_ = 2000;
 	}
 
+	// Resize frame buffer based on video resolution and target memory budget.
+	size_t optimal_buffer_size = CalculateFrameBufferSize(av_stream_codec_->width, av_stream_codec_->height);
+	if (optimal_buffer_size < frame_buffer_.size()) {
+		frame_buffer_.resize(optimal_buffer_size);
+	} else if (optimal_buffer_size > frame_buffer_.size()) {
+		while (frame_buffer_.size() < optimal_buffer_size) {
+			frame_buffer_.emplace_back(std::make_unique<FrameHolder>());
+		}
+	}
 	if (total_frames_ < frame_buffer_.size()) {
 		LOG->Trace("Video shorter than frame buffer, shrinking the buffer.");
 		frame_buffer_.resize(total_frames_);

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -607,10 +607,16 @@ RString MovieDecoder_FFMpeg::Open(RString file)
 			frame_buffer_.emplace_back(std::make_unique<FrameHolder>());
 		}
 	}
+	// Additional safeguard: if video is shorter than buffer, shrink to match.
 	if (total_frames_ < frame_buffer_.size()) {
-		LOG->Trace("Video shorter than frame buffer, shrinking the buffer.");
+		LOG->Trace("Video shorter than frame buffer (%zu frames vs %zu slots), shrinking the buffer.",
+			total_frames_, frame_buffer_.size());
 		frame_buffer_.resize(total_frames_);
 	}
+	LOG->Trace("Frame buffer finalized: %zu slots for %dx%d video at %.1f MB per frame, ~%.1f MB total.",
+		frame_buffer_.size(), av_stream_codec_->width, av_stream_codec_->height,
+		(av_stream_codec_->width * av_stream_codec_->height * kBytesPerPixelBGRA) / (1024.0 * 1024.0),
+		(frame_buffer_.size() * av_stream_codec_->width * av_stream_codec_->height * kBytesPerPixelBGRA) / (1024.0 * 1024.0));
 	LOG->Trace("Number of frames detected: %zu", total_frames_);
 
 	return RString();

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -393,6 +393,10 @@ int MovieDecoder_FFMpeg::DecodePacketIntoFrame(PacketHolder* packet, FrameHolder
 	int packet_offset = 0;
 	while (packet_offset <= packet->packet->size)
 	{
+		/* If we have no data on the first frame, just return EOF; passing an empty packet
+		 * to avcodec_decode_video in this case is crashing it.  However, passing an empty
+		 * packet is normal with B-frames, to flush.  This may be unnecessary in newer
+		 * versions of avcodec, but I'm waiting until a new stable release to upgrade. */
 		if (packet->packet->size == 0 && packet_buffer_position_ == 0) {
 			return 0; /* eof */
 		}

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -156,7 +156,13 @@ void MovieDecoder_FFMpeg::Init()
 {
 	end_of_file_ = 0;
 	display_frame_num_ = 0;
+	if (av_sws_context_ != nullptr)
+	{
+		avcodec::sws_freeContext(av_sws_context_);
+	}
 	av_sws_context_ = nullptr;
+	sws_width_ = 0;
+	sws_height_ = 0;
 	av_io_context_ = nullptr;
 	av_buffer_ = nullptr;
 }
@@ -440,13 +446,16 @@ bool MovieDecoder_FFMpeg::EnsureSwsContext()
 		return true;
 	}
 
+	sws_width_ = sws_width_ == 0 ? GetWidth() : sws_width_;
+	sws_height_ = sws_height_ == 0 ? GetHeight() : sws_height_;
+
 	av_sws_context_ = avcodec::sws_getCachedContext(av_sws_context_,
-		GetWidth(), GetHeight(), av_stream_codec_->pix_fmt,
-		GetWidth(), GetHeight(), av_pixel_format_,
+		sws_width_, sws_height_, av_stream_codec_->pix_fmt,
+		sws_width_, sws_height_, av_pixel_format_,
 		kSwsFlags, nullptr, nullptr, nullptr);
 	if (av_sws_context_ == nullptr)
 	{
-		LOG->Warn("Cannot initialize sws conversion context for (%d,%d) %d->%d", GetWidth(), GetHeight(), av_stream_codec_->pix_fmt, av_pixel_format_);
+		LOG->Warn("Cannot initialize sws conversion context for (%d,%d) %d->%d", sws_width_, sws_height_, av_stream_codec_->pix_fmt, av_pixel_format_);
 		return false;
 	}
 
@@ -465,8 +474,8 @@ int MovieDecoder_FFMpeg::BlitFrameToSurface(FrameHolder* frame, RageSurface* sur
 
 	if (frame->packet_num == display_frame_num_) {
 		return avcodec::sws_scale(av_sws_context_,
-			frame->frame->data, frame->frame->linesize, 0, GetHeight(),
-			pict.data, pict.linesize);
+			frame->frame->data, frame->frame->linesize, 0, sws_height_,
+			rgb_frame_->data, rgb_frame_->linesize);
 	}
 
 	LOG->Warn("Unexpected frame trying to display! display_frame_num_ = %zu, packet_num = %zu", display_frame_num_, frame->packet_num);

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -366,6 +366,8 @@ void MovieDecoder_FFMpeg::UpdateFrameTiming(PacketHolder* packet, FrameHolder* f
 	}
 	else
 	{
+		/* If the timestamp is zero, this frame is to be played at the
+		 * time of the last frame plus the length of the last frame. */
 		if (packet_buffer_position_ != 0) {
 			packet->frame_timestamp += packet_buffer_[packet_buffer_.size() - 2]->frame_delay;
 		}
@@ -374,10 +376,13 @@ void MovieDecoder_FFMpeg::UpdateFrameTiming(PacketHolder* packet, FrameHolder* f
 		}
 	}
 
+	// Some movies start at a non-zero point in time (audio before video?)
 	if (packet_buffer_position_ == 0 && packet->frame_timestamp != 0) {
 		timestamp_offset_ = packet->frame_timestamp;
 	}
 
+	// Length of this frame, only used as a fallback for getting the frame
+	// timestamp above.
 	packet->frame_delay = static_cast<float>(av_q2d(av_stream_->time_base));
 	packet->frame_delay += frame->frame->repeat_pict * (packet->frame_delay * 0.5f);
 }
@@ -386,6 +391,8 @@ int MovieDecoder_FFMpeg::DecodePacketIntoFrame(PacketHolder* packet, FrameHolder
 	std::lock_guard<std::mutex> frame_lock(frame->lock);
 	std::lock_guard<std::mutex> packet_lock(packet->lock);
 
+	// If the movie is looping naturally, next_offset_ is decided where
+	// packet_buffer_position_ zero is decoded.
 	if (packet->decoded && packet_buffer_position_ == 0) {
 		next_offset_ = frame_buffer_position_;
 	}
@@ -401,6 +408,8 @@ int MovieDecoder_FFMpeg::DecodePacketIntoFrame(PacketHolder* packet, FrameHolder
 			return 0; /* eof */
 		}
 
+		/* Hack: we need to send size = 0 to flush frames at the end, but we have
+		 * to give it a buffer to read from since it tries to read anyway. */
 		packet->packet->data = packet->packet->size ? packet->packet->data : nullptr;
 		const int len = packet->packet->size;
 		avcodec::avcodec_send_packet(av_stream_codec_, packet->packet);
@@ -423,6 +432,8 @@ int MovieDecoder_FFMpeg::DecodePacketIntoFrame(PacketHolder* packet, FrameHolder
 				static_cast<int>(packet_buffer_.size() - 1),
 				avcodec_return);
 
+			// Not a fatal decoding error, and the FFMpeg code is robust enough to handle displaying
+			// somewhat mangled frames.
 			if (packet_offset <= packet->packet->size) {
 				continue;
 			}
@@ -504,6 +515,9 @@ int MovieDecoder_FFMpeg::GetFrame(RageSurface* surface_out)
 	std::lock_guard<std::mutex> lock(frame_buffer_[display_frame_in_buffer]->lock);
 
 	int scale_status = BlitFrameToSurface(frame_buffer_[display_frame_in_buffer].get(), surface_out);
+	
+	// Even if scale_status returns a failure, we mark displayed as true. The
+	// frame won't be displayed, but instead skipped over.
 	frame_buffer_[display_frame_in_buffer]->displayed = true;
 
 	if (LastFrame()) {

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.cpp
@@ -121,8 +121,9 @@ MovieDecoder_FFMpeg::MovieDecoder_FFMpeg()
 	av_pixel_format_ = avcodec::AV_PIX_FMT_BGRA; // Default RGB target; may be overwritten by surface setup.
 	total_frames_ = 0;
 	end_of_file_ = 0;
-	// Hardcoded frame buffer size of 50. Roughly translates to 100mb of ram.
-	for (int i = 0; i < 50; i++) {
+	// Frame buffer size will be calculated dynamically when the video is opened.
+	// For now, initialize with minimum slots to avoid null dereferences.
+	for (size_t i = 0; i < kFrameBufferMinSlots; i++) {
 		frame_buffer_.emplace_back(std::make_unique<FrameHolder>());
 	}
 }

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -153,9 +153,13 @@ private:
 	// Send the packet at packet_buffer_position_ to the frame buffer
 	// at the next open position.
 	// Returns -2 on cancel, -1 on error, 0 if the packet is finished.
-	int DecodePacketToFrame();
+	int ProcessFrameFromPacket();
+
+	// Returns true if the packet buffer size is smaller than the frame buffer size.
+	// Performs a 1ms wait while the frame is displayed and returns false if we get
+	// a cancel or reset signal. 
 	bool PrepareFrameSlot(FrameHolder* frame);
-	int DecodePacketIntoFrame(PacketHolder* packet, FrameHolder* frame);
+	int DecodePacketToFrame(PacketHolder* packet, FrameHolder* frame);
 	void UpdateFrameTiming(PacketHolder* packet, FrameHolder* frame);
 	bool EnsureSwsContext();
 	int BlitFrameToSurface(FrameHolder* frame, RageSurface* surface_out);

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -22,7 +22,7 @@ namespace avcodec
 	}
 };
 
-constexpr size_t kFFMpegBufferSize = 4096;
+constexpr size_t kFFMpegBufferSize = 32768; // 32kb
 constexpr int kSwsFlags = SWS_BICUBIC; // XXX: Reasonable default?
 // Target memory budget for frame buffer in bytes (100 MB). Actual buffer size is calculated
 // dynamically based on video resolution to stay within this budget.

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -24,6 +24,13 @@ namespace avcodec
 
 constexpr size_t kFFMpegBufferSize = 4096;
 constexpr int kSwsFlags = SWS_BICUBIC; // XXX: Reasonable default?
+// Target memory budget for frame buffer in bytes (100 MB). Actual buffer size is calculated
+// dynamically based on video resolution to stay within this budget.
+constexpr size_t kFrameBufferTargetMemory = 100 * 1024 * 1024; // 100 MB
+// Minimum frame buffer slots to maintain (for safety and smooth playback)
+constexpr size_t kFrameBufferMinSlots = 3;
+// Bytes per pixel for BGRA format (default)
+constexpr size_t kBytesPerPixelBGRA = 4;
 
 struct FrameHolder {
 	avcodec::AVFrame* frame = avcodec::av_frame_alloc();
@@ -133,6 +140,12 @@ private:
 	void Init();
 	RString OpenCodec();
 
+	// Returns the number of frame slots to allocate. Respects minimum slot requirement.
+	size_t CalculateFrameBufferSize(int width, int height);
+
+	// This encapsulates the sliding window logic: (display_frame_num + offset) % frame_buffer.size()
+	size_t GetFrameBufferIndex(std::size_t logical_frame_num) const;
+
 	// Read a packet and send it to our frame data buffer.
 	// Returns -2 on cancel, -1 on error, 0 on EOF, 1 on OK.
 	int SendPacketToBuffer();
@@ -153,6 +166,9 @@ private:
 	avcodec::SwsContext* av_sws_context_;
 	avcodec::AVCodecContext* av_stream_codec_;
 	avcodec::AVFormatContext* av_format_context_;
+	avcodec::AVFrame* rgb_frame_ = nullptr; // Reused destination frame for RGB blits.
+	int sws_width_ = 0;
+	int sws_height_ = 0;
 	std::size_t total_frames_; // Total number of frames in the movie.
 
 	unsigned char* av_buffer_;

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -139,6 +139,7 @@ public:
 private:
 	void Init();
 	RString OpenCodec();
+	void HandleReset();
 
 	// Returns the number of frame slots to allocate. Respects minimum slot requirement.
 	size_t CalculateFrameBufferSize(int width, int height);
@@ -159,11 +160,24 @@ private:
 	// Performs a 1ms wait while the frame is displayed and returns false if we get
 	// a cancel or reset signal. 
 	bool PrepareFrameSlot(FrameHolder* frame);
+
+	// Packet decoding and offset management logic. Called from within ProcessFrameFromPacket.
+	// Returns 1 if frame decode succeeded, 0 if packet is finished, -1 on error
 	int DecodePacketToFrame(PacketHolder* packet, FrameHolder* frame);
+
+	// Determines the frame timestamp. Will use the frame length as a fallback if necessary.
 	void UpdateFrameTiming(PacketHolder* packet, FrameHolder* frame);
+
+	// Checks if we already have a SWS context to use. If so, this returns true early and uses
+	// the cached context. If it has to create a new context, it will return true after doing so.
 	bool EnsureSwsContext();
+
+	// Ensures a SWS context exist to blit to our reusable RGB destination frame, and calls
+	// sws_scale on the target frame. Returns the number of output lines written by sws_scale
+	// on success, 0 if no blit performed (presumably due to packet/frame mismatch), or a
+	// negative value on error. -1 is returned if the SWS context fails to initialize. Other
+	// negative values would be returned directly from sws_scale.
 	int BlitFrameToSurface(FrameHolder* frame, RageSurface* surface_out);
-	void HandleReset();
 
 	avcodec::AVStream* av_stream_;
 	avcodec::AVPixelFormat av_pixel_format_;	/* pixel format of output surface */

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -144,7 +144,7 @@ private:
 	size_t CalculateFrameBufferSize(int width, int height);
 
 	// This encapsulates the sliding window logic: (display_frame_num + offset) % frame_buffer.size()
-	size_t GetFrameBufferIndex(std::size_t logical_frame_num) const;
+	size_t GetFrameBufferIndex(size_t logical_frame_num) const;
 
 	// Read a packet and send it to our frame data buffer.
 	// Returns -2 on cancel, -1 on error, 0 on EOF, 1 on OK.

--- a/src/arch/MovieTexture/MovieTexture_FFMpeg.h
+++ b/src/arch/MovieTexture/MovieTexture_FFMpeg.h
@@ -141,6 +141,11 @@ private:
 	// at the next open position.
 	// Returns -2 on cancel, -1 on error, 0 if the packet is finished.
 	int DecodePacketToFrame();
+	bool PrepareFrameSlot(FrameHolder* frame);
+	int DecodePacketIntoFrame(PacketHolder* packet, FrameHolder* frame);
+	void UpdateFrameTiming(PacketHolder* packet, FrameHolder* frame);
+	bool EnsureSwsContext();
+	int BlitFrameToSurface(FrameHolder* frame, RageSurface* surface_out);
 	void HandleReset();
 
 	avcodec::AVStream* av_stream_;


### PR DESCRIPTION
This is a working proof-of-concept PR! Fair warning - review will likely take a long time, but the improvement in video playback is very significant. It is well tested and has been in use on various setups for a while now so it is also safe to merge as-is.  I've left the commit history un-squashed so it's easy to follow along with the thought process here. This PR is mostly just restructuring of existing code.

This PR features several commits that likely should be split into other PR's, but i wanted to give people the opportunity to pull this PR and test it on their own machines, and I also wanted to give a chance to show my idea of the "finished product" here.

There are further specifics below, but since it's a working patch, i would encourage testing this vs. the existing code with the biggest mp4 video files you have! :)

<details>

## Why would we want to refactor how color conversion is handled?

<details>
To understand why this is significant, it is necessary to think about how the video decoding process works.

We can't decouple video playback from the main thread, even though it seems appealing to do so, because sprite rendering happens on the main thread, and texture updates require GPU sync. A major restructuring would be required to change this behavior.

Implementing asynchronous texture uploads would be appealing, but does not hae a clear path forward or guarantee of significant  improvement relative to effort.

Given that the above options are unfeasible, the best option is to remove the YUV-RGB conversion.

The current method of color conversion is inefficient because the decoder outputs YUV, sws_scale converts to RGB in CPU, and then the GPU renders RGB.  RGB video encoding was common in the old days, but now YUV is much more common. If one downloads a video using `yt-dlp` as mp4, it will be in YUV.

**So, considering the above, what we can do here is to pre-convert to RGB in the video decode thread.** 

We basically just make the color conversion the decode thread's job, rather than the main thread's job, and non-RGB video works wonderfully as a result.

Semi-related, the FFMpeg buffer size of 4kb chosen ~20 years ago seems unlikely to be adequate for modern file formats/resolutions. I have bumped this up to 32Kb.
</details>

## Why are seemingly unrelated functions being reorganized here?

<details>

The first major change besides the color conversion here is to refactor the hardcoded frame buffer size.  We now set up the minimum acceptable buffer size in the constructor, and then figure out how big of a buffer we need based on the maximum amount of memory we're willing to use (I set it to 100MB) and the resolution of the video. This helps with memory management because the amount of memory consumed by a buffer is dependent on the video resolution.


The other main change is to identify duplicated code as well as logic in the FFmpeg video decoding code path which could be  encapsulated  into more finely-focused functions.



When working thru this code I noted several instances of duplicated code which could be consolidated into smaller functions, or functions which were doing several jobs (e.g. the non-obvious color conversion residing in MovieDecoder_FFMpeg::GetFrame).


Mainly I needed to rethink how some of these functions were organized to be able to pull out the color conversion into the video decoding thread. I believe, as an added benefit, it also benefits code correctness and predictability to make these changes. 
</details>

## Testing

<details>
As proof, here is ITGmania with this PR's changes, achieving a high FPS and good performance while succeasfully playing back a 3 hour 2GB 1080p mp4  exactly as downloaded, so the color space is YUV and the codec is AV1.

<img width="1392" height="860" alt="Screenshot 2025-12-09 at 9 02 17 PM" src="https://github.com/user-attachments/assets/f1c09cfb-9fb2-445c-9aac-e07e655fec85" />
<img width="1392" height="860" alt="Screenshot 2025-12-09 at 11 34 11 PM" src="https://github.com/user-attachments/assets/082194fe-3ecf-4016-b109-3d00477a3e2c" />
<img width="654" height="86" alt="Screenshot 2025-12-10 at 4 20 55 AM" src="https://github.com/user-attachments/assets/08b7168f-f7a3-4284-a2ba-688ebc22733d" />

I have played several 2hr+ mp4 av1 files with YUV color space with this change and I always get nice consistent frame time and good responsiveness - this is visible in the screenshots above.
</details>

## The commits, in further detail

<details>
The second and third commits 6cb4c7dd47a90e6e6e5d17af3dba19224db2de62 and 922b00cfd33e8ac27302c82482cc92cdd2c5517f implement methods that can be used to dynamically calculate a proper buffer size to replace the existing code which always uses a hardcoded value of 50. These new methods are implemented in f77eeb0586d9d0fa5e3ae747c000fdc7f91e029c to reduce code duplication.

780c5c8299c5340f4d65a0a0a14ce4ba3a863731 implements the logic to resize the frame buffer as needed based on the video's resolution and our target memory budget of 100mb (which is defined in the previous commit).

f069be4aaac52a39de1c23ff71721a807ebbbf42 updates video buffer logging to reflect the new methods.

90b2ec73ad63225b613f8675f4bc2bdec4ce5ca6 creates some local variables to avoid repeated calls to GetWidth() and GetHeight(). It also properly resets the sws context in Init() to prevent memory leaks.

192f139de0c0a7312d115fafeb3fda82f91f4c40 sets up the FFmpeg decoder to use the RGB pixel format as default and reuse a `rgb_frame_` which exists to improve performance of RGB blits. This is a big time save because converting to RGB later on can be an expensive and slow calculation to do that can block the main thread, so we really want to avoid this.

Lastly, ad34955370554fce658fc6aa2f048a1604ceda38 replaces the hardcoded frame buffer size logic.
</details>

</details>