### PR TITLE
Remove misleading comment

### DIFF
--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -1,14 +1,3 @@
-/*
- * If you're going to use threads, remember this:
- *
- * Threads suck.
- *
- * If there's any way to avoid them, take it!  Threaded code an order of
- * magnitude more complicated, harder to debug and harder to make robust.
- *
- * That said, here are a few helpers for when they're unavoidable.
- */
-
 #include "global.h"
 
 #include "RageThreads.h"


### PR DESCRIPTION
Threading is expected on modern hardware and has been for some time, so avoiding threading at all costs is a very outdated sentiment which does not line up any longer with our current practices and goals.