### PR TITLE
Turn off clang-format when including multiple windows headers

### DIFF
--- a/src/CommandLineActions.cpp
+++ b/src/CommandLineActions.cpp
@@ -15,10 +15,12 @@
 #include "ver.h"
 
 // only used for Version()
+// clang-format off
 #if defined(_WIN32)
 #include <windows.h>
 #include <conio.h>
 #endif
+// clang-format on
 
 std::vector<CommandLineActions::CommandLineArgs> CommandLineActions::ToProcess;
 

--- a/src/RageFileDriverDirect.cpp
+++ b/src/RageFileDriverDirect.cpp
@@ -20,8 +20,10 @@
 #endif
 
 #if defined(_WIN32)
+// clang-format off
 #include <windows.h>
 #include <io.h>
+// clang-format on
 
 #include "archutils/Win32/ErrorStrings.h"
 #else

--- a/src/RageFileDriverDirectHelpers.cpp
+++ b/src/RageFileDriverDirectHelpers.cpp
@@ -13,8 +13,10 @@
 #include "global.h"
 
 #if defined(_WIN32)
-    #include <windows.h>
-    #include <io.h>
+// clang-format off
+#include <windows.h>
+#include <io.h>
+// clang-format on
 #else
     #if defined(HAVE_DIRENT_H)
         #include <dirent.h>

--- a/src/arch/ArchHooks/ArchHooks_Win32.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32.cpp
@@ -1,7 +1,9 @@
 #include "ArchHooks_Win32.h"
 
+// clang-format off
 #include <windows.h>
 #include <versionhelpers.h>
+// clang-format on
 
 #include <cstdint>
 #include <string>

--- a/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
@@ -11,9 +11,11 @@
 #include "archutils/Win32/SpecialDirs.h"
 #include "global.h"
 
+// clang-format off
 // for QueryPerformanceCounter
 #include <windows.h>
 #include <mmsystem.h>
+// clang-format on
 #if defined(_MSC_VER)
 #pragma comment(lib, "winmm.lib")
 #endif

--- a/src/arch/InputHandler/InputHandler_Win32_MIDI.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_MIDI.cpp
@@ -1,7 +1,9 @@
 #include "InputHandler_Win32_MIDI.h"
 
+// clang-format off
 #include <windows.h>
 #include <mmsystem.h>
+// clang-format on
 
 #include <string>
 #include <vector>

--- a/src/arch/InputHandler/InputHandler_Win32_ddrio.cpp
+++ b/src/arch/InputHandler/InputHandler_Win32_ddrio.cpp
@@ -1,7 +1,9 @@
 #include "InputHandler_Win32_ddrio.h"
 
+// clang-format off
 #include <windows.h>
 #include <process.h>
+// clang-format on
 
 #include <cstdint>
 #include <string>

--- a/src/arch/LoadingWindow/LoadingWindow_Win32.cpp
+++ b/src/arch/LoadingWindow/LoadingWindow_Win32.cpp
@@ -1,7 +1,9 @@
 #include "LoadingWindow_Win32.h"
 
+// clang-format off
 #include <windows.h>
 #include <commctrl.h>
+// clang-format on
 
 #include <cmath>
 #include <string>

--- a/src/arch/Sound/DSoundHelpers.h
+++ b/src/arch/Sound/DSoundHelpers.h
@@ -5,8 +5,10 @@
 #include <string>
 
 #if defined(_WIN32)
+// clang-format off
 #include <windows.h>
 #include <wtypes.h>
+// clang-format on
 #endif
 
 struct IDirectSound;

--- a/src/arch/Sound/RageSoundDriver_WDMKS.cpp
+++ b/src/arch/Sound/RageSoundDriver_WDMKS.cpp
@@ -18,12 +18,14 @@
 #define DEFINE_WAVEFORMATEX_GUID(x) (USHORT)(x), 0x0000, 0x0010, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71
 #endif
 
+// clang-format off
 #include <windows.h>
 #include <winioctl.h>
 #include <ks.h>
 #include <mmsystem.h>
 #include <ksmedia.h>
 #include <setupapi.h>
+// clang-format on
 
 typedef KSDDKAPI DWORD WINAPI KSCREATEPIN(HANDLE, PKSPIN_CONNECT, ACCESS_MASK, PHANDLE);
 
@@ -1023,7 +1025,6 @@ bool WinWdmStream::SubmitPacket( int iPacket, std::string &sError )
 }
 
 
-#include <windows.h>
 namespace
 {
 	void MapChannels( const int16_t *pIn, int16_t *pOut, int iInChannels, int iOutChannels, int iFrames, const int *pChannelMap )

--- a/src/arch/Sound/RageSoundDriver_WaveOut.h
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.h
@@ -1,8 +1,10 @@
 #ifndef RAGE_SOUND_WAVEOUT_H
 #define RAGE_SOUND_WAVEOUT_H
 
+// clang-format off
 #include <windows.h>
 #include <mmsystem.h>
+// clang-format on
 
 #include <cstdint>
 #include <string>

--- a/src/archutils/Win32/CommandLine.cpp
+++ b/src/archutils/Win32/CommandLine.cpp
@@ -1,7 +1,11 @@
 #include "global.h"
 #include "CommandLine.h"
+
+// clang-format off
 #include <windows.h>
 #include <shellapi.h>
+// clang-format on
+
 #include <vector>
 #include <string>
 

--- a/src/archutils/Win32/CrashHandlerChild.cpp
+++ b/src/archutils/Win32/CrashHandlerChild.cpp
@@ -1,6 +1,8 @@
+// clang-format off
 #include <windows.h>
 #include <commctrl.h>
 #include <io.h>
+// clang-format on
 
 #include <cerrno>
 #include <cstddef>

--- a/src/archutils/Win32/CrashHandlerNetworking.cpp
+++ b/src/archutils/Win32/CrashHandlerNetworking.cpp
@@ -11,8 +11,10 @@
 #include "global.h"
 
 #if defined(WINDOWS)
+// clang-format off
 #include <windows.h>
 #include <winsock2.h>
+// clang-format on
 #pragma comment(lib, "wsock32.lib")
 #pragma comment(lib, "ws2_32.lib")
 #endif

--- a/src/archutils/Win32/DebugInfoHunt.cpp
+++ b/src/archutils/Win32/DebugInfoHunt.cpp
@@ -1,7 +1,9 @@
 #include "DebugInfoHunt.h"
 
+// clang-format off
 #include <windows.h>
 #include <mmsystem.h>
+// clang-format on
 
 #include <string>
 #include <vector>

--- a/src/archutils/Win32/DirectXHelpers.cpp
+++ b/src/archutils/Win32/DirectXHelpers.cpp
@@ -1,9 +1,11 @@
 #include "DirectXHelpers.h"
 
+// clang-format off
 #include <mmsystem.h>  // dsound.h needs this
 #include <d3d9.h>
 #include <dinput.h>
 #include <dsound.h>
+// clang-format on
 
 #include <cstdarg>
 #include <stdexcept>

--- a/src/archutils/Win32/DirectXHelpers.h
+++ b/src/archutils/Win32/DirectXHelpers.h
@@ -1,8 +1,10 @@
 #ifndef DIRECTX_HELPERS_H
 #define DIRECTX_HELPERS_H
 
+// clang-format off
 #include <windows.h>
 #include <versionhelpers.h>
+// clang-format on
 
 #include <string>
 

--- a/src/archutils/Win32/GetFileInformation.cpp
+++ b/src/archutils/Win32/GetFileInformation.cpp
@@ -6,10 +6,13 @@
 
 #include <cstdint>
 #include <sys/stat.h>
-#include <windows.h>
-#include <tlhelp32.h>
 #include <vector>
 #include <string>
+
+// clang-format off
+#include <windows.h>
+#include <tlhelp32.h>
+// clang-format on
 
 #pragma comment(lib, "version.lib")
 


### PR DESCRIPTION
Apparently windows headers depend on <windows.h> being included before...