### PR TITLE
RageFile: defensively copy the file driver in constructor to avoid possible null deref

### DIFF
--- a/src/RageFile.cpp
+++ b/src/RageFile.cpp
@@ -25,7 +25,10 @@ RageFile::RageFile( const RageFile &cpy ):
 	RageFileBasic( cpy )
 {
 	/* This will copy the file driver, including its internal file pointer. */
-	m_File = cpy.m_File->Copy();
+	m_File = nullptr;
+	if (cpy.m_File != nullptr) {
+		m_File = cpy.m_File->Copy();
+	}
 	m_Path = cpy.m_Path;
 	m_Mode = cpy.m_Mode;
 }


### PR DESCRIPTION
Ensures the copy constructor safely avoids undefined behavior or potentially dereferencing a null pointer.