### PR TITLE
Decouple RString from files that do not include global.h (to reopen after 1.2.0)

### DIFF
--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -108,7 +108,7 @@ void GameLoop::ChangeTheme(const std::string &sNewTheme)
 	g_NewTheme = RString(sNewTheme);
 }
 
-void GameLoop::ChangeGame(const std::string& new_game, const std::string& new_theme)
+void GameLoop::ChangeGame(const std::string &new_game, const std::string &new_theme)
 {
 	g_NewGame = RString(new_game);
 	g_NewTheme = RString(new_theme);

--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -103,15 +103,15 @@ static void CheckInputDevices()
 // On the next update, change themes, and load sNewScreen.
 static RString g_NewTheme;
 static RString g_NewGame;
-void GameLoop::ChangeTheme(const RString &sNewTheme)
+void GameLoop::ChangeTheme(const std::string &sNewTheme)
 {
-	g_NewTheme = sNewTheme;
+	g_NewTheme = RString(sNewTheme);
 }
 
-void GameLoop::ChangeGame(const RString& new_game, const RString& new_theme)
+void GameLoop::ChangeGame(const std::string& new_game, const std::string& new_theme)
 {
-	g_NewGame= new_game;
-	g_NewTheme= new_theme;
+	g_NewGame = RString(new_game);
+	g_NewTheme = RString(new_theme);
 }
 
 #include "StepMania.h" // XXX

--- a/src/GameLoop.h
+++ b/src/GameLoop.h
@@ -11,7 +11,7 @@ namespace GameLoop
 	void SetUpdateRate(float fUpdateRate);
 	float GetUpdateRate();
 	void ChangeTheme(const std::string &sNewTheme);
-	void ChangeGame(const std::string& new_game, const std::string& new_theme= "");
+	void ChangeGame(const std::string &new_game, const std::string &new_theme= "");
 	void StartConcurrentRendering();
 	void FinishConcurrentRendering();
 

--- a/src/GameLoop.h
+++ b/src/GameLoop.h
@@ -1,5 +1,8 @@
 #ifndef GAME_LOOP_H
 #define GAME_LOOP_H
+
+#include <string>
+
 /** @brief Main rendering and update loop. */
 namespace GameLoop
 {
@@ -7,8 +10,8 @@ namespace GameLoop
 	void UpdateAllButDraw( bool bRunningFromVBLANK);
 	void SetUpdateRate(float fUpdateRate);
 	float GetUpdateRate();
-	void ChangeTheme(const RString &sNewTheme);
-	void ChangeGame(const RString& new_game, const RString& new_theme= "");
+	void ChangeTheme(const std::string &sNewTheme);
+	void ChangeGame(const std::string& new_game, const std::string& new_theme= "");
 	void StartConcurrentRendering();
 	void FinishConcurrentRendering();
 

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -3569,6 +3569,7 @@ public:
 				luaL_error(L, "SetGame: Invalid Theme: '%s'", theme.c_str());
 			}
 		}
+		// A future commit could make this function fully RString-free.
 		const std::string sGameName = game_name;
 		const std::string sTheme = theme;
 		GameLoop::ChangeGame(sGameName, sTheme);

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -3569,7 +3569,9 @@ public:
 				luaL_error(L, "SetGame: Invalid Theme: '%s'", theme.c_str());
 			}
 		}
-		GameLoop::ChangeGame(game_name, theme);
+		const std::string sGameName = game_name;
+		const std::string sTheme = theme;
+		GameLoop::ChangeGame(sGameName, sTheme);
 		return 0;
 	}
 

--- a/src/ScreenOptionsMaster.cpp
+++ b/src/ScreenOptionsMaster.cpp
@@ -137,7 +137,7 @@ void ScreenOptionsMaster::HandleScreenMessage( const ScreenMessage SM )
 		{
 			/* If the resolution or aspect ratio changes, always reload the theme.
 			 * Otherwise, only reload it if it changed. */
-			RString sNewTheme = PREFSMAN->m_sTheme.Get();
+			const std::string sNewTheme = PREFSMAN->m_sTheme.Get();
 			GameLoop::ChangeTheme(sNewTheme);
 		}
 
@@ -150,7 +150,8 @@ void ScreenOptionsMaster::HandleScreenMessage( const ScreenMessage SM )
 
 		if( m_iChangeMask & OPT_CHANGE_GAME )
 		{
-			GameLoop::ChangeGame(PREFSMAN->GetCurrentGame());
+			const std::string sNewGame = PREFSMAN->GetCurrentGame();
+			GameLoop::ChangeGame(sNewGame);
 		}
 
 		if( m_iChangeMask & OPT_APPLY_SOUND )

--- a/src/ScreenTitleMenu.cpp
+++ b/src/ScreenTitleMenu.cpp
@@ -59,7 +59,8 @@ bool ScreenTitleMenu::Input( const InputEventPlus &input )
 		if( CodeDetector::EnteredCode(input.GameI.controller,CODE_NEXT_THEME) ||
 			CodeDetector::EnteredCode(input.GameI.controller,CODE_NEXT_THEME2) )
 		{
-			GameLoop::ChangeTheme(THEME->GetNextSelectableTheme());
+			const std::string rNewTheme = THEME->GetNextSelectableTheme();
+			GameLoop::ChangeTheme(rNewTheme);
 			bHandled = true;
 		}
 		if( CodeDetector::EnteredCode(input.GameI.controller,CODE_NEXT_ANNOUNCER) ||

--- a/src/SpecialFiles.cpp
+++ b/src/SpecialFiles.cpp
@@ -1,25 +1,25 @@
 #include "global.h"
 #include "SpecialFiles.h"
 
-const RString SpecialFiles::PACKAGES_DIR = "Packages/";
-const RString SpecialFiles::KEYMAPS_PATH = "Save/Keymaps.ini";
-const RString SpecialFiles::EDIT_MODE_KEYMAPS_PATH = "Save/EditMode_Keymaps.ini";
-const RString SpecialFiles::PREFERENCES_INI_PATH = "Save/Preferences.ini";
-const RString SpecialFiles::THEMES_DIR  = "Themes/";
-const RString SpecialFiles::LANGUAGES_SUBDIR = "Languages/";
+const std::string SpecialFiles::PACKAGES_DIR = "Packages/";
+const std::string SpecialFiles::KEYMAPS_PATH = "Save/Keymaps.ini";
+const std::string SpecialFiles::EDIT_MODE_KEYMAPS_PATH = "Save/EditMode_Keymaps.ini";
+const std::string SpecialFiles::PREFERENCES_INI_PATH = "Save/Preferences.ini";
+const std::string SpecialFiles::THEMES_DIR  = "Themes/";
+const std::string SpecialFiles::LANGUAGES_SUBDIR = "Languages/";
 // TODO: A theme should be able to specify a base language.
-const RString SpecialFiles::BASE_LANGUAGE = "en";
-const RString SpecialFiles::METRICS_FILE = "metrics.ini";
-const RString SpecialFiles::CACHE_DIR = "Cache/";
-const RString SpecialFiles::BASE_THEME_NAME = "_fallback";
-const RString SpecialFiles::DEFAULTS_INI_PATH	= "Data/Defaults.ini";
-const RString SpecialFiles::STATIC_INI_PATH = "Data/Static.ini";
-const RString SpecialFiles::TYPE_TXT_FILE = "Data/Type.txt";
-const RString SpecialFiles::CA_BUNDLE_PATH = "Data/ca-bundle.crt";
-const RString SpecialFiles::SONGS_DIR = "Songs/";
-const RString SpecialFiles::COURSES_DIR	= "Courses/";
-const RString SpecialFiles::NOTESKINS_DIR = "NoteSkins/";
-const RString SpecialFiles::COINS_INI = "Save/Coin.ini";
+const std::string SpecialFiles::BASE_LANGUAGE = "en";
+const std::string SpecialFiles::METRICS_FILE = "metrics.ini";
+const std::string SpecialFiles::CACHE_DIR = "Cache/";
+const std::string SpecialFiles::BASE_THEME_NAME = "_fallback";
+const std::string SpecialFiles::DEFAULTS_INI_PATH	= "Data/Defaults.ini";
+const std::string SpecialFiles::STATIC_INI_PATH = "Data/Static.ini";
+const std::string SpecialFiles::TYPE_TXT_FILE = "Data/Type.txt";
+const std::string SpecialFiles::CA_BUNDLE_PATH = "Data/ca-bundle.crt";
+const std::string SpecialFiles::SONGS_DIR = "Songs/";
+const std::string SpecialFiles::COURSES_DIR	= "Courses/";
+const std::string SpecialFiles::NOTESKINS_DIR = "NoteSkins/";
+const std::string SpecialFiles::COINS_INI = "Save/Coin.ini";
 
 
 

--- a/src/SpecialFiles.h
+++ b/src/SpecialFiles.h
@@ -1,37 +1,39 @@
 #ifndef SpecialFiles_H
 #define SpecialFiles_H
 
+#include <string>
+
 /** @brief The listing of the special files and directories in use. */
 namespace SpecialFiles
 {
-	extern const RString PACKAGES_DIR;
-	extern const RString KEYMAPS_PATH;
+	extern const std::string PACKAGES_DIR;
+	extern const std::string KEYMAPS_PATH;
 	/** @brief Edit Mode keymaps are separate from standard keymaps because
 	 * it should not change with the gametype, and to avoid possible
 	 * interference with the normal keymaps system. -Kyz */
-	extern const RString EDIT_MODE_KEYMAPS_PATH;
-	extern const RString PREFERENCES_INI_PATH;
+	extern const std::string EDIT_MODE_KEYMAPS_PATH;
+	extern const std::string PREFERENCES_INI_PATH;
 	/** @brief The directory that contains the themes. */
-	extern const RString THEMES_DIR;
+	extern const std::string THEMES_DIR;
 	/** @brief The directory that contains the different languages. */
-	extern const RString LANGUAGES_SUBDIR;
+	extern const std::string LANGUAGES_SUBDIR;
 	/** @brief The base language for most users of this program. */
-	extern const RString BASE_LANGUAGE;
-	extern const RString METRICS_FILE;
-	extern const RString CACHE_DIR;
-	extern const RString BASE_THEME_NAME;
-	extern const RString DEFAULTS_INI_PATH;
-	extern const RString STATIC_INI_PATH;
-	extern const RString TYPE_TXT_FILE;
-	extern const RString CA_BUNDLE_PATH;
+	extern const std::string BASE_LANGUAGE;
+	extern const std::string METRICS_FILE;
+	extern const std::string CACHE_DIR;
+	extern const std::string BASE_THEME_NAME;
+	extern const std::string DEFAULTS_INI_PATH;
+	extern const std::string STATIC_INI_PATH;
+	extern const std::string TYPE_TXT_FILE;
+	extern const std::string CA_BUNDLE_PATH;
 	/** @brief The default Songs directory. */
-	extern const RString SONGS_DIR;
+	extern const std::string SONGS_DIR;
 	/** @brief The default courses directory. */
-	extern const RString COURSES_DIR;
+	extern const std::string COURSES_DIR;
 	/** @brief The default noteskins directory. */
-	extern const RString NOTESKINS_DIR;
+	extern const std::string NOTESKINS_DIR;
 
-	extern const RString COINS_INI;
+	extern const std::string COINS_INI;
 
 }
 

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -1440,13 +1440,12 @@ public:
 
 	static int SetTheme(T* p, lua_State* L)
 	{
-		RString theme_name= SArg(1);
+		const std::string theme_name= SArg(1);
 		if(!p->IsThemeSelectable(theme_name))
 		{
 			luaL_error(L, "SetTheme: Invalid Theme: '%s'", theme_name.c_str());
 		}
-		const std::string sThemeName= theme_name;
-		GameLoop::ChangeTheme(sThemeName);
+		GameLoop::ChangeTheme(theme_name);
 		return 0;
 	}
 

--- a/src/ThemeManager.cpp
+++ b/src/ThemeManager.cpp
@@ -1445,7 +1445,8 @@ public:
 		{
 			luaL_error(L, "SetTheme: Invalid Theme: '%s'", theme_name.c_str());
 		}
-		GameLoop::ChangeTheme(theme_name);
+		const std::string sThemeName= theme_name;
+		GameLoop::ChangeTheme(sThemeName);
 		return 0;
 	}
 


### PR DESCRIPTION
I noticed an error exposed by re-arranging includes via clang-format.  `GameLoop.h` and `SpecialFiles.h` do not include `global.h`, but make use of RString. Thus it is one of the first points the build will fail because RString is unknown in these files yet.

 This PR makes those headers less fragile by using `std::string` instead of `RString`, so that these files can correctly build without the RString dependency.  Also makes game/theme setting a bit more defensive in the process via const correctness.  

It is an invisible/seamless change. 