### PR TITLE
Add macOS Intel support to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, windows-2022] # TODO: macos-15-intel
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, macos-15-intel, windows-2022]
         include:
           - os: ubuntu-24.04
             name: Ubuntu (x86_64)
@@ -41,6 +41,14 @@ jobs:
             release-full: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DWITH_NIGHTLY_RELEASE=Off -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_CLUB_FANTASTIC=Off
             package: cmake --build build --target package
             path: build/ITGmania-*.dmg
+          - os: macos-15-intel
+            name: macOS (Intel)
+            install: brew install nasm
+            configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
+            release-nightly: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_CLUB_FANTASTIC=Off
+            release-full: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DWITH_NIGHTLY_RELEASE=Off -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_CLUB_FANTASTIC=Off
+            package: cmake --build build --target package
+            path: build/ITGmania-*-NIGHTLY-git-*-macOS-Intel-no-songs.dmg
           - os: windows-2022
             name: Windows
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"


### PR DESCRIPTION
Revisiting https://github.com/itgmania/itgmania/pull/819 following https://gitlab.kitware.com/cmake/cmake/-/commit/ef739edd2078be23761f6e9b2c9dff7a20493cc7.

macOS Intel release builds were previously failing with the issue reported in https://github.com/actions/runner-images/issues/7522, but the above commit to CMake seems to be intended to resolve (🤞🏻) and the macos-15-intel runner image includes it https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#tools

Succeeds on my fork - https://github.com/ScottBrenner/itgmania/actions/runs/21274889984/job/61232571383