### PR TITLE
Add Windows 11 Arm to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, macos-15-intel, windows-2022]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, macos-15-intel, windows-2022, windows-11-arm]
         include:
           - os: ubuntu-24.04
             name: Ubuntu (x86_64)
@@ -35,7 +35,11 @@ jobs:
             configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
             build: cmake --build build --parallel "$(sysctl -n hw.logicalcpu)"
           - os: windows-2022
-            name: Windows
+            name: Windows (x86_64)
+            configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
+            build: cmake --build build --parallel "$env:NUMBER_OF_PROCESSORS"
+          - os: windows-11-arm
+            name: Windows (ARM)
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
             build: cmake --build build --parallel "$env:NUMBER_OF_PROCESSORS"
     name: ${{ matrix.name }}
@@ -53,10 +57,10 @@ jobs:
      #     restore-keys: |
      #       ${{ runner.os }}-${{ runner.arch }}-cmake-build-ci-
       - name: Install dependencies
-        if: matrix.os != 'windows-2022'
+        if: runner.os != 'Windows'
         run: ${{ matrix.install }}
       - name: Add msbuild to PATH
-        if: matrix.os == 'windows-2022'
+        if: runner.os == 'Windows'
         uses: microsoft/setup-msbuild@v2
         with:
           msbuild-architecture: x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, macos-15-intel, windows-2022]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, macos-15-intel, windows-2022, windows-11-arm]
         include:
           - os: ubuntu-24.04
             name: Ubuntu (x86_64)
@@ -50,7 +50,14 @@ jobs:
             package: cmake --build build --target package
             path: build/ITGmania-*-NIGHTLY-git-*-macOS-Intel-no-songs.dmg
           - os: windows-2022
-            name: Windows
+            name: Windows (x86_64)
+            configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
+            release-nightly: cmake -B build -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
+            release-full: cmake -B build -DWITH_FULL_RELEASE=On -DWITH_NIGHTLY_RELEASE=Off -DWITH_CLUB_FANTASTIC=Off
+            package: cmake --build build --config Release --target package
+            path: build/ITGmania-*.exe
+          - os: windows-11-arm
+            name: Windows (ARM)
             configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
             release-nightly: cmake -B build -DWITH_FULL_RELEASE=Off -DWITH_NIGHTLY_RELEASE=On -DWITH_CLUB_FANTASTIC=Off
             release-full: cmake -B build -DWITH_FULL_RELEASE=On -DWITH_NIGHTLY_RELEASE=Off -DWITH_CLUB_FANTASTIC=Off
@@ -71,10 +78,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-cmake-build-${{ github.ref_name }}-
       - name: Install dependencies
-        if: matrix.os != 'windows-2022'
+        if: runner.os != 'Windows'
         run: ${{ matrix.install }}
       - name: Add msbuild to PATH
-        if: matrix.os == 'windows-2022'
+        if: runner.os == 'Windows'
         uses: microsoft/setup-msbuild@v2
         with:
           msbuild-architecture: x64


### PR DESCRIPTION
Discussed in https://discord.com/channels/292111865658474496/958039182327029840/1468814816389894308, reference https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories & https://github.com/actions/partner-runner-images/blob/main/images%2Farm-windows-11-image.md

_Needs https://github.com/libtom/libtomcrypt/commit/b96e96cf8b22a931e8e91098ac37bc72f9e2f033#diff-2db5eece44c5b2ec42c2e2a08d847e6b0e3723d7d11bf7d5bda16f20fe795ff9 / https://github.com/libtom/libtomcrypt/issues/568?_