### PR TITLE
Fix/suppress windows warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -121,7 +121,7 @@ target_compile_options("${SM_EXE_NAME}" PRIVATE
   $<$<CXX_COMPILER_ID:AppleClang>:
     -Wall -Wextra -Wno-unused -Wno-unused-parameter -Wno-unknown-pragmas -Wno-undefined-var-template -Wno-deprecated-declarations -Wno-unused-command-line-argument>
   $<$<CXX_COMPILER_ID:MSVC>:
-    /W4 /wd4100 /wd4189 /wd4244 /wd4267 /wd4702>
+    /W4 /wd4100 /wd4189 /wd4201 /wd4244 /wd4267 /wd4702>
 )
 
 set(SM_COMPILE_FLAGS "")

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -428,7 +428,7 @@ void SongManager::LoadSongDir(
   StripMacResourceForks(arrayGroupDirs);
 
   std::map<std::string, std::vector<std::string>> mapGroupSongDirs;
-  int groupIndex, songCount, songIndex;
+  int groupIndex, songCount;
 
   groupIndex = 0;
   songCount = 0;

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -199,35 +199,29 @@ void StageLayout::preGeneratePermutations() {
 }
 
 std::vector<FootPlacement> StageLayout::PermuteFootPlacements(
-    unsigned int mask, FootPlacement columns, unsigned long column) {
-  // MV: This is re-defined here because I was running into
-  // issues with StepParity::FEET being empty within this context?
-  // I don't understand C++ header initialization stuff
-  std::vector<StepParity::Foot> FEET = {
-      LEFT_HEEL, LEFT_TOE, RIGHT_HEEL, RIGHT_TOE};
-
+    unsigned int mask, FootPlacement test_columns, unsigned long column) {
   // If column >= columns.size(), we've reached the end of the row.
-  // Perform some final validation before returning the contents of columns
-  if (column >= columns.size()) {
+  // Perform some final validation before returning the contents of test_columns
+  if (column >= test_columns.size()) {
     int leftHeelIndex = StepParity::INVALID_COLUMN;
     int leftToeIndex = StepParity::INVALID_COLUMN;
     int rightHeelIndex = StepParity::INVALID_COLUMN;
     int rightToeIndex = StepParity::INVALID_COLUMN;
 
-    for (unsigned long i = 0; i < columns.size(); i++) {
-      if (columns[i] == NONE) {
+    for (unsigned long i = 0; i < test_columns.size(); i++) {
+      if (test_columns[i] == NONE) {
         continue;
       }
-      if (columns[i] == LEFT_HEEL) {
+      if (test_columns[i] == LEFT_HEEL) {
         leftHeelIndex = i;
       }
-      if (columns[i] == LEFT_TOE) {
+      if (test_columns[i] == LEFT_TOE) {
         leftToeIndex = i;
       }
-      if (columns[i] == RIGHT_HEEL) {
+      if (test_columns[i] == RIGHT_HEEL) {
         rightHeelIndex = i;
       }
-      if (columns[i] == RIGHT_TOE) {
+      if (test_columns[i] == RIGHT_TOE) {
         rightToeIndex = i;
       }
     }
@@ -254,7 +248,7 @@ std::vector<FootPlacement> StageLayout::PermuteFootPlacements(
         return std::vector<FootPlacement>();
       }
     }
-    return {columns};
+    return {test_columns};
   }
   // If this column has a valid tap/hold head, or is actively holding a note,
   // iterate through values of StepParity::Foot. For each foot part, check that
@@ -272,11 +266,12 @@ std::vector<FootPlacement> StageLayout::PermuteFootPlacements(
 
   if (active) {
     for (StepParity::Foot foot : FEET) {
-      if (std::find(columns.begin(), columns.end(), foot) != columns.end()) {
+      if (std::find(test_columns.begin(), test_columns.end(), foot) !=
+          test_columns.end()) {
         continue;
       }
 
-      FootPlacement newColumns = columns;
+      FootPlacement newColumns = test_columns;
 
       newColumns[column] = foot;
       std::vector<FootPlacement> p =
@@ -288,7 +283,7 @@ std::vector<FootPlacement> StageLayout::PermuteFootPlacements(
   // If the current column doesn't have any taps or holds,
   // then we don't need to generate any permutations for it.
   // Return the contents of calling PermuteFootPlacements() for the next column.
-  return PermuteFootPlacements(mask, columns, column + 1);
+  return PermuteFootPlacements(mask, test_columns, column + 1);
 }
 
 StagePoint StageLayout::averagePoint(int leftIndex, int rightIndex) const {

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -1,6 +1,7 @@
 #ifndef STEP_PARITY_DATASTRUCTS_H
 #define STEP_PARITY_DATASTRUCTS_H
 
+#include <array>
 #include <cstdint>
 #include <string>
 #include <unordered_map>
@@ -28,12 +29,12 @@ const int16_t FOOT_MASK_LEFT =
 const int16_t FOOT_MASK_RIGHT =
     FOOT_MASKS[Foot::RIGHT_HEEL] | FOOT_MASKS[Foot::RIGHT_TOE];
 
-const std::vector<StepParity::Foot> FEET = {
+const std::array<StepParity::Foot, 4> FEET = {
     LEFT_HEEL, LEFT_TOE, RIGHT_HEEL, RIGHT_TOE};
 // A map for getting the other part of the foot, when you don't actually care
 // what part it is.
 // OTHER_PART_OF_FOOT[LEFT_HEEL] == LEFT_TOE
-const std::vector<StepParity::Foot> OTHER_PART_OF_FOOT = {
+const std::array<StepParity::Foot, 5> OTHER_PART_OF_FOOT = {
     NONE, LEFT_TOE, LEFT_HEEL, RIGHT_TOE, RIGHT_HEEL};
 
 const std::string FEET_LABELS[] = {"N", "L", "l", "R", "r", "5??", "6??"};

--- a/src/archutils/Common/HidDevice.cpp
+++ b/src/archutils/Common/HidDevice.cpp
@@ -8,6 +8,16 @@
 #include "RageLog.h"
 #include "hidapi.h"
 
+std::vector<int> make_pids(int base_pid, int size) {
+  std::vector<int> vec(size);
+
+  for (int i = 0; i < size; i++) {
+    vec[i] = base_pid + i;
+  }
+
+  return vec;
+}
+
 HidDevice::HidDevice(
     int vid, const std::vector<int> pids, int interfaceNum,
     bool autoReconnection, bool nonBlockingRead)

--- a/src/archutils/Common/HidDevice.h
+++ b/src/archutils/Common/HidDevice.h
@@ -13,15 +13,7 @@ enum HidResults {
   Success = 0,
 };
 
-static std::vector<int> make_pids(int base_pid, int size) {
-  std::vector<int> vec(size);
-
-  for (int i = 0; i < size; i++) {
-    vec[i] = base_pid + i;
-  }
-
-  return vec;
-}
+std::vector<int> make_pids(int base_pid, int size);
 
 struct HidDeviceInfo {
   char* path{nullptr};


### PR DESCRIPTION
C4201 complains about nameless structs which are used in a lot of the input handler code and doesn't seem useful.

Some parameter names are shadowing member variables.