### PR TITLE
RageLog: stdout consistency between operating systems

### DIFF
--- a/src/RageLog.cpp
+++ b/src/RageLog.cpp
@@ -281,10 +281,31 @@ void RageLog::Write( int where, const RString &sLine )
 		if( sWarning.size() )
 			sStr.insert( 0, sWarning );
 
-		if( m_bShowLogOutput || (where&WRITE_TO_INFO) )
-			puts(sStr.c_str()); //fputws( (const wchar_t *)sStr.c_str(), stdout );
-		if( where & WRITE_TO_INFO )
-			AddToInfo( sStr );
+		// NOTE: On Windows, m_bShowLogOutput determines whether we
+		// will open a console window for log output.
+		// But, on Linux/macOS, that preference won't open a new
+		// console window. Instead it determines whether or not
+		// info & trace logs are printed to stdout. This way,
+		// we have a consistent logging behavior across platforms,
+		// since typically in macOS or Linux, if one wants to see
+		// the stdout output, they'll run the game from a terminal.
+#ifdef _WIN32
+		if (m_bShowLogOutput || (where & WRITE_TO_INFO))
+		{
+			puts(sStr.c_str()); // fputws( (const wchar_t *)sStr.c_str(), stdout );
+		}
+		if (where & WRITE_TO_INFO)
+		{
+			AddToInfo(sStr);
+		}
+#else
+		if (where & WRITE_TO_INFO)
+		{
+			puts(sStr.c_str());
+			AddToInfo(sStr);
+		}
+#endif
+
 		if( m_bLogToDisk && (where&WRITE_TO_INFO) && g_fileInfo->IsOpen() )
 			g_fileInfo->PutLine( sStr );
 		if( m_bUserLogToDisk && (where&WRITE_TO_USER_LOG) && g_fileUserLog->IsOpen() )


### PR DESCRIPTION
I know not many people use the `ShowLogOutput` option, but I think this would be nice for consistent behavior across OS's.

Windows will **always** show Info and Trace tier logs in stdout, because (intentional or not) the preference to show the log window also determines whether Info and Trace logs are written to stdout or not. It does not affect whether Info and Trace logs are written to `log.txt`. This can be confusing if you use run the game from the terminal expecting stdout logs, because it's not immediately obvious why Linux and macOS don't provide all logs in stdout, even though Info and Trace tier logs will be written to `log.txt`.

Initially, I thought stdout logging was broken, because you get other levels of logs in stdout, just not the Info and Trace level logs. The log going to stdout will print everything up thru the graphics driver initialization, but then suddenly stop, which is confusing.

In short, this patch reduces the scope of `ShowLogOutput` so that it does not also determine whether Info and Trace info is written to stdout.