### PR TITLE
MeasureInfo: Exclude fakes from NPS

### DIFF
--- a/src/MeasureInfo.cpp
+++ b/src/MeasureInfo.cpp
@@ -78,6 +78,11 @@ void MeasureInfo::CalculateMeasureInfo(const NoteData &in, TimingData * timing, 
 	{
 		if(curr_note.Row() != curr_row)
 		{
+			if (timing->IsFakeAtRow(curr_row) || timing->IsWarpAtRow(curr_row))
+			{
+				// Don't include fakes and warped-over notes in the count.
+				notes_this_row = 0;
+			}
 			// Before moving on to a new row, update the notes per measure for the current measure.
 			out.notesPerMeasure[iMeasureIndexOut] += notes_this_row;
 			// Update iMeasureIndex for the current row


### PR DESCRIPTION
Fakes and notes in warp sections are not real notes so they shouldn't be counted in notes per second.

Currently, Simply Love implements its own NPS calculations, so this doesn't affect it. But if that's ever changed to use the NPS from the engine, this will fix density graphs and peak NPS for charts with warps. For example, Cursed Metamorph from Tachyon Eta:
<img width="45%" alt="warps-in-density-graph-broken" src="https://github.com/user-attachments/assets/3a848ac2-cdae-4f48-a3ed-053981d52b60" /> <img width="45%" src="https://github.com/user-attachments/assets/cebe825e-c0f2-454d-8002-5135edc103e9" />
