### PR TITLE
Add support for passing in a table of preferred songs for SetPreferredS…

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -994,6 +994,7 @@
 			<Function name='SetNumMultiplayerNoteFields'/>
 			<Function name='SetPreferredDifficulty'/>
 			<Function name='SetPreferredSong'/>
+			<Function name='SetPreferredSongsFromTable'/>
 			<Function name='SetPreferredSongGroup'/>
 			<Function name='SetSongOptions'/>
 			<Function name='SetStepsForEditMode'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -5975,6 +5975,17 @@ local args = {
 		(New since ITGmania 0.6.0) If the optional argument <code>bIsAbsolute</code> is set, instead treats
 		sListName as an absolute path instead of loading it from the Theme's <code>Other</code> directory.
 	</Function>
+	<Function name='SetPreferredSongsFromTable' return='void' arguments='table' since='ITGmania 1.2.0'>
+		An alternate version of SetPreferredSongs that takes a key value table of songs where the key is the
+		section name and the value is a table of songs that belong in that section. This allows themes to
+		set preferred songs without needing to read from a file.
+<pre><code>
+{
+	"Section Name 1" = { song1, song2, song3 },
+	"Section Name 2" = { song4, song5, song6 }
+}
+</code></pre>
+	</Function>
 	<Function name='SongToPreferredSortSectionName' return='string' arguments='Song s'>
 		Returns the preferred sort section name for the specified Song.
 	</Function>

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -1946,6 +1946,66 @@ void SongManager::UpdateShuffled() {
 }
 
 void SongManager::SetPreferredSongs(
+    std::map<std::string, std::vector<Song*>> mapSectionToSongs) {
+  ASSERT(UNLOCKMAN != nullptr);
+  m_vPreferredSongSort.clear();
+  m_mapPreferredSectionToSongs.clear();
+
+  PreferredSortSection section;
+  for (const std::pair<const std::string, std::vector<Song*>>& pair :
+       mapSectionToSongs) {
+    if (pair.second.empty()) {
+      continue;
+    }
+    section = PreferredSortSection();
+    section.sName = pair.first;
+    for (Song* song : pair.second) {
+      if (song == nullptr) {
+        continue;
+      }
+      if (UNLOCKMAN->SongIsLocked(song) & LOCKED_SELECTABLE) {
+        continue;
+      }
+
+      section.vpSongs.push_back(song);
+    }
+    m_vPreferredSongSort.push_back(section);
+    m_mapPreferredSectionToSongs[section.sName] = section.vpSongs;
+  }
+
+  if (MOVE_UNLOCKS_TO_BOTTOM_OF_PREFERRED_SORT.GetValue()) {
+    // move all unlock songs to a group at the bottom
+    PreferredSortSection PFSection;
+    PFSection.sName = "Unlocks";
+    for (const UnlockEntry& ue : UNLOCKMAN->m_UnlockEntries) {
+      if (ue.m_Type == UnlockRewardType_Song) {
+        Song* pSong = ue.m_Song.ToSong();
+        if (pSong) {
+          PFSection.vpSongs.push_back(pSong);
+        }
+      }
+    }
+
+    m_vPreferredSongSort.push_back(PFSection);
+    m_mapPreferredSectionToSongs[PFSection.sName] = PFSection.vpSongs;
+  }
+
+  // prune empty groups
+  for (int i = m_vPreferredSongSort.size() - 1; i >= 0; i--) {
+    if (m_vPreferredSongSort[i].vpSongs.empty()) {
+      m_mapPreferredSectionToSongs.erase(m_vPreferredSongSort[i].sName);
+      m_vPreferredSongSort.erase(m_vPreferredSongSort.begin() + i);
+    }
+  }
+
+  for (const PreferredSortSection& i : m_vPreferredSongSort) {
+    for (const Song* j : i.vpSongs) {
+      ASSERT(j != nullptr);
+    }
+  }
+}
+
+void SongManager::SetPreferredSongs(
     std::string sPreferredSongs, bool bIsAbsolute) {
   ASSERT(UNLOCKMAN != nullptr);
 
@@ -2413,6 +2473,40 @@ class LunaSongManager : public Luna<SongManager> {
 
     COMMON_RETURN_SELF;
   }
+
+  static int SetPreferredSongsFromTable(T* p, lua_State* L) {
+    if (!lua_istable(L, 1)) {
+      return luaL_error(
+          L, "Expected a table for SetPreferredSongsFromTable. Got %s.",
+          luaL_typename(L, 1));
+    }
+
+    std::map<std::string, std::vector<Song*>> mapSectionToSongs;
+    lua_pushnil(L);  // first key
+    while (lua_next(L, 1) != 0) {
+      std::string sectionName = SArg(-2);
+      std::vector<Song*> songs;
+
+      if (lua_istable(L, -1)) {
+        lua_pushnil(L);  // first key in the inner table
+        while (lua_next(L, -2) != 0) {
+          // value is at index -1
+          Song* pSong = Luna<Song>::check(L, -1);
+          if (pSong) {
+            songs.push_back(pSong);
+          }
+          lua_pop(L, 1);  // remove value, keep key for next iteration
+        }
+      }
+
+      mapSectionToSongs[sectionName] = songs;
+      lua_pop(L, 1);  // remove value, keep key for next iteration
+    }
+
+    p->SetPreferredSongs(mapSectionToSongs);
+    COMMON_RETURN_SELF;
+  }
+
   static int SetPreferredCourses(T* p, lua_State* L) {
     std::string sPreferredCourses = SArg(1);
     if (lua_gettop(L) >= 2 && !lua_isnil(L, 2)) {
@@ -2677,6 +2771,7 @@ class LunaSongManager : public Luna<SongManager> {
     ADD_METHOD(GetCoursesInGroup);
     ADD_METHOD(ShortenGroupName);
     ADD_METHOD(SetPreferredSongs);
+    ADD_METHOD(SetPreferredSongsFromTable);
     ADD_METHOD(SetPreferredCourses);
     ADD_METHOD(GetPreferredSortSongs);
     ADD_METHOD(GetPreferredSortCourses);

--- a/src/SongManager.cpp
+++ b/src/SongManager.cpp
@@ -1945,7 +1945,7 @@ void SongManager::UpdateShuffled() {
       g_RandomNumberGenerator);
 }
 
-void SongManager::SetPreferredSongs(
+void SongManager::SetPreferredSongsFromTable(
     std::map<std::string, std::vector<Song*>> mapSectionToSongs) {
   ASSERT(UNLOCKMAN != nullptr);
   m_vPreferredSongSort.clear();
@@ -2503,7 +2503,7 @@ class LunaSongManager : public Luna<SongManager> {
       lua_pop(L, 1);  // remove value, keep key for next iteration
     }
 
-    p->SetPreferredSongs(mapSectionToSongs);
+    p->SetPreferredSongsFromTable(mapSectionToSongs);
     COMMON_RETURN_SELF;
   }
 

--- a/src/SongManager.h
+++ b/src/SongManager.h
@@ -225,7 +225,7 @@ class SongManager {
   void UpdateShuffled();  // re-shuffle songs and courses
   std::map<int, std::vector<Song*>> UpdateMeterSort(std::vector<Song*> songs);
   void SetPreferredSongs(std::string sPreferredSongs, bool bIsAbsolute = false);
-  void SetPreferredSongs(
+  void SetPreferredSongsFromTable(
       std::map<std::string, std::vector<Song*>> mapSectionToSongs);
   void SetPreferredCourses(
       std::string sPreferredCourses, bool bIsAbsolute = false);

--- a/src/SongManager.h
+++ b/src/SongManager.h
@@ -225,6 +225,8 @@ class SongManager {
   void UpdateShuffled();  // re-shuffle songs and courses
   std::map<int, std::vector<Song*>> UpdateMeterSort(std::vector<Song*> songs);
   void SetPreferredSongs(std::string sPreferredSongs, bool bIsAbsolute = false);
+  void SetPreferredSongs(
+      std::map<std::string, std::vector<Song*>> mapSectionToSongs);
   void SetPreferredCourses(
       std::string sPreferredCourses, bool bIsAbsolute = false);
   void UpdatePreferredSort(


### PR DESCRIPTION
This PR adds a new method and accompanying lua method ``SetPreferredSongsFromTable``. This allows us to set our preferred songs (favorites) via lua using a table instead of requiring a file: https://github.com/CrashCringle12/Simply-Love-SM5/wiki/Preferred-Sorting

The structure of the table is as follows;
{
	"Section Name 1" = { song1, song2, song3 },
	"Section Name 2" = { song4, song5, song6 }
}
