### PR TITLE
Modify CI to cache extern build outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-     ### TEMPORARY FIX:  Disable cmake cache until it expires so that windows builds work for the time being
-     # - name: Cache CMake build directory
-     #   uses: actions/cache@v4
-     #   with:
-     #     path: |
-     #       build
-     #     key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-ci-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
-     #     restore-keys: |
-     #       ${{ runner.os }}-${{ runner.arch }}-cmake-build-ci-
+      - name: Cache extern build outputs
+        uses: actions/cache@v5
+        with:
+          path: |
+            extern
+          key: ${{ runner.os }}-${{ runner.arch }}-extern-${{ hashFiles('**/CMakeLists.txt', 'extern/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-extern-
       - name: Install dependencies
         if: matrix.os != 'windows-2022'
         run: ${{ matrix.install }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - name: Cache extern dependencies
+      - name: Cache extern build outputs
         uses: actions/cache@v5
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,15 +53,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - name: Cache CMake build directory
-        uses: actions/cache@v4
+      - name: Cache extern dependencies
+        uses: actions/cache@v5
         with:
           path: |
-            build/*
-            !${{ matrix.path }}
-          key: ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ github.ref_name }}-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+            extern
+          key: ${{ runner.os }}-${{ runner.arch }}-extern-${{ hashFiles('**/CMakeLists.txt', 'extern/CMakeLists.txt') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ github.ref_name }}-
+            ${{ runner.os }}-${{ runner.arch }}-extern-
       - name: Install dependencies
         if: matrix.os != 'windows-2022'
         run: ${{ matrix.install }}


### PR DESCRIPTION
Modifies the caching step in CI workflows to cache external dependencies, hopefully reducing build times.