### PR TITLE
Fix bugs in TimingData::NoteRowToMeasureAndBeat

### DIFF
--- a/src/TimingData.cpp
+++ b/src/TimingData.cpp
@@ -1258,18 +1258,19 @@ void TimingData::NoteRowToMeasureAndBeat( int iNoteRow, int &iMeasureIndexOut, i
 	for (unsigned i = 0; i < tSigs.size(); i++)
 	{
 		TimeSignatureSegment *curSig = ToTimeSignature(tSigs[i]);
-		int iSegmentEndRow = (i + 1 == tSigs.size()) ? INT_MAX : curSig->GetRow();
+		int iSegmentEndRow = (i + 1 == tSigs.size()) ? INT_MAX : tSigs[i + 1]->GetRow();
 
 		int iRowsPerMeasureThisSegment = curSig->GetNoteRowsPerMeasure();
 
-		if( iNoteRow >= curSig->GetRow() )
+		if( iNoteRow < iSegmentEndRow )
 		{
 			// iNoteRow lands in this segment
 			int iNumRowsThisSegment = iNoteRow - curSig->GetRow();
 			int iNumMeasuresThisSegment = (iNumRowsThisSegment) / iRowsPerMeasureThisSegment;	// don't round up
 			iMeasureIndexOut += iNumMeasuresThisSegment;
-			iBeatIndexOut = iNumRowsThisSegment / iRowsPerMeasureThisSegment;
-			iRowsRemainder = iNumRowsThisSegment % iRowsPerMeasureThisSegment;
+			int iNumRowsThisMeasure = iNumRowsThisSegment % iRowsPerMeasureThisSegment;
+			iBeatIndexOut = iNumRowsThisMeasure / ROWS_PER_BEAT;
+			iRowsRemainder = iNumRowsThisMeasure % ROWS_PER_BEAT;
 			return;
 		}
 		else

--- a/src/TimingData.h
+++ b/src/TimingData.h
@@ -351,6 +351,16 @@ public:
 
 	void MultiplyBPMInBeatRange( int iStartIndex, int iEndIndex, float fFactor );
 
+	/**
+	 * @brief Get measure and beat at a note row.
+	 * @param iNoteRow the note row
+	 * @param iMeasureIndexOut returns the number of full measures from the
+	 *                         start of the song to iNoteRow
+	 * @param iBeatIndexOut returns the number of full beats from the start
+	 *                      of the last full measure to iNoteRow
+	 * @param iRowsRemainder returns the number of rows from the start of
+	 *                       the last full beat to iNoteRow
+	 */
 	void NoteRowToMeasureAndBeat( int iNoteRow, int &iMeasureIndexOut, int &iBeatIndexOut, int &iRowsRemainder ) const;
 
 	void GetBeatInternal(GetBeatStarts& start, GetBeatArgs& args,


### PR DESCRIPTION
1\. Fixes the comparison for checking if the row falls within the current time signature segment. The original code was

	iNoteRow >= curSig->GetRow()

which is always true for the first segment starting at the first beat. The function used the first time signature for the whole song.

This fixes CalculateMeasureInfo outputting a different number of measures that there are in the song and the metronome assist playing in the wrong time signature.

2\. Fixes the beat index and rows remainder return values. Based on their usage in GameplayAssist, the beat index was intended to count from the start of the measure and the rows remainder from the start of the beat. The original code instead set the beat index to the number of measures from the start of the time signature segment and the rows remainder to the number of rows from the last measure.

This fixes the metronome assist not playing at the correct times.