### PR TITLE
Add methods for dynamically hiding/showing and refreshing OptionRows

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -1745,6 +1745,8 @@
 			<Function name='GetNumRows'/>
 			<Function name='GetOptionRow'/>
 			<Function name='SetOptionRowIndex'/>
+			<Function name='SetOptionRowVisible'/>
+			<Function name='RedrawOptions'/>
 		</Class>
 		<Class base='ScreenOptions' name='ScreenPlayerOptions'>
 			<Function name='GetGoToOptions'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -5500,6 +5500,13 @@ Details of the <code>event</code> table:
 	<Function name='SetOptionRowIndex' return='' arguments='PlayerNumber pn, int iRow' since='ITGmania 1.2.0'>
 		Sets OptionRow <code>iRow</code> as the active row for player <code>pn</code>.  The first row has index <code>0</code>.
 	</Function>
+	<Function name='SetOptionRowVisible' return='' arguments='int iRow, bool bVisible, bool bRedraw' since='ITGmania 1.2.0'>
+			Sets OptionRow <code>iRow</code> to be visible or invisible according to <code>bVisible</code>.  The first row has index <code>0</code>.	<br />
+			Setting an option row to invisible disables it for both players and pops it out of the options list. Use <code>bRedraw</code> to leverage whether the rows are repositioned immediately.
+	</Function>
+	<Function name='RedrawOptions' return='' arguments='' since='ITGmania 1.2.0'>
+			Redraws the options list which updates each row's position and visibility, maintains current indexes and will exclude disabled rows.
+	</Function>
 </Class>
 <Class name='ScreenPlayerOptions' grouping='Screen'>
 	<Function name='GetGoToOptions' return='bool' arguments=''>

--- a/src/OptionRow.cpp
+++ b/src/OptionRow.cpp
@@ -416,8 +416,10 @@ void OptionRow::AfterImportOptions(PlayerNumber pn) {
     m_textItems[pn]->SetVisible(GAMESTATE->IsHumanPlayer(pn));
   }
 
-  // Hide underlines for disabled players.
-  if (!GAMESTATE->IsHumanPlayer(pn)) {
+  // Hide underlines for disabled players or disabled options.
+  if (!GAMESTATE->IsHumanPlayer(pn) ||
+      m_pHand->m_Def.m_vEnabledForPlayers.find(pn) ==
+          m_pHand->m_Def.m_vEnabledForPlayers.end()) {
     for (unsigned c = 0; c < m_Underline[pn].size(); c++) {
       m_Underline[pn][c]->SetVisible(false);
     }

--- a/src/ScreenOptions.cpp
+++ b/src/ScreenOptions.cpp
@@ -639,6 +639,15 @@ void ScreenOptions::PositionRows(bool bTween) {
   first_end = std::min(first_end, (int)Rows.size());
   second_end = std::min(second_end, (int)Rows.size());
 
+  // Count disabled rows and expand viewport to compensate
+  int disabled_count = 0;
+  for (int i = 0; i < (int)Rows.size(); i++) {
+    if (Rows[i]->GetRowDef().m_vEnabledForPlayers.empty()) {
+      disabled_count++;
+    }
+  }
+  second_end = std::min(second_end + disabled_count, (int)Rows.size());
+
   /* If less than total (and Rows.size()) are displayed, fill in the empty
    * space intelligently. */
   for (;;) {
@@ -665,6 +674,13 @@ void ScreenOptions::PositionRows(bool bTween) {
   for (int i = 0; i < (int)Rows.size(); i++)  // foreach row
   {
     OptionRow& row = *Rows[i];
+
+    // Skip disabled rows entirely (no positioning, no visibility)
+    bool bRowEnabled = !row.GetRowDef().m_vEnabledForPlayers.empty();
+    if (!bRowEnabled) {
+      row.SetVisible(false);
+      continue;
+    }
 
     float fPos = (float)pos;
 
@@ -1336,6 +1352,67 @@ void ScreenOptions::MenuUpDown(const InputEventPlus& input, int iDir) {
     }
   }
 }
+void ScreenOptions::RedrawOptions() {
+  // Save current row indices before redraw
+  int saved_row[NUM_PLAYERS];
+  FOREACH_PlayerNumber(pn) saved_row[pn] = m_iCurrentRow[pn];
+
+  // RestartOptions();
+
+  // Restore current row indices if they're still valid
+  FOREACH_PlayerNumber(pn) {
+    if (saved_row[pn] >= 0 && saved_row[pn] < GetNumRows()) {
+      const OptionRow& row = *GetRow(saved_row[pn]);
+      if (row.GetRowDef().IsEnabledForPlayer(pn)) {
+        m_iCurrentRow[pn] = saved_row[pn];
+      }
+    }
+  }
+
+  // Update positioning and cursors for restored indices
+  PositionRows(true);
+  FOREACH_HumanPlayer(pn) { PositionCursor(pn); }
+  FOREACH_PlayerNumber(pn) { AfterChangeRow(pn); }
+
+  Message msg("OptionsRedrawn");
+  MESSAGEMAN->Broadcast(msg);
+}
+
+void ScreenOptions::SetOptionRowVisible(
+    int row_index, bool visible, bool bRedraw) {
+  if (row_index < 0 || row_index >= (int)m_pRows.size()) {
+    LuaHelpers::ReportScriptErrorFmt(
+        "SetOptionRowVisible: Row index %d is out of bounds", row_index);
+    return;
+  }
+
+  OptionRow* pOptRow = m_pRows[row_index];
+  if (pOptRow == nullptr) {
+    LuaHelpers::ReportScriptErrorFmt(
+        "SetOptionRowVisible: Row index %d is invalid", row_index);
+    return;
+  }
+
+  pOptRow->SetVisible(visible);
+
+  OptionRowDefinition& def = pOptRow->GetRowDef();
+  if (visible) {
+    if (def.m_vEnabledForPlayers.empty()) {
+      FOREACH_PlayerNumber(pn) def.m_vEnabledForPlayers.insert(pn);
+    }
+  } else {
+    def.m_vEnabledForPlayers.clear();
+  }
+
+  if (bRedraw) {
+    RedrawOptions();
+  }
+
+  Message msg("OptionRowVisibilityChanged");
+  msg.SetParam("RowIndex", row_index);
+  msg.SetParam("Visible", visible);
+  MESSAGEMAN->Broadcast(msg);
+}
 
 // lua start
 #include "LuaBinding.h"
@@ -1369,6 +1446,19 @@ class LunaScreenOptions : public Luna<ScreenOptions> {
     }
     return 1;
   }
+  static int SetOptionRowVisible(T* p, lua_State* L) {
+    int row_index = IArg(1);
+    bool visible = BArg(2);
+    bool redraw = lua_isnone(L, 3) ? true : BArg(3);
+
+    p->SetOptionRowVisible(row_index, visible, redraw);
+    COMMON_RETURN_SELF;
+  }
+  static int RedrawOptions(T* p, lua_State* L) {
+    p->RedrawOptions();
+    COMMON_RETURN_SELF;
+  }
+
   DEFINE_METHOD(GetNumRows, GetNumRows());
 
   static int SetOptionRowIndex(T* p, lua_State* L) {
@@ -1387,6 +1477,8 @@ class LunaScreenOptions : public Luna<ScreenOptions> {
     ADD_METHOD(GetCurrentRowIndex);
     ADD_METHOD(GetOptionRow);
     ADD_METHOD(GetNumRows);
+    ADD_METHOD(SetOptionRowVisible);
+    ADD_METHOD(RedrawOptions);
     ADD_METHOD(SetOptionRowIndex);
   }
 };

--- a/src/ScreenOptions.cpp
+++ b/src/ScreenOptions.cpp
@@ -675,12 +675,7 @@ void ScreenOptions::PositionRows(bool bTween) {
   {
     OptionRow& row = *Rows[i];
 
-    // Skip disabled rows entirely (no positioning, no visibility)
     bool bRowEnabled = !row.GetRowDef().m_vEnabledForPlayers.empty();
-    if (!bRowEnabled) {
-      row.SetVisible(false);
-      continue;
-    }
 
     float fPos = (float)pos;
 
@@ -698,6 +693,12 @@ void ScreenOptions::PositionRows(bool bTween) {
 
     bool bHidden = i < first_start || (i >= first_end && i < second_start) ||
                    i >= second_end;
+    if (!bRowEnabled) {
+      bHidden = true;
+      row.SetVisible(false);
+    } else {
+      row.SetVisible(true);
+    }
     for (int j = 0; j < NUM_DIFFUSE_COLORS; j++) {
       tsDestination.diffuse[j].a = bHidden ? 0.0f : 1.0f;
     }

--- a/src/ScreenOptions.h
+++ b/src/ScreenOptions.h
@@ -75,6 +75,8 @@ class ScreenOptions : public ScreenWithMenuElements {
   void PositionRows(bool bTween);
   void TweenCursor(PlayerNumber pn);
   void StoreFocus(PlayerNumber pn);
+  void SetOptionRowVisible(int iRow, bool bVisible, bool bRedraw = true);
+  void RedrawOptions();
 
   void BeginFadingOut();
   virtual bool FocusedItemEndsScreen(PlayerNumber pn) const;


### PR DESCRIPTION
This adds and exposes 2 methods to lua for toggling an option row's visibility. This would allow you to pop a row in and out during runtime without needing to leave/reload the screen. This PR is related to https://github.com/itgmania/itgmania/pull/1173 as I wanted to be able to optionally show the variant's row in PlayerOptions only when the currently selected NoteSkin has variants.
Methods:
```
void SetOptionRowVisible(int iRow, bool bVisible, bool bRedraw = true);
void RedrawOptions(); // Redraw Options, this will update the positions of the optionrows to shift things up/down accordingly
```

This video shows me hiding the NoteSkin variant OptionRow and showing it dynamically
https://github.com/user-attachments/assets/19cbf08d-cf96-449b-9182-f96f8bacab9f