### PR TITLE
Applying some step parity optimizations from DeadSync

### DIFF
--- a/src/StepParityCost.cpp
+++ b/src/StepParityCost.cpp
@@ -130,7 +130,7 @@ float StepParityCost::calcHoldSwitchCost(State * initialState, State * resultSta
 		  (previousFoot == INVALID_COLUMN
 			? 1
 			: sqrt(
-				layout.getDistanceSq(c, previousFoot)
+				layout->getDistanceSq(c, previousFoot)
 			  ));
 	  }
 	}
@@ -317,12 +317,12 @@ float StepParityCost::calcTwistedFootCost(State * resultState)
 	int rightHeel = resultState->whatNoteTheFootIsHitting[RIGHT_HEEL];
 	int rightToe = resultState->whatNoteTheFootIsHitting[RIGHT_TOE];
 
-	StagePoint leftPos = layout.averagePoint(leftHeel, leftToe);
-	StagePoint rightPos = layout.averagePoint(rightHeel, rightToe);
+	StagePoint leftPos = layout->averagePoint(leftHeel, leftToe);
+	StagePoint rightPos = layout->averagePoint(rightHeel, rightToe);
 
 	bool crossedOver = rightPos.x < leftPos.x;
-	bool rightBackwards = rightHeel != INVALID_COLUMN && rightToe != INVALID_COLUMN ? layout.columns[rightToe].y < layout.columns[rightHeel].y : false;
-	bool leftBackwards = leftHeel != INVALID_COLUMN && leftToe != INVALID_COLUMN ? layout.columns[leftToe].y < layout.columns[leftHeel].y : false;
+	bool rightBackwards = rightHeel != INVALID_COLUMN && rightToe != INVALID_COLUMN ? layout->columns[rightToe].y < layout->columns[rightHeel].y : false;
+	bool leftBackwards = leftHeel != INVALID_COLUMN && leftToe != INVALID_COLUMN ? layout->columns[leftToe].y < layout->columns[leftHeel].y : false;
 
 	if(!crossedOver && (rightBackwards || leftBackwards))
 	{
@@ -354,10 +354,10 @@ float StepParityCost::calcFacingCosts(State * initialState, State * resultState,
 	if (endLeftToe == INVALID_COLUMN) endLeftToe = endLeftHeel;
 	if (endRightToe == INVALID_COLUMN) endRightToe = endRightHeel;
 
-	float heelFacingPenalty = layout.getXFacingPenalty(endLeftHeel, endRightHeel) * FACING;
-	float toesFacingPenalty = layout.getXFacingPenalty(endLeftToe, endRightToe) * FACING;
-	float leftFacingPenalty = layout.getYFacingPenalty(endLeftHeel, endLeftToe) * FACING;
-	float rightFacingPenalty = layout.getYFacingPenalty(endRightHeel, endRightToe) * FACING;
+	float heelFacingPenalty = layout->getXFacingPenalty(endLeftHeel, endRightHeel) * FACING;
+	float toesFacingPenalty = layout->getXFacingPenalty(endLeftToe, endRightToe) * FACING;
+	float leftFacingPenalty = layout->getYFacingPenalty(endLeftHeel, endLeftToe) * FACING;
+	float rightFacingPenalty = layout->getYFacingPenalty(endRightHeel, endRightToe) * FACING;
 
 	float cost = heelFacingPenalty + toesFacingPenalty + leftFacingPenalty + rightFacingPenalty;
 	return cost;
@@ -376,16 +376,16 @@ float StepParityCost::calcSpinCosts(State * initialState, State * resultState, i
 	if (endRightToe == INVALID_COLUMN) endRightToe = endRightHeel;
 
 	// spin
-	StagePoint previousLeftPos = layout.averagePoint(
+	StagePoint previousLeftPos = layout->averagePoint(
 	 initialState->whereTheFeetAre[LEFT_HEEL],
 	 initialState->whereTheFeetAre[LEFT_TOE]
 	);
-	StagePoint previousRightPos = layout.averagePoint(
+	StagePoint previousRightPos = layout->averagePoint(
 	 initialState->whereTheFeetAre[RIGHT_HEEL],
 	 initialState->whereTheFeetAre[RIGHT_TOE]
 	);
-	StagePoint leftPos = layout.averagePoint(endLeftHeel, endLeftToe);
-	StagePoint rightPos = layout.averagePoint(endRightHeel, endRightToe);
+	StagePoint leftPos = layout->averagePoint(endLeftHeel, endLeftToe);
+	StagePoint rightPos = layout->averagePoint(endRightHeel, endRightToe);
 
 	if (
 	  rightPos.x < leftPos.x &&
@@ -446,7 +446,7 @@ float StepParityCost::caclFootswitchCost(State * initialState, State * resultSta
 float StepParityCost::calcSideswitchCost(State * initialState, State * resultState, int columnCount)
 {
 	float cost = 0;
-	for(auto c : layout.sideArrows)
+	for(auto c : layout->sideArrows)
 	{
 		if (
 			initialState->combinedColumns[c] != resultState->columns[c] &&
@@ -504,7 +504,7 @@ float StepParityCost::calcBigMovementsQuicklyCost(State * initialState, State * 
 			continue;
 		}
 
-		float dist = (layout.getDistance(initialPosition, resultPosition) * DISTANCE) / elapsedTime;
+		float dist = (layout->getDistance(initialPosition, resultPosition) * DISTANCE) / elapsedTime;
 		// Otherwise if we're still bracketing, this is probably a less drastic movement
 		if(isBracketing)
 		{

--- a/src/StepParityCost.cpp
+++ b/src/StepParityCost.cpp
@@ -20,7 +20,7 @@ namespace {
 	}
 }
 
-float StepParityCost::getActionCost(State * initialState, State * resultState, std::vector<Row>& rows, int rowIndex, float elapsedTime)
+float StepParityCost::getActionCost(State * initialState, State * resultState, std::vector<Row>& rows, const FootPlacement & columns, int rowIndex, float elapsedTime)
 {
 	Row &row = rows[rowIndex];
 	int columnCount = row.columnCount;
@@ -55,7 +55,7 @@ float StepParityCost::getActionCost(State * initialState, State * resultState, s
 	bool jackedLeft = didJackLeft(initialState, resultState, leftHeel, leftToe, movedLeft, didJump, columnCount);
 	bool jackedRight = didJackRight(initialState, resultState, rightHeel, rightToe, movedRight, didJump, columnCount);
 	
-	cost += calcMineCost( initialState, resultState, row, columnCount);
+	cost += calcMineCost( resultState, row, columnCount);
 	cost += calcHoldSwitchCost( initialState, resultState, row, columnCount);
 	cost += calcBracketTapCost( initialState, resultState, row, leftHeel, leftToe, rightHeel, rightToe, elapsedTime, columnCount);
 	cost += calcBracketJackCost( initialState, resultState, rows, rowIndex, movedLeft, movedRight, jackedLeft, jackedRight, didJump, columnCount);
@@ -64,8 +64,8 @@ float StepParityCost::getActionCost(State * initialState, State * resultState, s
 	cost += calcTwistedFootCost(resultState);
 	cost += calcFacingCosts( initialState, resultState, columnCount);
 	cost += calcSpinCosts(initialState, resultState, columnCount);
-	cost += caclFootswitchCost( initialState, resultState, row, elapsedTime, columnCount);
-	cost += calcSideswitchCost( initialState, resultState, columnCount);
+	cost += calcFootswitchCost( initialState, columns, row, elapsedTime, columnCount);
+	cost += calcSideswitchCost( initialState, resultState, columns, columnCount);
 	cost += calcMissedFootswitchCost( row, jackedLeft, jackedRight, columnCount);
 	cost += calcJackCost( movedLeft, movedRight, jackedLeft, jackedRight, elapsedTime, columnCount);
 	cost += calcBigMovementsQuicklyCost( initialState, resultState, elapsedTime, columnCount);
@@ -81,7 +81,7 @@ float StepParityCost::getActionCost(State * initialState, State * resultState, s
 //
 // 00M0
 // 0100 <- no cost
-float StepParityCost::calcMineCost(State * initialState, State * resultState, Row &row, int columnCount)
+float StepParityCost::calcMineCost(State * resultState, Row &row, int columnCount)
 {
 	if(row.mine_mask == 0)
 	{
@@ -89,6 +89,7 @@ float StepParityCost::calcMineCost(State * initialState, State * resultState, Ro
 	}
 	float cost = 0;
 
+	
 	for (int i = 0; i < columnCount; i++) {
 		if (resultState->combinedColumns[i] != NONE && row.mines[i] != 0) {
 			cost += MINE;
@@ -194,43 +195,6 @@ float StepParityCost::calcBracketTapCost(State * initialState, State * resultSta
 	  ) {
 		cost += BRACKETTAP * jackPenalty;
 	  }
-	}
-	return cost;
-}
-
-// Calculate a cost for moving the same foot while the other
-// isn't on the pad.
-//
-float StepParityCost::calcMovingFootWhileOtherIsntOnPadCost(State * initialState, State * resultState, int columnCount)
-{
-	float cost = 0;
-	// Weighting for moving a foot while the other isn't on the pad (so marked doublesteps are less bad than this)
-	if (std::any_of(initialState->combinedColumns.begin(), initialState->combinedColumns.end(), [](Foot elem) { return elem != NONE;  }))
-	{
-		for (auto f : resultState->movedFeet)
-		{
-			switch (f)
-			{
-			case LEFT_HEEL:
-			case LEFT_TOE:
-				if (
-					!(
-						initialState->whereTheFeetAre[RIGHT_HEEL] != INVALID_COLUMN ||
-						initialState->whereTheFeetAre[RIGHT_TOE] != INVALID_COLUMN))
-					cost += OTHER;
-				break;
-			case RIGHT_HEEL:
-			case RIGHT_TOE:
-				if (
-					!(
-						initialState->whereTheFeetAre[LEFT_HEEL] != INVALID_COLUMN ||
-						initialState->whereTheFeetAre[LEFT_TOE] != INVALID_COLUMN))
-					cost += OTHER;
-				break;
-			default:
-				break;
-			}
-		}
 	}
 	return cost;
 }
@@ -408,7 +372,7 @@ float StepParityCost::calcSpinCosts(State * initialState, State * resultState, i
 
 // Footswitches are harder to do when they get too slow.
 // Notes with an elapsed time greater than this will incur a penalty
-float StepParityCost::caclFootswitchCost(State * initialState, State * resultState, Row & row, float elapsedTime, int columnCount)
+float StepParityCost::calcFootswitchCost(State * initialState, const FootPlacement & columns, Row & row, float elapsedTime, int columnCount)
 {
 	if(elapsedTime < SLOW_FOOTSWITCH_THRESHOLD || elapsedTime >= SLOW_FOOTSWITCH_IGNORE)
 	{
@@ -428,12 +392,12 @@ float StepParityCost::caclFootswitchCost(State * initialState, State * resultSta
 	{
 		if (
 			initialState->combinedColumns[i] == NONE ||
-			resultState->columns[i] == NONE)
+			columns[i] == NONE)
 			continue;
 
 		if (
-			initialState->combinedColumns[i] != resultState->columns[i] &&
-			initialState->combinedColumns[i] != OTHER_PART_OF_FOOT[resultState->columns[i]]
+			initialState->combinedColumns[i] != columns[i] &&
+			initialState->combinedColumns[i] != OTHER_PART_OF_FOOT[columns[i]]
 			)
 		{
 			cost += (timeScaled / (SLOW_FOOTSWITCH_THRESHOLD + timeScaled)) * FOOTSWITCH;
@@ -443,14 +407,14 @@ float StepParityCost::caclFootswitchCost(State * initialState, State * resultSta
 	  return cost;
 }
 
-float StepParityCost::calcSideswitchCost(State * initialState, State * resultState, int columnCount)
+float StepParityCost::calcSideswitchCost(State * initialState, State * resultState, const FootPlacement & columns, int columnCount)
 {
 	float cost = 0;
 	for(auto c : layout->sideArrows)
 	{
 		if (
-			initialState->combinedColumns[c] != resultState->columns[c] &&
-			resultState->columns[c] != NONE &&
+			initialState->combinedColumns[c] != columns[c] &&
+			columns[c] != NONE &&
 			initialState->combinedColumns[c] != NONE &&
 			!resultState->didTheFootMove[initialState->combinedColumns[c]])
 		{
@@ -479,19 +443,19 @@ float StepParityCost::calcJackCost(bool movedLeft, bool movedRight, bool jackedL
 float StepParityCost::calcBigMovementsQuicklyCost(State * initialState, State * resultState, float elapsedTime, int columnCount)
 {
 	float cost = 0;
-	for (StepParity::Foot foot : resultState->movedFeet)
+	for( StepParity::Foot foot : FEET)
 	{
-		if(foot == NONE)
+		if((resultState->moved_mask &  FOOT_MASKS[foot]) == 0)
 		{
 			continue;
 		}
-
+		
 		int initialPosition = initialState->whereTheFeetAre[foot];
 		if(initialPosition == INVALID_COLUMN)
 		{
 			continue;
 		}
-
+		
 		int resultPosition = resultState->whatNoteTheFootIsHitting[foot];
 
 
@@ -515,73 +479,6 @@ float StepParityCost::calcBigMovementsQuicklyCost(State * initialState, State * 
 
 	return cost;
 }
-
-// Are we trying to bracket a column that the other foot was just on,
-// or are we trying to hit a note that the other foot was just bracketing?
-
-float StepParityCost::calcCrowdedBracketCost(State * initialState, State * resultState, float elapsedTime, int columnCount)
-{
-	float cost = 0;
-
-	bool resultLeftBracket = resultState->whatNoteTheFootIsHitting[LEFT_HEEL] > INVALID_COLUMN && resultState->whatNoteTheFootIsHitting[LEFT_TOE] > INVALID_COLUMN;
-	bool resultRightBracket = resultState->whatNoteTheFootIsHitting[RIGHT_HEEL] > INVALID_COLUMN && resultState->whatNoteTheFootIsHitting[RIGHT_TOE] > INVALID_COLUMN;
-
-	bool initialLeftBracket = initialState->whereTheFeetAre[LEFT_HEEL] > INVALID_COLUMN && initialState->whereTheFeetAre[LEFT_TOE] > INVALID_COLUMN;
-	bool initialRightBracket = initialState->whereTheFeetAre[RIGHT_HEEL] > INVALID_COLUMN && initialState->whereTheFeetAre[RIGHT_TOE] > INVALID_COLUMN;
-
-	// if we're trying to bracket with left foot, does it overlap the right foot
-	// in previous state?
-	if(
-	   (resultLeftBracket)
-	   && (
-		   initialState->combinedColumns[resultState->whatNoteTheFootIsHitting[LEFT_HEEL]] == RIGHT_HEEL ||
-		   initialState->combinedColumns[resultState->whatNoteTheFootIsHitting[LEFT_HEEL]] == RIGHT_TOE ||
-		   initialState->combinedColumns[resultState->whatNoteTheFootIsHitting[LEFT_TOE]] == RIGHT_HEEL ||
-		   initialState->combinedColumns[resultState->whatNoteTheFootIsHitting[LEFT_TOE]] == RIGHT_TOE
-		   )
-	   )
-	{
-		cost += CROWDED_BRACKET / elapsedTime;
-	}
-	else if(initialLeftBracket
-		&& (
-			resultState->columns[initialState->whereTheFeetAre[LEFT_HEEL]] == RIGHT_HEEL ||
-			resultState->columns[initialState->whereTheFeetAre[LEFT_HEEL]] == RIGHT_TOE ||
-			resultState->columns[initialState->whereTheFeetAre[LEFT_TOE]] == RIGHT_HEEL ||
-			resultState->columns[initialState->whereTheFeetAre[LEFT_TOE]] == RIGHT_TOE
-			)
-		)
-	{
-		cost += CROWDED_BRACKET / elapsedTime;
-	}
-
-	// and if we're trying to bracket with right foot, does it overlap the left ?
-	if((resultRightBracket )
-	   && (
-		   initialState->combinedColumns[resultState->whatNoteTheFootIsHitting[RIGHT_HEEL]] == LEFT_HEEL ||
-		   initialState->combinedColumns[resultState->whatNoteTheFootIsHitting[RIGHT_HEEL]] == LEFT_TOE ||
-		   initialState->combinedColumns[resultState->whatNoteTheFootIsHitting[RIGHT_TOE]] == LEFT_HEEL ||
-		   initialState->combinedColumns[resultState->whatNoteTheFootIsHitting[RIGHT_TOE]] == LEFT_TOE
-		   )
-	   )
-	{
-		cost += CROWDED_BRACKET / elapsedTime;
-	}
-	else if( initialRightBracket
-		&& (
-			resultState->columns[initialState->whereTheFeetAre[RIGHT_HEEL]] == LEFT_HEEL ||
-			resultState->columns[initialState->whereTheFeetAre[RIGHT_HEEL]] == LEFT_TOE ||
-			resultState->columns[initialState->whereTheFeetAre[RIGHT_TOE]] == LEFT_HEEL ||
-			resultState->columns[initialState->whereTheFeetAre[RIGHT_TOE]] == LEFT_TOE
-			)
-		)
-	{
-		cost += CROWDED_BRACKET / elapsedTime;
-	}
-
-	return cost;
-}
-
 
 bool StepParityCost::didDoubleStep(State * initialState, State * resultState, std::vector<Row> & rows, int rowIndex, bool movedLeft, bool jackedLeft, bool movedRight, bool jackedRight, int columnCount)
 {

--- a/src/StepParityCost.cpp
+++ b/src/StepParityCost.cpp
@@ -360,71 +360,20 @@ float StepParityCost::calcMissedFootswitchCost(Row & row, bool jackedLeft, bool 
 
 float StepParityCost::calcFacingCosts(State * initialState, State * resultState, int columnCount)
 {
-
-	float cost = 0;
-
-	int endLeftHeel = INVALID_COLUMN;
-	int endLeftToe = INVALID_COLUMN;
-	int endRightHeel = INVALID_COLUMN;
-	int endRightToe = INVALID_COLUMN;
-
-	for (int i = 0; i < columnCount; i++) {
-	  switch (resultState->combinedColumns[i]) {
-		case NONE:
-		  break;
-		case LEFT_HEEL:
-		  endLeftHeel = i;
-		  break;
-		case LEFT_TOE:
-		  endLeftToe = i;
-		  break;
-		case RIGHT_HEEL:
-		  endRightHeel = i;
-		  break;
-		case RIGHT_TOE:
-		  endRightToe = i;
-		default:
-		  break;
-	  }
-	}
+	int endLeftHeel = resultState->whereTheFeetAre[LEFT_HEEL];
+	int endLeftToe = resultState->whereTheFeetAre[LEFT_TOE];
+	int endRightHeel = resultState->whereTheFeetAre[RIGHT_HEEL];
+	int endRightToe = resultState->whereTheFeetAre[RIGHT_TOE];
 
 	if (endLeftToe == INVALID_COLUMN) endLeftToe = endLeftHeel;
 	if (endRightToe == INVALID_COLUMN) endRightToe = endRightHeel;
 
-	// facing backwards gives a bit of bad weight (scaled heavily the further back you angle, so crossovers aren't Too bad; less bad than doublesteps)
-	float heelFacing =
-	  endLeftHeel != INVALID_COLUMN && endRightHeel != INVALID_COLUMN
-		? layout.getXDifference(endLeftHeel, endRightHeel)
-		: 0;
-	float toeFacing =
-	  endLeftToe != INVALID_COLUMN && endRightToe != INVALID_COLUMN
-		? layout.getXDifference(endLeftToe, endRightToe)
-		: 0;
-	float leftFacing =
-	  endLeftHeel != INVALID_COLUMN && endLeftToe != INVALID_COLUMN
-		? layout.getYDifference(endLeftHeel, endLeftToe)
-		: 0;
-	float rightFacing =
-	  endRightHeel != INVALID_COLUMN && endRightToe != INVALID_COLUMN
-		? layout.getYDifference(endRightHeel, endRightToe)
-		: 0;
+	float heelFacingPenalty = layout.getXFacingPenalty(endLeftHeel, endRightHeel) * FACING;
+	float toesFacingPenalty = layout.getXFacingPenalty(endLeftToe, endRightToe) * FACING;
+	float leftFacingPenalty = layout.getYFacingPenalty(endLeftHeel, endLeftToe) * FACING;
+	float rightFacingPenalty = layout.getYFacingPenalty(endRightHeel, endRightToe) * FACING;
 
-
-	float heelFacingPenalty = pow(-1 * std::min(heelFacing, 0.0f), 1.8) * 100;
-	float toesFacingPenalty = pow(-1 * std::min(toeFacing, 0.0f), 1.8) * 100;
-	float leftFacingPenalty = pow(-1 * std::min(leftFacing, 0.0f), 1.8) * 100;
-	float rightFacingPenalty = pow(-1 * std::min(rightFacing, 0.0f), 1.8) * 100;
-
-
-	if (heelFacingPenalty > 0)
-		cost += heelFacingPenalty * FACING;
-	if (toesFacingPenalty > 0)
-		cost += toesFacingPenalty * FACING;
-	if (leftFacingPenalty > 0)
-		cost += leftFacingPenalty * FACING;
-	if (rightFacingPenalty > 0)
-		cost += rightFacingPenalty * FACING;
-
+	float cost = heelFacingPenalty + toesFacingPenalty + leftFacingPenalty + rightFacingPenalty;
 	return cost;
 }
 
@@ -588,7 +537,7 @@ float StepParityCost::calcBigMovementsQuicklyCost(State * initialState, State * 
 			continue;
 		}
 
-		float dist = (sqrt(layout.getDistanceSq(initialPosition, resultPosition)) * DISTANCE) / elapsedTime;
+		float dist = (layout.getDistance(initialPosition, resultPosition) * DISTANCE) / elapsedTime;
 		// Otherwise if we're still bracketing, this is probably a less drastic movement
 		if(isBracketing)
 		{

--- a/src/StepParityCost.cpp
+++ b/src/StepParityCost.cpp
@@ -28,31 +28,10 @@ float StepParityCost::getActionCost(State * initialState, State * resultState, s
 	float cost = 0;
 
 	// Mine weighting
-	int leftHeel = INVALID_COLUMN;
-	int leftToe = INVALID_COLUMN;
-	int rightHeel = INVALID_COLUMN;
-	int rightToe = INVALID_COLUMN;
-
-	for (int i = 0; i < columnCount; i++) {
-	  switch (resultState->columns[i]) {
-		case NONE:
-		  break;
-		case LEFT_HEEL:
-		  leftHeel = i;
-		  break;
-		case LEFT_TOE:
-		  leftToe = i;
-		  break;
-		case RIGHT_HEEL:
-		  rightHeel = i;
-		  break;
-		case RIGHT_TOE:
-		  rightToe = i;
-		  break;
-	  default:
-		  break;
-	  }
-	}
+	int leftHeel = resultState->whatNoteTheFootIsHitting[LEFT_HEEL];
+	int leftToe = resultState->whatNoteTheFootIsHitting[LEFT_TOE];
+	int rightHeel = resultState->whatNoteTheFootIsHitting[RIGHT_HEEL];
+	int rightToe = resultState->whatNoteTheFootIsHitting[RIGHT_TOE];
 
 	bool movedLeft =
 	  resultState->didTheFootMove[LEFT_HEEL] ||
@@ -258,47 +237,42 @@ float StepParityCost::calcMovingFootWhileOtherIsntOnPadCost(State * initialState
 
 float StepParityCost::calcBracketJackCost(State * initialState, State * resultState, std::vector<Row> & rows, int rowIndex, bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, bool didJump, int columnCount)
 {
-	float cost = 0;
-	if (
-		movedLeft != movedRight &&
-		(movedLeft || movedRight) &&
-		isEmpty(resultState->holdFeet, columnCount) &&
-		!didJump)
+	if(movedLeft == movedRight || resultState->holding_mask != 0 || didJump)
 	{
-
-	  if (
+		return 0.0f;
+	}
+	float cost = 0;
+	
+	if (
 		jackedLeft &&
 		resultState->didTheFootMove[LEFT_HEEL] &&
 		resultState->didTheFootMove[LEFT_TOE]
-	  ) {
+	) {
 		cost += BRACKETJACK;
-	  }
+	}
 
-	  if (
+	if (
 		jackedRight &&
 		resultState->didTheFootMove[RIGHT_HEEL] &&
 		resultState->didTheFootMove[RIGHT_TOE]
-	  ) {
+	) {
 		cost += BRACKETJACK;
-	  }
 	}
 	return cost;
 }
 
 float StepParityCost::calcDoublestepCost(State * initialState, State * resultState, std::vector<Row> & rows, int rowIndex, bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, bool didJump, int columnCount)
 {
-	float cost = 0;
-	if (
-		movedLeft != movedRight &&
-		(movedLeft || movedRight) &&
-		isEmpty(resultState->holdFeet, columnCount) &&
-		!didJump)
+	if((movedLeft || movedRight) || resultState->holding_mask != 0 || didJump)
 	{
-		bool doublestepped = didDoubleStep(initialState, resultState, rows, rowIndex, movedLeft, jackedLeft, movedRight, jackedRight, columnCount);
+		return 0.0f;
+	}
+	
+	float cost = 0;
+	bool doublestepped = didDoubleStep(initialState, resultState, rows, rowIndex, movedLeft, jackedLeft, movedRight, jackedRight, columnCount);
 
-		if (doublestepped) {
-			cost += DOUBLESTEP;
-		}
+	if (doublestepped) {
+		cost += DOUBLESTEP;
 	}
 	return cost;
 
@@ -393,30 +367,10 @@ float StepParityCost::calcSpinCosts(State * initialState, State * resultState, i
 {
 	float cost = 0;
 
-	int endLeftHeel = INVALID_COLUMN;
-	int endLeftToe = INVALID_COLUMN;
-	int endRightHeel = INVALID_COLUMN;
-	int endRightToe = INVALID_COLUMN;
-
-	for (int i = 0; i < columnCount; i++) {
-	  switch (resultState->combinedColumns[i]) {
-		case NONE:
-		  break;
-		case LEFT_HEEL:
-		  endLeftHeel = i;
-		  break;
-		case LEFT_TOE:
-		  endLeftToe = i;
-		  break;
-		case RIGHT_HEEL:
-		  endRightHeel = i;
-		  break;
-		case RIGHT_TOE:
-		  endRightToe = i;
-		default:
-		  break;
-	  }
-	}
+	int endLeftHeel = resultState->whereTheFeetAre[LEFT_HEEL];
+	int endLeftToe = resultState->whereTheFeetAre[LEFT_TOE];
+	int endRightHeel = resultState->whereTheFeetAre[RIGHT_HEEL];
+	int endRightToe = resultState->whereTheFeetAre[RIGHT_TOE];
 
 	if (endLeftToe == INVALID_COLUMN) endLeftToe = endLeftHeel;
 	if (endRightToe == INVALID_COLUMN) endRightToe = endRightHeel;

--- a/src/StepParityCost.cpp
+++ b/src/StepParityCost.cpp
@@ -104,6 +104,10 @@ float StepParityCost::getActionCost(State * initialState, State * resultState, s
 // 0100 <- no cost
 float StepParityCost::calcMineCost(State * initialState, State * resultState, Row &row, int columnCount)
 {
+	if(row.mine_mask == 0)
+	{
+		return 0.0f;
+	}
 	float cost = 0;
 
 	for (int i = 0; i < columnCount; i++) {
@@ -121,7 +125,13 @@ float StepParityCost::calcMineCost(State * initialState, State * resultState, Ro
 // If the initial foot doesn't move anywhere, then don't mulitply it by anything.
 float StepParityCost::calcHoldSwitchCost(State * initialState, State * resultState, Row &row, int columnCount)
 {
+	if(row.hold_mask == 0)
+	{
+		return 0.0f;
+	}
+	
 	float cost = 0;
+	
 	for (int c = 0; c < columnCount; c++)
 	{
 		if (row.holds[c].type == TapNoteType_Empty)
@@ -158,6 +168,11 @@ float StepParityCost::calcHoldSwitchCost(State * initialState, State * resultSta
 
 float StepParityCost::calcBracketTapCost(State * initialState, State * resultState, Row &row, int leftHeel, int leftToe, int rightHeel, int rightToe, float elapsedTime, int columnCount)
 {
+	if(row.hold_mask == 0)
+	{
+		return 0.0f;
+	}
+	
 	// Small penalty for trying to jack a bracket during a hold
 	float cost = 0;
 	if (leftHeel != INVALID_COLUMN && leftToe != INVALID_COLUMN)
@@ -347,14 +362,11 @@ float StepParityCost::calcMissedFootswitchCost(Row & row, bool jackedLeft, bool 
 	float cost = 0;
 	if (
 		(jackedLeft || jackedRight) &&
-		(std::any_of(row.mines.begin(), row.mines.end(), [](int mine)
-					 { return mine != 0; }) ||
-		 std::any_of(row.fakeMines.begin(), row.fakeMines.end(), [](int mine)
-					 { return mine != 0; })))
+		(row.mine_mask != 0 || row.fake_mine_mask != 0)
+		)
 	{
 		cost += MISSED_FOOTSWITCH;
 	}
-
 	return cost;
 }
 
@@ -444,33 +456,34 @@ float StepParityCost::calcSpinCosts(State * initialState, State * resultState, i
 // Notes with an elapsed time greater than this will incur a penalty
 float StepParityCost::caclFootswitchCost(State * initialState, State * resultState, Row & row, float elapsedTime, int columnCount)
 {
+	if(elapsedTime < SLOW_FOOTSWITCH_THRESHOLD || elapsedTime >= SLOW_FOOTSWITCH_IGNORE)
+	{
+		return 0.0f;
+	}
+	
+	// footswitching has no penalty if there's a mine nearby
+	if(row.mine_mask != 0 || row.fake_mine_mask != 0)
+	{
+		return 0.0f;
+	}
+	
 	float cost = 0;
-	if (elapsedTime >= SLOW_FOOTSWITCH_THRESHOLD && elapsedTime < SLOW_FOOTSWITCH_IGNORE) {
-		// footswitching has no penalty if there's a mine nearby
+	float timeScaled = elapsedTime - SLOW_FOOTSWITCH_THRESHOLD;
+
+	for (int i = 0; i < columnCount; i++)
+	{
 		if (
-			std::all_of(row.mines.begin(), row.mines.end(), [](int mine)
-						{ return mine == 0; }) &&
-			std::all_of(row.fakeMines.begin(), row.fakeMines.end(), [](int mine)
-						{ return mine == 0; }))
+			initialState->combinedColumns[i] == NONE ||
+			resultState->columns[i] == NONE)
+			continue;
+
+		if (
+			initialState->combinedColumns[i] != resultState->columns[i] &&
+			initialState->combinedColumns[i] != OTHER_PART_OF_FOOT[resultState->columns[i]]
+			)
 		{
-			float timeScaled = elapsedTime - SLOW_FOOTSWITCH_THRESHOLD;
-
-			for (int i = 0; i < columnCount; i++)
-			{
-				if (
-					initialState->combinedColumns[i] == NONE ||
-					resultState->columns[i] == NONE)
-					continue;
-
-				if (
-					initialState->combinedColumns[i] != resultState->columns[i] &&
-					initialState->combinedColumns[i] != OTHER_PART_OF_FOOT[resultState->columns[i]]
-					)
-				{
-					cost += (timeScaled / (SLOW_FOOTSWITCH_THRESHOLD + timeScaled)) * FOOTSWITCH;
-					break;
-				}
-			}
+			cost += (timeScaled / (SLOW_FOOTSWITCH_THRESHOLD + timeScaled)) * FOOTSWITCH;
+			break;
 		}
 	}
 	  return cost;

--- a/src/StepParityCost.cpp
+++ b/src/StepParityCost.cpp
@@ -263,7 +263,7 @@ float StepParityCost::calcBracketJackCost(State * initialState, State * resultSt
 
 float StepParityCost::calcDoublestepCost(State * initialState, State * resultState, std::vector<Row> & rows, int rowIndex, bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, bool didJump, int columnCount)
 {
-	if((movedLeft || movedRight) || resultState->holding_mask != 0 || didJump)
+	if((movedLeft == movedRight) || resultState->holding_mask != 0 || didJump)
 	{
 		return 0.0f;
 	}

--- a/src/StepParityCost.h
+++ b/src/StepParityCost.h
@@ -50,13 +50,12 @@ namespace StepParity
 		/// @param rows 
 		/// @param rowIndex The index of the row represented by resultState
 		/// @return The computed cost
-		float getActionCost(State * initialState, State * resultState, std::vector<Row> &rows, int rowIndex, float elapsedTime);
+		float getActionCost(State * initialState, State * resultState, std::vector<Row> &rows, const FootPlacement & columns, int rowIndex, float elapsedTime);
 
 	private:
-		float calcMineCost(State * initialState, State * resultState, Row &row, int columnCount);
+		float calcMineCost(State * resultState, Row &row, int columnCount);
 		float calcHoldSwitchCost(State * initialState, State * resultState, Row &row, int columnCount);
 		float calcBracketTapCost(State * initialState, State * resultState, Row &row, int leftHeel, int leftToe, int rightHeel, int rightToe, float elapsedTime, int columnCount);
-		float calcMovingFootWhileOtherIsntOnPadCost(State * initialState, State * resultState, int columnCount);
 		float calcBracketJackCost(State * initialState, State * resultState, std::vector<Row> &rows, int rowIndex, bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, bool didJump, int columnCount);
 		float calcDoublestepCost(State * initialState, State * resultState, std::vector<Row> & rows, int rowIndex, bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, bool didJump, int columnCount);
 		float calcJumpCost(Row &row, bool movedLeft, bool movedRight, float elapsedTime, int columnCount);
@@ -65,11 +64,10 @@ namespace StepParity
 		float calcMissedFootswitchCost(Row &row, bool jackedLeft, bool jackedRight, int columnCount);
 		float calcFacingCosts(State * initialState, State * resultState, int columnCount);
 		float calcSpinCosts(State * initialState, State * resultState, int columnCount);
-		float caclFootswitchCost(State * initialState, State * resultState, Row &row, float elapsedTime, int columnCount);
-		float calcSideswitchCost(State * initialState, State * resultState, int columnCount);
+		float calcFootswitchCost(State * initialState, const FootPlacement &columns, Row &row, float elapsedTime, int columnCount);
+		float calcSideswitchCost(State * initialState, State * resultState, const FootPlacement & columns, int columnCount);
 		float calcJackCost(bool movedLeft, bool movedRight, bool jackedLeft, bool jackedRight, float elapsedTime, int columnCount);
 		float calcBigMovementsQuicklyCost(State * initialState, State * resultState, float elapsedTime, int columnCount);
-		float calcCrowdedBracketCost(State * initialState, State * resultState, float elapsedTime, int columnCount);
         
 		bool didDoubleStep(State * initialState, State * resultState, std::vector<Row> &rows, int rowIndex, bool movedLeft, bool jackedLeft, bool movedRight, bool jackedRight, int columnCount);
 		bool didJackLeft(State * initialState, State * resultState, int leftHeel, int leftToe, bool movedLeft, bool didJump, int columnCount);

--- a/src/StepParityCost.h
+++ b/src/StepParityCost.h
@@ -39,10 +39,10 @@ namespace StepParity
 	class StepParityCost
 	{
 	private:
-		StageLayout layout;
+		const StageLayout* layout;
 
 	public:
-		StepParityCost(const StageLayout& _layout): layout(_layout) {}
+		StepParityCost(const StageLayout* _layout): layout(_layout) {}
 
 		/// @brief Computes and returns a cost value for the player moving from initialState to resultState.
 		/// @param initialState The starting position of the player

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -162,6 +162,8 @@ void StageLayout::preCalculateStuff()
 	}
 }
 
+// Counts the number of ones in the binary representation
+// of the given `x`.
 inline int popcount(unsigned int x) {
 #if defined(__GNUC__) || defined(__clang__)
 	return __builtin_popcount(x);
@@ -197,7 +199,11 @@ void StageLayout::preGeneratePermutations()
 
 std::vector<FootPlacement> StageLayout::PermuteFootPlacements(unsigned int mask, FootPlacement columns, unsigned long column)
 {
+	// MV: This is re-defined here because I was running into
+	// issues with StepParity::FEET being empty within this context?
+	// I don't understand C++ header initialization stuff
 	std::vector<StepParity::Foot> FEET = {LEFT_HEEL, LEFT_TOE, RIGHT_HEEL, RIGHT_TOE};
+	
 	// If column >= columns.size(), we've reached the end of the row.
 	// Perform some final validation before returning the contents of columns
 	if (column >= columns.size())

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -292,18 +292,10 @@ std::vector<FootPlacement> StageLayout::PermuteFootPlacements(unsigned int mask,
 		return PermuteFootPlacements(mask, columns, column + 1);
 }
 
-
-
-
-
 StagePoint StageLayout::averagePoint(int leftIndex, int rightIndex) const {
 	if (leftIndex == INVALID_COLUMN && rightIndex == INVALID_COLUMN) return { 0,0 };
 	if (leftIndex == INVALID_COLUMN) return columns[rightIndex];
 	if (rightIndex == INVALID_COLUMN) return columns[leftIndex];
-//	return {
-//	  (columns[leftIndex].x + columns[rightIndex].x) / 2.0f,
-//	  (columns[leftIndex].y + columns[rightIndex].y) / 2.0f,
-//	};
 	int idx = leftIndex * columnCount + rightIndex;
 	return avgPoints[idx];
 }

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -15,7 +15,8 @@ bool State::operator==(const State &other) const
 // StageLayout
 bool StageLayout::bracketCheck(int column1, int column2)
 {
-	return getDistance(column1, column2) <= 2;
+	float dist =getDistance(column1, column2);
+	return (dist * dist) <= 2;
 }
 
 bool StageLayout::isSideArrow(int column)

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -15,9 +15,7 @@ bool State::operator==(const State &other) const
 // StageLayout
 bool StageLayout::bracketCheck(int column1, int column2)
 {
-	StagePoint p1 = columns[column1];
-	StagePoint p2 = columns[column2];
-	return getDistanceSq(p1, p2) <= 2;
+	return getDistance(column1, column2) <= 2;
 }
 
 bool StageLayout::isSideArrow(int column)
@@ -43,6 +41,15 @@ float StageLayout::getDistanceSq(int c1, int c2)
 float StageLayout::getDistanceSq(StepParity::StagePoint p1, StepParity::StagePoint p2)
 {
 	return (p1.y - p2.y) * (p1.y - p2.y) + (p1.x - p2.x) * (p1.x - p2.x);
+}
+
+float StageLayout::getDistance(int leftIndex, int rightIndex) {
+	if(leftIndex == INVALID_COLUMN || rightIndex == INVALID_COLUMN)
+	{
+		return 0;
+	}
+	int idx = leftIndex * columnCount + rightIndex;
+	return distances[idx];
 }
 
 float StageLayout::getXDifference(int leftIndex, int rightIndex) {
@@ -79,14 +86,86 @@ float StageLayout::getYDifference(int leftIndex, int rightIndex) {
 	return dy;
 }
 
+float StageLayout::getXFacingPenalty(int leftIndex, int rightIndex) {
+	if(leftIndex == INVALID_COLUMN || rightIndex == INVALID_COLUMN)
+	{
+		return 0;
+	}
+	
+	int idx = leftIndex * columnCount + rightIndex;
+	return facingXPenalties[idx];
+}
+
+float StageLayout::getYFacingPenalty(int leftIndex, int rightIndex) {
+	if(leftIndex == INVALID_COLUMN || rightIndex == INVALID_COLUMN)
+	{
+		return 0;
+	}
+	
+	int idx = leftIndex * columnCount + rightIndex;
+	return facingYPenalties[idx];
+}
+
+float facing_penalty(float v) {
+	float base = -1 * std::min(v, 0.0f);
+	float result = pow(base, 1.8) * 100;
+	return result;
+}
+
+void StageLayout::preCalculateStuff()
+{
+	avgPoints.resize(columnCount * columnCount);
+	distances.resize(columnCount * columnCount);
+	facingXPenalties.resize(columnCount * columnCount);
+	facingYPenalties.resize(columnCount * columnCount);
+	
+	for(int left = 0; left < columnCount; left++)
+	{
+		for(int right = 0; right < columnCount; right++)
+		{
+			int idx = left * columnCount + right;
+			
+			StagePoint avgPoint = {
+				(columns[left].x + columns[right].x) / 2.0f,
+				(columns[left].y + columns[right].y) / 2.0f,
+			};
+			avgPoints[idx] = avgPoint;
+			
+			float dx = columns[left].x - columns[right].x;
+			float dy = columns[left].y - columns[right].y;
+			float distSq = (dx * dx) + (dy * dy);
+			float dist = sqrt(distSq);
+			distances[idx] = dist;
+			
+			if(dist == 0)
+			{
+				facingXPenalties[idx] = 0;
+				facingYPenalties[idx] = 0;
+			}
+			else
+			{
+				float normalized_dx = dx / dist;
+				float normalized_dy = dy / dist;
+				float xm = getXDifference(left, right);
+				float ym = getYDifference(left, right);
+				
+				facingXPenalties[idx] = std::max(0.0f, facing_penalty(xm));
+				facingYPenalties[idx] = std::max(0.0f, facing_penalty(ym));
+			}
+		}
+	}
+}
+
 StagePoint StageLayout::averagePoint(int leftIndex, int rightIndex) {
-	if (leftIndex == -1 && rightIndex == -1) return { 0,0 };
-	if (leftIndex == -1) return columns[rightIndex];
-	if (rightIndex == -1) return columns[leftIndex];
-	return {
-	  (columns[leftIndex].x + columns[rightIndex].x) / 2.0f,
-	  (columns[leftIndex].y + columns[rightIndex].y) / 2.0f,
-	};
+	if (leftIndex == INVALID_COLUMN && rightIndex == INVALID_COLUMN) return { 0,0 };
+	if (leftIndex == INVALID_COLUMN) return columns[rightIndex];
+	if (rightIndex == INVALID_COLUMN) return columns[leftIndex];
+//	return {
+//	  (columns[leftIndex].x + columns[rightIndex].x) / 2.0f,
+//	  (columns[leftIndex].y + columns[rightIndex].y) / 2.0f,
+//	};
+	int idx = leftIndex * columnCount + rightIndex;
+	return avgPoints[idx];
 }
 
 float StageLayout::getPlayerAngle(int c1, int c2)

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -13,38 +13,39 @@ bool State::operator==(const State &other) const
 }
 
 // StageLayout
-bool StageLayout::bracketCheck(int column1, int column2)
+bool StageLayout::bracketCheck(int column1, int column2) const
 {
 	float dist =getDistance(column1, column2);
 	return (dist * dist) <= 2;
 }
 
-bool StageLayout::isSideArrow(int column)
+bool StageLayout::isSideArrow(int column) const
 {
 	return std::find(sideArrows.begin(), sideArrows.end(), column) != sideArrows.end();
 }
 
-bool StageLayout::isUpArrow(int column)
+bool StageLayout::isUpArrow(int column) const
 {
 	return std::find(upArrows.begin(), upArrows.end(), column) != upArrows.end();
 }
 
-bool StageLayout::isDownArrow(int column)
+bool StageLayout::isDownArrow(int column) const
 {
 	return std::find(downArrows.begin(), downArrows.end(), column) != downArrows.end();
 }
 
-float StageLayout::getDistanceSq(int c1, int c2)
+float StageLayout::getDistanceSq(int c1, int c2) const
 {
 	return getDistanceSq(columns[c1], columns[c2]);
 }
 
-float StageLayout::getDistanceSq(StepParity::StagePoint p1, StepParity::StagePoint p2)
+float StageLayout::getDistanceSq(StepParity::StagePoint p1, StepParity::StagePoint p2) const
 {
 	return (p1.y - p2.y) * (p1.y - p2.y) + (p1.x - p2.x) * (p1.x - p2.x);
 }
 
-float StageLayout::getDistance(int leftIndex, int rightIndex) {
+float StageLayout::getDistance(int leftIndex, int rightIndex) const
+{
 	if(leftIndex == INVALID_COLUMN || rightIndex == INVALID_COLUMN)
 	{
 		return 0;
@@ -53,7 +54,8 @@ float StageLayout::getDistance(int leftIndex, int rightIndex) {
 	return distances[idx];
 }
 
-float StageLayout::getXDifference(int leftIndex, int rightIndex) {
+float StageLayout::getXDifference(int leftIndex, int rightIndex) const
+{
 	if (leftIndex == rightIndex) return 0;
 	float dx = columns[rightIndex].x - columns[leftIndex].x;
 	float dy = columns[rightIndex].y - columns[leftIndex].y;
@@ -70,7 +72,8 @@ float StageLayout::getXDifference(int leftIndex, int rightIndex) {
 	return dx;
 }
 
-float StageLayout::getYDifference(int leftIndex, int rightIndex) {
+float StageLayout::getYDifference(int leftIndex, int rightIndex) const
+{
 	if (leftIndex == rightIndex) return 0;
 	float dx = columns[rightIndex].x - columns[leftIndex].x;
 	float dy = columns[rightIndex].y - columns[leftIndex].y;
@@ -87,7 +90,8 @@ float StageLayout::getYDifference(int leftIndex, int rightIndex) {
 	return dy;
 }
 
-float StageLayout::getXFacingPenalty(int leftIndex, int rightIndex) {
+float StageLayout::getXFacingPenalty(int leftIndex, int rightIndex) const
+{
 	if(leftIndex == INVALID_COLUMN || rightIndex == INVALID_COLUMN)
 	{
 		return 0;
@@ -97,7 +101,8 @@ float StageLayout::getXFacingPenalty(int leftIndex, int rightIndex) {
 	return facingXPenalties[idx];
 }
 
-float StageLayout::getYFacingPenalty(int leftIndex, int rightIndex) {
+float StageLayout::getYFacingPenalty(int leftIndex, int rightIndex) const
+{
 	if(leftIndex == INVALID_COLUMN || rightIndex == INVALID_COLUMN)
 	{
 		return 0;
@@ -291,7 +296,7 @@ std::vector<FootPlacement> StageLayout::PermuteFootPlacements(unsigned int mask,
 
 
 
-StagePoint StageLayout::averagePoint(int leftIndex, int rightIndex) {
+StagePoint StageLayout::averagePoint(int leftIndex, int rightIndex) const {
 	if (leftIndex == INVALID_COLUMN && rightIndex == INVALID_COLUMN) return { 0,0 };
 	if (leftIndex == INVALID_COLUMN) return columns[rightIndex];
 	if (rightIndex == INVALID_COLUMN) return columns[leftIndex];
@@ -303,11 +308,11 @@ StagePoint StageLayout::averagePoint(int leftIndex, int rightIndex) {
 	return avgPoints[idx];
 }
 
-float StageLayout::getPlayerAngle(int c1, int c2)
+float StageLayout::getPlayerAngle(int c1, int c2)const
 {
 	return getPlayerAngle(columns[c1], columns[c2]);
 }
-float StageLayout::getPlayerAngle(StepParity::StagePoint left, StepParity::StagePoint right)
+float StageLayout::getPlayerAngle(StepParity::StagePoint left, StepParity::StagePoint right) const
 {
 	float x1 = right.x - left.x;
 	float y1 = right.y - left.y;

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -6,10 +6,9 @@ using namespace StepParity;
 
 bool State::operator==(const State &other) const
 {
-   return columns == other.columns &&
-	combinedColumns == other.combinedColumns &&
-   movedFeet == other.movedFeet &&
-   holdFeet == other.holdFeet;
+	return combined_mask == other.combined_mask &&
+	moved_mask == other.moved_mask &&
+	holding_mask == other.holding_mask;
 }
 
 // StageLayout
@@ -330,13 +329,13 @@ float StageLayout::getPlayerAngle(StepParity::StagePoint left, StepParity::Stage
 }
 
 // Row
-void Row::setFootPlacement(const std::vector<Foot> & footPlacement)
+void Row::setFootPlacement(const StepParity::State * state)
 {
 	for (int c = 0; c < columnCount; c++) {
 		if(notes[c].type != TapNoteType_Empty) {
-			notes[c].parity = footPlacement[c];
-			columns[c] = footPlacement[c];
-			whereTheFeetAre[footPlacement[c]] = c;
+			notes[c].parity = state->combinedColumns[c];
+			columns[c] = state->combinedColumns[c];
+			whereTheFeetAre[state->combinedColumns[c]] = c;
 			noteCount += 1;
 		}
 	}

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -183,6 +183,11 @@ inline int popcount(unsigned int x) {
 
 void StageLayout::preGeneratePermutations()
 {
+	// Set an empty array for a bitmask of 0x0, this is used
+	// by StepParityGenerator::getFootPlacementPermutations
+	// to return an empty array
+	permuteCache[0] = {};
+	
 	for(unsigned int i = 0; i < pow(2, columnCount); i++)
 	{
 		int bits = popcount(i);
@@ -193,7 +198,10 @@ void StageLayout::preGeneratePermutations()
 		FootPlacement blankColumns(columnCount, NONE);
 		
 		std::vector<FootPlacement> placements = PermuteFootPlacements(i, blankColumns, 0);
-		permuteCache[i] = std::move(placements);
+		if(placements.size() > 0)
+		{
+			permuteCache[i] = std::move(placements);
+		}
 	}
 }
 

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -203,7 +203,6 @@ bool Row::operator==(const Row& other) const
 	rowIndex == other.rowIndex &&
 	columnCount == other.columnCount &&
 	noteCount == other.noteCount &&
-	holdTails == other.holdTails &&
 	mines == other.mines &&
 	fakeMines == other.fakeMines &&
 	columns == other.columns &&

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -157,6 +157,140 @@ void StageLayout::preCalculateStuff()
 	}
 }
 
+inline int popcount(unsigned int x) {
+#if defined(__GNUC__) || defined(__clang__)
+	return __builtin_popcount(x);
+#elif defined(_MSC_VER)
+	#include <intrin.h>
+	return __popcnt(x);
+#else
+	// Fallback implementation
+	int count = 0;
+	while (x) {
+		x &= x - 1;  // Clear the lowest set bit
+		count++;
+	}
+	return count;
+#endif
+}
+
+void StageLayout::preGeneratePermutations()
+{
+	for(unsigned int i = 0; i < pow(2, columnCount); i++)
+	{
+		int bits = popcount(i);
+		if(bits > 4)
+		{
+			continue;
+		}
+		FootPlacement blankColumns(columnCount, NONE);
+		
+		std::vector<FootPlacement> placements = PermuteFootPlacements(i, blankColumns, 0);
+		permuteCache[i] = std::move(placements);
+	}
+}
+
+std::vector<FootPlacement> StageLayout::PermuteFootPlacements(unsigned int mask, FootPlacement columns, unsigned long column)
+{
+	std::vector<StepParity::Foot> FEET = {LEFT_HEEL, LEFT_TOE, RIGHT_HEEL, RIGHT_TOE};
+	// If column >= columns.size(), we've reached the end of the row.
+	// Perform some final validation before returning the contents of columns
+	if (column >= columns.size())
+	{
+		int leftHeelIndex = StepParity::INVALID_COLUMN;
+		int leftToeIndex = StepParity::INVALID_COLUMN;
+		int rightHeelIndex = StepParity::INVALID_COLUMN;
+		int rightToeIndex = StepParity::INVALID_COLUMN;
+		
+		for (unsigned long i = 0; i < columns.size(); i++)
+		{
+			if (columns[i] == NONE)
+			{
+				continue;
+			}
+			if (columns[i] == LEFT_HEEL)
+			{
+				leftHeelIndex = i;
+			}
+			if (columns[i] == LEFT_TOE)
+			{
+				leftToeIndex = i;
+			}
+			if (columns[i] == RIGHT_HEEL)
+			{
+				rightHeelIndex = i;
+			}
+			if (columns[i] == RIGHT_TOE)
+			{
+				rightToeIndex = i;
+			}
+		}
+		
+		// Filter out actually invalid combinations:
+		// - We don't want permutations where the toe is on an arrow, but not the heel
+		// - We don't want impossible brackets (eg you can't bracket up and down)
+		if (
+			(leftHeelIndex == StepParity::INVALID_COLUMN && leftToeIndex != StepParity::INVALID_COLUMN) ||
+			(rightHeelIndex == StepParity::INVALID_COLUMN && rightToeIndex != StepParity::INVALID_COLUMN))
+		{
+			return std::vector<FootPlacement>();
+		}
+		if (leftHeelIndex != StepParity::INVALID_COLUMN && leftToeIndex != StepParity::INVALID_COLUMN)
+		{
+			if (!bracketCheck(leftHeelIndex, leftToeIndex))
+			{
+				return std::vector<FootPlacement>();
+			}
+		}
+		if (rightHeelIndex != StepParity::INVALID_COLUMN && rightToeIndex != StepParity::INVALID_COLUMN)
+		{
+			if (!bracketCheck(rightHeelIndex, rightToeIndex))
+			{
+				return std::vector<FootPlacement>();
+			}
+		}
+		return {columns};
+	}
+		// If this column has a valid tap/hold head, or is actively holding a note,
+		// iterate through values of StepParity::Foot. For each foot part, check that
+		// it's not already present in columns, and if not, create a copy of columns,
+		// and set the current foot part to the current column.
+		// Then pass it to PermuteFootPlacements() and increment the column index.
+		// Collect each permutationm, and then return all of them.
+		//
+		// The `ignoreHolds` flag is used as a workaround for situations where
+		// we can't find a valid foot placement that allows us to continue the holds
+		// (BREACH PROTOCOL doubles has  a row 0311 1000 which isn't bracketable
+		// while still holding p1 down)
+		std::vector<FootPlacement> permutations;
+		bool active = (mask & (0x1 << column)) != 0;
+	
+		if (active)
+		{
+			for (StepParity::Foot foot: FEET) {
+				if(std::find(columns.begin(), columns.end(), foot) != columns.end())
+				{
+					continue;
+				}
+
+				FootPlacement newColumns = columns;
+
+				newColumns[column] = foot;
+				std::vector<FootPlacement> p = PermuteFootPlacements(mask, newColumns, column + 1);
+				permutations.insert(permutations.end(), p.begin(), p.end());
+			}
+			  return permutations;
+		}
+		// If the current column doesn't have any taps or holds,
+		// then we don't need to generate any permutations for it.
+		// Return the contents of calling PermuteFootPlacements() for the next column.
+		return PermuteFootPlacements(mask, columns, column + 1);
+}
+
+
+
+
+
 StagePoint StageLayout::averagePoint(int leftIndex, int rightIndex) {
 	if (leftIndex == INVALID_COLUMN && rightIndex == INVALID_COLUMN) return { 0,0 };
 	if (leftIndex == INVALID_COLUMN) return columns[rightIndex];

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -275,23 +275,14 @@ namespace StepParity {
 		int rowIndex = 0;
 		float second = 0;
 		
-		// Connections to, and the cost of moving to, the connected nodes
-		std::unordered_map<StepParityNode *, float> neighbors;
+		float totalCost = 0;
+		StepParityNode* previousNode = 0;
 		
-		~StepParityNode()
-		{
-			neighbors.clear();
-		}
 		StepParityNode(State *_state, float _second, int _rowIndex)
 		{
 			state = _state;
 			rowIndex = _rowIndex;
 			second = _second;
-		}
-		
-		int neighborCount()
-		{
-			return static_cast<int>(neighbors.size());
 		}
 	};
 };

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -116,20 +116,20 @@ namespace StepParity {
 		}
 		
 		
-		bool bracketCheck(int column1, int column2);
-		bool isSideArrow(int column);
-		bool isUpArrow(int column);
-		bool isDownArrow(int column);
-		float getDistanceSq(int c1, int c2);
-		float getDistanceSq(StagePoint p1, StagePoint p2);
-		float getDistance(int leftIndex, int rightIndex);
-		float getXFacingPenalty(int leftIndex, int rightIndex);
-		float getYFacingPenalty(int leftIndex, int rightIndex);
-		float getXDifference(int leftIndex, int rightIndex);
-		float getYDifference(int leftIndex, int rightIndex);
-		StagePoint averagePoint(int leftIndex, int rightIndex);
-		float getPlayerAngle(int c1, int c2);
-		float getPlayerAngle(StepParity::StagePoint left, StepParity::StagePoint right);
+		bool bracketCheck(int column1, int column2) const;
+		bool isSideArrow(int column) const;
+		bool isUpArrow(int column) const;
+		bool isDownArrow(int column) const;
+		float getDistanceSq(int c1, int c2) const;
+		float getDistanceSq(StagePoint p1, StagePoint p2) const;
+		float getDistance(int leftIndex, int rightIndex) const;
+		float getXFacingPenalty(int leftIndex, int rightIndex) const;
+		float getYFacingPenalty(int leftIndex, int rightIndex) const;
+		float getXDifference(int leftIndex, int rightIndex) const;
+		float getYDifference(int leftIndex, int rightIndex) const;
+		StagePoint averagePoint(int leftIndex, int rightIndex) const;
+		float getPlayerAngle(int c1, int c2) const;
+		float getPlayerAngle(StepParity::StagePoint left, StepParity::StagePoint right) const;
 		
 		void preCalculateStuff();
 		void preGeneratePermutations();

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -10,6 +10,7 @@ namespace StepParity {
 	
 	const int INVALID_COLUMN = -1;
 	const float CLM_SECOND_INVALID = -1;
+	const int MAX_COLUMNS = 16;
 
 	enum Foot
 	{
@@ -140,36 +141,18 @@ namespace StepParity {
 	/// @brief Represents a specific possible state of the player's position
 	/// for a given row of the step chart.
 	struct State {
-		FootPlacement columns;	 // what the feet are hitting on this row
-		FootPlacement combinedColumns; // The resulting position of the player
-		FootPlacement movedFeet; // Any feet that have moved from the previous state to this one
-		FootPlacement holdFeet;  // Any feet that stayed in place due to a hold/roll note.
+		StepParity::Foot combinedColumns[MAX_COLUMNS] = {}; // The resulting position of the player
 		
 		// masks that indicate which foot moved/is holding.
 		uint16_t moved_mask = 0;
 		uint16_t holding_mask = 0;
+		// mask equivalent of combinedColumns, 3 bits for each column
+		uint32_t combined_mask = 0;
 		
-		int whereTheFeetAre[NUM_Foot]; // the inverse of combinedColumns
-		int whatNoteTheFootIsHitting[NUM_Foot]; // the inverse of columns
-		bool didTheFootMove[NUM_Foot]; // the inverse of movedFeet
-		bool isTheFootHolding[NUM_Foot]; //inverse of holdFeet
-		
-		State(int columnCount)
-		{
-			columns = FootPlacement(columnCount, NONE);
-			combinedColumns = FootPlacement(columnCount, NONE);
-			movedFeet = FootPlacement(columnCount, NONE);
-			holdFeet = FootPlacement(columnCount, NONE);
-			
-			for(int i = 0; i < NUM_Foot; i++)
-			{
-				whatNoteTheFootIsHitting[i] = INVALID_COLUMN;
-				whereTheFeetAre[i] = INVALID_COLUMN;
-				didTheFootMove[i] = false;
-				isTheFootHolding[i] = false;
-			}
-		}
-		
+		int whereTheFeetAre[NUM_Foot] = {}; // the inverse of combinedColumns
+		int whatNoteTheFootIsHitting[NUM_Foot] = {};
+		bool didTheFootMove[NUM_Foot] = {};
+		bool isTheFootHolding[NUM_Foot] = {};
 		
 		bool operator==(const State& other) const;
 	};
@@ -236,7 +219,7 @@ namespace StepParity {
 			whereTheFeetAre = std::vector<int>(StepParity::NUM_Foot, INVALID_COLUMN);
 		}
 		
-		void setFootPlacement(const std::vector<Foot> & footPlacement);
+		void setFootPlacement(const StepParity::State * state);
 		
 		bool operator==(const Row& other) const;
 		bool operator!=(const Row& other) const;

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -7,7 +7,7 @@
 #include <unordered_map>
 
 namespace StepParity {
-
+	
 	const int INVALID_COLUMN = -1;
 	const float CLM_SECOND_INVALID = -1;
 
@@ -89,12 +89,19 @@ namespace StepParity {
 		std::vector<int> downArrows;
 		std::vector<int> sideArrows;
 		
+		std::vector<StagePoint> avgPoints;
+		std::vector<float> distances;
+		std::vector<float> facingXPenalties;
+		std::vector<float> facingYPenalties;
+		
 		StageLayout(StepsType t,
 					 const std::vector<StagePoint>& c,
 					 const std::vector<int> & u,
 					 const std::vector<int> & d,
 					 const std::vector<int> & s) : type(t), columns(c), upArrows(u), downArrows(d), sideArrows(s) {
 			this->columnCount = static_cast<int>(this->columns.size());
+			this->preCalculateStuff();
+			
 		}
 		
 		
@@ -104,11 +111,17 @@ namespace StepParity {
 		bool isDownArrow(int column);
 		float getDistanceSq(int c1, int c2);
 		float getDistanceSq(StagePoint p1, StagePoint p2);
+		float getDistance(int leftIndex, int rightIndex);
+		float getXFacingPenalty(int leftIndex, int rightIndex);
+		float getYFacingPenalty(int leftIndex, int rightIndex);
 		float getXDifference(int leftIndex, int rightIndex);
 		float getYDifference(int leftIndex, int rightIndex);
 		StagePoint averagePoint(int leftIndex, int rightIndex);
 		float getPlayerAngle(int c1, int c2);
 		float getPlayerAngle(StepParity::StagePoint left, StepParity::StagePoint right);
+		
+		void preCalculateStuff();
+		
 	};
 
 	/// @brief A vector of Foot values, which represents the player's

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -21,6 +21,10 @@ namespace StepParity {
 		NUM_Foot
 	};
 
+	/// @brief A vector of Foot values, which represents the player's
+	/// foot placement on the dance stage.
+	typedef std::vector<Foot> FootPlacement;
+
 	const std::vector<uint16_t> FOOT_MASKS = {0,1,2,4,8};
 	
 	const int16_t FOOT_MASK_LEFT = FOOT_MASKS[Foot::LEFT_HEEL] | FOOT_MASKS[Foot::LEFT_TOE];
@@ -34,7 +38,7 @@ namespace StepParity {
 	
 	const RString FEET_LABELS[] = {"N", "L", "l", "R", "r", "5??", "6??"};
 	const RString TapNoteTypeShortNames[] = { "Empty", "Tap",  "Mine",  "Attack", "AutoKeySound", "Fake", "", "" };
-	const RString TapNoteSubTypeShortNames[] = { "Hold", "Roll", "", "" };	
+	const RString TapNoteSubTypeShortNames[] = { "Hold", "Roll", "", "" };
 
 	enum Cost
 	{
@@ -98,6 +102,7 @@ namespace StepParity {
 		std::vector<float> distances;
 		std::vector<float> facingXPenalties;
 		std::vector<float> facingYPenalties;
+		std::unordered_map < int, std::vector<FootPlacement>> permuteCache;
 		
 		StageLayout(StepsType t,
 					 const std::vector<StagePoint>& c,
@@ -106,6 +111,7 @@ namespace StepParity {
 					 const std::vector<int> & s) : type(t), columns(c), upArrows(u), downArrows(d), sideArrows(s) {
 			this->columnCount = static_cast<int>(this->columns.size());
 			this->preCalculateStuff();
+			this->preGeneratePermutations();
 			
 		}
 		
@@ -126,12 +132,10 @@ namespace StepParity {
 		float getPlayerAngle(StepParity::StagePoint left, StepParity::StagePoint right);
 		
 		void preCalculateStuff();
+		void preGeneratePermutations();
+		std::vector<StepParity::FootPlacement> PermuteFootPlacements(unsigned int, StepParity::FootPlacement columns, unsigned long column);
 		
 	};
-
-	/// @brief A vector of Foot values, which represents the player's
-	/// foot placement on the dance stage.
-	typedef std::vector<Foot> FootPlacement;
 
 	/// @brief Represents a specific possible state of the player's position
 	/// for a given row of the step chart.

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -189,8 +189,7 @@ namespace StepParity {
 		std::vector<IntermediateNoteData> notes;
 		// Any active hold notes, including ones that started before this row
 		std::vector<IntermediateNoteData> holds;
-		// Column index of any holds that end on this row
-		std::set<int> holdTails;
+		
 		// If a mine occurred either on this row, or on a row on its own immediately
 		// preceding this one, the time of when that mine occurred, indexed by column.
 		std::vector<float> mines;
@@ -199,6 +198,12 @@ namespace StepParity {
 
 		FootPlacement columns;
 		std::vector<int> whereTheFeetAre;
+		
+		// bit masks for quick comparisons
+		uint16_t note_mask = 0;
+		uint16_t hold_mask = 0;
+		uint16_t mine_mask = 0;
+		uint16_t fake_mine_mask = 0;
 		
 		float second = 0;
 		float beat = 0;
@@ -212,7 +217,6 @@ namespace StepParity {
 			columnCount = _columnCount;
 			notes = std::vector<IntermediateNoteData>(columnCount);
 			holds = std::vector<IntermediateNoteData>(columnCount);
-			holdTails.clear();
 			mines = std::vector<float>(columnCount, 0);
 			fakeMines = std::vector<float>(columnCount, 0);
 			columns = std::vector<StepParity::Foot>(columnCount, StepParity::NONE);

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -21,6 +21,11 @@ namespace StepParity {
 		NUM_Foot
 	};
 
+	const std::vector<uint16_t> FOOT_MASKS = {0,1,2,4,8};
+	
+	const int16_t FOOT_MASK_LEFT = FOOT_MASKS[Foot::LEFT_HEEL] | FOOT_MASKS[Foot::LEFT_TOE];
+	const int16_t FOOT_MASK_RIGHT = FOOT_MASKS[Foot::RIGHT_HEEL] | FOOT_MASKS[Foot::RIGHT_TOE];
+
 	const std::vector<StepParity::Foot> FEET = {LEFT_HEEL, LEFT_TOE, RIGHT_HEEL, RIGHT_TOE};
 	// A map for getting the other part of the foot, when you don't actually care
 	// what part it is.
@@ -135,7 +140,11 @@ namespace StepParity {
 		FootPlacement combinedColumns; // The resulting position of the player
 		FootPlacement movedFeet; // Any feet that have moved from the previous state to this one
 		FootPlacement holdFeet;  // Any feet that stayed in place due to a hold/roll note.
-
+		
+		// masks that indicate which foot moved/is holding.
+		uint16_t moved_mask = 0;
+		uint16_t holding_mask = 0;
+		
 		int whereTheFeetAre[NUM_Foot]; // the inverse of combinedColumns
 		int whatNoteTheFootIsHitting[NUM_Foot]; // the inverse of columns
 		bool didTheFootMove[NUM_Foot]; // the inverse of movedFeet

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -103,7 +103,7 @@ void StepParityGenerator::buildStateGraph()
 	// which just get connected to the endState
 	endingState = new State();
 	endNode = addNode(endingState, rows[rows.size() - 1].second + 1, rows.size());
-	endNode->totalCost = MAXFLOAT;
+	endNode->totalCost = FLT_MAX;
 	
 	for(StepParityNode *node : previousNodes)
 	{

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -49,8 +49,13 @@ void StepParityGenerator::buildStateGraph()
 	previousNodes.push(startNode);
 	StepParityCost costCalculator(layout);
 
+	// maps the current row's Nodes based on their State's cache key
+	std::unordered_map<uint64_t, StepParityNode*> stateMap;
+	
 	for (unsigned long i = 0; i < rows.size(); i++)
 	{
+		stateMap.clear();
+		
 		std::vector<StepParityNode *> resultNodes;
 		Row &row = rows[i];
 		const std::vector<FootPlacement> *permutations = getFootPlacementPermutations(row);
@@ -62,10 +67,33 @@ void StepParityGenerator::buildStateGraph()
 			for(auto it = permutations->begin(); it != permutations->end(); it++)
 			{
 				State * resultState = initResultState(initialNode->state, row, *it);
-				
 				float cost = costCalculator.getActionCost(initialNode->state, resultState, rows, *it, i, elapsedTime);
-				addStateToGraph(resultState, initialNode, row, resultNodes, cost);
 				
+				std::uint64_t key = getStateCacheKey(resultState);
+				
+				// Do we already have a Node in this row for this same resultState?
+				// If so, and the totalCost is lower, update that node's totalCost
+				// and previousNode.
+				// Otherwise, add a new node and save it to stateMap
+				auto itn = stateMap.find(key);
+				if(itn != stateMap.end())
+				{
+					StepParityNode * existingNode = itn->second;
+					float totalCost = initialNode->totalCost + cost;
+					if(totalCost < existingNode->totalCost)
+					{
+						existingNode->totalCost = totalCost;
+						existingNode->previousNode = initialNode;
+					}
+				}
+				else
+				{
+					StepParityNode * newNode = addNode(resultState, row.second, i);
+					newNode->totalCost = initialNode->totalCost + cost;
+					newNode->previousNode = initialNode;
+					stateMap[key] = newNode;
+					resultNodes.push_back(newNode);
+				}
 			}
 			previousNodes.pop();
 		}
@@ -80,30 +108,20 @@ void StepParityGenerator::buildStateGraph()
 	// which just get connected to the endState
 	endingState = new State();
 	endNode = addNode(endingState, rows[rows.size() - 1].second + 1, rows.size());
+	endNode->totalCost = MAXFLOAT;
 	
 	while(!previousNodes.empty())
 	{
 		StepParityNode *node = previousNodes.front();
-		addEdge(node, endNode, 0);
+		if(node->totalCost < endNode->totalCost)
+		{
+			endNode->totalCost = node->totalCost;
+			endNode->previousNode = node;
+		}
 		previousNodes.pop();
 	}
 }
 
-void StepParityGenerator::addStateToGraph(State * resultState, StepParityNode * initialNode, Row & row, std::vector<StepParityNode *> &existingNodesForThisRow, float cost)
-{
-	
-	for(StepParityNode * existingNode : existingNodesForThisRow)
-	{
-		if(existingNode->state == resultState)
-		{
-			addEdge(initialNode, existingNode, cost);
-			return;
-		}
-	}
-	StepParityNode *resultNode = addNode(resultState, row.second, row.rowIndex);
-	addEdge(initialNode, resultNode, cost);
-	existingNodesForThisRow.push_back(resultNode);
-}
 
 
 State * StepParityGenerator::initResultState(State * initialState, Row &row, const FootPlacement &columns)
@@ -115,7 +133,6 @@ State * StepParityGenerator::initResultState(State * initialState, Row &row, con
 	
 	State * resultState = tmpState;
 	
-
 	// reset resultState
 	
 	resultState->moved_mask = 0;
@@ -276,48 +293,37 @@ const std::vector<FootPlacement>* StepParityGenerator::getFootPlacementPermutati
 
 std::vector<int> StepParityGenerator::computeCheapestPath()
 {
-	int start = startNode->id;
-	int end = endNode->id;
-	std::vector<int> shortest_path;
-	std::vector<float> cost(nodes.size(), FLT_MAX);
-	std::vector<int> predecessor(nodes.size(), -1);
-
-	cost[start] = 0;
-	for (int i = start; i <= end; i++)
+	// Find the best final node
+	StepParityNode* bestFinalNode = endNode->previousNode;  // If you're using the endNode approach
+	
+	// OR if you're tracking the best final node directly:
+	// StepParityNode* bestFinalNode = ... (the one with minimum totalCost)
+	
+	if (bestFinalNode == nullptr)
 	{
-		
-		StepParityNode *node = nodes[i];
-		for(auto neighbor: node->neighbors)
-		{
-			int neighbor_id = neighbor.first->id;
-			float weight = neighbor.second;
-			if(cost[i] + weight < cost[neighbor_id])
-			{
-				cost[neighbor_id] = cost[i] + weight;
-				predecessor[neighbor_id] = i;
-			}
-		}
+		LOG->Info("StepParityGenerator::computeCheapestPath: no valid path found");
+		return {};
 	}
-
-	int current_node = end;
-	while(current_node != start)
+	
+	std::vector<int> path;
+	StepParityNode* current = bestFinalNode;
+	
+	// Walk backwards using pred pointers
+	while (current != startNode && current != nullptr)
 	{
-		
-		if(current_node == -1)
-		{
-			LOG->Info("StepParityGenerator::computeCheapestPath: encountered a value of -1 for 'current_node', this means that we did not produce a valid chart.");
-			return {};
-		}
-		if(current_node != end)
-		{
-			shortest_path.push_back(current_node);
-		}
-		current_node = predecessor[current_node];
+		path.push_back(current->id);
+		current = current->previousNode;
 	}
-	std::reverse(shortest_path.begin(), shortest_path.end());
-	return shortest_path;
+	
+	if (current == nullptr)
+	{
+		LOG->Info("StepParityGenerator::computeCheapestPath: path did not reach start node");
+		return {};
+	}
+	
+	std::reverse(path.begin(), path.end());
+	return path;
 }
-
 void StepParityGenerator::CreateIntermediateNoteData(
 		const NoteData &in, std::vector<IntermediateNoteData> &out)
 {
@@ -540,9 +546,4 @@ StepParityNode * StepParityGenerator::addNode(State *state, float second, int ro
 	newNode->id = int(nodes.size());
 	nodes.push_back(newNode);
 	return newNode;
-}
-
-void StepParityGenerator::addEdge(StepParityNode* from, StepParityNode* to, float cost)
-{
-	from->neighbors[to] = cost;
 }

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -53,7 +53,7 @@ void StepParityGenerator::buildStateGraph()
 	{
 		std::vector<StepParityNode *> resultNodes;
 		Row &row = rows[i];
-		std::vector<FootPlacement> *permutations = getFootPlacementPermutations(row);
+		const std::vector<FootPlacement> *permutations = getFootPlacementPermutations(row);
 		
 		while (!previousNodes.empty())
 		{
@@ -250,20 +250,20 @@ void StepParityGenerator::mergeInitialAndResultPosition(State * initialState, St
 	}
 }
 
-std::vector<FootPlacement>* StepParityGenerator::getFootPlacementPermutations(const Row &row)
+const std::vector<FootPlacement>* StepParityGenerator::getFootPlacementPermutations(const Row &row)
 {
 	int cacheKey = row.note_mask | row.hold_mask;
 	
-	auto maybePermuteFootPlacements = layout.permuteCache.find(cacheKey);
+	auto maybePermuteFootPlacements = layout->permuteCache.find(cacheKey);
 	
-	if (maybePermuteFootPlacements == layout.permuteCache.end())
+	if (maybePermuteFootPlacements == layout->permuteCache.end())
 	{
-		maybePermuteFootPlacements = layout.permuteCache.find(row.note_mask);
+		maybePermuteFootPlacements = layout->permuteCache.find(row.note_mask);
 	}
 	
-	if(maybePermuteFootPlacements == layout.permuteCache.end())
+	if(maybePermuteFootPlacements == layout->permuteCache.end())
 	{
-		return &layout.permuteCache[0];
+		return &(layout->permuteCache.at(0));
 	}
 	else
 	{

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -33,7 +33,7 @@ bool StepParityGenerator::analyzeGraph() {
 	for (unsigned long i = 0; i < rows.size(); i++)
 	{
 		StepParityNode *node = nodes[nodes_for_rows[i]];
-		rows[i].setFootPlacement(node->state->combinedColumns);
+		rows[i].setFootPlacement(node->state);
 	}
 	return true;
 }
@@ -42,7 +42,7 @@ void StepParityGenerator::buildStateGraph()
 {
 	// The first node of the graph is beginningState, which represents the time before
 	// the first note (and so it's roIndex is considered -1)
-	beginningState = new State(columnCount_);
+	beginningState = new State();
 	startNode = addNode(beginningState, rows[0].second - 1, -1);
 	
 	std::queue<StepParityNode *> previousNodes;
@@ -63,7 +63,7 @@ void StepParityGenerator::buildStateGraph()
 			{
 				State * resultState = initResultState(initialNode->state, row, *it);
 				
-				float cost = costCalculator.getActionCost(initialNode->state, resultState, rows, i, elapsedTime);
+				float cost = costCalculator.getActionCost(initialNode->state, resultState, rows, *it, i, elapsedTime);
 				addStateToGraph(resultState, initialNode, row, resultNodes, cost);
 				
 			}
@@ -78,7 +78,7 @@ void StepParityGenerator::buildStateGraph()
 	
 	// at this point, previousStates holds all of the states for the very last row,
 	// which just get connected to the endState
-	endingState = new State(columnCount_);
+	endingState = new State();
 	endNode = addNode(endingState, rows[rows.size() - 1].second + 1, rows.size());
 	
 	while(!previousNodes.empty())
@@ -110,7 +110,7 @@ State * StepParityGenerator::initResultState(State * initialState, Row &row, con
 {
 	if(tmpState == nullptr)
 	{
-		tmpState = new State(row.columnCount);
+		tmpState = new State();
 	}
 	
 	State * resultState = tmpState;
@@ -120,6 +120,8 @@ State * StepParityGenerator::initResultState(State * initialState, Row &row, con
 	
 	resultState->moved_mask = 0;
 	resultState->holding_mask = 0;
+	resultState->combined_mask = 0;
+	
 	for(int i = 0; i < NUM_Foot; i++)
 	{
 		resultState->whereTheFeetAre[i] = INVALID_COLUMN;
@@ -130,16 +132,12 @@ State * StepParityGenerator::initResultState(State * initialState, Row &row, con
 	
 	for (unsigned long i = 0; i < columns.size(); i++)
 	{
-		resultState->columns[i] = NONE;
 		resultState->combinedColumns[i] = NONE;
-		resultState->movedFeet[i] = NONE;
-		resultState->holdFeet[i] = NONE;
 	}
 		
 	// I tried to condense this, but kept getting the logic messed up
 	for (unsigned long i = 0; i < columns.size(); i++)
 	{
-		resultState->columns[i] = columns[i];
 		if(columns[i] == NONE) {
 			continue;
 		}
@@ -147,13 +145,12 @@ State * StepParityGenerator::initResultState(State * initialState, Row &row, con
 
 		if(row.holds[i].type == TapNoteType_Empty)
 		{
-			resultState->movedFeet[i] = columns[i];
 			resultState->didTheFootMove[columns[i]] = true;
 			continue;
 		}
+		
 		if(initialState->combinedColumns[i] != columns[i])
 		{
-			resultState->movedFeet[i] = columns[i];
 			resultState->didTheFootMove[columns[i]] = true;
 		}
 	}
@@ -166,7 +163,6 @@ State * StepParityGenerator::initResultState(State * initialState, Row &row, con
 
 		if(row.holds[i].type != TapNoteType_Empty)
 		{
-			resultState->holdFeet[i] = columns[i];
 			resultState->isTheFootHolding[columns[i]] = true;
 		}
 		
@@ -182,7 +178,7 @@ State * StepParityGenerator::initResultState(State * initialState, Row &row, con
 		}
 	}
 	
-	mergeInitialAndResultPosition(initialState, resultState, (int)columns.size());
+	mergeInitialAndResultPosition(initialState, resultState, columns, (int)columns.size());
 	
 	std::uint64_t stateHash = getStateCacheKey(resultState);
 	
@@ -199,20 +195,20 @@ State * StepParityGenerator::initResultState(State * initialState, Row &row, con
 	return resultState;
 }
 
-// This merges the `columns` properties of initialState and resultState, which
+// This merges the `combinedColumns` of initialState with the next `columns`, which
 // fully represents the player's position on the dance stage.
 // For example:
 // initialState.combinedColumns = [L,0,0,R]
-// resultState.columns = [0,L,0,0]
-// combinedColumns = [0,L,0,R]
+// columns = [0,L,0,0]
+// resultState.combinedColumns = [0,L,0,R]
 // This eventually gets saved back to resultState
-void StepParityGenerator::mergeInitialAndResultPosition(State * initialState, State * resultState, int columnCount)
+void StepParityGenerator::mergeInitialAndResultPosition(State * initialState, State * resultState, const FootPlacement & columns, int columnCount)
 {
 	// Merge initial + result position
 	for (int i = 0; i < columnCount; i++) {
-	  	  // copy in data from resultState over the top which overrides it, as long as it's not nothing
-	  	  if (resultState->columns[i] != NONE) {
-		  	  resultState->combinedColumns[i] = resultState->columns[i];
+	  	  // copy in data from columns over the top which overrides it, as long as it's not nothing
+	  	  if (columns[i] != NONE) {
+		  	  resultState->combinedColumns[i] = columns[i];
 		continue;
 	  	  }
 
@@ -247,6 +243,7 @@ void StepParityGenerator::mergeInitialAndResultPosition(State * initialState, St
 		{
 			resultState->whereTheFeetAre[resultState->combinedColumns[i]] = i;
 		}
+		resultState->combined_mask |= (static_cast<uint32_t>(resultState->combinedColumns[i])) << (i * 3);
 	}
 }
 
@@ -533,27 +530,7 @@ int StepParityGenerator::getPermuteCacheKey(const Row &row)
 std::uint64_t StepParityGenerator::getStateCacheKey(State * state)
 {
 	std::uint64_t value = 0;
-	const std::uint64_t prime = 31;
-	for(Foot f : state->columns)
-	{
-		value *= prime;
-		value += f;
-	}
-	for(Foot f : state->combinedColumns)
-	{
-		value *= prime;
-		value += f;
-	}
-	for(Foot f : state->movedFeet)
-	{
-		value *= prime;
-		value += f;
-	}
-	for(Foot f : state->holdFeet)
-	{
-		value *= prime;
-		value += f;
-	}
+	value = state->combined_mask | (static_cast<uint64_t>(state->moved_mask) << 30) | (static_cast<uint64_t>(state->holding_mask) << 46);
 	return value;
 }
 

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -54,7 +54,7 @@ void StepParityGenerator::buildStateGraph()
 		std::vector<StepParityNode *> resultNodes;
 		Row &row = rows[i];
 		std::vector<FootPlacement> *permutations = getFootPlacementPermutations(row);
-				
+		
 		while (!previousNodes.empty())
 		{
 			StepParityNode *initialNode = previousNodes.front();
@@ -250,135 +250,26 @@ void StepParityGenerator::mergeInitialAndResultPosition(State * initialState, St
 	}
 }
 
-// For the given row, generate all of the possible foot placements
-// (even if they're not physically possible)
-//
-// We cache this data and return a pointer for two reasons:
-// - It takes a long time to generate the permutations
-// - We end up generating a lot of redundant data, so caching it saves memory
-
 std::vector<FootPlacement>* StepParityGenerator::getFootPlacementPermutations(const Row &row)
 {
-	int cacheKey = getPermuteCacheKey(row);	
-	auto maybePermuteFootPlacements = permuteCache.find(cacheKey);
+	int cacheKey = row.note_mask | row.hold_mask;
 	
-	if (maybePermuteFootPlacements == permuteCache.end())
+	auto maybePermuteFootPlacements = layout.permuteCache.find(cacheKey);
+	
+	if (maybePermuteFootPlacements == layout.permuteCache.end())
 	{
-		FootPlacement blankColumns(row.columnCount, NONE);
-		std::vector<FootPlacement> computedPermutations = PermuteFootPlacements(row, blankColumns, 0, false);
-		
-		// if we didn't get any permutations, try again, ignoring holds
-		if(computedPermutations.size() == 0)
-		{
-			computedPermutations = PermuteFootPlacements(row, blankColumns, 0, true);
-		}
-		// and if we _still_ don't have any permutations, just return a blank row
-		// (this will all buildStateGraph to at least generate a fully connected graph)
-		if(computedPermutations.size() == 0)
-		{
-			computedPermutations.push_back(blankColumns);
-		}
-		permuteCache[cacheKey] = std::move(computedPermutations);
-		
+		maybePermuteFootPlacements = layout.permuteCache.find(row.note_mask);
 	}
-	return &permuteCache[cacheKey];
-}
-
-// Recursively generate each permutation for the given row.
-std::vector<FootPlacement> StepParityGenerator::PermuteFootPlacements(const Row &row, FootPlacement columns, unsigned long column, bool ignoreHolds)
-{
-	// If column >= columns.size(), we've reached the end of the row.
-	// Perform some final validation before returning the contents of columns
-	if (column >= columns.size())
+	
+	if(maybePermuteFootPlacements == layout.permuteCache.end())
 	{
-		int leftHeelIndex = StepParity::INVALID_COLUMN;
-		int leftToeIndex = StepParity::INVALID_COLUMN;
-		int rightHeelIndex = StepParity::INVALID_COLUMN;
-		int rightToeIndex = StepParity::INVALID_COLUMN;
-		
-		for (unsigned long i = 0; i < columns.size(); i++)
-		{
-			if (columns[i] == NONE)
-			{
-				continue;
-			}
-			if (columns[i] == LEFT_HEEL)
-			{
-				leftHeelIndex = i;
-			}
-			if (columns[i] == LEFT_TOE)
-			{
-				leftToeIndex = i;
-			}
-			if (columns[i] == RIGHT_HEEL)
-			{
-				rightHeelIndex = i;
-			}
-			if (columns[i] == RIGHT_TOE)
-			{
-				rightToeIndex = i;
-			}
-		}
-		
-		// Filter out actually invalid combinations:
-		// - We don't want permutations where the toe is on an arrow, but not the heel
-		// - We don't want impossible brackets (eg you can't bracket up and down)
-		if (
-			(leftHeelIndex == StepParity::INVALID_COLUMN && leftToeIndex != StepParity::INVALID_COLUMN) ||
-			(rightHeelIndex == StepParity::INVALID_COLUMN && rightToeIndex != StepParity::INVALID_COLUMN))
-		{
-			return std::vector<FootPlacement>();
-		}
-		if (leftHeelIndex != StepParity::INVALID_COLUMN && leftToeIndex != StepParity::INVALID_COLUMN)
-		{
-			if (!layout.bracketCheck(leftHeelIndex, leftToeIndex))
-			{
-				return std::vector<FootPlacement>();
-			}
-		}
-		if (rightHeelIndex != StepParity::INVALID_COLUMN && rightToeIndex != StepParity::INVALID_COLUMN)
-		{
-			if (!layout.bracketCheck(rightHeelIndex, rightToeIndex))
-			{
-				return std::vector<FootPlacement>();
-			}
-		}
-		return {columns};
+		return &layout.permuteCache[0];
 	}
-
-	// If this column has a valid tap/hold head, or is actively holding a note,
-	// iterate through values of StepParity::Foot. For each foot part, check that
-	// it's not already present in columns, and if not, create a copy of columns,
-	// and set the current foot part to the current column.
-	// Then pass it to PermuteFootPlacements() and increment the column index.
-	// Collect each permutationm, and then return all of them.
-	//
-	// The `ignoreHolds` flag is used as a workaround for situations where
-	// we can't find a valid foot placement that allows us to continue the holds
-	// (BREACH PROTOCOL doubles has  a row 0311 1000 which isn't bracketable
-	// while still holding p1 down)
-	std::vector<FootPlacement> permutations;
-	if (row.notes[column].type != TapNoteType_Empty  ||
-			(ignoreHolds == false && row.holds[column].type != TapNoteType_Empty))
+	else
 	{
-	  	  for (StepParity::Foot foot: FEET) {
-		if(std::find(columns.begin(), columns.end(), foot) != columns.end())
-		{
-			continue;
-		}
-
-		FootPlacement newColumns = columns;
-
-		newColumns[column] = foot;
-		std::vector<FootPlacement> p = PermuteFootPlacements(row, newColumns, column + 1, ignoreHolds);
-		permutations.insert(permutations.end(), p.begin(), p.end());
-	  	  }
-	  	  return permutations;
+		auto& value = maybePermuteFootPlacements->second;
+		return &value;
 	}
-	// If the current column doesn't have any taps or holds,
-	// then we don't need to generate any permutations for it.
-	// Return the contents of calling PermuteFootPlacements() for the next column.
-	return PermuteFootPlacements(row, columns, column + 1, ignoreHolds);
 }
 
 std::vector<int> StepParityGenerator::computeCheapestPath()

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -45,8 +45,9 @@ void StepParityGenerator::buildStateGraph()
 	beginningState = new State();
 	startNode = addNode(beginningState, rows[0].second - 1, -1);
 	
-	std::queue<StepParityNode *> previousNodes;
-	previousNodes.push(startNode);
+	std::vector<StepParityNode *> previousNodes;
+	std::vector<StepParityNode *> resultNodes;
+	previousNodes.push_back(startNode);
 	StepParityCost costCalculator(layout);
 
 	// maps the current row's Nodes based on their State's cache key
@@ -55,14 +56,13 @@ void StepParityGenerator::buildStateGraph()
 	for (unsigned long i = 0; i < rows.size(); i++)
 	{
 		stateMap.clear();
+		resultNodes.clear();
 		
-		std::vector<StepParityNode *> resultNodes;
 		Row &row = rows[i];
 		const std::vector<FootPlacement> *permutations = getFootPlacementPermutations(row);
 		
-		while (!previousNodes.empty())
+		for(StepParityNode *initialNode : previousNodes)
 		{
-			StepParityNode *initialNode = previousNodes.front();
 			float elapsedTime = row.second - initialNode->second;
 			for(auto it = permutations->begin(); it != permutations->end(); it++)
 			{
@@ -95,13 +95,8 @@ void StepParityGenerator::buildStateGraph()
 					resultNodes.push_back(newNode);
 				}
 			}
-			previousNodes.pop();
 		}
-		
-		for (StepParityNode * n : resultNodes)
-		{
-			previousNodes.push(n);
-		}
+		std::swap(previousNodes, resultNodes);
 	}
 	
 	// at this point, previousStates holds all of the states for the very last row,
@@ -110,15 +105,13 @@ void StepParityGenerator::buildStateGraph()
 	endNode = addNode(endingState, rows[rows.size() - 1].second + 1, rows.size());
 	endNode->totalCost = MAXFLOAT;
 	
-	while(!previousNodes.empty())
+	for(StepParityNode *node : previousNodes)
 	{
-		StepParityNode *node = previousNodes.front();
 		if(node->totalCost < endNode->totalCost)
 		{
 			endNode->totalCost = node->totalCost;
 			endNode->previousNode = node;
 		}
-		previousNodes.pop();
 	}
 }
 

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -589,32 +589,36 @@ Row StepParityGenerator::CreateRow(RowCounter &counter)
 		{
 			row.holds[c] = counter.activeHolds[c];
 		}
-
-		// save any hold tails
-
-		if (counter.activeHolds[c].type != TapNoteType_Empty)
+		
+		// write to masks
+		uint16_t bit = 0x1 << c;
+		if(row.notes[c].type == TapNoteType_Tap || row.notes[c].type == TapNoteType_HoldHead)
 		{
-			if (abs(counter.activeHolds[c].beat + counter.activeHolds[c].hold_length - counter.lastColumnBeat) < 0.0005)
-			{
-				row.holdTails.insert(c);
-			}
+			row.note_mask |= bit;
 		}
+		
+		if(row.holds[c].type != TapNoteType_Empty)
+		{
+			row.hold_mask |= bit;
+		}
+		
+		if(row.mines[c] != 0)
+		{
+			row.mine_mask |= bit;
+		}
+		if(row.fakeMines[c] != 0)
+		{
+			row.fake_mine_mask |= bit;
+		}
+		
 	}
 	return row;
 }
 
 int StepParityGenerator::getPermuteCacheKey(const Row &row)
 {
-	int key = 0;
-
-	for (unsigned long i = 0; i < row.notes.size() && i < row.holds.size(); i++)
-	{
-		if(row.notes[i].type != TapNoteType_Empty || row.holds[i].type != TapNoteType_Empty)
-		{
-			key += pow(2, i);
-		}
-	}
-	return key;
+	int mask_key = row.note_mask | row.hold_mask;
+	return mask_key;
 }
 
 std::uint64_t StepParityGenerator::getStateCacheKey(State * state)

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -118,6 +118,8 @@ State * StepParityGenerator::initResultState(State * initialState, Row &row, con
 
 	// reset resultState
 	
+	resultState->moved_mask = 0;
+	resultState->holding_mask = 0;
 	for(int i = 0; i < NUM_Foot; i++)
 	{
 		resultState->whereTheFeetAre[i] = INVALID_COLUMN;
@@ -166,6 +168,17 @@ State * StepParityGenerator::initResultState(State * initialState, Row &row, con
 		{
 			resultState->holdFeet[i] = columns[i];
 			resultState->isTheFootHolding[columns[i]] = true;
+		}
+		
+		uint16_t bit = 0x1 << i;
+		uint16_t foot_mask = FOOT_MASKS[columns[i]];
+		if((row.hold_mask & bit) != 0)
+		{
+			resultState->holding_mask |= foot_mask;
+		}
+		if((row.hold_mask & bit) == 0 || (initialState->combinedColumns[i] != columns[i]))
+		{
+			resultState->moved_mask |= foot_mask;
 		}
 	}
 	

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -256,11 +256,16 @@ const std::vector<FootPlacement>* StepParityGenerator::getFootPlacementPermutati
 	
 	auto maybePermuteFootPlacements = layout->permuteCache.find(cacheKey);
 	
+	// If no valid foot placements were found for (note_mask | hold_mask), then
+	// check if there is a valid placement for just note_mask
+	// (basically, assume that the player has to drop the holds)
 	if (maybePermuteFootPlacements == layout->permuteCache.end())
 	{
 		maybePermuteFootPlacements = layout->permuteCache.find(row.note_mask);
 	}
 	
+	// And if there still aren't any valid placements, return
+	// permuteCache[0], which will be an empty array.
 	if(maybePermuteFootPlacements == layout->permuteCache.end())
 	{
 		return &(layout->permuteCache.at(0));

--- a/src/StepParityGenerator.h
+++ b/src/StepParityGenerator.h
@@ -103,7 +103,7 @@ namespace StepParity {
 		/// @return The resulting state
 		State * initResultState(State * initialState, Row &row, const FootPlacement &columns);
 
-		void mergeInitialAndResultPosition(State * initialState, State * resultState, int columnCount);
+		void mergeInitialAndResultPosition(State * initialState, State * resultState, const FootPlacement & columns, int columnCount);
 		
 		/// @brief Returns a pointer to a vector of foot possible foot placements for the given row.
 		/// Utilizes the permuteCache to re-use vectors. The returned pointer points to a vector within the permuteCache.

--- a/src/StepParityGenerator.h
+++ b/src/StepParityGenerator.h
@@ -35,7 +35,7 @@ namespace StepParity {
 	class StepParityGenerator 
 	{
 	private:
-		StageLayout layout;
+		const StageLayout * layout;
 		TimingData * timing;
 		
 		StepParity::State * beginningState = nullptr;
@@ -50,7 +50,7 @@ namespace StepParity {
 		std::vector<int> nodes_for_rows;
 		int columnCount_;
 		
-		StepParityGenerator(const StageLayout & l, TimingData * t) : layout(l) {
+		StepParityGenerator(const StageLayout * l, TimingData * t) : layout(l) {
 			timing = t;
 		}
 		
@@ -109,7 +109,7 @@ namespace StepParity {
 		/// Utilizes the permuteCache to re-use vectors. The returned pointer points to a vector within the permuteCache.
 		/// @param row The row to calculate foot placement permutations for.
 		/// @return A pointer to a vector of foot placements.
-		std::vector<FootPlacement>* getFootPlacementPermutations(const Row &row);
+		const std::vector<FootPlacement>* getFootPlacementPermutations(const Row &row);
 
 		/// @brief Computes the "cheapest" path through the given graph.
 		/// This relies on the fact that the nodes stored in the graph are topologically sorted (that is, all

--- a/src/StepParityGenerator.h
+++ b/src/StepParityGenerator.h
@@ -94,7 +94,6 @@ namespace StepParity {
 		/// and one that represents the end of the song, after the final note.
 		void buildStateGraph();
 
-		void addStateToGraph(State * resultState, StepParityNode * initialNode, Row & row, std::vector<StepParityNode *> &existingNodesForThisRow, float cost);
 		/// @brief Creates a new State, which is the result of moving from the given initialState
 		/// to the steps of the given row with the given foot placements in columns.
 		/// @param initialState The state of the player prior to the next row
@@ -129,7 +128,6 @@ namespace StepParity {
 		int getPermuteCacheKey(const Row &row);
 		std::uint64_t getStateCacheKey(State * state);
 		StepParityNode * addNode(State *state, float second, int rowIndex);
-		void addEdge(StepParityNode* from, StepParityNode* to, float cost);
 	};
 };
 

--- a/src/StepParityGenerator.h
+++ b/src/StepParityGenerator.h
@@ -37,7 +37,6 @@ namespace StepParity {
 	private:
 		StageLayout layout;
 		TimingData * timing;
-		std::unordered_map < int, std::vector<std::vector<StepParity::Foot>>> permuteCache;
 		
 		StepParity::State * beginningState = nullptr;
 		StepParity::StepParityNode * startNode = nullptr;
@@ -111,14 +110,6 @@ namespace StepParity {
 		/// @param row The row to calculate foot placement permutations for.
 		/// @return A pointer to a vector of foot placements.
 		std::vector<FootPlacement>* getFootPlacementPermutations(const Row &row);
-
-		/// @brief A recursive function that generates a vector of possible foot placements for the given row.
-		/// This function should not be used directly, instead use getFootPlacementPermutations().
-		/// @param row
-		/// @param columns
-		/// @param column
-		/// @param ignoreHolds
-		std::vector<FootPlacement> PermuteFootPlacements(const Row &row, FootPlacement columns, unsigned long column, bool ignoreHolds);
 
 		/// @brief Computes the "cheapest" path through the given graph.
 		/// This relies on the fact that the nodes stored in the graph are topologically sorted (that is, all

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -398,7 +398,7 @@ void Steps::CalculateTechCounts()
 	{
 		return;
 	}
-	StepParity::StageLayout layout = StepParity::Layouts.at(this->m_StepsType);
+	const StepParity::StageLayout* layout = &StepParity::Layouts.at(this->m_StepsType);
 	TimingData * timing = this->GetTimingData();
 	StepParity::StepParityGenerator gen = StepParity::StepParityGenerator(layout, timing);
 	gen.analyzeNoteData(tempNoteData);

--- a/src/TechCounts.cpp
+++ b/src/TechCounts.cpp
@@ -90,7 +90,7 @@ void TechCounts::FromString( RString sTechCounts )
 	}
 }
 
-void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> &rows, StepParity::StageLayout & layout, TechCounts &out)
+void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> &rows, const StepParity::StageLayout * layout, TechCounts &out)
 {
 	for (unsigned long i = 1; i < rows.size(); i++)
 	{
@@ -149,7 +149,7 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 		}
 
 		// Check for up footswitches
-		for(int c : layout.upArrows)
+		for(int c : layout->upArrows)
 		{
 			if(isFootswitch(c, currentRow, previousRow, elapsedTime))
 			{
@@ -158,7 +158,7 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 			}
 		}
 		// Check for down footswitches
-		for(int c: layout.downArrows)
+		for(int c: layout->downArrows)
 		{
 			if(isFootswitch(c, currentRow, previousRow, elapsedTime))
 			{
@@ -168,7 +168,7 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 		}
 		
 		// Check for sideswitches
-		for(int c: layout.sideArrows)
+		for(int c: layout->sideArrows)
 		{
 			if(isFootswitch(c, currentRow, previousRow, elapsedTime))
 			{
@@ -199,8 +199,8 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 		//     - otherwise, then this was probably a half crossover (like UDL, starting on right foot)
 		if(rightHeel != StepParity::INVALID_COLUMN && previousLeftHeel != StepParity::INVALID_COLUMN && previousRightHeel == StepParity::INVALID_COLUMN)
 		{
-			StepParity::StagePoint leftPos = layout.averagePoint(previousLeftHeel, previousLeftToe);
-			StepParity::StagePoint rightPos = layout.averagePoint(rightHeel, rightToe);
+			StepParity::StagePoint leftPos = layout->averagePoint(previousLeftHeel, previousLeftToe);
+			StepParity::StagePoint rightPos = layout->averagePoint(rightHeel, rightToe);
 			
 			if(rightPos.x < leftPos.x)
 			{
@@ -211,7 +211,7 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 					
 					if(previousPreviousRightHeel != StepParity::INVALID_COLUMN && previousPreviousRightHeel != rightHeel)
 					{
-						StepParity::StagePoint previousPreviousRightPos = layout.columns[previousPreviousRightHeel];
+						StepParity::StagePoint previousPreviousRightPos = layout->columns[previousPreviousRightHeel];
 						if(previousPreviousRightPos.x > leftPos.x)
 						{
 							out[TechCountsCategory_FullCrossovers] += 1;
@@ -233,8 +233,8 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 		// And check the same thing, starting with left foot
 		else if(leftHeel != StepParity::INVALID_COLUMN && previousRightHeel != StepParity::INVALID_COLUMN && previousLeftHeel == StepParity::INVALID_COLUMN)
 		{
-			StepParity::StagePoint leftPos = layout.averagePoint(leftHeel, leftToe);
-			StepParity::StagePoint rightPos = layout.averagePoint(previousRightHeel, previousRightToe);
+			StepParity::StagePoint leftPos = layout->averagePoint(leftHeel, leftToe);
+			StepParity::StagePoint rightPos = layout->averagePoint(previousRightHeel, previousRightToe);
 			
 			if(rightPos.x < leftPos.x)
 			{
@@ -244,7 +244,7 @@ void TechCounts::CalculateTechCountsFromRows(const std::vector<StepParity::Row> 
 					int previousPreviousLeftHeel = previousPreviousRow.whereTheFeetAre[StepParity::LEFT_HEEL];
 					if(previousPreviousLeftHeel != StepParity::INVALID_COLUMN && previousPreviousLeftHeel != leftHeel)
 					{
-						StepParity::StagePoint previousPreviousLeftPos = layout.columns[previousPreviousLeftHeel];
+						StepParity::StagePoint previousPreviousLeftPos = layout->columns[previousPreviousLeftHeel];
 						if(rightPos.x > previousPreviousLeftPos.x)
 						{
 							out[TechCountsCategory_FullCrossovers] += 1;

--- a/src/TechCounts.h
+++ b/src/TechCounts.h
@@ -80,7 +80,7 @@ public:
 	void FromString( RString sValues );
 
 	void PushSelf( lua_State *L );
-	static void CalculateTechCountsFromRows(const std::vector<StepParity::Row> &rows, StepParity::StageLayout & layout, TechCounts &out);
+	static void CalculateTechCountsFromRows(const std::vector<StepParity::Row> &rows, const StepParity::StageLayout * layout, TechCounts &out);
 private:
 	static bool isFootswitch(int c, const StepParity::Row & currentRow, const StepParity::Row & previousRow, float elapsedTime);
 };


### PR DESCRIPTION
This PR adds some of the optimizations made in @pnn64 's Rust implementation of the note parsing code https://github.com/pnn64/rssp

Big changes include:
- `StageLayout` struct pre-calculates distances between points, average position between two points, "facing X"/"facing Y" penalties, and possible foot permutations (this eliminates a ton of `sqrt`, `pow`, and other math from the main loop)
- Added several bit-mask fields to `Row` and `State` structs
- Replaced several loops within `StepParityCost` functions with bit-mask checks
- Passes pointer references to `StageLayout` objects instead of copying them

I did some basic profiling using `std::chrono::high_resolution_clock::now()` to compare this to my fix-keysounds-tech-counts branch (which is just current beta branch + a small fix to not count auto-keysound notes towards tech counts). The results suggest that these changes improve the speed of `StepParityGenerator::analyzeNoteData()` by about 30%. This is about an 8-10% decrease in overall time to load and cache 7,500 step files. The parity/tech count calculations account for about 20-30% of the overall time it takes to load files, so there's a limit to what optimizing this code can accomplish.

This introduces some minor changes to the tech count results. From the 7500 step files, only 25 show differences. Most of them were +/- one XO or FS. I'm still investigating a few files that are showing pretty major differences.

Results, loading 7,498 files from an external hdd:

fix-keysounds-tech-counts branch:
```
02:10.280: Found 7498 songs in 128.389038 seconds.
02:10.280: analyzeNoteData: 57014060 us
```

step-parity-optimizations branch:
```
01:50.787: Found 7498 songs in 110.586998 seconds.
01:50.787: analyzeNoteData: 40164811 us
```

And from loading 6500 songs from internal ssd:

fix-keysounds-tech-counts branch:
```
02:06.168: Found 6590 songs in 124.666267 seconds.
02:06.168: analyzeNoteData: 56614572 us
```

step-parity-optimizations branch:
```
01:55.830: Found 6590 songs in 115.603020 seconds.
01:55.830: analyzeNoteData: 40646806 us
```


Compared to DeadSync, which apparently parses everything in about 20 seconds:
```
[2026-01-19T21:21:21Z INFO  deadsync::game::parsing::simfile] Finished scan. Found 191 packs / 6583 songs 
(parsed 6583, cache hits 0, failed 0) in 19.87s.
```