### PR TITLE
Add ITG flat noteskin to complete the ITG2 noteskin lineup

### DIFF
--- a/NoteSkins/dance/flat/metrics.ini
+++ b/NoteSkins/dance/flat/metrics.ini
@@ -1,0 +1,8 @@
+[Global]
+FallbackNoteSkin=metal
+
+[NoteDisplay]
+TapNoteNoteColorTextureCoordSpacingX=0
+TapAdditionNoteColorTextureCoordSpacingX=0
+HoldHeadNoteColorTextureCoordSpacingX=0
+RollHeadNoteColorTextureCoordSpacingX=0


### PR DESCRIPTION
Now ITGMania comes with all five default ITG noteskins: Metal, Cel, Robot, Vivid, and now Flat.