### PR TITLE
RageThreads: use an atomic flag for thread safety (1 of 2)

### DIFF
--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -20,6 +20,7 @@
 #include <cinttypes>
 #include <cstdint>
 #include <set>
+#include <atomic>
 
 #include "arch/Threads/Threads.h"
 #include "arch/Dialog/Dialog.h"
@@ -34,7 +35,9 @@
 
 /* Assume TLS doesn't work until told otherwise.  It's ArchHooks's job to set this. */
 bool RageThread::s_bSystemSupportsTLS = false;
-bool RageThread::s_bIsShowingDialog = false;
+
+// Set in Dialog.cpp via SetIsShowingDialog, read in RageThread.cpp
+std::atomic<bool> RageThread::s_bIsShowingDialog( false );
 
 #define MAX_THREADS 128
 //static std::vector<RageMutex*> *g_MutexList = nullptr; /* watch out for static initialization order problems */

--- a/src/RageThreads.h
+++ b/src/RageThreads.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <atomic>
 
 struct ThreadSlot;
 class RageTimer;
@@ -42,8 +43,8 @@ public:
 	static bool GetSupportsTLS() { return s_bSystemSupportsTLS; }
 	static void SetSupportsTLS( bool b ) { s_bSystemSupportsTLS = b; }
 
-	static bool GetIsShowingDialog() { return s_bIsShowingDialog; }
-	static void SetIsShowingDialog( bool b ) { s_bIsShowingDialog = b; }
+	static bool GetIsShowingDialog() { return s_bIsShowingDialog.load(); }
+	static void SetIsShowingDialog( bool b ) { s_bIsShowingDialog.store(b); }
 	static uint64_t GetInvalidThreadID();
 
 private:
@@ -51,7 +52,7 @@ private:
 	RString m_sName;
 
 	static bool s_bSystemSupportsTLS;
-	static bool s_bIsShowingDialog;
+	static std::atomic<bool> s_bIsShowingDialog;
 
 	// Swallow up warnings. If they must be used, define them.
 	RageThread& operator=(const RageThread& rhs);


### PR DESCRIPTION
This boolean s_bIsShowingDialog is written from dialog code, but is read in RageSemphore::Wait's do-while loop, so this is made atomic for thread safety.