### PR TITLE
Fail CI on warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,26 +17,26 @@ jobs:
           - os: ubuntu-24.04
             name: Ubuntu (x86_64)
             install: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
-            configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
+            configure: cmake -B build -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DWITH_FFMPEG_JOBS="$(nproc)"
             build: cmake --build build --parallel "$(nproc)"
           - os: ubuntu-24.04-arm
             name: Ubuntu (ARM)
             install: sudo apt-get update && sudo apt-get install -y libasound2-dev libgl-dev libglu1-mesa-dev libgtk-3-dev libjack-dev libmad0-dev libpulse-dev libudev-dev libxinerama-dev libx11-dev libxrandr-dev libxtst-dev nasm
-            configure: cmake -B build -DWITH_FFMPEG_JOBS="$(nproc)"
+            configure: cmake -B build -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DWITH_FFMPEG_JOBS="$(nproc)"
             build: cmake --build build --parallel "$(nproc)"
           - os: macos-15
             name: macOS (M1)
             install: brew install nasm
-            configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
+            configure: cmake -B build -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_OSX_ARCHITECTURES=arm64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
             build: cmake --build build --parallel "$(sysctl -n hw.logicalcpu)"
           - os: macos-15-intel
             name: macOS (Intel)
             install: brew install nasm
-            configure: cmake -B build -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
+            configure: cmake -B build -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_OSX_ARCHITECTURES=x86_64 -DWITH_FFMPEG_JOBS="$(sysctl -n hw.logicalcpu)"
             build: cmake --build build --parallel "$(sysctl -n hw.logicalcpu)"
           - os: windows-2022
             name: Windows
-            configure: cmake -B build -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
+            configure: cmake -B build -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DWITH_FFMPEG_JOBS="$env:NUMBER_OF_PROCESSORS"
             build: cmake --build build --parallel "$env:NUMBER_OF_PROCESSORS"
     name: ${{ matrix.name }}
     steps:


### PR DESCRIPTION
Don't enable for developer builds since warnings in local builds is fine for prototyping, but submitted code shouldn't have warnings.

Verified that this failed on the Windows CI before the Windows warnings were fixed.