### PR TITLE
Add "Set Default Song" line to ScreenDebugOverlay to allow selection of starting song

### DIFF
--- a/Themes/_fallback/Languages/en.ini
+++ b/Themes/_fallback/Languages/en.ini
@@ -1543,6 +1543,7 @@ off=off
 on=on
 or=or
 Zoom In Camera=Zoom In Camera
+Set Default Song=Set Default Song
 
 [ScreenEdit]
 '%s' is not a track id.='%s' is not a track id.

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -108,9 +108,28 @@ ThemeMetric<std::string> DEFAULT_SORT("GameState", "DefaultSort");
 SortOrder GetDefaultSort() { return StringToSortOrder(DEFAULT_SORT); }
 ThemeMetric<std::string> DEFAULT_SONG("GameState", "DefaultSong");
 Song* GameState::GetDefaultSong() const {
+  std::string defaultSong = PREFSMAN->m_sDefaultSong.Get();
+  if (defaultSong == "") {
+    defaultSong = DEFAULT_SONG;
+  }
   SongID sid;
-  sid.FromString(DEFAULT_SONG);
+  sid.FromString(defaultSong);
   return sid.ToSong();
+}
+
+bool GameState::SetDefaultSongToCurrent()
+{
+    Song* song = m_pCurSong.Get();
+    if (song) {
+        std::string prev = PREFSMAN->m_sDefaultSong.Get();
+        std::string next = song->GetSongDir();
+        if (prev != next) {
+            PREFSMAN->m_sDefaultSong.Set(next);
+            return true;
+        }
+    }
+
+    return false;
 }
 
 static const ThemeMetric<bool> EDIT_ALLOWED_FOR_EXTRA(

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -77,6 +77,7 @@ class GameState {
    * @param pn the PlayerNumber to save the stats to. */
   void SaveCurrentSettingsToProfile(PlayerNumber pn);
   Song* GetDefaultSong() const;
+  bool SetDefaultSongToCurrent();
 
   bool CanSafelyEnterGameplay(std::string& reason);
   void SetCompatibleStylesForPlayers();

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -299,6 +299,7 @@ PrefsManager::PrefsManager()
           "AdditionalFoldersReadOnly", "", nullptr, PreferenceType::Immutable),
       m_sAdditionalFoldersWritable(
           "AdditionalFoldersWritable", "", nullptr, PreferenceType::Immutable),
+      m_sDefaultSong("DefaultSong", ""),
       m_sDefaultTheme("DefaultTheme", "Simply Love"),
       m_sLastSeenVideoDriver("LastSeenVideoDriver", ""),
       m_sVideoRenderers(

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -321,6 +321,8 @@ class PrefsManager {
   Preference<std::string> m_sAdditionalFoldersReadOnly;
   Preference<std::string> m_sAdditionalFoldersWritable;
 
+  // First song selected when entering the Select Music Screen.
+  Preference<std::string> m_sDefaultSong;
   // failsafe
   Preference<std::string> m_sDefaultTheme;
 

--- a/src/ScreenDebugOverlay.cpp
+++ b/src/ScreenDebugOverlay.cpp
@@ -652,6 +652,7 @@ static LocalizedString CPU("ScreenDebugOverlay", "CPU");
 static LocalizedString SONG("ScreenDebugOverlay", "Song");
 static LocalizedString MACHINE("ScreenDebugOverlay", "Machine");
 static LocalizedString SYNC_TEMPO("ScreenDebugOverlay", "Tempo");
+static LocalizedString SET_DEFAULT_SONG("ScreenDebugOverlay", "Set Default Song");
 
 class DebugLineAutoplay : public IDebugLine {
   virtual std::string GetDisplayTitle() {
@@ -1361,6 +1362,26 @@ class DebugLineUptime : public IDebugLine {
   virtual void DoAndLog(std::string& sMessageOut) {}
 };
 
+class DebugSetDefaultSong : public IDebugLine {
+    virtual std::string GetDisplayTitle() { return SET_DEFAULT_SONG.GetValue(); }
+    virtual std::string GetDisplayValue()
+    {
+        Song* song = GAMESTATE->GetDefaultSong();
+        return song ? song->GetSongDir() : std::string();
+    }
+    virtual bool IsEnabled()
+    {
+        Screen* topScreen = SCREENMAN->GetTopScreen();
+        return topScreen && topScreen->GetName() == "ScreenSelectMusic";
+    }
+    virtual void DoAndLog(std::string& sMessageOut)
+    {
+        if (GAMESTATE->SetDefaultSongToCurrent())
+        {
+            IDebugLine::DoAndLog(sMessageOut);
+        }
+    }
+};
 /* If you comment out a DECLARE_ONE at the end of the file, it will remove that
  * debug menu line, but it will also change the arrangement of keys to debug
  * menu options. We need a way to generate fake classes in order to preserve the
@@ -1440,7 +1461,7 @@ DECLARE_ONE(FakeDebugLine2);  // force crash
 DECLARE_ONE(DebugLineUptime);
 DECLARE_ONE(DebugLineResetKeyMapping);
 DECLARE_ONE(DebugLineMuteActions);
-
+DECLARE_ONE(DebugSetDefaultSong);
 /*
  * (c) 2001-2005 Chris Danford, Glenn Maynard
  * All rights reserved.

--- a/src/ScreenTestLights.cpp
+++ b/src/ScreenTestLights.cpp
@@ -55,13 +55,19 @@ void ScreenTestLights::Update(float fDeltaTime) {
   GameInput gi = LIGHTSMAN->GetFirstLitGameButtonLight();
 
   std::string s;
+  std::string lightMode;
+  std::string cabinetLightId;
+  std::string gameButtonLightId;
+  std::string side;
 
   switch (LIGHTSMAN->GetLightsMode()) {
     case LIGHTSMODE_TEST_AUTO_CYCLE:
       s += AUTO_CYCLE.GetValue() + "\n";
+      lightMode += AUTO_CYCLE.GetValue();
       break;
     case LIGHTSMODE_TEST_MANUAL_CYCLE:
       s += MANUAL_CYCLE.GetValue() + "\n";
+      lightMode += MANUAL_CYCLE.GetValue();
       break;
     default:
       break;
@@ -69,14 +75,17 @@ void ScreenTestLights::Update(float fDeltaTime) {
 
   if (cl == CabinetLight_Invalid) {
     s += CABINET_LIGHT.GetValue() + ": -----\n";
+    cabinetLightId += "None";
   } else {
     s += ssprintf(
         "%s: %d %s\n", CABINET_LIGHT.GetValue().c_str(), cl,
         CabinetLightToString(cl).c_str());
+    cabinetLightId += CabinetLightToString(cl).c_str();
   }
 
   if (!gi.IsValid()) {
     s += CONTROLLER_LIGHT.GetValue() + ": -----\n";
+    gameButtonLightId += "None";
   } else {
     std::string sGameButton =
         GameButtonToLocalizedString(INPUTMAPPER->GetInputScheme(), gi.button);
@@ -84,8 +93,17 @@ void ScreenTestLights::Update(float fDeltaTime) {
     s += ssprintf(
         "%s: %s %d %s\n", CONTROLLER_LIGHT.GetValue().c_str(),
         PlayerNumberToString(pn).c_str(), gi.button, sGameButton.c_str());
+    gameButtonLightId += sGameButton.c_str();
+    side += PlayerNumberToString(pn).c_str();
   }
 
+  Message msg("TestLightEvent");
+  msg.SetParam("LightMode", lightMode);
+  msg.SetParam("CabinetLightId", cabinetLightId);
+  msg.SetParam("Side", side);
+  msg.SetParam("GameButtonLightId", gameButtonLightId);
+
+  MESSAGEMAN->Broadcast( msg );
   m_textInputs.SetText(s);
 }
 


### PR DESCRIPTION
Currently you need to add the following lines to theme metrics.ini to set the default song firstly selected when opening the `ScreenSelectMusic`:

```
[GameState]
DefaultSong="Songs/Pack/SongName"
```

This is not ideal and I think it is better to have a dedicated preference in "Preferences.ini"

This pull requests adds the `DefaultSong` preference and a line in ScreenDebugOverlay to allow selection of this default song.

In Preferences.ini:

```
DefaultSong=/Songs/StepMania 5/MechaTribe Assault/
```

In ScreenDebugOverlay

<img width="1954" height="1309" alt="Screenshot From 2025-12-14 17-42-47" src="https://github.com/user-attachments/assets/9c8c0cc2-34fd-458e-a02b-db6fcdaa4e3b" />

Option is disabled when outside of ScreenSelectMusic and shows the currently set song, if present.



