### PR TITLE
Remove unnecessary permissions from CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,13 +18,6 @@ jobs:
       # required for all workflows
       security-events: write
 
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
-      # only required for workflows in private repositories
-      actions: read
-      contents: read
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6


### PR DESCRIPTION
These additional workflow permissions are not necessary here, removing.