### PR TITLE
Fix warnings on mac

### DIFF
--- a/src/arch/InputHandler/InputHandler_NSEvent.hpp
+++ b/src/arch/InputHandler/InputHandler_NSEvent.hpp
@@ -8,32 +8,23 @@
 #ifndef InputHandler_NSEvent_hpp
 #define InputHandler_NSEvent_hpp
 
-#include <cstdint>
-#include <cstdio>
 #include "InputHandler.h"
+#include "archutils/Darwin/CocoaEventDispatcher.h"
 
-#if __OBJC__
-#   import <Cocoa/Cocoa.h>
-#   define EVENT_TYPE NSEvent *
-#else
-#   define EVENT_TYPE void *
-#endif
+class InputHandler_NSEvent : public InputHandler {
+ public:
+  InputHandler_NSEvent();
+  ~InputHandler_NSEvent();
 
-class InputHandler_NSEvent : public InputHandler
-{
-public:
-    InputHandler_NSEvent();
-    ~InputHandler_NSEvent();
+  void GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut);
 
-    void GetDevicesAndDescriptions( std::vector<InputDeviceInfo>& vDevicesOut );
-    
-protected:
-    void HandleEvent( EVENT_TYPE e );
-    void InitKeyCodeMap();
-        
-private:
-    DeviceButton m_NSKeyCodeMap[0x100];
-    unsigned     m_ResponderID;
+ protected:
+  void HandleEvent(EVENT_TYPE e);
+  void InitKeyCodeMap();
+
+ private:
+  DeviceButton m_NSKeyCodeMap[0x100];
+  unsigned m_ResponderID;
 };
 
 #endif /* InputHandler_NSEvent_hpp */


### PR DESCRIPTION
EVENT_TYPE was defined in two headers.

Also format the header, I missed this in the formatting change because it's a .hpp file.