### PR TITLE
Add lua binding for seeking through songs in EditMode / PracticeMode.

### DIFF
--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -6565,18 +6565,31 @@ void ScreenEdit::DoHelp()
 	EditMiniMenu( &g_EditHelp );
 }
 
+void ScreenEdit::SeekSong(float second) {
+    float desired_beat = GetAppropriateTiming().GetBeatFromElapsedTime(second);
+    // Don't seek past the final beat of the song.
+    ScrollTo(std::min(desired_beat, GetMaximumBeatForNewNote()));
+    m_fTrailingBeat = GetBeat();
+}
+
 // lua start
 #include "LuaBinding.h"
 
 /** @brief Allow Lua to have access to ScreenEdit. */
 class LunaScreenEdit: public Luna<ScreenEdit>
 {
-public:
-	DEFINE_METHOD( GetEditState, GetEditState() )
-	LunaScreenEdit()
-	{
-		ADD_METHOD( GetEditState );
-	}
+ public:
+  static int SeekSong(T* p, lua_State* L) {
+    p->SeekSong( FArg(1) );
+    return 1;
+  }
+  DEFINE_METHOD(GetEditState, GetEditState());
+
+  LunaScreenEdit()
+  {
+    ADD_METHOD( GetEditState );
+    ADD_METHOD( SeekSong );
+  }
 };
 
 LUA_REGISTER_DERIVED_CLASS( ScreenEdit, ScreenWithMenuElements )

--- a/src/ScreenEdit.h
+++ b/src/ScreenEdit.h
@@ -226,6 +226,9 @@ public:
 
 	EditState GetEditState(){ return m_EditState; }
 
+	// For seeking through the song instantly.
+	void SeekSong(float second);
+
 	// Lua
 	virtual void PushSelf( lua_State *L );
 


### PR DESCRIPTION
A feature request I see around the ITC discord often is the ability to instantly seek to the failure point of a song when entering practice mode.

As of https://github.com/Simply-Love/Simply-Love-SM5/pull/694 we can enter practice mode from the results screen, so a possible next step would be taking the `deathSecond` as calculated in Lua ([TrackFailTime.lua](https://github.com/Simply-Love/Simply-Love-SM5/blob/itgmania-beta/BGAnimations/ScreenGameplay%20overlay/TrackFailTime.lua#L116)) and passing that to the engine to seek upon entering practice mode. This would be done via the binding in this PR.

I'm planning on raising a PR for the SL side of this as well, but if we don't want it in SL that's also fine. This change at least gives themers the option to Seek upon entering PracticeMode.