### PR TITLE
Resolve Lua thread safety violation in NetworkManager

### DIFF
--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -10,6 +10,7 @@
 #include "LightsManager.h"
 #include "LuaManager.h"
 #include "MemoryCardManager.h"
+#include "NetworkManager.h"
 #include "PeriodicCaller.h"
 #include "Preference.h"
 #include "PrefsManager.h"
@@ -284,8 +285,9 @@ void GameLoop::UpdateAllButDraw(bool bRunningFromVBLANK) {
    * acting on song beat from last frame */
   HandleInputEvents(fDeltaTime);
 
-  // Update the lights
+  // Update the lights, and process any queued network tasks.
   LIGHTSMAN->Update(fDeltaTime);
+  NetworkManager::ProcessQueuedNetworkTasks();
 }
 
 void GameLoop::RunGameLoop() {

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -43,13 +43,14 @@ std::mutex networkThreadSyncMutex;
 std::queue<std::function<void()>> networkTaskQueue;
 }  // namespace
 
-// Lua handlers never execute on the same thread that enqueued them.
+// Used by IXWebSocket worker threads to queue work for Lua to
+// executed in the main loop via ProcessQueuedNetworkTasks.
 void NetworkManager::Enqueue(std::function<void()> task) {
   std::lock_guard<std::mutex> lock(networkThreadSyncMutex);
   networkTaskQueue.push(std::move(task));
 }
 
-// Runs in the game loop on every frame.
+// Called from GameLoop.cpp only.
 void NetworkManager::ProcessQueuedNetworkTasks() {
   std::queue<std::function<void()>> tasks;
   {
@@ -776,6 +777,146 @@ class LunaNetworkManager : public Luna<NetworkManager> {
   }
 
  private:
+  // Shared callback metadata and Lua registry refs, created in Lua
+  // HttpRequest(). The atomic 'done' flag prevents multiple tasks
+  // (progress, error, or response) from running concurrently and
+  // prevents duplicate Lua callback invocations.
+  struct HttpLuaCallbackState {
+    std::atomic<bool> done;
+    int onProgressRef;
+    int onResponseRef;
+
+    HttpLuaCallbackState(int onProgressRef_, int onResponseRef_)
+        : done(false),
+          onProgressRef(onProgressRef_),
+          onResponseRef(onResponseRef_) {}
+  };
+
+  // Executable task queued from ixwebsocket's thread and drained on the main
+  // thread. Calls the Lua onProgress handler with current/total bytes.
+  struct HttpLuaProgressTask {
+    std::shared_ptr<HttpLuaCallbackState> state;
+    int current;
+    int total;
+
+    void operator()() const {
+      if (!state || state->done.load()) {
+        return;
+      }
+      if (state->onProgressRef == LUA_NOREF) {
+        return;
+      }
+
+      Lua* L = LUA->Get();
+      handleProgress(L, current, total, state->onProgressRef);
+      LUA->Release(L);
+    }
+  };
+
+  // Queued from ixwebsocket's thread and drained on the main
+  // thread. Will be called if the download write fails.
+  struct HttpLuaFileErrorTask {
+    std::shared_ptr<HttpLuaCallbackState> state;
+    std::string errorMessage;
+
+    void operator()() const {
+      if (!state) {
+        return;
+      }
+
+      bool expected = false;
+      if (!state->done.compare_exchange_strong(expected, true)) {
+        return;
+      }
+
+      Lua* L = LUA->Get();
+
+      if (state->onProgressRef != LUA_NOREF) {
+        luaL_unref(L, LUA_REGISTRYINDEX, state->onProgressRef);
+      }
+
+      if (state->onResponseRef != LUA_NOREF) {
+        handleFileError(L, errorMessage, state->onResponseRef);
+      }
+
+      LUA->Release(L);
+    }
+  };
+
+  // Queued from ixwebsocket's thread, and drained on the main
+  // thread. Will be called when the HTTP response is ready.
+  struct HttpLuaResponseTask {
+    std::shared_ptr<HttpLuaCallbackState> state;
+    ix::HttpResponsePtr response;
+
+    void operator()() const {
+      if (!state) {
+        return;
+      }
+
+      bool expected = false;
+      if (!state->done.compare_exchange_strong(expected, true)) {
+        return;
+      }
+
+      Lua* L = LUA->Get();
+
+      if (state->onProgressRef != LUA_NOREF) {
+        luaL_unref(L, LUA_REGISTRYINDEX, state->onProgressRef);
+      }
+
+      if (state->onResponseRef != LUA_NOREF) {
+        handleHttpResponse(L, response, state->onResponseRef);
+      }
+
+      LUA->Release(L);
+    }
+  };
+
+  // Invoked from ixwebsocket's internal worker thread during HTTP download.
+  // Enqueues an HttpLuaProgressTask to run progress callback on main thread.
+  struct EnqueueHttpProgressCallback {
+    std::shared_ptr<HttpLuaCallbackState> state;
+
+    bool operator()(int current, int total) const {
+      if (!state || state->done.load()) {
+        return true;
+      }
+
+      if (state->onProgressRef != LUA_NOREF) {
+        NetworkManager::Enqueue(HttpLuaProgressTask{state, current, total});
+      }
+
+      return true;
+    }
+  };
+
+  // Invoked from ixwebsocket's internal worker thread if a
+  // write error occurs (e.g., disk full).
+  struct EnqueueHttpFileErrorCallback {
+    std::shared_ptr<HttpLuaCallbackState> state;
+
+    void operator()(const std::string& errorMessage) const {
+      if (!state) {
+        return;
+      }
+      NetworkManager::Enqueue(HttpLuaFileErrorTask{state, errorMessage});
+    }
+  };
+
+  // Invoked from ixwebsocket's internal worker thread when the
+  // HTTP response is ready (success or protocol error).
+  struct EnqueueHttpResponseCallback {
+    std::shared_ptr<HttpLuaCallbackState> state;
+
+    void operator()(const ix::HttpResponsePtr& response) const {
+      if (!state) {
+        return;
+      }
+      NetworkManager::Enqueue(HttpLuaResponseTask{state, response});
+    }
+  };
+
   static void handleUrlForbidden(Lua* L, std::string& url, int onResponseRef) {
     lua_rawgeti(L, LUA_REGISTRYINDEX, onResponseRef);
     luaL_unref(L, LUA_REGISTRYINDEX, onResponseRef);

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -6,10 +6,12 @@
 #include <ixwebsocket/IXWebSocket.h>
 
 #include <algorithm>
+#include <atomic>
 #include <climits>
 #include <cstddef>
 #include <memory>
 #include <mutex>
+#include <queue>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -35,6 +37,34 @@
 
 NetworkManager* NETWORK =
     nullptr;  // global and accessible from anywhere in our program
+
+namespace {
+std::mutex networkThreadSyncMutex;
+std::queue<std::function<void()>> networkTaskQueue;
+}  // namespace
+
+// Lua handlers never execute on the same thread that enqueued them.
+void NetworkManager::Enqueue(std::function<void()> task) {
+  std::lock_guard<std::mutex> lock(networkThreadSyncMutex);
+  networkTaskQueue.push(std::move(task));
+}
+
+// Runs in the game loop on every frame.
+void NetworkManager::ProcessQueuedNetworkTasks() {
+  std::queue<std::function<void()>> tasks;
+  {
+    std::lock_guard<std::mutex> lock(networkThreadSyncMutex);
+    std::swap(tasks, networkTaskQueue);
+  }
+
+  while (!tasks.empty()) {
+    auto task = std::move(tasks.front());
+    tasks.pop();
+    if (task) {
+      task();
+    }
+  }
+}
 
 Preference<bool> NetworkManager::httpEnabled(
     "HttpEnabled", true, nullptr, PreferenceType::Immutable);

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -561,14 +561,6 @@ class LunaNetworkManager : public Luna<NetworkManager> {
       if (lua_isfunction(L, -1)) {
         lua_pushvalue(L, -1);
         onProgressRef = luaL_ref(L, LUA_REGISTRYINDEX);
-
-        args.onProgress = [onProgressRef](int current, int total) {
-          Lua* L = LUA->Get();
-          handleProgress(L, current, total, onProgressRef);
-          LUA->Release(L);
-
-          return true;
-        };
       } else {
         luaL_error(L, "onProgress must be a function");
       }
@@ -587,31 +579,15 @@ class LunaNetworkManager : public Luna<NetworkManager> {
     }
     lua_pop(L, 1);
 
-    args.onFileError = [onProgressRef,
-                        onResponseRef](const std::string& errorMessage) {
-      Lua* L = LUA->Get();
+    std::shared_ptr<HttpLuaCallbackState> callbackState =
+        std::make_shared<HttpLuaCallbackState>(onProgressRef, onResponseRef);
 
-      luaL_unref(L, LUA_REGISTRYINDEX, onProgressRef);
+    if (onProgressRef != LUA_NOREF) {
+      args.onProgress = EnqueueHttpProgressCallback{callbackState};
+    }
 
-      if (onResponseRef != LUA_NOREF) {
-        handleFileError(L, errorMessage, onResponseRef);
-      }
-
-      LUA->Release(L);
-    };
-
-    args.onResponse = [onProgressRef,
-                       onResponseRef](const ix::HttpResponsePtr& response) {
-      Lua* L = LUA->Get();
-
-      luaL_unref(L, LUA_REGISTRYINDEX, onProgressRef);
-
-      if (onResponseRef != LUA_NOREF) {
-        handleHttpResponse(L, response, onResponseRef);
-      }
-
-      LUA->Release(L);
-    };
+    args.onFileError = EnqueueHttpFileErrorCallback{callbackState};
+    args.onResponse = EnqueueHttpResponseCallback{callbackState};
 
     if (p->IsUrlAllowed(args.url)) {
       auto fut = p->HttpRequest(args);

--- a/src/NetworkManager.h
+++ b/src/NetworkManager.h
@@ -147,6 +147,14 @@ class NetworkManager {
   NetworkManager();
   ~NetworkManager();
 
+  // Lua HTTP callbacks (progress, error, response) are invoked from
+  // ixwebsocket's internal worker threads during async HTTP operations. Since
+  // Lua uses a global lock and must be executed on the main thread only, we
+  // enqueue these callbacks from the worker thread and drain them each frame in
+  // the main game loop.
+  static void Enqueue(std::function<void()> task);
+  static void ProcessQueuedNetworkTasks();
+
   bool IsUrlAllowed(const std::string& url);
   HttpRequestFuturePtr HttpRequest(const HttpRequestArgs& args);
   WebSocketHandlePtr WebSocket(const WebSocketArgs& args);


### PR DESCRIPTION
**tl;dr Lua uses a global lock and should only execute on the main thread, but callbacks that invoke Lua directly from worker threads violate this behavior pattern. This PR restructures NetworkManager so that Lua is not executed from IXWebSocket helper threads.** 

------

I've replaced [my prior NetworkManager PR](https://github.com/itgmania/itgmania/pull/1017) with this PR, as I believe I've found a legitimate potential Lua safety issue in NetworkManager. While this expands on the work I've previously done to attempt to improve NetworkManager efficiency, much of the credit to realizing the problem here was actually possible due to the discovery that [Websocket requests can not be threaded as-is](https://github.com/itgmania/itgmania/commit/c98bfdbaf241863784bc7cfb4ae001b6b03c9573).

This PR now improves NetworkManager predictability by centralizing Lua ref management and LUA->Get/Release usage, as well as implementing a thread-safe queue to ensure tasks are processed in a predictable manner.


See below for further details.

<details>

### Preface

Following the need to revert the Websocket Threading commit, I decided to look deeper into why threading individual requests is non-viable, and expanded upon my previously-proposed "dumb approach" of spawning a background thread to check status, which was enough to improved network throughput almost two-fold in some cases, but did not address the root issue.

[My old proof-of-concept commit](https://github.com/itgmania/itgmania/commit/b8ddc55bf06ab17960452c978d86a1a616b4d4b9) proved the existing method could be improved by doing a dumb check every 100ms, and this consistently reduced the time taken by network requests. However, we've found that threading the individual websocket I/O requests is fragile and prone to error, which led me to wonder what was causing breakage here. With this knowledge, I was better able to determine what I believed to be the issue at hand.

### Approach & Theory

The existing code involes HTTP callbacks (progress, file error, response) from ixwebsocket on the library's internal worker threads. In these, we call Lua.

Lua uses a global lock and should only execute on the main thread, but callbacks that invoke Lua directly from worker threads violate this behavior pattern. 

This design can lead to increased lock contention. The more serious risk is undefined behavior caused by Lua working across threads.

To eliminate contention and ensure safe Lua execution, HTTP callback results are now captured in C++ and enqueued as tasks in the main thread, rather than running Lua directly from the worker.  

### Execution & Implementation

With this change, each HTTP request will create a shared_ptr `HttpLuaCallbackState` containing an atomic done flag and Lua registry refs.

Worker-thread callbacks now will enqueue tasks onto a mutex-protected queue. Each frame, GameLoop::UpdateAllButDraw drains all queued tasks and executes them on the main thread.

The atomic done flag ensures that only one terminal callback (error or response) executes per request, preventing duplicate or concurrent Lua invocations.

This approach effectively prevents cross-thread lock contention, and ensures Lua executes in a thread safe manner.

</details>