### PR TITLE
Fixes for ffmpeg-w32.yml

### DIFF
--- a/.github/workflows/ffmpeg-w32.yml
+++ b/.github/workflows/ffmpeg-w32.yml
@@ -59,9 +59,11 @@ jobs:
         git submodule update --init extern/ffmpeg
         
         FFMPEG_SHA="$(git -C extern/ffmpeg rev-parse --short=12 HEAD)"
+        FFMPEG_REF="$(git -C extern/ffmpeg describe --tags --exact-match HEAD 2>/dev/null)"
         ln -s extern/ffmpeg ffmpeg-src
         {
           echo "FFMPEG_SHA=$FFMPEG_SHA"
+          echo "FFMPEG_REF=$FFMPEG_REF"
         } >> "$GITHUB_ENV"
         
         # Keep this list arch-neutral so we can add other targets (e.g. arm64) later.

--- a/.github/workflows/ffmpeg-w32.yml
+++ b/.github/workflows/ffmpeg-w32.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - extern/ffmpeg
       - extern/ffmpeg/**
+      - .github/workflows/ffmpeg-w32.yml
 
 jobs:
   build-ffmpeg-w32:

--- a/.github/workflows/ffmpeg-w32.yml
+++ b/.github/workflows/ffmpeg-w32.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build-ffmpeg-w32:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Fixes [a few problems](https://github.com/itgmania/itgmania/actions/runs/21279559060) that came up post-merge.

1. I accidentally chose a runner for `ffmpeg-w32.yml` which has a [15-minute runtime limit](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/runners/github-hosted-runners). This is because it is a single-CPU runner. Unfortunately, after merging, it exceeded the 15 minute limit. So, this PR switches out the more heavily restricted `ubuntu-slim` runner for the standard `ubuntu-24.04` runner.

2. I am now having `ffmpeg-w32.yml` watch itself for changes. This is so that the CI will re-run if this PR is merged.

3. Lastly, I forgot to pass one of the needed environment variables to `$GITHUB_ENV`, so that's now fixed.

Working test run & commit:
 - https://github.com/sukibaby/itgmania-testing/actions/runs/21282047599
 - https://github.com/sukibaby/itgmania-testing/commit/70aabd6c249c3a93ba782a5ea169dd9634317105#diff-baa7991220b8b092a3919e2588461a5f3cca27ef5ccc78d3675078c8fa240e8d

Sorry about that!