### PR TITLE
Update metrics.ini

### DIFF
--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -29,7 +29,7 @@ ScreenHeight=480
 AutoSetStyle=false
 
 # Default modifiers and noteskin.
-DefaultModifiers="1x"
+DefaultModifiers=""
 DefaultNoteSkinName="default"
 
 # Difficulties to show. Useful for custom games where you want to hide these.
@@ -4708,3 +4708,4 @@ AmbientFailedColor=color(".2,.1,.1,1")
 DiffuseColor=color("1,.95,.95,1")
 DiffuseDangerColor=color(".8,.1,.1,1")
 DiffuseFailedColor=color(".4,.1,.1,1")
+


### PR DESCRIPTION
Remove the 1x speed mod default to reduce the number of places you need to look when setting the speed mod default. (There isn't any reason to set it there, since the program automatically defaults to 1x barring any user or theme changes, and this particular override makes defaults configuration needlessly confusing)