### PR TITLE
Sunset RageSoundDriver_WDMKS.cpp

### DIFF
--- a/src/arch/Sound/RageSoundDriver_WDMKS.cpp
+++ b/src/arch/Sound/RageSoundDriver_WDMKS.cpp
@@ -1331,6 +1331,17 @@ RageSoundDriver_WDMKS::RageSoundDriver_WDMKS() {
   m_bShutdown = false;
   m_iLastCursorPos = 0;
   m_hSignal = CreateEvent(nullptr, FALSE, FALSE, nullptr); /* abort event */
+
+  LOG->Warn(
+      "RageSoundDriver_WDMKS is no longer supported in Windows and will be "
+      "removed in a future "
+      "version of ITGmania. There is no support for WDMKS and the game may "
+      "crash "
+      "when using WDMKS."
+      "Please remove the SoundDrivers setting in Save/Preferences.ini, or "
+      "switch "
+      "to DirectSound-sw "
+      "or WaveOut instead.");
 }
 
 std::string RageSoundDriver_WDMKS::Init() {


### PR DESCRIPTION
Remake of #832 , basically this API was dropped in Vista and can lead to random crashes or failure of the game to start depending on OS sample rate, so it's not recommended. 