### PR TITLE
RageThreads: use an atomic flag for thread safety (2 of 2)

### DIFF
--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -77,7 +77,7 @@ struct ThreadSlot
 		m_pImpl = nullptr;
 
 		/* Reset used last; otherwise, a thread creation might pick up the slot. */
-		m_bUsed.store(false);
+		m_bUsed.store(false, std::memory_order_release);
 	}
 
 	void Release()
@@ -158,10 +158,10 @@ static int FindEmptyThreadSlot()
 	LockMut( GetThreadSlotsLock() );
 	for( int entry = 0; entry < MAX_THREADS; ++entry )
 	{
-		if( g_ThreadSlots[entry].m_bUsed.load() )
+		if( g_ThreadSlots[entry].m_bUsed.load(std::memory_order_acquire) )
 			continue;
 
-		g_ThreadSlots[entry].m_bUsed.store( true );
+		g_ThreadSlots[entry].m_bUsed.store( true, std::memory_order_release );
 		return entry;
 	}
 
@@ -200,7 +200,7 @@ static ThreadSlot *GetThreadSlotFromID( uint64_t iID )
 
 	for( int entry = 0; entry < MAX_THREADS; ++entry )
 	{
-		if( !g_ThreadSlots[entry].m_bUsed.load() )
+		if( !g_ThreadSlots[entry].m_bUsed.load(std::memory_order_acquire) )
 			continue;
 		if( g_ThreadSlots[entry].m_iID == iID )
 			return &g_ThreadSlots[entry];
@@ -311,7 +311,7 @@ bool RageThread::EnumThreadIDs( int n, uint64_t &iID )
 	LockMut(GetThreadSlotsLock());
 	const ThreadSlot *slot = &g_ThreadSlots[n];
 
-	if( slot->m_bUsed.load() )
+	if( slot->m_bUsed.load(std::memory_order_acquire) )
 		iID = slot->m_iID;
 	else
 		iID = GetInvalidThreadId();
@@ -350,7 +350,7 @@ void RageThread::HaltAllThreads( bool Kill )
 	const uint64_t ThisThreadID = GetThisThreadId();
 	for( int entry = 0; entry < MAX_THREADS; ++entry )
 	{
-		if( !g_ThreadSlots[entry].m_bUsed.load() )
+		if( !g_ThreadSlots[entry].m_bUsed.load(std::memory_order_acquire) )
 			continue;
 		if( ThisThreadID == g_ThreadSlots[entry].m_iID || g_ThreadSlots[entry].m_pImpl == nullptr )
 			continue;
@@ -363,7 +363,7 @@ void RageThread::ResumeAllThreads()
 	const uint64_t ThisThreadID = GetThisThreadId();
 	for( int entry = 0; entry < MAX_THREADS; ++entry )
 	{
-		if( !g_ThreadSlots[entry].m_bUsed.load() )
+		if( !g_ThreadSlots[entry].m_bUsed.load(std::memory_order_acquire) )
 			continue;
 		if( ThisThreadID == g_ThreadSlots[entry].m_iID || g_ThreadSlots[entry].m_pImpl == nullptr )
 			continue;
@@ -430,7 +430,7 @@ void Checkpoints::SetCheckpoint( const char *file, int line, const char *message
 static const char *GetCheckpointLog( int slotno, int lineno )
 {
 	ThreadSlot &slot = g_ThreadSlots[slotno];
-	if( !slot.m_bUsed.load() )
+	if( !slot.m_bUsed.load(std::memory_order_acquire) )
 		return nullptr;
 
 	/* Only show the "Unknown thread" entry if it has at least one checkpoint. */

--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -20,6 +20,7 @@
 #include <cinttypes>
 #include <cstdint>
 #include <set>
+#include <atomic>
 
 #include "arch/Threads/Threads.h"
 #include "arch/Dialog/Dialog.h"

--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -46,7 +46,7 @@ struct ThreadSlot
 	/* Format this beforehand, since it's easier to do that than to do it under crash conditions. */
 	char m_szThreadFormattedOutput[1024];
 
-	bool m_bUsed;
+	std::atomic<bool> m_bUsed;
 	uint64_t m_iID;
 
 	ThreadImpl *m_pImpl;
@@ -67,7 +67,7 @@ struct ThreadSlot
 	int m_iCurCheckpoint, m_iNumCheckpoints;
 	const char *GetFormattedCheckpoint( int lineno );
 
-	ThreadSlot(): m_bUsed(false), m_iID(GetInvalidThreadId()),
+	ThreadSlot(): m_bUsed{false}, m_iID(GetInvalidThreadId()),
 		m_pImpl(nullptr), m_iCurCheckpoint(0), m_iNumCheckpoints(0) {}
 	void Init()
 	{
@@ -76,7 +76,7 @@ struct ThreadSlot
 		m_pImpl = nullptr;
 
 		/* Reset used last; otherwise, a thread creation might pick up the slot. */
-		m_bUsed = false;
+		m_bUsed.store(false);
 	}
 
 	void Release()
@@ -157,10 +157,10 @@ static int FindEmptyThreadSlot()
 	LockMut( GetThreadSlotsLock() );
 	for( int entry = 0; entry < MAX_THREADS; ++entry )
 	{
-		if( g_ThreadSlots[entry].m_bUsed )
+		if( g_ThreadSlots[entry].m_bUsed.load() )
 			continue;
 
-		g_ThreadSlots[entry].m_bUsed = true;
+		g_ThreadSlots[entry].m_bUsed.store( true );
 		return entry;
 	}
 
@@ -199,7 +199,7 @@ static ThreadSlot *GetThreadSlotFromID( uint64_t iID )
 
 	for( int entry = 0; entry < MAX_THREADS; ++entry )
 	{
-		if( !g_ThreadSlots[entry].m_bUsed )
+		if( !g_ThreadSlots[entry].m_bUsed.load() )
 			continue;
 		if( g_ThreadSlots[entry].m_iID == iID )
 			return &g_ThreadSlots[entry];
@@ -310,7 +310,7 @@ bool RageThread::EnumThreadIDs( int n, uint64_t &iID )
 	LockMut(GetThreadSlotsLock());
 	const ThreadSlot *slot = &g_ThreadSlots[n];
 
-	if( slot->m_bUsed )
+	if( slot->m_bUsed.load() )
 		iID = slot->m_iID;
 	else
 		iID = GetInvalidThreadId();
@@ -349,7 +349,7 @@ void RageThread::HaltAllThreads( bool Kill )
 	const uint64_t ThisThreadID = GetThisThreadId();
 	for( int entry = 0; entry < MAX_THREADS; ++entry )
 	{
-		if( !g_ThreadSlots[entry].m_bUsed )
+		if( !g_ThreadSlots[entry].m_bUsed.load() )
 			continue;
 		if( ThisThreadID == g_ThreadSlots[entry].m_iID || g_ThreadSlots[entry].m_pImpl == nullptr )
 			continue;
@@ -362,7 +362,7 @@ void RageThread::ResumeAllThreads()
 	const uint64_t ThisThreadID = GetThisThreadId();
 	for( int entry = 0; entry < MAX_THREADS; ++entry )
 	{
-		if( !g_ThreadSlots[entry].m_bUsed )
+		if( !g_ThreadSlots[entry].m_bUsed.load() )
 			continue;
 		if( ThisThreadID == g_ThreadSlots[entry].m_iID || g_ThreadSlots[entry].m_pImpl == nullptr )
 			continue;
@@ -429,7 +429,7 @@ void Checkpoints::SetCheckpoint( const char *file, int line, const char *message
 static const char *GetCheckpointLog( int slotno, int lineno )
 {
 	ThreadSlot &slot = g_ThreadSlots[slotno];
-	if( !slot.m_bUsed )
+	if( !slot.m_bUsed.load() )
 		return nullptr;
 
 	/* Only show the "Unknown thread" entry if it has at least one checkpoint. */


### PR DESCRIPTION
m_bUsed is checked from various places without synchronization, so using an atomic variable here should remove any ambiguous state or unintended behavior surrounding the use of this variable.