### PR TITLE
Feature - Add Support for "NoteSkin Variants"

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -1180,6 +1180,9 @@
 			<Function name='GetPathForNoteSkin'/>
 			<Function name='LoadActor'/>
 			<Function name='LoadActorForNoteSkin'/>
+			<Function name='HasVariants'/>
+			<Function name='IsNoteSkinVariant'/>
+			<Function name='GetVariantNamesForNoteSkin'/>
 		</Class>
 		<Class base='ActorFrame' name='OptionRow'>
 			<Function name='FirstItemGoesDown'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -3863,9 +3863,18 @@ NETWORK:WebSocket{
 	<Function name='DoesNoteSkinExist' return='bool' arguments='string strName'>
 		Returns <code>true</code> if the <code>strName</code> noteskin exists in the current gametype.
 	</Function>
-	<Function name='GetNoteSkinNames' return='{string}' arguments=''>
-		Returns a table of noteskin names for the current gametype.
+	<Function name='GetNoteSkinNames' return='{string}' arguments='bool bIncludeVariants'>
+		Returns a table of noteskin names for the current gametype. If <code>bIncludeVariants</code> is true or omitted, the list will include both base noteskin names and their variants.
 	</Function>
+	<Function name='HasVariants' return='bool' arguments='string strName'>
+		Returns <code>true</code> if the noteskin <code>strName</code> has any variants.
+	</Function>
+	<Function name='GetVariantNamesForNoteSkin' return='{string}' arguments='string strName'>
+		Returns a table of variant names for the noteskin <code>strName</code>. If the noteskin has no variants, returns an empty table.
+	</Function>
+	<Function name='IsNoteSkinVariant' return='bool' arguments='string strName'>
+		Returns <code>true</code> if the noteskin <code>strName</code> is a variant of another noteskin.
+	</Function>	
 </Class>
 <Class name='NCSplineHandler'>
 	<Description>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -3863,16 +3863,16 @@ NETWORK:WebSocket{
 	<Function name='DoesNoteSkinExist' return='bool' arguments='string strName'>
 		Returns <code>true</code> if the <code>strName</code> noteskin exists in the current gametype.
 	</Function>
-	<Function name='GetNoteSkinNames' return='{string}' arguments='bool bIncludeVariants'>
-		Returns a table of noteskin names for the current gametype. If <code>bIncludeVariants</code> is true or omitted, the list will include both base noteskin names and their variants.
+<Function name='GetNoteSkinNames' return='{string}' arguments='bool bIncludeVariants'>
+		Returns a table of noteskin names for the current gametype. (New since ITGmania 1.2.0) If the optional argument <code>bIncludeVariants</code> is true or omitted, the table will include both base noteskin names and their variants.
 	</Function>
-	<Function name='HasVariants' return='bool' arguments='string strName'>
+	<Function name='HasVariants' return='bool' arguments='string strName' since='ITGmania 1.2.0'>
 		Returns <code>true</code> if the noteskin <code>strName</code> has any variants.
 	</Function>
-	<Function name='GetVariantNamesForNoteSkin' return='{string}' arguments='string strName'>
+	<Function name='GetVariantNamesForNoteSkin' return='{string}' arguments='string strName' since='ITGmania 1.2.0'>
 		Returns a table of variant names for the noteskin <code>strName</code>. If the noteskin has no variants, returns an empty table.
 	</Function>
-	<Function name='IsNoteSkinVariant' return='bool' arguments='string strName'>
+	<Function name='IsNoteSkinVariant' return='bool' arguments='string strName' since='ITGmania 1.2.0'>
 		Returns <code>true</code> if the noteskin <code>strName</code> is a variant of another noteskin.
 	</Function>	
 </Class>

--- a/src/NoteSkinManager.cpp
+++ b/src/NoteSkinManager.cpp
@@ -43,10 +43,16 @@ const std::string GAME_BASE_NOTESKIN_NAME = "default";
 
 static std::map<std::string, std::string> g_PathCache;
 
+struct VariantNoteSkinData {
+  std::string sName;
+  std::string sParentNoteSkin;
+};
+
 struct NoteSkinData {
   std::string sName;
   IniFile metrics;
-
+  VariantNoteSkinData variant_data;
+  bool bIsVariant;
   // When looking for an element, search these dirs from head to tail.
   std::vector<std::string> vsDirSearchOrder;
 
@@ -55,7 +61,9 @@ struct NoteSkinData {
 
 namespace {
 static std::map<std::string, NoteSkinData> g_mapNameToData;
-};
+static std::map<std::string, std::vector<std::string>>
+    g_mapParentNameToVariantNames;
+};  // namespace
 
 NoteSkinManager::NoteSkinManager() {
   m_pCurGame = nullptr;
@@ -94,6 +102,7 @@ void NoteSkinManager::RefreshNoteSkinData(const Game* pGame) {
   StripMacResourceForks(asNoteSkinNames);
 
   g_mapNameToData.clear();
+  g_mapParentNameToVariantNames.clear();
   for (unsigned j = 0; j < asNoteSkinNames.size(); j++) {
     std::string sName = asNoteSkinNames[j];
     MakeLower(sName);
@@ -104,6 +113,35 @@ void NoteSkinManager::RefreshNoteSkinData(const Game* pGame) {
       std::map<std::string, NoteSkinData>::iterator entry =
           g_mapNameToData.find(sName);
       g_mapNameToData.erase(entry);
+    } else {
+      // Determine if this noteskin has variants
+      // If the Noteskin has a "variants" folder with at least one subfolder,
+      // we consider it to have variants.
+      std::string sVariantDir =
+          sBaseSkinFolder + asNoteSkinNames[j] + "/variants/";
+      std::vector<std::string> asVariantNames;
+      GetDirListing(sVariantDir + "*", asVariantNames, true);
+      StripCvsAndSvn(asVariantNames);
+      StripMacResourceForks(asVariantNames);
+
+      if (!asVariantNames.empty()) {
+        for (unsigned k = 0; k < asVariantNames.size(); k++) {
+          std::string sVariantName = asVariantNames[k];
+          MakeLower(sVariantName);
+          // Name in map should be parent name _<variant>
+          std::string sVariantKey = sName + "_" + sVariantName;
+          g_mapParentNameToVariantNames[sName].push_back(sVariantKey);
+          g_mapNameToData[sVariantKey].variant_data.sParentNoteSkin = sName;
+          g_mapNameToData[sVariantKey].variant_data.sName = sVariantName;
+          g_mapNameToData[sVariantKey].bIsVariant = true;
+          if (!LoadNoteSkinData(sVariantKey, g_mapNameToData[sVariantKey])) {
+            std::map<std::string, NoteSkinData>::iterator entry =
+                g_mapNameToData.find(sVariantKey);
+            g_mapNameToData.erase(entry);
+            g_mapParentNameToVariantNames[sName].pop_back();
+          }
+        }
+      }
     }
   }
 }
@@ -132,17 +170,32 @@ bool NoteSkinManager::LoadNoteSkinDataRecursive(
           "Circular NoteSkin fallback references detected.", "NOTESKIN_ERROR");
       return false;
     }
-
+    bool bIsVariant = false;
     std::string sDir = SpecialFiles::NOTESKINS_DIR + m_pCurGame->m_szName +
                        "/" + sNoteSkinName + "/";
     if (!FILEMAN->IsADirectory(sDir)) {
       sDir = GLOBAL_BASE_DIR + sNoteSkinName + "/";
       if (!FILEMAN->IsADirectory(sDir)) {
-        LuaHelpers::ReportScriptError(
-            "NoteSkin \"" + data_out.sName + "\" references skin \"" +
-                sNoteSkinName + "\" that is not present",
-            "NOTESKIN_ERROR");
-        return false;
+        // Check if it's a variant
+        if (g_mapNameToData.find(sNoteSkinName) != g_mapNameToData.end()) {
+          bIsVariant = g_mapNameToData[sNoteSkinName].bIsVariant;
+        }
+        if (bIsVariant) {
+          sDir = SpecialFiles::NOTESKINS_DIR + m_pCurGame->m_szName + "/" +
+                 g_mapNameToData[sNoteSkinName].variant_data.sParentNoteSkin +
+                 "/variants/" +
+                 g_mapNameToData[sNoteSkinName].variant_data.sName + "/";
+          if (!FILEMAN->IsADirectory(sDir)) {
+            LuaHelpers::ReportScriptError(
+                "NoteSkin \"" + data_out.sName +
+                    "\" references variant skin \"" + sNoteSkinName +
+                    "\" that is not present",
+                "NOTESKIN_ERROR");
+            LuaHelpers::ReportScriptError(
+                "Checked for \"" + sDir + "\".", "NOTESKIN_ERROR");
+            return false;
+          }
+        }
       }
     }
 
@@ -152,7 +205,34 @@ bool NoteSkinManager::LoadNoteSkinDataRecursive(
 
     // read global fallback the current NoteSkin (if any)
     IniFile ini;
-    ini.ReadFile(sDir + "metrics.ini");
+
+    if (!ini.ReadFile(sDir + "metrics.ini")) {
+      if (bIsVariant) {
+        // Read the metrics.ini from the parent Noteskin
+        if (!g_mapNameToData[sNoteSkinName]
+                 .variant_data.sParentNoteSkin.empty()) {
+          if (!ini.ReadFile(
+                  SpecialFiles::NOTESKINS_DIR + m_pCurGame->m_szName + "/" +
+                  g_mapNameToData[sNoteSkinName].variant_data.sParentNoteSkin +
+                  "/metrics.ini")) {
+            LuaHelpers::ReportScriptError(
+                "Failed to read metrics.ini for NoteSkin \"" + data_out.sName +
+                    "\" and its parent skin \"" +
+                    g_mapNameToData[sNoteSkinName]
+                        .variant_data.sParentNoteSkin +
+                    "\".",
+                "NOTESKIN_ERROR");
+            return false;
+          }
+        } else {
+          LuaHelpers::ReportScriptError(
+              "Failed to read metrics.ini for NoteSkin \"" + data_out.sName +
+                  "\".",
+              "NOTESKIN_ERROR");
+          return false;
+        }
+      }
+    }
 
     if (!CompareNoCase(sNoteSkinName, GAME_BASE_NOTESKIN_NAME)) {
       bLoadedBase = true;
@@ -173,6 +253,11 @@ bool NoteSkinManager::LoadNoteSkinDataRecursive(
     XmlFileUtil::MergeIniUnder(&ini, &data_out.metrics);
 
     data_out.vsDirSearchOrder.push_back(sDir);
+    if (bIsVariant) {
+      data_out.vsDirSearchOrder.push_back(
+          SpecialFiles::NOTESKINS_DIR + m_pCurGame->m_szName + "/" +
+          g_mapNameToData[sNoteSkinName].variant_data.sParentNoteSkin + "/");
+    }
 
     if (sFallback.empty()) {
       break;
@@ -210,13 +295,29 @@ bool NoteSkinManager::LoadNoteSkinDataRecursive(
   return true;
 }
 
-void NoteSkinManager::GetNoteSkinNames(std::vector<std::string>& AddTo) {
-  GetNoteSkinNames(GAMESTATE->m_pCurGame, AddTo);
+void NoteSkinManager::GetNoteSkinNames(
+    std::vector<std::string>& AddTo, bool bIncludeVariants) {
+  GetNoteSkinNames(GAMESTATE->m_pCurGame, AddTo, bIncludeVariants);
 }
 
 void NoteSkinManager::GetNoteSkinNames(
-    const Game* pGame, std::vector<std::string>& AddTo) {
-  GetAllNoteSkinNamesForGame(pGame, AddTo);
+    const Game* pGame, std::vector<std::string>& AddTo, bool bIncludeVariants) {
+  GetAllNoteSkinNamesForGame(pGame, AddTo, bIncludeVariants);
+}
+
+void NoteSkinManager::GetVariantNamesForNoteSkin(
+    const std::string& sNoteSkin, std::vector<std::string>& AddTo) {
+  GetVariantNamesForNoteSkin(GAMESTATE->m_pCurGame, sNoteSkin, AddTo);
+}
+
+void NoteSkinManager::GetVariantNamesForNoteSkin(
+    const Game* game, const std::string& sNoteSkin,
+    std::vector<std::string>& AddTo) {
+  std::map<std::string, std::vector<std::string>>::const_iterator it =
+      g_mapParentNameToVariantNames.find(sNoteSkin);
+  if (it != g_mapParentNameToVariantNames.end()) {
+    AddTo = it->second;
+  }
 }
 
 bool NoteSkinManager::NoteSkinNameInList(
@@ -227,6 +328,18 @@ bool NoteSkinManager::NoteSkinNameInList(
     }
   }
   return false;
+}
+
+bool NoteSkinManager::HasVariants(const std::string& sNoteSkin) {
+  std::map<std::string, std::vector<std::string>>::const_iterator it =
+      g_mapParentNameToVariantNames.find(sNoteSkin);
+  return it != g_mapParentNameToVariantNames.end() && !it->second.empty();
+}
+
+bool NoteSkinManager::IsVariantNoteSkin(const std::string& sNoteSkin) {
+  std::map<std::string, NoteSkinData>::const_iterator it =
+      g_mapNameToData.find(sNoteSkin);
+  return it != g_mapNameToData.end() && it->second.bIsVariant;
 }
 
 bool NoteSkinManager::DoesNoteSkinExist(const std::string& sSkinName) {
@@ -266,12 +379,15 @@ void NoteSkinManager::ValidateNoteSkinName(std::string& name) {
 }
 
 void NoteSkinManager::GetAllNoteSkinNamesForGame(
-    const Game* pGame, std::vector<std::string>& AddTo) {
+    const Game* pGame, std::vector<std::string>& AddTo, bool bIncludeVariants) {
   if (pGame == m_pCurGame) {
     // Faster:
     for (std::map<std::string, NoteSkinData>::const_iterator iter =
              g_mapNameToData.begin();
          iter != g_mapNameToData.end(); ++iter) {
+      if (!bIncludeVariants && iter->second.bIsVariant) {
+        continue;
+      }
       AddTo.push_back(iter->second.sName);
     }
   } else {
@@ -354,6 +470,7 @@ std::string NoteSkinManager::GetPath(
   MakeLower(sNoteSkinName);
   std::map<std::string, NoteSkinData>::const_iterator iter =
       g_mapNameToData.find(sNoteSkinName);
+
   ASSERT(iter != g_mapNameToData.end());
   const NoteSkinData& data = iter->second;
 
@@ -597,10 +714,22 @@ class LunaNoteSkinManager : public Luna<NoteSkinManager> {
 #undef FOR_NOTESKIN
   static int GetNoteSkinNames(T* p, lua_State* L) {
     std::vector<std::string> vNoteskins;
-    p->GetNoteSkinNames(vNoteskins);
+    bool bIncludeVariants = true;
+    if (lua_gettop(L) > 0) {
+      bIncludeVariants = lua_toboolean(L, 1) != 0;
+    }
+    p->GetNoteSkinNames(vNoteskins, bIncludeVariants);
     LuaHelpers::CreateTableFromArray(vNoteskins, L);
     return 1;
   }
+  static int GetVariantNamesForNoteSkin(T* p, lua_State* L) {
+    std::string sNoteSkin = SArg(1);
+    std::vector<std::string> vVariants;
+    p->GetVariantNamesForNoteSkin(sNoteSkin, vVariants);
+    LuaHelpers::CreateTableFromArray(vVariants, L);
+    return 1;
+  }
+
   /*
   static int GetNoteSkinNamesForGame( T* p, lua_State *L )
   {
@@ -613,6 +742,16 @@ class LunaNoteSkinManager : public Luna<NoteSkinManager> {
   */
   static int DoesNoteSkinExist(T* p, lua_State* L) {
     lua_pushboolean(L, p->DoesNoteSkinExist(SArg(1)));
+    return 1;
+  }
+
+  static int HasVariants(T* p, lua_State* L) {
+    lua_pushboolean(L, p->HasVariants(SArg(1)));
+    return 1;
+  }
+
+  static int IsVariantNoteSkin(T* p, lua_State* L) {
+    lua_pushboolean(L, p->IsVariantNoteSkin(SArg(1)));
     return 1;
   }
 
@@ -633,6 +772,9 @@ class LunaNoteSkinManager : public Luna<NoteSkinManager> {
     ADD_METHOD(LoadActorForNoteSkin);
     ADD_METHOD(GetNoteSkinNames);
     ADD_METHOD(DoesNoteSkinExist);  // for the current game
+    ADD_METHOD(HasVariants);
+    ADD_METHOD(IsVariantNoteSkin);
+    ADD_METHOD(GetVariantNamesForNoteSkin);
   }
 };
 

--- a/src/NoteSkinManager.cpp
+++ b/src/NoteSkinManager.cpp
@@ -336,7 +336,7 @@ bool NoteSkinManager::HasVariants(const std::string& sNoteSkin) {
   return it != g_mapParentNameToVariantNames.end() && !it->second.empty();
 }
 
-bool NoteSkinManager::IsVariantNoteSkin(const std::string& sNoteSkin) {
+bool NoteSkinManager::IsNoteSkinVariant(const std::string& sNoteSkin) {
   std::map<std::string, NoteSkinData>::const_iterator it =
       g_mapNameToData.find(sNoteSkin);
   return it != g_mapNameToData.end() && it->second.bIsVariant;
@@ -750,8 +750,8 @@ class LunaNoteSkinManager : public Luna<NoteSkinManager> {
     return 1;
   }
 
-  static int IsVariantNoteSkin(T* p, lua_State* L) {
-    lua_pushboolean(L, p->IsVariantNoteSkin(SArg(1)));
+  static int IsNoteSkinVariant(T* p, lua_State* L) {
+    lua_pushboolean(L, p->IsNoteSkinVariant(SArg(1)));
     return 1;
   }
 
@@ -773,7 +773,7 @@ class LunaNoteSkinManager : public Luna<NoteSkinManager> {
     ADD_METHOD(GetNoteSkinNames);
     ADD_METHOD(DoesNoteSkinExist);  // for the current game
     ADD_METHOD(HasVariants);
-    ADD_METHOD(IsVariantNoteSkin);
+    ADD_METHOD(IsNoteSkinVariant);
     ADD_METHOD(GetVariantNamesForNoteSkin);
   }
 };

--- a/src/NoteSkinManager.h
+++ b/src/NoteSkinManager.h
@@ -20,8 +20,17 @@ class NoteSkinManager {
   ~NoteSkinManager();
 
   void RefreshNoteSkinData(const Game* game);
-  void GetNoteSkinNames(const Game* game, std::vector<std::string>& AddTo);
   void GetNoteSkinNames(
+      const Game* game, std::vector<std::string>& AddTo,
+      bool bIncludeVariants = true);
+  void GetNoteSkinNames(
+      std::vector<std::string>& AddTo,
+      bool bIncludeVariants =
+          true);  // looks up current const Game* in GAMESTATE
+  void GetVariantNamesForNoteSkin(
+      const std::string& sNoteSkin, std::vector<std::string>& AddTo);
+  void GetVariantNamesForNoteSkin(
+      const Game* game, const std::string& sNoteSkin,
       std::vector<std::string>&
           AddTo);  // looks up current const Game* in GAMESTATE
   bool NoteSkinNameInList(
@@ -29,6 +38,9 @@ class NoteSkinManager {
   bool DoesNoteSkinExist(
       const std::string&
           sNoteSkin);  // looks up current const Game* in GAMESTATE
+  bool HasVariants(const std::string& sNoteSkin);  // looks up current const
+                                                   // Game* in GAMESTATE
+  bool IsVariantNoteSkin(const std::string& sNoteSkin);
   bool DoNoteSkinsExistForGame(const Game* pGame);
   std::string
   GetDefaultNoteSkinName();  // looks up current const Game* in GAMESTATE
@@ -70,7 +82,8 @@ class NoteSkinManager {
   std::string GetPathFromDirAndFile(
       const std::string& sDir, const std::string& sFileName);
   void GetAllNoteSkinNamesForGame(
-      const Game* pGame, std::vector<std::string>& AddTo);
+      const Game* pGame, std::vector<std::string>& AddTo,
+      bool bIncludeVariants = true);
 
   bool LoadNoteSkinData(
       const std::string& sNoteSkinName, NoteSkinData& data_out);

--- a/src/NoteSkinManager.h
+++ b/src/NoteSkinManager.h
@@ -40,7 +40,7 @@ class NoteSkinManager {
           sNoteSkin);  // looks up current const Game* in GAMESTATE
   bool HasVariants(const std::string& sNoteSkin);  // looks up current const
                                                    // Game* in GAMESTATE
-  bool IsVariantNoteSkin(const std::string& sNoteSkin);
+  bool IsNoteSkinVariant(const std::string& sNoteSkin);
   bool DoNoteSkinsExistForGame(const Game* pGame);
   std::string
   GetDefaultNoteSkinName();  // looks up current const Game* in GAMESTATE


### PR DESCRIPTION
## NoteSkin Variants
This PR adds support for drop-in "NoteSkin Variants." NoteSkin variants are children of existing noteskins. The idea here is to  help prevent clutter in the selector. So instead of adding a new noteskin for every slightly modified variation of existing noteskin (for example, if someone wanted to add a color-blind supported version of a skin) you can add these variations to the ``variants`` folder in your respective NoteSkin. 

## How to add variants to my noteskin?

First inside your NoteSkin's folder create a new folder called ``variants`` as shown below:

<img width="782" height="450" alt="image" src="https://github.com/user-attachments/assets/6645d34e-83a0-4d2b-ab8c-0c1832d2ea81" /><br>


Inside the variants folder you can create new folders for each "variant." The contents of each folder is the same as a normal NoteSkin. The Parent NoteSkin will be treated as a fallback so if any file is missing or not provided it will fallback on the Parent NoteSkin...This includes textures, lua files, and even the metrics file. Another way of looking at it is a given variant noteskin provides overrides for the parent noteskin.



**So for example, I have 4 variants provided for cel:**

<img width="886" height="257" alt="image" src="https://github.com/user-attachments/assets/5d7de75a-b1f4-477e-9519-2f0b6d1608d2" />


If we take a look at my ``despero`` variant, it's mostly just images. When I use ``despero`` it will use the metrics and NoteSkin.lua of ``cel`` but these files will be overridden so it will have some different textures

<img width="986" height="571" alt="image" src="https://github.com/user-attachments/assets/1d6dcc79-fc8b-480a-91f2-44fd9e07c712" />


## Using Variants

By default variants will still be listed along with regular NoteSkins so to the user it would still appear the same. It's up to themes to implement separation. I've added an optional boolean parameter to ``GetNoteSkinNames`` which toggles whether variants are returned or not. You can then separately grab the variants of a given NoteSkin by using ``GetVariantNamesForNoteSkin`` and passing in the name of the parent NoteSkin.

Variant NoteSkins are treated just like normal NoteSkins. The only difference is that their name will always be {PARENT}_{variant}.
So if I added a variant in a folder called ``colorblind`` to cel, the name of the NoteSkin will be ``cel_colorblind``. Otherwise you can set a player's NoteSkin to this all the same.

In order to reduce clutter in the Player Options list, I also have a related PR which adds support for dynamically hiding/showing an OptionRow. This allows us to pop the ``NoteSkin Variants`` option row in and out depending on if the currently selected NoteSkin has a variant. More on this in that PR (will update desc with link)


## FAQ


### Q: Will an existing theme break if a user has variants?
  - **A:** No, if the theme is unchanged all variants will appear in the noteskin selector with all the "parents". It will appear the same and a player would have no idea that there are 'formal' variants
### **Q** Is there a minimum amount of content required in a variant for it to work? Is there a specific file that needs to be there?
- **A:** Nope, in theory you could have 1 file in your variant and it would still work. You should be able to replace anything that a "parent" noteskin has. The load order is variant --> parent --> fallbacks
### Q: Can a variant have variants?
- **A** Originally when I was working on this yes, but it introduced a few issues and additional considerations. I removed support for "nested variants" for now so tl;dr no.


Potential Theme Implementation (wip):
https://github.com/user-attachments/assets/19cbf08d-cf96-449b-9182-f96f8bacab9f

