### PR TITLE
Cache NoteSkins per game

### DIFF
--- a/src/NoteSkinManager.cpp
+++ b/src/NoteSkinManager.cpp
@@ -100,7 +100,7 @@ void NoteSkinManager::RefreshNoteSkinData( const Game* pGame )
 	StripMacResourceForks( asNoteSkinNames );
 
 	std::map<RString, NoteSkinData> loadedNoteSkins;
-	for( unsigned j=0; j<asNoteSkinNames.size(); j++ )
+	for( size_t j=0; j<asNoteSkinNames.size(); j++ )
 	{
 		RString sName = asNoteSkinNames[j];
 		MakeLower(sName);

--- a/src/NoteSkinManager.cpp
+++ b/src/NoteSkinManager.cpp
@@ -46,6 +46,7 @@ struct NoteSkinData
 namespace
 {
 	static std::map<RString,NoteSkinData> g_mapNameToData;
+	static std::map<RString, std::map<RString, NoteSkinData>> g_mapGameToNoteSkinData;
 };
 
 NoteSkinManager::NoteSkinManager()
@@ -70,6 +71,7 @@ NoteSkinManager::~NoteSkinManager()
 	LUA->UnsetGlobal( "NOTESKIN" );
 
 	g_mapNameToData.clear();
+	g_mapGameToNoteSkinData.clear();
 }
 
 void NoteSkinManager::RefreshNoteSkinData( const Game* pGame )
@@ -79,6 +81,17 @@ void NoteSkinManager::RefreshNoteSkinData( const Game* pGame )
 	// clear path cache
 	g_PathCache.clear();
 
+	RString sGameName = pGame->m_szName;
+	MakeLower( sGameName );
+	std::map<RString, std::map<RString, NoteSkinData>>::iterator cached = g_mapGameToNoteSkinData.find( sGameName );
+	if( cached != g_mapGameToNoteSkinData.end() )
+	{
+		// Found cached noteskin data for this game: reuse it instead of
+		// re-scanning and reloading all noteskins and metrics.
+		g_mapNameToData = cached->second;
+		return;
+	}
+
 	RString sBaseSkinFolder = SpecialFiles::NOTESKINS_DIR + pGame->m_szName + "/";
 	std::vector<RString> asNoteSkinNames;
 	GetDirListing( sBaseSkinFolder + "*", asNoteSkinNames, true );
@@ -86,7 +99,7 @@ void NoteSkinManager::RefreshNoteSkinData( const Game* pGame )
 	StripCvsAndSvn( asNoteSkinNames );
 	StripMacResourceForks( asNoteSkinNames );
 
-	g_mapNameToData.clear();
+	std::map<RString, NoteSkinData> loadedNoteSkins;
 	for( unsigned j=0; j<asNoteSkinNames.size(); j++ )
 	{
 		RString sName = asNoteSkinNames[j];
@@ -94,12 +107,15 @@ void NoteSkinManager::RefreshNoteSkinData( const Game* pGame )
 		// Don't feel like changing the structure of this code to load the skin
 		// into a temp variable and move it, so if the load fails, then just
 		// delete it from the map. -Kyz
-		if(!LoadNoteSkinData(sName, g_mapNameToData[sName]))
+		if(!LoadNoteSkinData(sName, loadedNoteSkins[sName]))
 		{
-			std::map<RString, NoteSkinData>::iterator entry= g_mapNameToData.find(sName);
-			g_mapNameToData.erase(entry);
+			std::map<RString, NoteSkinData>::iterator entry= loadedNoteSkins.find(sName);
+			loadedNoteSkins.erase(entry);
 		}
 	}
+
+	g_mapNameToData = loadedNoteSkins;
+	g_mapGameToNoteSkinData[sGameName] = loadedNoteSkins;
 }
 
 bool NoteSkinManager::LoadNoteSkinData( const RString &sNoteSkinName, NoteSkinData& data_out )

--- a/src/NoteSkinManager.cpp
+++ b/src/NoteSkinManager.cpp
@@ -82,16 +82,19 @@ void NoteSkinManager::RefreshNoteSkinData( const Game* pGame )
 	// clear path cache
 	g_PathCache.clear();
 
+	LOG->Info( "RefreshNoteSkinData called for game '%s'", pGame->m_szName );
+
 	RString sGameName = pGame->m_szName;
 	MakeLower( sGameName );
 	std::map<RString, std::map<RString, std::shared_ptr<NoteSkinData>>>::iterator cached = g_mapGameToNoteSkinData.find( sGameName );
 	if( cached != g_mapGameToNoteSkinData.end() )
 	{
-		// Found cached noteskin data for this game: reuse it instead of
-		// re-scanning and reloading all noteskins and metrics.
+		LOG->Info( "Using cached noteskins for game '%s' (%zu)", sGameName.c_str(), cached->second.size() );
 		g_mapNameToData = cached->second;
 		return;
 	}
+
+	LOG->Info( "Found noteskins that weren't cached for game '%s'", sGameName.c_str() );
 
 	RString sBaseSkinFolder = SpecialFiles::NOTESKINS_DIR + pGame->m_szName + "/";
 	std::vector<RString> asNoteSkinNames;
@@ -118,10 +121,12 @@ void NoteSkinManager::RefreshNoteSkinData( const Game* pGame )
 
 	g_mapNameToData = loadedNoteSkins;
 	g_mapGameToNoteSkinData.emplace(sGameName, loadedNoteSkins);
+	LOG->Info( "Cached %zu noteskins for game '%s'", loadedNoteSkins.size(), sGameName.c_str() );
 }
 
 bool NoteSkinManager::LoadNoteSkinData( const RString &sNoteSkinName, NoteSkinData& data_out )
 {
+	LOG->Info( "LoadNoteSkinData called for '%s'", sNoteSkinName.c_str() );
 	data_out.sName = sNoteSkinName;
 	data_out.metrics.Clear();
 	data_out.vsDirSearchOrder.clear();

--- a/src/NoteSkinManager.cpp
+++ b/src/NoteSkinManager.cpp
@@ -17,6 +17,7 @@
 
 #include <cstddef>
 #include <map>
+#include <memory>
 #include <vector>
 
 
@@ -45,8 +46,8 @@ struct NoteSkinData
 
 namespace
 {
-	static std::map<RString,NoteSkinData> g_mapNameToData;
-	static std::map<RString, std::map<RString, NoteSkinData>> g_mapGameToNoteSkinData;
+	static std::map<RString, std::shared_ptr<NoteSkinData>> g_mapNameToData;
+	static std::map<RString, std::map<RString, std::shared_ptr<NoteSkinData>>> g_mapGameToNoteSkinData;
 };
 
 NoteSkinManager::NoteSkinManager()
@@ -83,7 +84,7 @@ void NoteSkinManager::RefreshNoteSkinData( const Game* pGame )
 
 	RString sGameName = pGame->m_szName;
 	MakeLower( sGameName );
-	std::map<RString, std::map<RString, NoteSkinData>>::iterator cached = g_mapGameToNoteSkinData.find( sGameName );
+	std::map<RString, std::map<RString, std::shared_ptr<NoteSkinData>>>::iterator cached = g_mapGameToNoteSkinData.find( sGameName );
 	if( cached != g_mapGameToNoteSkinData.end() )
 	{
 		// Found cached noteskin data for this game: reuse it instead of
@@ -99,7 +100,7 @@ void NoteSkinManager::RefreshNoteSkinData( const Game* pGame )
 	StripCvsAndSvn( asNoteSkinNames );
 	StripMacResourceForks( asNoteSkinNames );
 
-	std::map<RString, NoteSkinData> loadedNoteSkins;
+	std::map<RString, std::shared_ptr<NoteSkinData>> loadedNoteSkins;
 	for( size_t j=0; j<asNoteSkinNames.size(); j++ )
 	{
 		RString sName = asNoteSkinNames[j];
@@ -107,15 +108,16 @@ void NoteSkinManager::RefreshNoteSkinData( const Game* pGame )
 		// Don't feel like changing the structure of this code to load the skin
 		// into a temp variable and move it, so if the load fails, then just
 		// delete it from the map. -Kyz
-		if(!LoadNoteSkinData(sName, loadedNoteSkins[sName]))
+		auto data = std::make_shared<NoteSkinData>();
+		if(!LoadNoteSkinData(sName, *data))
 		{
-			std::map<RString, NoteSkinData>::iterator entry= loadedNoteSkins.find(sName);
-			loadedNoteSkins.erase(entry);
+			continue;
 		}
+		loadedNoteSkins.emplace(sName, std::move(data));
 	}
 
 	g_mapNameToData = loadedNoteSkins;
-	g_mapGameToNoteSkinData[sGameName] = loadedNoteSkins;
+	g_mapGameToNoteSkinData.emplace(sGameName, loadedNoteSkins);
 }
 
 bool NoteSkinManager::LoadNoteSkinData( const RString &sNoteSkinName, NoteSkinData& data_out )
@@ -287,10 +289,10 @@ void NoteSkinManager::GetAllNoteSkinNamesForGame( const Game *pGame, std::vector
 	if( pGame == m_pCurGame )
 	{
 		// Faster:
-		for( std::map<RString, NoteSkinData>::const_iterator iter = g_mapNameToData.begin();
+		for( std::map<RString, std::shared_ptr<NoteSkinData>>::const_iterator iter = g_mapNameToData.begin();
 		     iter != g_mapNameToData.end(); ++iter )
 		{
-			AddTo.push_back( iter->second.sName );
+			AddTo.push_back( iter->second->sName );
 		}
 	}
 	else
@@ -311,9 +313,9 @@ RString NoteSkinManager::GetMetric( const RString &sButtonName, const RString &s
 	}
 	RString sNoteSkinName = m_sCurrentNoteSkin;
 	MakeLower(sNoteSkinName);
-	std::map<RString, NoteSkinData>::const_iterator it = g_mapNameToData.find(sNoteSkinName);
+	std::map<RString, std::shared_ptr<NoteSkinData>>::const_iterator it = g_mapNameToData.find(sNoteSkinName);
 	ASSERT_M( it != g_mapNameToData.end(), sNoteSkinName );	// this NoteSkin doesn't exist!
-	const NoteSkinData& data = it->second;
+	const NoteSkinData& data = *it->second;
 
 	RString sReturn;
 	if( data.metrics.GetValue( sButtonName, sValue, sReturn ) )
@@ -363,9 +365,9 @@ RString NoteSkinManager::GetPath( const RString &sButtonName, const RString &sEl
 	}
 	RString sNoteSkinName = m_sCurrentNoteSkin;
 	MakeLower(sNoteSkinName);
-	std::map<RString, NoteSkinData>::const_iterator iter = g_mapNameToData.find( sNoteSkinName );
+	std::map<RString, std::shared_ptr<NoteSkinData>>::const_iterator iter = g_mapNameToData.find( sNoteSkinName );
 	ASSERT( iter != g_mapNameToData.end() );
-	const NoteSkinData &data = iter->second;
+	const NoteSkinData &data = *iter->second;
 
 	RString sPath;	// fill this in below
 	for (RString const &directory : data.vsDirSearchOrder)
@@ -476,13 +478,13 @@ RString NoteSkinManager::GetPath( const RString &sButtonName, const RString &sEl
 
 bool NoteSkinManager::PushActorTemplate( Lua *L, const RString &sButton, const RString &sElement, bool bSpriteOnly )
 {
-	std::map<RString, NoteSkinData>::const_iterator iter = g_mapNameToData.find( m_sCurrentNoteSkin );
+	std::map<RString, std::shared_ptr<NoteSkinData>>::const_iterator iter = g_mapNameToData.find( m_sCurrentNoteSkin );
 	if(iter == g_mapNameToData.end())
 	{
 		LuaHelpers::ReportScriptError("No current noteskin set!", "NOTESKIN_ERROR");
 		return false;
 	}
-	const NoteSkinData &data = iter->second;
+	const NoteSkinData &data = *iter->second;
 
 	LuaThreadVariable varPlayer( "Player", LuaReference::Create(m_PlayerNumber) );
 	LuaThreadVariable varController( "Controller", LuaReference::Create(m_GameController) );


### PR DESCRIPTION
# Premise

Avoids redundant loading of noteskins during gameplay by adding a second `std::map` to track available noteskins for a given game style.

Considerably reduces disk I/O during screen changes and song loading, reducing wait times.

Doesn't meaningfully affect RAM consumption. On Debian, with the current beta, I pretty much always stay under 150MB RAM used altogether with or without this PR  (assuming no background videos).

# How you know it works

Normally, the log file is very cluttered with noteskin loading as noteskins may be completely reloaded between songs. With this PR, the logs clearly indicate when the noteskins are cached and whether a new noteskin that was previous uncached is detected or if we used our cached noteskins.

# Why this PR introduces `std::shared_ptr` to the static maps

Clang was stricter about the copy operator of `std::map` than MSVC or GCC were, which prevented the inital commit from building on Mac. 

Clang failed because change the map's value (NoteSkinData) was not something copyable. For this reason, I added a commit to use `std::shared_ptr` in the map. This prevents the need to assign NoteSkinData, and makes the usage of `std::map` correct according to all compilers.