### PR TITLE
Websocket thread fix

### DIFF
--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -18,6 +18,7 @@
 #include "InputMapper.h"
 #include "RageFileManager.h"
 #include "LightsManager.h"
+#include "NetworkManager.h"
 #include "RageTimer.h"
 #include "RageInput.h"
 
@@ -295,6 +296,7 @@ void GameLoop::UpdateAllButDraw(bool bRunningFromVBLANK)
 	GAMESTATE->Update(fDeltaTime);
 	SCREENMAN->Update(fDeltaTime);
 	MEMCARDMAN->Update();
+    NETWORK->Update(fDeltaTime);
 
 	/* Important: Process input AFTER updating game logic, or input will be
 	 * acting on song beat from last frame */

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -109,6 +109,16 @@ NetworkManager::~NetworkManager()
 	ix::uninitNetSystem();
 }
 
+void NetworkManager::Update(float fDelta) {
+	for (std::shared_ptr<WebSocketHandle> handle : webSocketHandles) {
+		std::lock_guard mtxLock(handle->readMutex);
+		while (!handle->readQueue.empty()) {
+			handle->onMessage(&handle->readQueue.front());
+			handle->readQueue.pop();
+		}
+	}
+}
+
 bool NetworkManager::IsUrlAllowed(const std::string& url)
 {
 	if (!this->httpEnabled.Get())
@@ -241,7 +251,19 @@ WebSocketHandlePtr NetworkManager::WebSocket(const WebSocketArgs& args)
 
 	handle->webSocket.setUrl(args.url);
 	handle->webSocket.setTLSOptions(this->tlsOptions);
-	handle->webSocket.setOnMessageCallback(args.onMessage);
+	// handle->webSocket.setOnMessageCallback(args.onMessage);
+	handle->webSocket.setOnMessageCallback(
+		[args, handle](const ix::WebSocketMessagePtr& response) {
+			CopiedWebSocketMessage messageCopy(response);
+
+			if (messageCopy.type == ix::WebSocketMessageType::Message) {
+				std::lock_guard<std::mutex> lock(handle->readMutex);
+				handle->readQueue.push(messageCopy);
+			} else {
+				// Dispatch now
+				args.onMessage(&messageCopy);
+			}
+		});
 
 	ix::WebSocketHttpHeaders headers;
 	headers["User-Agent"] = this->GetUserAgent();
@@ -267,6 +289,7 @@ WebSocketHandlePtr NetworkManager::WebSocket(const WebSocketArgs& args)
 	}
 
 	handle->webSocket.start();
+	handle->sendThread = std::thread(&WebSocketHandle::SendThread, handle);
 
 	webSocketHandles.push_back(handle);
 
@@ -325,7 +348,34 @@ int HttpRequestFuture::Cancel(lua_State *L)
 }
 
 WebSocketHandle::~WebSocketHandle() {
+	{// Neatly clonse the send thread
+		{
+			std::lock_guard<std::mutex> lock(sendQueueMutex);
+			stopFlag = true;
+		}
+		sendQueueCV.notify_all();
+		if (sendThread.joinable()) {
+			sendThread.join();
+		}
+	}
 	webSocket.stop();
+}
+
+void WebSocketHandle::SendThread() {
+	while (true) {
+		std::unique_lock<std::mutex> lock(sendQueueMutex);
+		sendQueueCV.wait(lock, [&] { return !sendQueue.empty() || stopFlag; });
+
+		if (stopFlag && sendQueue.empty()) {
+			break;
+		}
+
+		std::string message = std::move(sendQueue.front());
+		sendQueue.pop();
+		lock.unlock();
+
+		webSocket.send(message);
+	}
 }
 
 int WebSocketHandle::Collect(lua_State *L)
@@ -767,7 +817,7 @@ public:
 		}
 		lua_pop(L, 1);
 
-		args.onMessage = [onMessageRef](const ix::WebSocketMessagePtr& msg)
+		args.onMessage = [onMessageRef](const CopiedWebSocketMessage* msg)
 		{
 			Lua *L = LUA->Get();
 
@@ -990,7 +1040,7 @@ private:
 		LuaHelpers::RunScriptOnStack(L, error, 1, 0, true);
 	}
 
-	static void handleMessage(Lua *L, const ix::WebSocketMessagePtr& msg, int onMessageRef)
+	static void handleMessage(Lua *L, const CopiedWebSocketMessage* msg, int onMessageRef)
 	{
 		lua_rawgeti(L, LUA_REGISTRYINDEX, onMessageRef);
 

--- a/src/NetworkManager.h
+++ b/src/NetworkManager.h
@@ -95,6 +95,25 @@ private:
 
 typedef std::shared_ptr<HttpRequestFuture> HttpRequestFuturePtr;
 
+struct CopiedWebSocketMessage {
+	ix::WebSocketMessageType type;
+	const std::string str;
+	size_t wireSize;
+	ix::WebSocketErrorInfo errorInfo;
+	ix::WebSocketOpenInfo openInfo;
+	ix::WebSocketCloseInfo closeInfo;
+	bool binary;
+
+	CopiedWebSocketMessage(const ix::WebSocketMessagePtr& wsmp)
+		: type(wsmp->type),
+		str(wsmp->str),
+		wireSize(wsmp->wireSize),
+		errorInfo(wsmp->errorInfo),
+		openInfo(wsmp->openInfo),
+		closeInfo(wsmp->closeInfo),
+		binary(wsmp->binary) {}
+};
+
 struct WebSocketArgs
 {
 	std::string url;
@@ -102,7 +121,7 @@ struct WebSocketArgs
 	int handshakeTimeout = -1;
 	int pingInterval = -1;
 	bool automaticReconnect = true;
-	std::function<void(const ix::WebSocketMessagePtr& response)> onMessage;
+	std::function<void(const CopiedWebSocketMessage*)> onMessage;
 	std::function<void()> onClose;
 };
 
@@ -111,6 +130,8 @@ class WebSocketHandle
 public:
 	WebSocketHandle() {};
 	~WebSocketHandle();
+
+	void SendThread();
 	
 	static int Collect(lua_State *L);
 	static int Close(lua_State *L);
@@ -118,6 +139,15 @@ public:
 
 	ix::WebSocket webSocket;
 	std::function<void()> onClose;
+	std::queue<CopiedWebSocketMessage> readQueue;
+	std::mutex readMutex;
+	std::function<void(const CopiedWebSocketMessage* response)> onMessage;
+
+	std::thread sendThread;
+	std::queue<std::string> sendQueue;
+	std::mutex sendQueueMutex;
+	std::condition_variable sendQueueCV;
+	std::atomic<bool> stopFlag = false;
 };
 
 typedef std::shared_ptr<WebSocketHandle> WebSocketHandlePtr;
@@ -133,6 +163,8 @@ public:
 	WebSocketHandlePtr WebSocket(const WebSocketArgs& args);
 	std::string UrlEncode(const std::string& value);
 	std::string EncodeQueryParameters(const std::unordered_map<std::string, std::string>& query);
+
+	void Update(float fDelta);
 
 	// Lua
 	void PushSelf(lua_State *L);


### PR DESCRIPTION
Move websocket sending to it's own thread to prevent blocking the main thread. Move websocket read handling to the main thread to prevent locking the Messsage Manager