### PR TITLE
Revert "Move websocket sending to it's own thread to prevent blocking…

### DIFF
--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -10,7 +10,6 @@
 #include "LightsManager.h"
 #include "LuaManager.h"
 #include "MemoryCardManager.h"
-#include "NetworkManager.h"
 #include "PeriodicCaller.h"
 #include "Preference.h"
 #include "PrefsManager.h"
@@ -280,7 +279,6 @@ void GameLoop::UpdateAllButDraw(bool bRunningFromVBLANK) {
   GAMESTATE->Update(fDeltaTime);
   SCREENMAN->Update(fDeltaTime);
   MEMCARDMAN->Update();
-  NETWORK->Update(fDeltaTime);
 
   /* Important: Process input AFTER updating game logic, or input will be
    * acting on song beat from last frame */

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -119,16 +119,6 @@ NetworkManager::~NetworkManager() {
   ix::uninitNetSystem();
 }
 
-void NetworkManager::Update(float fDelta) {
-  for (std::shared_ptr<WebSocketHandle> handle : webSocketHandles) {
-    std::lock_guard mtxLock(handle->readMutex);
-    while (!handle->readQueue.empty()) {
-      handle->onMessage(&handle->readQueue.front());
-      handle->readQueue.pop();
-    }
-  }
-}
-
 bool NetworkManager::IsUrlAllowed(const std::string& url) {
   if (!this->httpEnabled.Get()) {
     return false;
@@ -261,19 +251,7 @@ WebSocketHandlePtr NetworkManager::WebSocket(const WebSocketArgs& args) {
 
   handle->webSocket.setUrl(args.url);
   handle->webSocket.setTLSOptions(this->tlsOptions);
-  // handle->webSocket.setOnMessageCallback(args.onMessage);
-  handle->webSocket.setOnMessageCallback(
-      [args, handle](const ix::WebSocketMessagePtr& response) {
-        CopiedWebSocketMessage messageCopy(response);
-
-        if (messageCopy.type == ix::WebSocketMessageType::Message) {
-          std::lock_guard<std::mutex> lock(handle->readMutex);
-          handle->readQueue.push(messageCopy);
-        } else {
-          // Dispatch now
-          args.onMessage(&messageCopy);
-        }
-      });
+  handle->webSocket.setOnMessageCallback(args.onMessage);
 
   ix::WebSocketHttpHeaders headers;
   headers["User-Agent"] = this->GetUserAgent();
@@ -297,7 +275,6 @@ WebSocketHandlePtr NetworkManager::WebSocket(const WebSocketArgs& args) {
   }
 
   handle->webSocket.start();
-  handle->sendThread = std::thread(&WebSocketHandle::SendThread, handle);
 
   webSocketHandles.push_back(handle);
 
@@ -346,36 +323,7 @@ int HttpRequestFuture::Cancel(lua_State* L) {
   return 0;
 }
 
-WebSocketHandle::~WebSocketHandle() {
-  {  // Neatly clonse the send thread
-    {
-      std::lock_guard<std::mutex> lock(sendQueueMutex);
-      stopFlag = true;
-    }
-    sendQueueCV.notify_all();
-    if (sendThread.joinable()) {
-      sendThread.join();
-    }
-  }
-  webSocket.stop();
-}
-
-void WebSocketHandle::SendThread() {
-  while (true) {
-    std::unique_lock<std::mutex> lock(sendQueueMutex);
-    sendQueueCV.wait(lock, [&] { return !sendQueue.empty() || stopFlag; });
-
-    if (stopFlag && sendQueue.empty()) {
-      break;
-    }
-
-    std::string message = std::move(sendQueue.front());
-    sendQueue.pop();
-    lock.unlock();
-
-    webSocket.send(message);
-  }
-}
+WebSocketHandle::~WebSocketHandle() { webSocket.stop(); }
 
 int WebSocketHandle::Collect(lua_State* L) {
   void* udata = luaL_checkudata(L, 1, "WebSocketHandle");
@@ -736,7 +684,7 @@ class LunaNetworkManager : public Luna<NetworkManager> {
     }
     lua_pop(L, 1);
 
-    args.onMessage = [onMessageRef](const CopiedWebSocketMessage* msg) {
+    args.onMessage = [onMessageRef](const ix::WebSocketMessagePtr& msg) {
       Lua* L = LUA->Get();
 
       if (onMessageRef != LUA_NOREF) {
@@ -975,7 +923,7 @@ class LunaNetworkManager : public Luna<NetworkManager> {
   }
 
   static void handleMessage(
-      Lua* L, const CopiedWebSocketMessage* msg, int onMessageRef) {
+      Lua* L, const ix::WebSocketMessagePtr& msg, int onMessageRef) {
     lua_rawgeti(L, LUA_REGISTRYINDEX, onMessageRef);
 
     lua_newtable(L);

--- a/src/NetworkManager.h
+++ b/src/NetworkManager.h
@@ -98,24 +98,24 @@ class HttpRequestFuture {
 
 typedef std::shared_ptr<HttpRequestFuture> HttpRequestFuturePtr;
 
-struct CopiedWebSocketMessage {
-  ix::WebSocketMessageType type;
-  const std::string str;
-  size_t wireSize;
-  ix::WebSocketErrorInfo errorInfo;
-  ix::WebSocketOpenInfo openInfo;
-  ix::WebSocketCloseInfo closeInfo;
-  bool binary;
+// struct CopiedWebSocketMessage {
+//   ix::WebSocketMessageType type;
+//   const std::string str;
+//   size_t wireSize;
+//   ix::WebSocketErrorInfo errorInfo;
+//   ix::WebSocketOpenInfo openInfo;
+//   ix::WebSocketCloseInfo closeInfo;
+//   bool binary;
 
-  CopiedWebSocketMessage(const ix::WebSocketMessagePtr& wsmp)
-      : type(wsmp->type),
-        str(wsmp->str),
-        wireSize(wsmp->wireSize),
-        errorInfo(wsmp->errorInfo),
-        openInfo(wsmp->openInfo),
-        closeInfo(wsmp->closeInfo),
-        binary(wsmp->binary) {}
-};
+//   CopiedWebSocketMessage(const ix::WebSocketMessagePtr& wsmp)
+//       : type(wsmp->type),
+//         str(wsmp->str),
+//         wireSize(wsmp->wireSize),
+//         errorInfo(wsmp->errorInfo),
+//         openInfo(wsmp->openInfo),
+//         closeInfo(wsmp->closeInfo),
+//         binary(wsmp->binary) {}
+// };
 
 struct WebSocketArgs {
   std::string url;
@@ -123,7 +123,7 @@ struct WebSocketArgs {
   int handshakeTimeout = -1;
   int pingInterval = -1;
   bool automaticReconnect = true;
-  std::function<void(const CopiedWebSocketMessage*)> onMessage;
+  std::function<void(const ix::WebSocketMessagePtr& response)> onMessage;
   std::function<void()> onClose;
 };
 
@@ -132,23 +132,12 @@ class WebSocketHandle {
   WebSocketHandle() {};
   ~WebSocketHandle();
 
-  void SendThread();
-
   static int Collect(lua_State* L);
   static int Close(lua_State* L);
   static int Send(lua_State* L);
 
   ix::WebSocket webSocket;
   std::function<void()> onClose;
-  std::queue<CopiedWebSocketMessage> readQueue;
-  std::mutex readMutex;
-  std::function<void(const CopiedWebSocketMessage* response)> onMessage;
-
-  std::thread sendThread;
-  std::queue<std::string> sendQueue;
-  std::mutex sendQueueMutex;
-  std::condition_variable sendQueueCV;
-  std::atomic<bool> stopFlag = false;
 };
 
 typedef std::shared_ptr<WebSocketHandle> WebSocketHandlePtr;
@@ -164,8 +153,6 @@ class NetworkManager {
   std::string UrlEncode(const std::string& value);
   std::string EncodeQueryParameters(
       const std::unordered_map<std::string, std::string>& query);
-
-  void Update(float fDelta);
 
   // Lua
   void PushSelf(lua_State* L);


### PR DESCRIPTION
… the main thread. Move websocket read handling to the main thread to prevent locking the Messsage Manager"

Reverts: https://github.com/itgmania/itgmania/pull/1134 / Commit: a5e0a5343aae49cbfb70c23952c0f4128ee5d852

Seems to break QR Login (See: #1153) and crash goes away with this commit.