### PR TITLE
CodeQL - exclude `extern` from scanning to reduce runtime

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+paths:
+  - src
+
+paths-ignore:
+  - extern

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,6 +38,7 @@ jobs:
         languages: c-cpp
         build-mode: manual
         dependency-caching: true
+        config-file: ./.github/codeql/codeql-config.yml
 
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install -y


### PR DESCRIPTION
# Cuts down CodeQL runtime.

https://docs.github.com/en/code-security/how-tos/scan-code-for-vulnerabilities/configure-code-scanning/customizing-your-advanced-setup-for-code-scanning