### PR TITLE
RageFile: use initializer list in constructor

### DIFF
--- a/src/RageFile.cpp
+++ b/src/RageFile.cpp
@@ -16,10 +16,7 @@
 #include <cstddef>
 #include <cstdint>
 
-RageFile::RageFile()
-{
-	m_File = nullptr;
-}
+RageFile::RageFile(): m_File(nullptr), m_Mode(0) {}
 
 RageFile::RageFile( const RageFile &cpy ):
 	RageFileBasic( cpy )


### PR DESCRIPTION
Simplifies the default constructor using an initializer list. same kind of change that has been applied elsewhere.