### PR TITLE
Only run clang-format on touched files in the CI

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -8,13 +8,48 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - name: Install clang-format 21
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 21
           sudo apt-get install -y clang-format-21
-      - name: Check formatting
+      - name: Collect changed source files
+        id: changed-files
         run: |
-          find src -type f \( -name '*.h' -o -name '*.hpp' -o -name '*.cpp' -o -name '*.mm' \) -print0 \
-            | xargs -0 -r clang-format-21 --dry-run --Werror --style=file:.clang-format
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE_SHA="${{ github.event.before }}"
+            HEAD_SHA="${{ github.sha }}"
+            if [[ "$BASE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+              BASE_SHA="$(git rev-list --max-parents=0 "$HEAD_SHA" | tail -n 1)"
+            fi
+          fi
+
+          files=()
+          while IFS= read -r -d '' file; do
+            if [[ "$file" =~ ^src/.*\.(h|hpp|cpp|mm)$ ]]; then
+              files+=("$file")
+            fi
+          done < <(git diff -z --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA")
+
+          if (( ${#files[@]} == 0 )); then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          printf '%s\0' "${files[@]}" > changed_files.txt
+          echo "count=${#files[@]}" >> "$GITHUB_OUTPUT"
+
+      - name: Check formatting
+        if: steps.changed-files.outputs.count != '0'
+        run: |
+          xargs -0 -r clang-format-21 --dry-run --Werror --style=file:.clang-format < changed_files.txt
+
+      - name: No matching changed files
+        if: steps.changed-files.outputs.count == '0'
+        run: echo "No changed C/C++/Obj-C++ files in src/. Skipping clang-format."


### PR DESCRIPTION
Should save some time for it to complete.