### PR TITLE
Linux input: Improve BTN_DPAD key mapping

### DIFF
--- a/src/arch/InputHandler/InputHandler_Linux_Event.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Event.cpp
@@ -478,6 +478,8 @@ void InputHandler_Linux_Event::InputThread()
 				} else if (event.code >= BTN_TRIGGER_HAPPY1 && event.code <= BTN_TRIGGER_HAPPY40) {
 					// Actually, we only have 32 buttons defined.
 					iNum = event.code - BTN_TRIGGER_HAPPY1 + 0x10;
+				} else if (event.code >= BTN_DPAD_UP && event.code <= BTN_DPAD_RIGHT) {
+					iNum = event.code - BTN_DPAD_UP + 0x10;
 				} else {
 					// If the button number is >40+0xf, it gets mapped to a code with no #define.
 					// I don't know if this is appropriate at all, but what else to do?


### PR DESCRIPTION
My dance pad has a USB connector and identifies as a PS3 controller. It has the typical 4 up/down/left/right directions, plus the four corner squares are buttons ABXY.

When I went to map and test, I found that 3 of the corner buttons, when pressed, triggered direction inputs. I tested on two different Linux PCs, with the same result. Looking in the KDE controller settings, I could see that the directions and corners _did_ register as separate buttons - so it seemed like the problem was in ITGmania.

I did a little debugging and I think I've found the cause and a reasonable fix. Thanks!

Commit msg:

> BTN_DPAD buttons were not explicitly handled, so the input code placed them into the button list (max 32 buttons) arbitrarily.
> 
> This could lead to conflicts with BTN_JOYSTICK or BTN_GAMEPAD buttons.
> 
> BTN_JOYSTICK and BTN_GAMEPAD buttons are always mapped to the first half of the button list. BTN_TRIGGER_HAPPY buttons are mapped to the second half of the button list.
> 
> Treat BTN_DPAD buttons like BTN_TRIGGER_HAPPY buttons and map them to the second half of the button list.
> 
> I believe this change aligns with a change in the Linux kernel where dpad buttons now map to BTN_DPAD instead of BTN_TRIGGER_HAPPY: https://github.com/torvalds/linux/commit/a43a503df996739ae34f179f6b73b0ae91000c5c