### PR TITLE
Add Dependabot configuration for gitsubmodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,12 @@ updates:
     # Check the for updates once a week
     schedule:
       interval: "weekly"
+  # Enable version updates for gitsubmodules
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    # Raise pull requests for version updates
+    # against the `beta` branch
+    target-branch: "beta"
+    # Check the for updates once a month
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Adding monthly updates for gitsubmodules to the Dependabot configuration, reference https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories#supported-ecosystems-maintained-by-github

Output on my fork: https://github.com/ScottBrenner/itgmania/pulls