### PR TITLE
Move repeated CI configrations to job-level environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     env:
-      UBUNTU_INSTALL: |
-        sudo apt-get update && sudo apt-get install -y \
-        libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev \
-        libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev \
-        libxrandr-dev libxtst-dev nasm
+      UBUNTU_INSTALL: "sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm"
       MAC_INSTALL: brew install nasm
       CMAKE_CONFIG_PREFIX: cmake -B build -DWITH_FFMPEG_JOBS=
       CMAKE_BUILD_PREFIX: cmake --build build --parallel
@@ -36,17 +32,17 @@ jobs:
           - os: macos-15
             name: macOS (M1)
             install: $MAC_INSTALL
-            configure: '$(sysctl -n hw.logicalcpu)'
+            configure: '$(sysctl -n hw.logicalcpu) -DCMAKE_OSX_ARCHITECTURES=arm64' 
             build: '$(sysctl -n hw.logicalcpu)'
           - os: macos-15-intel
             name: macOS (Intel)
             install: $MAC_INSTALL
-            configure: '$(sysctl -n hw.logicalcpu)'
+            configure: '$(sysctl -n hw.logicalcpu) -DCMAKE_OSX_ARCHITECTURES=x86_64'
             build: '$(sysctl -n hw.logicalcpu)'
           - os: windows-2022
             name: Windows
-            configure: '$env:NUMBER_OF_PROCESSORS'
-            build: '$env:NUMBER_OF_PROCESSORS'
+            configure: '"$env:NUMBER_OF_PROCESSORS"'
+            build: '"$env:NUMBER_OF_PROCESSORS"'
     name: ${{ matrix.name }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,22 +25,22 @@ jobs:
         include:
           - os: ubuntu-24.04
             name: Ubuntu (x86_64)
-            install: $UBUNTU_INSTALL
+            install: ${{ env.UBUNTU_INSTALL }}
             configure: '$(nproc)'
             build: '$(nproc)'
           - os: ubuntu-24.04-arm
             name: Ubuntu (ARM)
-            install: $UBUNTU_INSTALL
+            install: ${{ env.UBUNTU_INSTALL }}
             configure: '$(nproc)'
             build: '$(nproc)'
           - os: macos-15
             name: macOS (M1)
-            install: $MAC_INSTALL
+            install: ${{ env.MAC_INSTALL }}
             configure: '$(sysctl -n hw.logicalcpu)'
             build: '$(sysctl -n hw.logicalcpu)'
           - os: macos-15-intel
             name: macOS (Intel)
-            install: $MAC_INSTALL
+            install: ${{ env.MAC_INSTALL }}
             configure: '$(sysctl -n hw.logicalcpu)'
             build: '$(sysctl -n hw.logicalcpu)'
           - os: windows-2022
@@ -70,9 +70,9 @@ jobs:
         with:
           msbuild-architecture: x64
       - name: Configure
-        run: $CMAKE_CONFIG_PREFIX ${{ matrix.configure }}
+        run: ${{ env.CMAKE_CONFIG_PREFIX }}${{ matrix.configure }}
       - name: Build
-        run: $CMAKE_BUILD_PREFIX${{ matrix.build }}
+        run: ${{ env.CMAKE_BUILD_PREFIX }}${{ matrix.build }}
 
   validate-xml-docs:
     name: Validate Lua.xml, LuaDocumentation.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,22 +25,22 @@ jobs:
         include:
           - os: ubuntu-24.04
             name: Ubuntu (x86_64)
-            install: ${{ env.UBUNTU_INSTALL }}
+            install: $UBUNTU_INSTALL
             configure: '$(nproc)'
             build: '$(nproc)'
           - os: ubuntu-24.04-arm
             name: Ubuntu (ARM)
-            install: ${{ env.UBUNTU_INSTALL }}
+            install: $UBUNTU_INSTALL
             configure: '$(nproc)'
             build: '$(nproc)'
           - os: macos-15
             name: macOS (M1)
-            install: ${{ env.MAC_INSTALL }}
+            install: $MAC_INSTALL
             configure: '$(sysctl -n hw.logicalcpu)'
             build: '$(sysctl -n hw.logicalcpu)'
           - os: macos-15-intel
             name: macOS (Intel)
-            install: ${{ env.MAC_INSTALL }}
+            install: $MAC_INSTALL
             configure: '$(sysctl -n hw.logicalcpu)'
             build: '$(sysctl -n hw.logicalcpu)'
           - os: windows-2022
@@ -70,9 +70,9 @@ jobs:
         with:
           msbuild-architecture: x64
       - name: Configure
-        run: ${{ env.CMAKE_CONFIG_PREFIX }}${{ matrix.configure }}
+        run: $CMAKE_CONFIG_PREFIX ${{ matrix.configure }}
       - name: Build
-        run: ${{ env.CMAKE_BUILD_PREFIX }}${{ matrix.build }}
+        run: $CMAKE_BUILD_PREFIX${{ matrix.build }}
 
   validate-xml-docs:
     name: Validate Lua.xml, LuaDocumentation.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     env:
-      UBUNTU_INSTALL: "sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm"
+      UBUNTU_INSTALL: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
       MAC_INSTALL: brew install nasm
       CMAKE_CONFIG_PREFIX: cmake -B build -DWITH_FFMPEG_JOBS=
       CMAKE_BUILD_PREFIX: cmake --build build --parallel
@@ -41,8 +41,8 @@ jobs:
             build: '$(sysctl -n hw.logicalcpu)'
           - os: windows-2022
             name: Windows
-            configure: '"$env:NUMBER_OF_PROCESSORS"'
-            build: '"$env:NUMBER_OF_PROCESSORS"'
+            configure: $env:NUMBER_OF_PROCESSORS
+            build: $env:NUMBER_OF_PROCESSORS
     name: ${{ matrix.name }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,15 @@ name: Continuous integration
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    env:
+      UBUNTU_INSTALL: |
+        sudo apt-get update && sudo apt-get install -y \
+        libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev \
+        libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev \
+        libxrandr-dev libxtst-dev nasm
+      MAC_INSTALL: brew install nasm
+      CMAKE_CONFIG_PREFIX: cmake -B build -DWITH_FFMPEG_JOBS=
+      CMAKE_BUILD_PREFIX: cmake --build build --parallel
     strategy:
       fail-fast: false
       matrix:
@@ -16,28 +25,28 @@ jobs:
         include:
           - os: ubuntu-24.04
             name: Ubuntu (x86_64)
-            install: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
-            configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
-            build: cmake --build build --parallel "$(nproc)"
+            install: ${{ env.UBUNTU_INSTALL }}
+            configure: '$(nproc)'
+            build: '$(nproc)'
           - os: ubuntu-24.04-arm
             name: Ubuntu (ARM)
-            install: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
-            configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
-            build: cmake --build build --parallel "$(nproc)"
+            install: ${{ env.UBUNTU_INSTALL }}
+            configure: '$(nproc)'
+            build: '$(nproc)'
           - os: macos-15
             name: macOS (M1)
-            install: brew install nasm
-            configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
-            build: cmake --build build --parallel "$(sysctl -n hw.logicalcpu)"
+            install: ${{ env.MAC_INSTALL }}
+            configure: '$(sysctl -n hw.logicalcpu)'
+            build: '$(sysctl -n hw.logicalcpu)'
           - os: macos-15-intel
             name: macOS (Intel)
-            install: brew install nasm
-            configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
-            build: cmake --build build --parallel "$(sysctl -n hw.logicalcpu)"
+            install: ${{ env.MAC_INSTALL }}
+            configure: '$(sysctl -n hw.logicalcpu)'
+            build: '$(sysctl -n hw.logicalcpu)'
           - os: windows-2022
             name: Windows
-            configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
-            build: cmake --build build --parallel "$env:NUMBER_OF_PROCESSORS"
+            configure: '$env:NUMBER_OF_PROCESSORS'
+            build: '$env:NUMBER_OF_PROCESSORS'
     name: ${{ matrix.name }}
     steps:
       - uses: actions/checkout@v6
@@ -61,9 +70,9 @@ jobs:
         with:
           msbuild-architecture: x64
       - name: Configure
-        run: ${{ matrix.configure }}
+        run: ${{ env.CMAKE_CONFIG_PREFIX }}${{ matrix.configure }}
       - name: Build
-        run: ${{ matrix.build }}
+        run: ${{ env.CMAKE_BUILD_PREFIX }}${{ matrix.build }}
 
   validate-xml-docs:
     name: Validate Lua.xml, LuaDocumentation.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,22 +25,22 @@ jobs:
         include:
           - os: ubuntu-24.04
             name: Ubuntu (x86_64)
-            install: ${{ UBUNTU_INSTALL }}
+            install: $UBUNTU_INSTALL
             configure: '$(nproc)'
             build: '$(nproc)'
           - os: ubuntu-24.04-arm
             name: Ubuntu (ARM)
-            install: ${{ UBUNTU_INSTALL }}
+            install: $UBUNTU_INSTALL
             configure: '$(nproc)'
             build: '$(nproc)'
           - os: macos-15
             name: macOS (M1)
-            install: ${{ MAC_INSTALL }}
+            install: $MAC_INSTALL
             configure: '$(sysctl -n hw.logicalcpu)'
             build: '$(sysctl -n hw.logicalcpu)'
           - os: macos-15-intel
             name: macOS (Intel)
-            install: ${{ MAC_INSTALL }}
+            install: $MAC_INSTALL
             configure: '$(sysctl -n hw.logicalcpu)'
             build: '$(sysctl -n hw.logicalcpu)'
           - os: windows-2022
@@ -70,9 +70,9 @@ jobs:
         with:
           msbuild-architecture: x64
       - name: Configure
-        run: ${{ CMAKE_CONFIG_PREFIX }}${{ matrix.configure }}
+        run: $CMAKE_CONFIG_PREFIX${{ matrix.configure }}
       - name: Build
-        run: ${{ CMAKE_BUILD_PREFIX }}${{ matrix.build }}
+        run: $CMAKE_BUILD_PREFIX${{ matrix.build }}
 
   validate-xml-docs:
     name: Validate Lua.xml, LuaDocumentation.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,22 +25,22 @@ jobs:
         include:
           - os: ubuntu-24.04
             name: Ubuntu (x86_64)
-            install: ${{ env.UBUNTU_INSTALL }}
+            install: ${{ UBUNTU_INSTALL }}
             configure: '$(nproc)'
             build: '$(nproc)'
           - os: ubuntu-24.04-arm
             name: Ubuntu (ARM)
-            install: ${{ env.UBUNTU_INSTALL }}
+            install: ${{ UBUNTU_INSTALL }}
             configure: '$(nproc)'
             build: '$(nproc)'
           - os: macos-15
             name: macOS (M1)
-            install: ${{ env.MAC_INSTALL }}
+            install: ${{ MAC_INSTALL }}
             configure: '$(sysctl -n hw.logicalcpu)'
             build: '$(sysctl -n hw.logicalcpu)'
           - os: macos-15-intel
             name: macOS (Intel)
-            install: ${{ env.MAC_INSTALL }}
+            install: ${{ MAC_INSTALL }}
             configure: '$(sysctl -n hw.logicalcpu)'
             build: '$(sysctl -n hw.logicalcpu)'
           - os: windows-2022
@@ -70,9 +70,9 @@ jobs:
         with:
           msbuild-architecture: x64
       - name: Configure
-        run: ${{ env.CMAKE_CONFIG_PREFIX }}${{ matrix.configure }}
+        run: ${{ CMAKE_CONFIG_PREFIX }}${{ matrix.configure }}
       - name: Build
-        run: ${{ env.CMAKE_BUILD_PREFIX }}${{ matrix.build }}
+        run: ${{ CMAKE_BUILD_PREFIX }}${{ matrix.build }}
 
   validate-xml-docs:
     name: Validate Lua.xml, LuaDocumentation.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,42 +30,42 @@ jobs:
         include:
           - os: ubuntu-24.04
             name: Ubuntu (x86_64)
-            install: ${{ env.UBUNTU_INSTALL }}
+            install: ${{ UBUNTU_INSTALL }}
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
-            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }}
-            release-full: ${{ env.RELEASE_FULL_FLAGS }}
-            package: ${{ env.PACKAGE_CMD }}
+            release-nightly: ${{ RELEASE_NIGHTLY_FLAGS }}
+            release-full: ${{ RELEASE_FULL_FLAGS }}
+            package: ${{ PACKAGE_CMD }}
             path: build/ITGmania-*.tar.gz
           - os: ubuntu-24.04-arm
             name: Ubuntu (ARM)
-            install: ${{ env.UBUNTU_INSTALL }}
+            install: ${{ UBUNTU_INSTALL }}
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
-            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }}
-            release-full: ${{ env.RELEASE_FULL_FLAGS }}
-            package: ${{ env.PACKAGE_CMD }}
+            release-nightly: ${{ RELEASE_NIGHTLY_FLAGS }}
+            release-full: ${{ RELEASE_FULL_FLAGS }}
+            package: ${{ PACKAGE_CMD }}
             path: build/ITGmania-*.tar.gz
           - os: macos-15
             name: macOS (M1)
-            install: ${{ env.MAC_INSTALL }}
+            install: ${{ MAC_INSTALL }}
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
-            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=arm64
-            release-full: ${{ env.RELEASE_FULL_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=arm64
-            package: ${{ env.PACKAGE_CMD }}
+            release-nightly: ${{ RELEASE_NIGHTLY_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=arm64
+            release-full: ${{ RELEASE_FULL_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=arm64
+            package: ${{ PACKAGE_CMD }}
             path: build/ITGmania-*.dmg
           - os: macos-15-intel
             name: macOS (Intel)
-            install: ${{ env.MAC_INSTALL }}
+            install: ${{ MAC_INSTALL }}
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
-            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=x86_64
-            release-full: ${{ env.RELEASE_FULL_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=x86_64
-            package: ${{ env.PACKAGE_CMD }}
+            release-nightly: ${{ RELEASE_NIGHTLY_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=x86_64
+            release-full: ${{ RELEASE_FULL_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=x86_64
+            package: ${{ PACKAGE_CMD }}
             path: build/ITGmania-*-NIGHTLY-git-*-macOS-Intel-no-songs.dmg
           - os: windows-2022
             name: Windows
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
-            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }}
-            release-full: ${{ env.RELEASE_FULL_FLAGS }}
-            package: ${{ env.PACKAGE_CMD_WINDOWS }}
+            release-nightly: ${{ RELEASE_NIGHTLY_FLAGS }}
+            release-full: ${{ RELEASE_FULL_FLAGS }}
+            package: ${{ PACKAGE_CMD_WINDOWS }}
             path: build/ITGmania-*.exe
     name: ${{ matrix.name }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,17 @@ name: Release
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    env:
+      UBUNTU_INSTALL: |
+        sudo apt-get update && sudo apt-get install -y \
+        libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev \
+        libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev \
+        libxrandr-dev libxtst-dev nasm
+      MAC_INSTALL: brew install nasm
+      PACKAGE_CMD: cmake --build build --target package
+      PACKAGE_CMD_WINDOWS: cmake --build build --config Release --target package
+      RELEASE_NIGHTLY_FLAGS: '-DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off'
+      RELEASE_FULL_FLAGS: '-DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DWITH_NIGHTLY_RELEASE=Off -DWITH_CLUB_FANTASTIC=Off'
     permissions:
       id-token: write
       attestations: write
@@ -19,42 +30,42 @@ jobs:
         include:
           - os: ubuntu-24.04
             name: Ubuntu (x86_64)
-            install: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
+            install: ${{ env.UBUNTU_INSTALL }}
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
-            release-nightly: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
-            release-full: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DWITH_NIGHTLY_RELEASE=Off -DWITH_CLUB_FANTASTIC=Off
-            package: cmake --build build --target package
+            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }}
+            release-full: ${{ env.RELEASE_FULL_FLAGS }}
+            package: ${{ env.PACKAGE_CMD }}
             path: build/ITGmania-*.tar.gz
           - os: ubuntu-24.04-arm
             name: Ubuntu (ARM)
-            install: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
+            install: ${{ env.UBUNTU_INSTALL }}
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
-            release-nightly: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
-            release-full: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DWITH_NIGHTLY_RELEASE=Off -DWITH_CLUB_FANTASTIC=Off
-            package: cmake --build build --target package
+            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }}
+            release-full: ${{ env.RELEASE_FULL_FLAGS }}
+            package: ${{ env.PACKAGE_CMD }}
             path: build/ITGmania-*.tar.gz
           - os: macos-15
             name: macOS (M1)
-            install: brew install nasm
+            install: ${{ env.MAC_INSTALL }}
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
-            release-nightly: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_CLUB_FANTASTIC=Off
-            release-full: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DWITH_NIGHTLY_RELEASE=Off -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_CLUB_FANTASTIC=Off
-            package: cmake --build build --target package
+            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=arm64
+            release-full: ${{ env.RELEASE_FULL_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=arm64
+            package: ${{ env.PACKAGE_CMD }}
             path: build/ITGmania-*.dmg
           - os: macos-15-intel
             name: macOS (Intel)
-            install: brew install nasm
+            install: ${{ env.MAC_INSTALL }}
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
-            release-nightly: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_CLUB_FANTASTIC=Off
-            release-full: cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_FULL_RELEASE=On -DWITH_NIGHTLY_RELEASE=Off -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_CLUB_FANTASTIC=Off
-            package: cmake --build build --target package
+            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=x86_64
+            release-full: ${{ env.RELEASE_FULL_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=x86_64
+            package: ${{ env.PACKAGE_CMD }}
             path: build/ITGmania-*-NIGHTLY-git-*-macOS-Intel-no-songs.dmg
           - os: windows-2022
             name: Windows
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
-            release-nightly: cmake -B build -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
-            release-full: cmake -B build -DWITH_FULL_RELEASE=On -DWITH_NIGHTLY_RELEASE=Off -DWITH_CLUB_FANTASTIC=Off
-            package: cmake --build build --config Release --target package
+            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }}
+            release-full: ${{ env.RELEASE_FULL_FLAGS }}
+            package: ${{ env.PACKAGE_CMD_WINDOWS }}
             path: build/ITGmania-*.exe
     name: ${{ matrix.name }}
     steps:
@@ -80,14 +91,13 @@ jobs:
           msbuild-architecture: x64
       - name: Create nightly release
         if: github.ref_name == 'beta'
-        run: ${{ matrix.release-nightly }}
+        run: cmake -B build ${{ matrix.release-nightly }}
       - name: Create full release
         if: github.ref_name == 'release'
-        run: ${{ matrix.release-full }}
+        run: cmake -B build ${{ matrix.release-full }}
       - name: Create package
         id: package
-        run: |
-          ${{ matrix.package }}
+        run: ${{ matrix.package }}
       - name: Upload artifacts
         id: upload
         uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,41 +30,41 @@ jobs:
         include:
           - os: ubuntu-24.04
             name: Ubuntu (x86_64)
-            install: $UBUNTU_INSTALL
+            install: ${{ env.UBUNTU_INSTALL }}
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
-            release-nightly: $RELEASE_NIGHTLY_FLAGS 
-            release-full: $RELEASE_FULL_FLAGS
-            package: $PACKAGE_CMD
+            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }}
+            release-full: ${{ env.RELEASE_FULL_FLAGS }}
+            package: ${{ env.PACKAGE_CMD }}
             path: build/ITGmania-*.tar.gz
           - os: ubuntu-24.04-arm
             name: Ubuntu (ARM)
-            install: $UBUNTU_INSTALL
+            install: ${{ env.UBUNTU_INSTALL }}
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
-            release-nightly: $RELEASE_NIGHTLY_FLAGS 
-            release-full: $RELEASE_FULL_FLAGS
-            package: $PACKAGE_CMD
+            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }}
+            release-full: ${{ env.RELEASE_FULL_FLAGS }}
+            package: ${{ env.PACKAGE_CMD }}
             path: build/ITGmania-*.tar.gz
           - os: macos-15
             name: macOS (M1)
-            install: $MAC_INSTALL
+            install: ${{ env.MAC_INSTALL }}
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
-            release-nightly: $RELEASE_NIGHTLY_FLAGS  -DCMAKE_OSX_ARCHITECTURES=arm64
-            release-full: $RELEASE_FULL_FLAGS -DCMAKE_OSX_ARCHITECTURES=arm64
-            package: $PACKAGE_CMD
+            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=arm64
+            release-full: ${{ env.RELEASE_FULL_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=arm64
+            package: ${{ env.PACKAGE_CMD }}
             path: build/ITGmania-*.dmg
           - os: macos-15-intel
             name: macOS (Intel)
-            install: $MAC_INSTALL
+            install: ${{ env.MAC_INSTALL }}
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
-            release-nightly: $RELEASE_NIGHTLY_FLAGS  -DCMAKE_OSX_ARCHITECTURES=x86_64
-            release-full: $RELEASE_FULL_FLAGS -DCMAKE_OSX_ARCHITECTURES=x86_64
-            package: $PACKAGE_CMD
+            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=x86_64
+            release-full: ${{ env.RELEASE_FULL_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=x86_64
+            package: ${{ env.PACKAGE_CMD }}
             path: build/ITGmania-*-NIGHTLY-git-*-macOS-Intel-no-songs.dmg
           - os: windows-2022
             name: Windows
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
-            release-nightly: $RELEASE_NIGHTLY_FLAGS 
-            release-full: $RELEASE_FULL_FLAGS
+            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }}
+            release-full: ${{ env.RELEASE_FULL_FLAGS }}
             package: ${{ env.PACKAGE_CMD_WINDOWS }}
             path: build/ITGmania-*.exe
     name: ${{ matrix.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     env:
-      UBUNTU_INSTALL: "sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm"
+      UBUNTU_INSTALL: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
       MAC_INSTALL: brew install nasm
       PACKAGE_CMD: cmake --build build --target package
       PACKAGE_CMD_WINDOWS: cmake --build build --config Release --target package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,42 +30,42 @@ jobs:
         include:
           - os: ubuntu-24.04
             name: Ubuntu (x86_64)
-            install: ${{ UBUNTU_INSTALL }}
+            install: $UBUNTU_INSTALL
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
-            release-nightly: ${{ RELEASE_NIGHTLY_FLAGS }}
-            release-full: ${{ RELEASE_FULL_FLAGS }}
-            package: ${{ PACKAGE_CMD }}
+            release-nightly: $RELEASE_NIGHTLY_FLAGS
+            release-full: $RELEASE_FULL_FLAGS
+            package: $PACKAGE_CMD
             path: build/ITGmania-*.tar.gz
           - os: ubuntu-24.04-arm
             name: Ubuntu (ARM)
-            install: ${{ UBUNTU_INSTALL }}
+            install: $UBUNTU_INSTALL
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
-            release-nightly: ${{ RELEASE_NIGHTLY_FLAGS }}
-            release-full: ${{ RELEASE_FULL_FLAGS }}
-            package: ${{ PACKAGE_CMD }}
+            release-nightly: $RELEASE_NIGHTLY_FLAGS
+            release-full: $RELEASE_FULL_FLAGS
+            package: $PACKAGE_CMD
             path: build/ITGmania-*.tar.gz
           - os: macos-15
             name: macOS (M1)
-            install: ${{ MAC_INSTALL }}
+            install: $MAC_INSTALL
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
-            release-nightly: ${{ RELEASE_NIGHTLY_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=arm64
-            release-full: ${{ RELEASE_FULL_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=arm64
-            package: ${{ PACKAGE_CMD }}
+            release-nightly: $RELEASE_NIGHTLY_FLAGS -DCMAKE_OSX_ARCHITECTURES=arm64
+            release-full: $RELEASE_FULL_FLAGS -DCMAKE_OSX_ARCHITECTURES=arm64
+            package: $PACKAGE_CMD
             path: build/ITGmania-*.dmg
           - os: macos-15-intel
             name: macOS (Intel)
-            install: ${{ MAC_INSTALL }}
+            install: $MAC_INSTALL
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
-            release-nightly: ${{ RELEASE_NIGHTLY_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=x86_64
-            release-full: ${{ RELEASE_FULL_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=x86_64
-            package: ${{ PACKAGE_CMD }}
+            release-nightly: $RELEASE_NIGHTLY_FLAGS -DCMAKE_OSX_ARCHITECTURES=x86_64
+            release-full: $RELEASE_FULL_FLAGS -DCMAKE_OSX_ARCHITECTURES=x86_64
+            package: $PACKAGE_CMD
             path: build/ITGmania-*-NIGHTLY-git-*-macOS-Intel-no-songs.dmg
           - os: windows-2022
             name: Windows
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
-            release-nightly: ${{ RELEASE_NIGHTLY_FLAGS }}
-            release-full: ${{ RELEASE_FULL_FLAGS }}
-            package: ${{ PACKAGE_CMD_WINDOWS }}
+            release-nightly: $RELEASE_NIGHTLY_FLAGS
+            release-full: $RELEASE_FULL_FLAGS
+            package: $PACKAGE_CMD_WINDOWS
             path: build/ITGmania-*.exe
     name: ${{ matrix.name }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,41 +30,41 @@ jobs:
         include:
           - os: ubuntu-24.04
             name: Ubuntu (x86_64)
-            install: ${{ env.UBUNTU_INSTALL }}
+            install: $UBUNTU_INSTALL
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
-            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }}
-            release-full: ${{ env.RELEASE_FULL_FLAGS }}
-            package: ${{ env.PACKAGE_CMD }}
+            release-nightly: $RELEASE_NIGHTLY_FLAGS 
+            release-full: $RELEASE_FULL_FLAGS
+            package: $PACKAGE_CMD
             path: build/ITGmania-*.tar.gz
           - os: ubuntu-24.04-arm
             name: Ubuntu (ARM)
-            install: ${{ env.UBUNTU_INSTALL }}
+            install: $UBUNTU_INSTALL
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
-            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }}
-            release-full: ${{ env.RELEASE_FULL_FLAGS }}
-            package: ${{ env.PACKAGE_CMD }}
+            release-nightly: $RELEASE_NIGHTLY_FLAGS 
+            release-full: $RELEASE_FULL_FLAGS
+            package: $PACKAGE_CMD
             path: build/ITGmania-*.tar.gz
           - os: macos-15
             name: macOS (M1)
-            install: ${{ env.MAC_INSTALL }}
+            install: $MAC_INSTALL
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
-            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=arm64
-            release-full: ${{ env.RELEASE_FULL_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=arm64
-            package: ${{ env.PACKAGE_CMD }}
+            release-nightly: $RELEASE_NIGHTLY_FLAGS  -DCMAKE_OSX_ARCHITECTURES=arm64
+            release-full: $RELEASE_FULL_FLAGS -DCMAKE_OSX_ARCHITECTURES=arm64
+            package: $PACKAGE_CMD
             path: build/ITGmania-*.dmg
           - os: macos-15-intel
             name: macOS (Intel)
-            install: ${{ env.MAC_INSTALL }}
+            install: $MAC_INSTALL
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
-            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=x86_64
-            release-full: ${{ env.RELEASE_FULL_FLAGS }} -DCMAKE_OSX_ARCHITECTURES=x86_64
-            package: ${{ env.PACKAGE_CMD }}
+            release-nightly: $RELEASE_NIGHTLY_FLAGS  -DCMAKE_OSX_ARCHITECTURES=x86_64
+            release-full: $RELEASE_FULL_FLAGS -DCMAKE_OSX_ARCHITECTURES=x86_64
+            package: $PACKAGE_CMD
             path: build/ITGmania-*-NIGHTLY-git-*-macOS-Intel-no-songs.dmg
           - os: windows-2022
             name: Windows
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
-            release-nightly: ${{ env.RELEASE_NIGHTLY_FLAGS }}
-            release-full: ${{ env.RELEASE_FULL_FLAGS }}
+            release-nightly: $RELEASE_NIGHTLY_FLAGS 
+            release-full: $RELEASE_FULL_FLAGS
             package: ${{ env.PACKAGE_CMD_WINDOWS }}
             path: build/ITGmania-*.exe
     name: ${{ matrix.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     env:
-      UBUNTU_INSTALL: |
-        sudo apt-get update && sudo apt-get install -y \
-        libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev \
-        libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev \
-        libxrandr-dev libxtst-dev nasm
+      UBUNTU_INSTALL: "sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm"
       MAC_INSTALL: brew install nasm
       PACKAGE_CMD: cmake --build build --target package
       PACKAGE_CMD_WINDOWS: cmake --build build --config Release --target package


### PR DESCRIPTION
Refactoring much of the repeated configurations, those shared across operating systems and architectures, to job-level environment variables - reference https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables