### PR TITLE
Update .clang-format(to reopen after 1.2.0) 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,11 @@
-BasedOnStyle: Google
+BasedOnStyle: Microsoft
+BracesStyle: Allman
 AlignAfterOpenBracket: AlwaysBreak
 DerivePointerAlignment: false
 PointerAlignment: Left
 QualifierAlignment: Left
 ReferenceAlignment: Left
 InsertBraces: true
+SortIncludes: false
+ReorderIncludes: false
+IncludeBlocks: Preserve


### PR DESCRIPTION
In order to most closely match the style of the existing code, I'm swapping the base style from Google's to Microsoft's, which is based on Visual Studio's default style settings.

This software was historically mainly developed in Visual Studio, so this is the closest fitting style to the existing code. This configuration nearly identically matches the existing code's intended style.

I'm also disabling sorting/reordering of includes for now, since that's the main thing breaking the build when running clang-format.

_We need to add clang-format exclusions to a few files, such as `verstub.in.cpp`, to prevent the build from breaking when using clang-format._
