### PR TITLE
Update .clang-format to match existing style most closely

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,11 @@
-BasedOnStyle: Google
+BasedOnStyle: Microsoft
+BracesStyle: Allman
 AlignAfterOpenBracket: AlwaysBreak
 DerivePointerAlignment: false
 PointerAlignment: Left
 QualifierAlignment: Left
 ReferenceAlignment: Left
 InsertBraces: true
+SortIncludes: false
+ReorderIncludes: false
+IncludeBlocks: Preserve


### PR DESCRIPTION
This is nearly identical to the existing style used throughout the project, and also noted in `Docs/Devdocs/CodingStyle.txt`.  So, it should minimize the amount of changes when reformatting with clang-format.

 The `Microsoft` BasedOnStyle is valid in clang-format, and basically is a collection of presets that most closely align with traditional Visual Studio formatting.