### PR TITLE
Generate Note Annotations, save to cache, and expose to Lua

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -2418,6 +2418,13 @@
 			<EnumValue name='&apos;FileType_Lua&apos;' value='7'/>
 			<EnumValue name='&apos;FileType_Ini&apos;' value='8'/>
 		</Enum>
+		<Enum name='Foot'>
+			<EnumValue name='&apos;Foot_None&apos;' value='0'/>
+			<EnumValue name='&apos;Foot_LeftHeel&apos;' value='1'/>
+			<EnumValue name='&apos;Foot_LeftToe&apos;' value='2'/>
+			<EnumValue name='&apos;Foot_RightHeel&apos;' value='3'/>
+			<EnumValue name='&apos;Foot_RightToe&apos;' value='4'/>
+		</Enum>
 		<Enum name='GameController'>
 			<EnumValue name='&apos;GameController_1&apos;' value='0'/>
 			<EnumValue name='&apos;GameController_2&apos;' value='1'/>
@@ -2946,6 +2953,18 @@
 			<EnumValue name='&apos;TapNoteType_Attack&apos;' value='6'/>
 			<EnumValue name='&apos;TapNoteType_AutoKeySound&apos;' value='7'/>
 			<EnumValue name='&apos;TapNoteType_Fake&apos;' value='8'/>
+		</Enum>
+		<Enum name='TechCountsCategory'>
+			<EnumValue name='&apos;TechCountsCategory_Crossovers&apos;' value='0'/>
+			<EnumValue name='&apos;TechCountsCategory_HalfCrossovers&apos;' value='1'/>
+			<EnumValue name='&apos;TechCountsCategory_FullCrossovers&apos;' value='2'/>
+			<EnumValue name='&apos;TechCountsCategory_Footswitches&apos;' value='3'/>
+			<EnumValue name='&apos;TechCountsCategory_UpFootswitches&apos;' value='4'/>
+			<EnumValue name='&apos;TechCountsCategory_DownFootswitches&apos;' value='5'/>
+			<EnumValue name='&apos;TechCountsCategory_Sideswitches&apos;' value='6'/>
+			<EnumValue name='&apos;TechCountsCategory_Jacks&apos;' value='7'/>
+			<EnumValue name='&apos;TechCountsCategory_Brackets&apos;' value='8'/>
+			<EnumValue name='&apos;TechCountsCategory_Doublesteps&apos;' value='9'/>
 		</Enum>
 		<Enum name='TextGlowMode'>
 			<EnumValue name='&apos;TextGlowMode_Inner&apos;' value='0'/>

--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -2421,6 +2421,13 @@
 			<EnumValue name='&apos;FileType_Lua&apos;' value='7'/>
 			<EnumValue name='&apos;FileType_Ini&apos;' value='8'/>
 		</Enum>
+		<Enum name='Foot'>
+			<EnumValue name='&apos;Foot_None&apos;' value='0'/>
+			<EnumValue name='&apos;Foot_LeftHeel&apos;' value='1'/>
+			<EnumValue name='&apos;Foot_LeftToe&apos;' value='2'/>
+			<EnumValue name='&apos;Foot_RightHeel&apos;' value='3'/>
+			<EnumValue name='&apos;Foot_RightToe&apos;' value='4'/>
+		</Enum>
 		<Enum name='GameController'>
 			<EnumValue name='&apos;GameController_1&apos;' value='0'/>
 			<EnumValue name='&apos;GameController_2&apos;' value='1'/>
@@ -2949,6 +2956,18 @@
 			<EnumValue name='&apos;TapNoteType_Attack&apos;' value='6'/>
 			<EnumValue name='&apos;TapNoteType_AutoKeySound&apos;' value='7'/>
 			<EnumValue name='&apos;TapNoteType_Fake&apos;' value='8'/>
+		</Enum>
+		<Enum name='TechCountsCategory'>
+			<EnumValue name='&apos;TechCountsCategory_Crossovers&apos;' value='0'/>
+			<EnumValue name='&apos;TechCountsCategory_HalfCrossovers&apos;' value='1'/>
+			<EnumValue name='&apos;TechCountsCategory_FullCrossovers&apos;' value='2'/>
+			<EnumValue name='&apos;TechCountsCategory_Footswitches&apos;' value='3'/>
+			<EnumValue name='&apos;TechCountsCategory_UpFootswitches&apos;' value='4'/>
+			<EnumValue name='&apos;TechCountsCategory_DownFootswitches&apos;' value='5'/>
+			<EnumValue name='&apos;TechCountsCategory_Sideswitches&apos;' value='6'/>
+			<EnumValue name='&apos;TechCountsCategory_Jacks&apos;' value='7'/>
+			<EnumValue name='&apos;TechCountsCategory_Brackets&apos;' value='8'/>
+			<EnumValue name='&apos;TechCountsCategory_Doublesteps&apos;' value='9'/>
 		</Enum>
 		<Enum name='TextGlowMode'>
 			<EnumValue name='&apos;TextGlowMode_Inner&apos;' value='0'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -3874,7 +3874,7 @@ NETWORK:WebSocket{
 	</Function>
 	<Function name='IsNoteSkinVariant' return='bool' arguments='string strName' since='ITGmania 1.2.0'>
 		Returns <code>true</code> if the noteskin <code>strName</code> is a variant of another noteskin.
-	</Function>	
+	</Function>
 </Class>
 <Class name='NCSplineHandler'>
 	<Description>
@@ -6296,6 +6296,24 @@ local spr = Def.Sprite{
 	</Function>
 	<Function name='GetMeter' return='int' arguments=''>
 		Returns the numerical difficulty of the Steps.
+	</Function>
+	<Function name='GetNoteAnnotations' return='table' arguments='PlayerNumber pn'>
+		Returns a table with additional information about the notes in this stepchart.
+		Each entry includes data about predicted foot placement for each note, as well as predicted tech notations for the given beat.
+		`footPlacement` is a table that maps column index to the predicted <Link class='ENUM' function='Foot'/> (NOTE that the column indexes are 1-based)
+		`tech` is an array of <Link class='ENUM' function='TechCountsCategory'/> predicted for the given beat. These are in no particular order, but each enum should only show up once.
+		<code>
+		[
+			{
+				"beat": 4.20,
+				"footPlacement": {
+					2: "Foot_LeftHeel",
+					3: "Foot_LeftToe"
+				},
+				"tech": ["TechCountsCategory_Brackets"]
+			}
+		]
+		</code>
 	</Function>
 	<Function name='HasAttacks' return='bool' arguments=''>
 		Returns <code>true</code> if the Steps has any attacks.

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -3874,7 +3874,7 @@ NETWORK:WebSocket{
 	</Function>
 	<Function name='IsNoteSkinVariant' return='bool' arguments='string strName' since='ITGmania 1.2.0'>
 		Returns <code>true</code> if the noteskin <code>strName</code> is a variant of another noteskin.
-	</Function>	
+	</Function>
 </Class>
 <Class name='NCSplineHandler'>
 	<Description>
@@ -6314,6 +6314,24 @@ local spr = Def.Sprite{
 	</Function>
 	<Function name='GetMeter' return='int' arguments=''>
 		Returns the numerical difficulty of the Steps.
+	</Function>
+	<Function name='GetNoteAnnotations' return='table' arguments='PlayerNumber pn'>
+		Returns a table with additional information about the notes in this stepchart.
+		Each entry includes data about predicted foot placement for each note, as well as predicted tech notations for the given beat.
+		`footPlacement` is a table that maps column index to the predicted <Link class='ENUM' function='Foot'/> (NOTE that the column indexes are 1-based)
+		`tech` is an array of <Link class='ENUM' function='TechCountsCategory'/> predicted for the given beat. These are in no particular order, but each enum should only show up once.
+		<code>
+		[
+			{
+				"beat": 4.20,
+				"footPlacement": {
+					2: "Foot_LeftHeel",
+					3: "Foot_LeftToe"
+				},
+				"tech": ["TechCountsCategory_Brackets"]
+			}
+		]
+		</code>
 	</Function>
 	<Function name='HasAttacks' return='bool' arguments=''>
 		Returns <code>true</code> if the Steps has any attacks.

--- a/src/CMakeData-data.cmake
+++ b/src/CMakeData-data.cmake
@@ -69,22 +69,26 @@ source_group("Data Structures\\\\Courses and Trails"
              ${SM_DATA_COURSE_HPP})
 
 list(APPEND SM_DATA_NOTEDATA_SRC
+            "NoteAnnotation.cpp"
             "NoteData.cpp"
             "NoteDataUtil.cpp"
             "NoteDataWithScoring.cpp"
             "ColumnCues.cpp"
             "TechCounts.cpp"
+            "TechCountsCategory.cpp"
             "MeasureInfo.cpp"
             "StepParityGenerator.cpp"
             "StepParityDatastructs.cpp"
             "StepParityCost.cpp")
 
 list(APPEND SM_DATA_NOTEDATA_HPP
+            "NoteAnnotation.h"
             "NoteData.h"
             "NoteDataUtil.h"
             "NoteDataWithScoring.h"
             "ColumnCues.h"
             "TechCounts.h"
+            "TechCountsCategory.h"
             "MeasureInfo.h"
             "StepParityGenerator.h"
             "StepParityDatastructs.h"

--- a/src/NoteAnnotation.cpp
+++ b/src/NoteAnnotation.cpp
@@ -1,0 +1,175 @@
+#include "NoteAnnotation.h"
+
+#include <cstdint>
+#include <cstring>
+#include <sstream>
+
+#include "mbedtls/base64.h"
+
+int base64_encode(const std::vector<uint8_t>& input, std::string& output) {
+  size_t out_len = 0;
+  // First call with null output to get required buffer size
+  mbedtls_base64_encode(nullptr, 0, &out_len, input.data(), input.size());
+
+  output.resize(out_len, '\0');
+  int encode_result = mbedtls_base64_encode(
+      reinterpret_cast<unsigned char*>(output.data()), out_len, &out_len,
+      input.data(), input.size());
+  output.resize(out_len);  // trim null terminator mbedtls adds
+  return encode_result;
+}
+
+int base64_decode(const std::string& input, std::vector<uint8_t>& output) {
+  size_t out_len = 0;
+  // First call to get required buffer size
+  mbedtls_base64_decode(
+      nullptr, 0, &out_len,
+      reinterpret_cast<const unsigned char*>(input.data()), input.size());
+
+  output.resize(out_len);
+  int decode_result = mbedtls_base64_decode(
+      output.data(), output.size(), &out_len,
+      reinterpret_cast<const unsigned char*>(input.data()), input.size());
+  output.resize(out_len);
+  return decode_result;
+}
+
+static void MakeUrlSafe(std::string& s) {
+  for (char& c : s) {
+    if (c == '+') {
+      c = '-';
+    } else if (c == '/') {
+      c = '_';
+    }
+  }
+}
+
+static void MakeStandardBase64(std::string& s) {
+  for (char& c : s) {
+    if (c == '-') {
+      c = '+';
+    } else if (c == '_') {
+      c = '/';
+    }
+  }
+}
+
+/**
+ * Serializes a NoteAnnotation into an 11-byte representation
+ *
+ * bytes 1-4: beat
+ * bytes 5-9: whereTheFeetAre
+ * bytes 10-11: tech bitmask
+ */
+void SerializeAnnotation(const NoteAnnotation& ann, std::vector<uint8_t>& out) {
+  size_t offset = out.size();
+  out.resize(offset + 11);
+
+  // 4 bytes: beat (float)
+  std::memcpy(&out[offset], &ann.beat, 4);
+  offset += 4;
+
+  // 5 bytes: whereTheFeetAre (int8_t each, -1 = no position)
+  for (int i = 0; i < 5; i++) {
+    out[offset++] = static_cast<int8_t>(ann.whereTheFeetAre[i]);
+  }
+
+  // 2 bytes: tech bitmask
+  uint16_t techMask = 0;
+  for (TechCountsCategory cat : ann.tech) {
+    if (cat < NUM_TechCountsCategory) {
+      techMask |= (1u << cat);
+    }
+  }
+  out[offset++] = techMask & 0xFF;
+  out[offset++] = (techMask >> 8) & 0xFF;
+}
+
+NoteAnnotation DeserializeAnnotation(const uint8_t* buf) {
+  NoteAnnotation ann;
+  size_t offset = 0;
+
+  // 4 bytes: beat
+  std::memcpy(&ann.beat, &buf[offset], 4);
+  offset += 4;
+
+  // 5 bytes: whereTheFeetAre
+  ann.whereTheFeetAre.resize(5);
+  for (int i = 0; i < 5; i++) {
+    ann.whereTheFeetAre[i] = static_cast<int8_t>(buf[offset++]);
+  }
+
+  // 2 bytes: tech bitmask
+  uint16_t techMask = buf[offset] | (buf[offset + 1] << 8);
+  ann.tech.clear();
+  for (int i = 0; i < NUM_TechCountsCategory; i++) {
+    if (techMask & (1u << i)) {
+      ann.tech.push_back(static_cast<TechCountsCategory>(i));
+    }
+  }
+
+  return ann;
+}
+
+void NoteAnnotation::FromString(
+    const std::string& input, std::vector<NoteAnnotation>& out) {
+  std::string inputCopy = input;
+  MakeStandardBase64(inputCopy);
+  std::vector<uint8_t> raw;
+  out.clear();
+  int decode_result = base64_decode(inputCopy, raw);
+
+  if (decode_result != 0 || raw.size() % 11 != 0) {
+    LOG->Warn(
+        "Could not decode NoteAnnotations string. decode_result=%d, raw.size() "
+        "mod 11 = %zu",
+        decode_result, raw.size() % 11);
+    return;
+  }
+
+  size_t annotationCount = raw.size() / 11;
+  out.reserve(annotationCount);
+
+  for (size_t i = 0; i < annotationCount; i++) {
+    out.push_back(DeserializeAnnotation(&raw[i * 11]));
+  }
+}
+
+std::string NoteAnnotation::ToString(std::vector<NoteAnnotation>& annotations) {
+  std::vector<uint8_t> raw;
+  raw.reserve(annotations.size() * 11);
+  for (const auto& ann : annotations) {
+    SerializeAnnotation(ann, raw);
+  }
+  std::string output;
+  int encode_result = base64_encode(raw, output);
+  if (encode_result != 0) {
+    LOG->Warn(
+        "Could not encode Note Annotations. encode_result=%d", encode_result);
+    return "";
+  }
+
+  MakeUrlSafe(output);
+  return output;
+}
+
+const std::string& NoteAnnotationCache::GetCompressed() const {
+  return compressed;
+}
+
+const std::vector<NoteAnnotation>& NoteAnnotationCache::GetNoteAnnotations()
+    const {
+  if (decompressed.empty() && !compressed.empty()) {
+    NoteAnnotation::FromString(compressed, decompressed);
+  }
+  return decompressed;
+}
+
+void NoteAnnotationCache::Compress() {
+  if (decompressed.size() > 0) {
+    compressed = NoteAnnotation::ToString(decompressed);
+  } else {
+    compressed = "";
+  }
+  decompressed.clear();
+}

--- a/src/NoteAnnotation.h
+++ b/src/NoteAnnotation.h
@@ -1,0 +1,28 @@
+#ifndef NOTE_ANNOTATION_H
+#define NOTE_ANNOTATION_H
+
+#include <string>
+#include <vector>
+
+#include "StepParityDatastructs.h"
+#include "TechCountsCategory.h"
+
+struct NoteAnnotation {
+  float beat;
+  std::vector<int8_t> whereTheFeetAre;
+  std::vector<TechCountsCategory> tech;
+
+  static void FromString(
+      const std::string& input, std::vector<NoteAnnotation>& out);
+  static std::string ToString(std::vector<NoteAnnotation>& annotations);
+};
+
+struct NoteAnnotationCache {
+  std::string compressed;
+  mutable std::vector<NoteAnnotation> decompressed;
+  const std::string& GetCompressed() const;
+  const std::vector<NoteAnnotation>& GetNoteAnnotations() const;
+  void Compress();
+};
+
+#endif

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -12,6 +12,7 @@
 #include "GameConstantsAndTypes.h"
 #include "GameManager.h"
 #include "MsdFile.h"  // No JSON here.
+#include "NoteAnnotation.h"
 #include "NoteTypes.h"
 #include "NotesLoaderSM.h"  // For programming shortcuts.
 #include "PlayerNumber.h"
@@ -358,6 +359,31 @@ void SetTechCounts(StepsTagInfo& info) {
   info.ssc_format = true;
 }
 
+void SetNoteAnnotations(StepsTagInfo& info) {
+  if (info.from_cache || info.for_load_edit) {
+    std::vector<std::string> valuesPerPlayer;
+    split((*info.params)[1], "|", valuesPerPlayer, true);
+
+    if (valuesPerPlayer.size() > NUM_PlayerNumber) {
+      LOG->Warn(
+          "#NOTEANNOTATIONS has more sections (%zu) than possible number of "
+          "players (%d)!",
+          valuesPerPlayer.size(), NUM_PlayerNumber);
+    }
+
+    std::vector<NoteAnnotationCache> annotationsPerPlayer;
+
+    for (std::size_t pn = 0;
+         pn < valuesPerPlayer.size() && pn < NUM_PlayerNumber; pn++) {
+      NoteAnnotationCache annotationCache;
+      annotationCache.compressed = valuesPerPlayer[pn];
+      annotationsPerPlayer.push_back(annotationCache);
+    }
+    info.steps->SetCachedNoteAnnotations(annotationsPerPlayer);
+  }
+  info.ssc_format = true;
+}
+
 void SetNpsPerMeasure(StepsTagInfo& info) {
   if (info.from_cache || info.for_load_edit) {
     std::vector<std::string> valuesPerPlayer;
@@ -674,6 +700,7 @@ struct ssc_parser_helper_t {
     steps_tag_handlers["NPSPERMEASURE"] = &SetNpsPerMeasure;
     steps_tag_handlers["NOTESPERMEASURE"] = &SetNotesPerMeasure;
     steps_tag_handlers["PEAKNPS"] = &SetPeakNps;
+    steps_tag_handlers["NOTEANNOTATIONS"] = &SetNoteAnnotations;
     steps_tag_handlers["GROOVESTATSHASH"] = &SetGrooveStatsHash;
     steps_tag_handlers["GROOVESTATSHASHVERSION"] = &SetGrooveStatsHashVersion;
 

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -12,6 +12,7 @@
 #include "GameConstantsAndTypes.h"
 #include "GameManager.h"
 #include "MsdFile.h"  // No JSON here.
+#include "NoteAnnotation.h"
 #include "NoteTypes.h"
 #include "NotesLoaderSM.h"  // For programming shortcuts.
 #include "PlayerNumber.h"
@@ -358,6 +359,31 @@ void SetTechCounts(StepsTagInfo& info) {
   info.ssc_format = true;
 }
 
+void SetNoteAnnotations(StepsTagInfo& info) {
+  if (info.from_cache || info.for_load_edit) {
+    std::vector<std::string> valuesPerPlayer;
+    split((*info.params)[1], "|", valuesPerPlayer, true);
+
+    if (valuesPerPlayer.size() > NUM_PlayerNumber) {
+      LOG->Warn(
+          "#NOTEANNOTATIONS has more sections (%zu) than possible number of "
+          "players (%d)!",
+          valuesPerPlayer.size(), NUM_PlayerNumber);
+    }
+
+    std::vector<NoteAnnotationCache> annotationsPerPlayer;
+
+    for (std::size_t pn = 0;
+         pn < valuesPerPlayer.size() && pn < NUM_PlayerNumber; pn++) {
+      NoteAnnotationCache annotationCache;
+      annotationCache.compressed = valuesPerPlayer[pn];
+      annotationsPerPlayer.push_back(annotationCache);
+    }
+    info.steps->SetNoteAnnotations(annotationsPerPlayer);
+  }
+  info.ssc_format = true;
+}
+
 void SetNpsPerMeasure(StepsTagInfo& info) {
   if (info.from_cache || info.for_load_edit) {
     std::vector<std::string> valuesPerPlayer;
@@ -674,6 +700,7 @@ struct ssc_parser_helper_t {
     steps_tag_handlers["NPSPERMEASURE"] = &SetNpsPerMeasure;
     steps_tag_handlers["NOTESPERMEASURE"] = &SetNotesPerMeasure;
     steps_tag_handlers["PEAKNPS"] = &SetPeakNps;
+    steps_tag_handlers["NOTEANNOTATIONS"] = &SetNoteAnnotations;
     steps_tag_handlers["GROOVESTATSHASH"] = &SetGrooveStatsHash;
     steps_tag_handlers["GROOVESTATSHASHVERSION"] = &SetGrooveStatsHashVersion;
 

--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -527,6 +527,17 @@ static std::string GetSSCNoteData(
     const std::vector<float>& peakNps = in.GetAllPeakNps();
     lines.push_back("#PEAKNPS:" + serialize(peakNps, "|", 3) + ";");
 
+    const std::vector<NoteAnnotationCache> noteAnnotations =
+        in.GetNoteAnnotationCaches();
+
+    std::vector<std::string> serializedAnnotations;
+    for (NoteAnnotationCache ann : noteAnnotations) {
+      const std::string seralizedAnn = ann.GetCompressed();
+      serializedAnnotations.push_back(seralizedAnn);
+    }
+    lines.push_back(ssprintf(
+        "#NOTEANNOTATIONS:%s;", join("|", serializedAnnotations).c_str()));
+
     std::string GrooveStatsHash = in.GetGrooveStatsHash();
     lines.push_back(ssprintf("#GROOVESTATSHASH:%s;", GrooveStatsHash.c_str()));
 

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -65,7 +65,7 @@
  * @brief The internal version of the cache for StepMania.
  *
  * Increment this value to invalidate the current cache. */
-const int FILE_CACHE_VERSION = 230;
+const int FILE_CACHE_VERSION = 231;
 
 /** @brief How long does a song sample last by default? */
 const float DEFAULT_MUSIC_SAMPLE_LENGTH = 12.f;

--- a/src/StepParityCost.cpp
+++ b/src/StepParityCost.cpp
@@ -30,27 +30,27 @@ float StepParityCost::getActionCost(
   float cost = 0;
 
   // Mine weighting
-  int leftHeel = resultState->whatNoteTheFootIsHitting[LEFT_HEEL];
-  int leftToe = resultState->whatNoteTheFootIsHitting[LEFT_TOE];
-  int rightHeel = resultState->whatNoteTheFootIsHitting[RIGHT_HEEL];
-  int rightToe = resultState->whatNoteTheFootIsHitting[RIGHT_TOE];
+  int leftHeel = resultState->whatNoteTheFootIsHitting[Foot_LeftHeel];
+  int leftToe = resultState->whatNoteTheFootIsHitting[Foot_LeftToe];
+  int rightHeel = resultState->whatNoteTheFootIsHitting[Foot_RightHeel];
+  int rightToe = resultState->whatNoteTheFootIsHitting[Foot_RightToe];
 
-  bool movedLeft = resultState->didTheFootMove[LEFT_HEEL] ||
-                   resultState->didTheFootMove[LEFT_TOE];
+  bool movedLeft = resultState->didTheFootMove[Foot_LeftHeel] ||
+                   resultState->didTheFootMove[Foot_LeftToe];
 
-  bool movedRight = resultState->didTheFootMove[RIGHT_HEEL] ||
-                    resultState->didTheFootMove[RIGHT_TOE];
+  bool movedRight = resultState->didTheFootMove[Foot_RightHeel] ||
+                    resultState->didTheFootMove[Foot_RightToe];
 
   // Note that this is checking whether the previous state was a jump, not
   // whether the current state is
-  bool didJump = ((initialState->didTheFootMove[LEFT_HEEL] &&
-                   !initialState->isTheFootHolding[LEFT_HEEL]) ||
-                  (initialState->didTheFootMove[LEFT_TOE] &&
-                   !initialState->isTheFootHolding[LEFT_TOE])) &&
-                 ((initialState->didTheFootMove[RIGHT_HEEL] &&
-                   !initialState->isTheFootHolding[RIGHT_HEEL]) ||
-                  (initialState->didTheFootMove[RIGHT_TOE] &&
-                   !initialState->isTheFootHolding[RIGHT_TOE]));
+  bool didJump = ((initialState->didTheFootMove[Foot_LeftHeel] &&
+                   !initialState->isTheFootHolding[Foot_LeftHeel]) ||
+                  (initialState->didTheFootMove[Foot_LeftToe] &&
+                   !initialState->isTheFootHolding[Foot_LeftToe])) &&
+                 ((initialState->didTheFootMove[Foot_RightHeel] &&
+                   !initialState->isTheFootHolding[Foot_RightHeel]) ||
+                  (initialState->didTheFootMove[Foot_RightToe] &&
+                   !initialState->isTheFootHolding[Foot_RightToe]));
 
   bool jackedLeft = didJackLeft(
       initialState, resultState, leftHeel, leftToe, movedLeft, didJump,
@@ -102,7 +102,7 @@ float StepParityCost::calcMineCost(
   float cost = 0;
 
   for (int i = 0; i < columnCount; i++) {
-    if (resultState->combinedColumns[i] != NONE && row.mines[i] != 0) {
+    if (resultState->combinedColumns[i] != Foot_None && row.mines[i] != 0) {
       cost += MINE;
       break;
     }
@@ -127,14 +127,14 @@ float StepParityCost::calcHoldSwitchCost(
     if (row.holds[c].type == TapNoteType_Empty) {
       continue;
     }
-    if (((resultState->combinedColumns[c] == LEFT_HEEL ||
-          resultState->combinedColumns[c] == LEFT_TOE) &&
-         initialState->combinedColumns[c] != LEFT_TOE &&
-         initialState->combinedColumns[c] != LEFT_HEEL) ||
-        ((resultState->combinedColumns[c] == RIGHT_HEEL ||
-          resultState->combinedColumns[c] == RIGHT_TOE) &&
-         initialState->combinedColumns[c] != RIGHT_TOE &&
-         initialState->combinedColumns[c] != RIGHT_HEEL)) {
+    if (((resultState->combinedColumns[c] == Foot_LeftHeel ||
+          resultState->combinedColumns[c] == Foot_LeftToe) &&
+         initialState->combinedColumns[c] != Foot_LeftToe &&
+         initialState->combinedColumns[c] != Foot_LeftHeel) ||
+        ((resultState->combinedColumns[c] == Foot_RightHeel ||
+          resultState->combinedColumns[c] == Foot_RightToe) &&
+         initialState->combinedColumns[c] != Foot_RightToe &&
+         initialState->combinedColumns[c] != Foot_RightHeel)) {
       int previousFoot =
           initialState->whereTheFeetAre[resultState->combinedColumns[c]];
       cost += HOLDSWITCH * (previousFoot == INVALID_COLUMN
@@ -165,8 +165,8 @@ float StepParityCost::calcBracketTapCost(
   float cost = 0;
   if (leftHeel != INVALID_COLUMN && leftToe != INVALID_COLUMN) {
     float jackPenalty = 1;
-    if (initialState->didTheFootMove[LEFT_HEEL] ||
-        initialState->didTheFootMove[LEFT_TOE]) {
+    if (initialState->didTheFootMove[Foot_LeftHeel] ||
+        initialState->didTheFootMove[Foot_LeftToe]) {
       jackPenalty = 1 / elapsedTime;
     }
     if (row.holds[leftHeel].type != TapNoteType_Empty &&
@@ -181,8 +181,8 @@ float StepParityCost::calcBracketTapCost(
 
   if (rightHeel != INVALID_COLUMN && rightToe != INVALID_COLUMN) {
     float jackPenalty = 1;
-    if (initialState->didTheFootMove[RIGHT_TOE] ||
-        initialState->didTheFootMove[RIGHT_HEEL]) {
+    if (initialState->didTheFootMove[Foot_RightToe] ||
+        initialState->didTheFootMove[Foot_RightHeel]) {
       jackPenalty = 1 / elapsedTime;
     }
 
@@ -207,13 +207,13 @@ float StepParityCost::calcBracketJackCost(
   }
   float cost = 0;
 
-  if (jackedLeft && resultState->didTheFootMove[LEFT_HEEL] &&
-      resultState->didTheFootMove[LEFT_TOE]) {
+  if (jackedLeft && resultState->didTheFootMove[Foot_LeftHeel] &&
+      resultState->didTheFootMove[Foot_LeftToe]) {
     cost += BRACKETJACK;
   }
 
-  if (jackedRight && resultState->didTheFootMove[RIGHT_HEEL] &&
-      resultState->didTheFootMove[RIGHT_TOE]) {
+  if (jackedRight && resultState->didTheFootMove[Foot_RightHeel] &&
+      resultState->didTheFootMove[Foot_RightToe]) {
     cost += BRACKETJACK;
   }
   return cost;
@@ -274,10 +274,10 @@ float StepParityCost::calcSlowBracketCost(
 // we even get to calculating costs.
 float StepParityCost::calcTwistedFootCost(State* resultState) {
   float cost = 0;
-  int leftHeel = resultState->whatNoteTheFootIsHitting[LEFT_HEEL];
-  int leftToe = resultState->whatNoteTheFootIsHitting[LEFT_TOE];
-  int rightHeel = resultState->whatNoteTheFootIsHitting[RIGHT_HEEL];
-  int rightToe = resultState->whatNoteTheFootIsHitting[RIGHT_TOE];
+  int leftHeel = resultState->whatNoteTheFootIsHitting[Foot_LeftHeel];
+  int leftToe = resultState->whatNoteTheFootIsHitting[Foot_LeftToe];
+  int rightHeel = resultState->whatNoteTheFootIsHitting[Foot_RightHeel];
+  int rightToe = resultState->whatNoteTheFootIsHitting[Foot_RightToe];
 
   StagePoint leftPos = layout->averagePoint(leftHeel, leftToe);
   StagePoint rightPos = layout->averagePoint(rightHeel, rightToe);
@@ -310,10 +310,10 @@ float StepParityCost::calcMissedFootswitchCost(
 
 float StepParityCost::calcFacingCosts(
     State* initialState, State* resultState, int columnCount) {
-  int endLeftHeel = resultState->whereTheFeetAre[LEFT_HEEL];
-  int endLeftToe = resultState->whereTheFeetAre[LEFT_TOE];
-  int endRightHeel = resultState->whereTheFeetAre[RIGHT_HEEL];
-  int endRightToe = resultState->whereTheFeetAre[RIGHT_TOE];
+  int endLeftHeel = resultState->whereTheFeetAre[Foot_LeftHeel];
+  int endLeftToe = resultState->whereTheFeetAre[Foot_LeftToe];
+  int endRightHeel = resultState->whereTheFeetAre[Foot_RightHeel];
+  int endRightToe = resultState->whereTheFeetAre[Foot_RightToe];
 
   if (endLeftToe == INVALID_COLUMN) {
     endLeftToe = endLeftHeel;
@@ -340,10 +340,10 @@ float StepParityCost::calcSpinCosts(
     State* initialState, State* resultState, int columnCount) {
   float cost = 0;
 
-  int endLeftHeel = resultState->whereTheFeetAre[LEFT_HEEL];
-  int endLeftToe = resultState->whereTheFeetAre[LEFT_TOE];
-  int endRightHeel = resultState->whereTheFeetAre[RIGHT_HEEL];
-  int endRightToe = resultState->whereTheFeetAre[RIGHT_TOE];
+  int endLeftHeel = resultState->whereTheFeetAre[Foot_LeftHeel];
+  int endLeftToe = resultState->whereTheFeetAre[Foot_LeftToe];
+  int endRightHeel = resultState->whereTheFeetAre[Foot_RightHeel];
+  int endRightToe = resultState->whereTheFeetAre[Foot_RightToe];
 
   if (endLeftToe == INVALID_COLUMN) {
     endLeftToe = endLeftHeel;
@@ -354,11 +354,11 @@ float StepParityCost::calcSpinCosts(
 
   // spin
   StagePoint previousLeftPos = layout->averagePoint(
-      initialState->whereTheFeetAre[LEFT_HEEL],
-      initialState->whereTheFeetAre[LEFT_TOE]);
+      initialState->whereTheFeetAre[Foot_LeftHeel],
+      initialState->whereTheFeetAre[Foot_LeftToe]);
   StagePoint previousRightPos = layout->averagePoint(
-      initialState->whereTheFeetAre[RIGHT_HEEL],
-      initialState->whereTheFeetAre[RIGHT_TOE]);
+      initialState->whereTheFeetAre[Foot_RightHeel],
+      initialState->whereTheFeetAre[Foot_RightToe]);
   StagePoint leftPos = layout->averagePoint(endLeftHeel, endLeftToe);
   StagePoint rightPos = layout->averagePoint(endRightHeel, endRightToe);
 
@@ -392,7 +392,8 @@ float StepParityCost::calcFootswitchCost(
   float timeScaled = elapsedTime - SLOW_FOOTSWITCH_THRESHOLD;
 
   for (int i = 0; i < columnCount; i++) {
-    if (initialState->combinedColumns[i] == NONE || columns[i] == NONE) {
+    if (initialState->combinedColumns[i] == Foot_None ||
+        columns[i] == Foot_None) {
       continue;
     }
 
@@ -411,8 +412,9 @@ float StepParityCost::calcSideswitchCost(
     int columnCount) {
   float cost = 0;
   for (auto c : layout->sideArrows) {
-    if (initialState->combinedColumns[c] != columns[c] && columns[c] != NONE &&
-        initialState->combinedColumns[c] != NONE &&
+    if (initialState->combinedColumns[c] != columns[c] &&
+        columns[c] != Foot_None &&
+        initialState->combinedColumns[c] != Foot_None &&
         !resultState->didTheFootMove[initialState->combinedColumns[c]]) {
       cost += SIDESWITCH;
     }
@@ -486,17 +488,17 @@ bool StepParityCost::didDoubleStep(
   Row& row = rows[rowIndex];
   bool doublestepped = false;
   if (movedLeft && !jackedLeft &&
-      ((initialState->didTheFootMove[LEFT_HEEL] &&
-        !initialState->isTheFootHolding[LEFT_HEEL]) ||
-       (initialState->didTheFootMove[LEFT_TOE] &&
-        !initialState->isTheFootHolding[LEFT_TOE]))) {
+      ((initialState->didTheFootMove[Foot_LeftHeel] &&
+        !initialState->isTheFootHolding[Foot_LeftHeel]) ||
+       (initialState->didTheFootMove[Foot_LeftToe] &&
+        !initialState->isTheFootHolding[Foot_LeftToe]))) {
     doublestepped = true;
   }
   if (movedRight && !jackedRight &&
-      ((initialState->didTheFootMove[RIGHT_HEEL] &&
-        !initialState->isTheFootHolding[RIGHT_HEEL]) ||
-       (initialState->didTheFootMove[RIGHT_TOE] &&
-        !initialState->isTheFootHolding[RIGHT_TOE]))) {
+      ((initialState->didTheFootMove[Foot_RightHeel] &&
+        !initialState->isTheFootHolding[Foot_RightHeel]) ||
+       (initialState->didTheFootMove[Foot_RightToe] &&
+        !initialState->isTheFootHolding[Foot_RightToe]))) {
     doublestepped = true;
   }
 
@@ -529,21 +531,21 @@ bool StepParityCost::didJackLeft(
   bool jackedLeft = false;
   if (!didJump && movedLeft) {
     if (leftHeel > INVALID_COLUMN &&
-        initialState->combinedColumns[leftHeel] == LEFT_HEEL &&
-        !resultState->isTheFootHolding[LEFT_HEEL] &&
-        ((initialState->didTheFootMove[LEFT_HEEL] &&
-          !initialState->isTheFootHolding[LEFT_HEEL]) ||
-         (initialState->didTheFootMove[LEFT_TOE] &&
-          !initialState->isTheFootHolding[LEFT_TOE]))) {
+        initialState->combinedColumns[leftHeel] == Foot_LeftHeel &&
+        !resultState->isTheFootHolding[Foot_LeftHeel] &&
+        ((initialState->didTheFootMove[Foot_LeftHeel] &&
+          !initialState->isTheFootHolding[Foot_LeftHeel]) ||
+         (initialState->didTheFootMove[Foot_LeftToe] &&
+          !initialState->isTheFootHolding[Foot_LeftToe]))) {
       jackedLeft = true;
     }
     if (leftToe > INVALID_COLUMN &&
-        initialState->combinedColumns[leftToe] == LEFT_TOE &&
-        !resultState->isTheFootHolding[LEFT_TOE] &&
-        ((initialState->didTheFootMove[LEFT_HEEL] &&
-          !initialState->isTheFootHolding[LEFT_HEEL]) ||
-         (initialState->didTheFootMove[LEFT_TOE] &&
-          !initialState->isTheFootHolding[LEFT_TOE]))) {
+        initialState->combinedColumns[leftToe] == Foot_LeftToe &&
+        !resultState->isTheFootHolding[Foot_LeftToe] &&
+        ((initialState->didTheFootMove[Foot_LeftHeel] &&
+          !initialState->isTheFootHolding[Foot_LeftHeel]) ||
+         (initialState->didTheFootMove[Foot_LeftToe] &&
+          !initialState->isTheFootHolding[Foot_LeftToe]))) {
       jackedLeft = true;
     }
   }
@@ -556,21 +558,21 @@ bool StepParityCost::didJackRight(
   bool jackedRight = false;
   if (!didJump && movedRight) {
     if (rightHeel > INVALID_COLUMN &&
-        initialState->combinedColumns[rightHeel] == RIGHT_HEEL &&
-        !resultState->isTheFootHolding[RIGHT_HEEL] &&
-        ((initialState->didTheFootMove[RIGHT_HEEL] &&
-          !initialState->isTheFootHolding[RIGHT_HEEL]) ||
-         (initialState->didTheFootMove[RIGHT_TOE] &&
-          !initialState->isTheFootHolding[RIGHT_TOE]))) {
+        initialState->combinedColumns[rightHeel] == Foot_RightHeel &&
+        !resultState->isTheFootHolding[Foot_RightHeel] &&
+        ((initialState->didTheFootMove[Foot_RightHeel] &&
+          !initialState->isTheFootHolding[Foot_RightHeel]) ||
+         (initialState->didTheFootMove[Foot_RightToe] &&
+          !initialState->isTheFootHolding[Foot_RightToe]))) {
       jackedRight = true;
     }
     if (rightToe > INVALID_COLUMN &&
-        initialState->combinedColumns[rightToe] == RIGHT_TOE &&
-        !resultState->isTheFootHolding[RIGHT_TOE] &&
-        ((initialState->didTheFootMove[RIGHT_HEEL] &&
-          !initialState->isTheFootHolding[RIGHT_HEEL]) ||
-         (initialState->didTheFootMove[RIGHT_TOE] &&
-          !initialState->isTheFootHolding[RIGHT_TOE]))) {
+        initialState->combinedColumns[rightToe] == Foot_RightToe &&
+        !resultState->isTheFootHolding[Foot_RightToe] &&
+        ((initialState->didTheFootMove[Foot_RightHeel] &&
+          !initialState->isTheFootHolding[Foot_RightHeel]) ||
+         (initialState->didTheFootMove[Foot_RightToe] &&
+          !initialState->isTheFootHolding[Foot_RightToe]))) {
       jackedRight = true;
     }
   }

--- a/src/StepParityCost.cpp
+++ b/src/StepParityCost.cpp
@@ -102,7 +102,8 @@ float StepParityCost::calcMineCost(
   float cost = 0;
 
   for (int i = 0; i < columnCount; i++) {
-    if (resultState->combinedColumns[i] != Foot_None && (row.mines[i] != 0 || row.fakeMines[i] != 0)) {
+    if (resultState->combinedColumns[i] != Foot_None &&
+        (row.mines[i] != 0 || row.fakeMines[i] != 0)) {
       cost += MINE;
       break;
     }

--- a/src/StepParityCost.cpp
+++ b/src/StepParityCost.cpp
@@ -30,27 +30,27 @@ float StepParityCost::getActionCost(
   float cost = 0;
 
   // Mine weighting
-  int leftHeel = resultState->whatNoteTheFootIsHitting[LEFT_HEEL];
-  int leftToe = resultState->whatNoteTheFootIsHitting[LEFT_TOE];
-  int rightHeel = resultState->whatNoteTheFootIsHitting[RIGHT_HEEL];
-  int rightToe = resultState->whatNoteTheFootIsHitting[RIGHT_TOE];
+  int leftHeel = resultState->whatNoteTheFootIsHitting[Foot_LeftHeel];
+  int leftToe = resultState->whatNoteTheFootIsHitting[Foot_LeftToe];
+  int rightHeel = resultState->whatNoteTheFootIsHitting[Foot_RightHeel];
+  int rightToe = resultState->whatNoteTheFootIsHitting[Foot_RightToe];
 
-  bool movedLeft = resultState->didTheFootMove[LEFT_HEEL] ||
-                   resultState->didTheFootMove[LEFT_TOE];
+  bool movedLeft = resultState->didTheFootMove[Foot_LeftHeel] ||
+                   resultState->didTheFootMove[Foot_LeftToe];
 
-  bool movedRight = resultState->didTheFootMove[RIGHT_HEEL] ||
-                    resultState->didTheFootMove[RIGHT_TOE];
+  bool movedRight = resultState->didTheFootMove[Foot_RightHeel] ||
+                    resultState->didTheFootMove[Foot_RightToe];
 
   // Note that this is checking whether the previous state was a jump, not
   // whether the current state is
-  bool didJump = ((initialState->didTheFootMove[LEFT_HEEL] &&
-                   !initialState->isTheFootHolding[LEFT_HEEL]) ||
-                  (initialState->didTheFootMove[LEFT_TOE] &&
-                   !initialState->isTheFootHolding[LEFT_TOE])) &&
-                 ((initialState->didTheFootMove[RIGHT_HEEL] &&
-                   !initialState->isTheFootHolding[RIGHT_HEEL]) ||
-                  (initialState->didTheFootMove[RIGHT_TOE] &&
-                   !initialState->isTheFootHolding[RIGHT_TOE]));
+  bool didJump = ((initialState->didTheFootMove[Foot_LeftHeel] &&
+                   !initialState->isTheFootHolding[Foot_LeftHeel]) ||
+                  (initialState->didTheFootMove[Foot_LeftToe] &&
+                   !initialState->isTheFootHolding[Foot_LeftToe])) &&
+                 ((initialState->didTheFootMove[Foot_RightHeel] &&
+                   !initialState->isTheFootHolding[Foot_RightHeel]) ||
+                  (initialState->didTheFootMove[Foot_RightToe] &&
+                   !initialState->isTheFootHolding[Foot_RightToe]));
 
   bool jackedLeft = didJackLeft(
       initialState, resultState, leftHeel, leftToe, movedLeft, didJump,
@@ -102,8 +102,7 @@ float StepParityCost::calcMineCost(
   float cost = 0;
 
   for (int i = 0; i < columnCount; i++) {
-    if (resultState->combinedColumns[i] != NONE &&
-        (row.mines[i] != 0 || row.fakeMines[i] != 0)) {
+    if (resultState->combinedColumns[i] != Foot_None && (row.mines[i] != 0 || row.fakeMines[i] != 0)) {
       cost += MINE;
       break;
     }
@@ -128,14 +127,14 @@ float StepParityCost::calcHoldSwitchCost(
     if (row.holds[c].type == TapNoteType_Empty) {
       continue;
     }
-    if (((resultState->combinedColumns[c] == LEFT_HEEL ||
-          resultState->combinedColumns[c] == LEFT_TOE) &&
-         initialState->combinedColumns[c] != LEFT_TOE &&
-         initialState->combinedColumns[c] != LEFT_HEEL) ||
-        ((resultState->combinedColumns[c] == RIGHT_HEEL ||
-          resultState->combinedColumns[c] == RIGHT_TOE) &&
-         initialState->combinedColumns[c] != RIGHT_TOE &&
-         initialState->combinedColumns[c] != RIGHT_HEEL)) {
+    if (((resultState->combinedColumns[c] == Foot_LeftHeel ||
+          resultState->combinedColumns[c] == Foot_LeftToe) &&
+         initialState->combinedColumns[c] != Foot_LeftToe &&
+         initialState->combinedColumns[c] != Foot_LeftHeel) ||
+        ((resultState->combinedColumns[c] == Foot_RightHeel ||
+          resultState->combinedColumns[c] == Foot_RightToe) &&
+         initialState->combinedColumns[c] != Foot_RightToe &&
+         initialState->combinedColumns[c] != Foot_RightHeel)) {
       int previousFoot =
           initialState->whereTheFeetAre[resultState->combinedColumns[c]];
       cost += HOLDSWITCH * (previousFoot == INVALID_COLUMN
@@ -166,8 +165,8 @@ float StepParityCost::calcBracketTapCost(
   float cost = 0;
   if (leftHeel != INVALID_COLUMN && leftToe != INVALID_COLUMN) {
     float jackPenalty = 1;
-    if (initialState->didTheFootMove[LEFT_HEEL] ||
-        initialState->didTheFootMove[LEFT_TOE]) {
+    if (initialState->didTheFootMove[Foot_LeftHeel] ||
+        initialState->didTheFootMove[Foot_LeftToe]) {
       jackPenalty = 1 / elapsedTime;
     }
     if (row.holds[leftHeel].type != TapNoteType_Empty &&
@@ -182,8 +181,8 @@ float StepParityCost::calcBracketTapCost(
 
   if (rightHeel != INVALID_COLUMN && rightToe != INVALID_COLUMN) {
     float jackPenalty = 1;
-    if (initialState->didTheFootMove[RIGHT_TOE] ||
-        initialState->didTheFootMove[RIGHT_HEEL]) {
+    if (initialState->didTheFootMove[Foot_RightToe] ||
+        initialState->didTheFootMove[Foot_RightHeel]) {
       jackPenalty = 1 / elapsedTime;
     }
 
@@ -208,13 +207,13 @@ float StepParityCost::calcBracketJackCost(
   }
   float cost = 0;
 
-  if (jackedLeft && resultState->didTheFootMove[LEFT_HEEL] &&
-      resultState->didTheFootMove[LEFT_TOE]) {
+  if (jackedLeft && resultState->didTheFootMove[Foot_LeftHeel] &&
+      resultState->didTheFootMove[Foot_LeftToe]) {
     cost += BRACKETJACK;
   }
 
-  if (jackedRight && resultState->didTheFootMove[RIGHT_HEEL] &&
-      resultState->didTheFootMove[RIGHT_TOE]) {
+  if (jackedRight && resultState->didTheFootMove[Foot_RightHeel] &&
+      resultState->didTheFootMove[Foot_RightToe]) {
     cost += BRACKETJACK;
   }
   return cost;
@@ -275,10 +274,10 @@ float StepParityCost::calcSlowBracketCost(
 // we even get to calculating costs.
 float StepParityCost::calcTwistedFootCost(State* resultState) {
   float cost = 0;
-  int leftHeel = resultState->whatNoteTheFootIsHitting[LEFT_HEEL];
-  int leftToe = resultState->whatNoteTheFootIsHitting[LEFT_TOE];
-  int rightHeel = resultState->whatNoteTheFootIsHitting[RIGHT_HEEL];
-  int rightToe = resultState->whatNoteTheFootIsHitting[RIGHT_TOE];
+  int leftHeel = resultState->whatNoteTheFootIsHitting[Foot_LeftHeel];
+  int leftToe = resultState->whatNoteTheFootIsHitting[Foot_LeftToe];
+  int rightHeel = resultState->whatNoteTheFootIsHitting[Foot_RightHeel];
+  int rightToe = resultState->whatNoteTheFootIsHitting[Foot_RightToe];
 
   StagePoint leftPos = layout->averagePoint(leftHeel, leftToe);
   StagePoint rightPos = layout->averagePoint(rightHeel, rightToe);
@@ -311,10 +310,10 @@ float StepParityCost::calcMissedFootswitchCost(
 
 float StepParityCost::calcFacingCosts(
     State* initialState, State* resultState, int columnCount) {
-  int endLeftHeel = resultState->whereTheFeetAre[LEFT_HEEL];
-  int endLeftToe = resultState->whereTheFeetAre[LEFT_TOE];
-  int endRightHeel = resultState->whereTheFeetAre[RIGHT_HEEL];
-  int endRightToe = resultState->whereTheFeetAre[RIGHT_TOE];
+  int endLeftHeel = resultState->whereTheFeetAre[Foot_LeftHeel];
+  int endLeftToe = resultState->whereTheFeetAre[Foot_LeftToe];
+  int endRightHeel = resultState->whereTheFeetAre[Foot_RightHeel];
+  int endRightToe = resultState->whereTheFeetAre[Foot_RightToe];
 
   if (endLeftToe == INVALID_COLUMN) {
     endLeftToe = endLeftHeel;
@@ -341,10 +340,10 @@ float StepParityCost::calcSpinCosts(
     State* initialState, State* resultState, int columnCount) {
   float cost = 0;
 
-  int endLeftHeel = resultState->whereTheFeetAre[LEFT_HEEL];
-  int endLeftToe = resultState->whereTheFeetAre[LEFT_TOE];
-  int endRightHeel = resultState->whereTheFeetAre[RIGHT_HEEL];
-  int endRightToe = resultState->whereTheFeetAre[RIGHT_TOE];
+  int endLeftHeel = resultState->whereTheFeetAre[Foot_LeftHeel];
+  int endLeftToe = resultState->whereTheFeetAre[Foot_LeftToe];
+  int endRightHeel = resultState->whereTheFeetAre[Foot_RightHeel];
+  int endRightToe = resultState->whereTheFeetAre[Foot_RightToe];
 
   if (endLeftToe == INVALID_COLUMN) {
     endLeftToe = endLeftHeel;
@@ -355,11 +354,11 @@ float StepParityCost::calcSpinCosts(
 
   // spin
   StagePoint previousLeftPos = layout->averagePoint(
-      initialState->whereTheFeetAre[LEFT_HEEL],
-      initialState->whereTheFeetAre[LEFT_TOE]);
+      initialState->whereTheFeetAre[Foot_LeftHeel],
+      initialState->whereTheFeetAre[Foot_LeftToe]);
   StagePoint previousRightPos = layout->averagePoint(
-      initialState->whereTheFeetAre[RIGHT_HEEL],
-      initialState->whereTheFeetAre[RIGHT_TOE]);
+      initialState->whereTheFeetAre[Foot_RightHeel],
+      initialState->whereTheFeetAre[Foot_RightToe]);
   StagePoint leftPos = layout->averagePoint(endLeftHeel, endLeftToe);
   StagePoint rightPos = layout->averagePoint(endRightHeel, endRightToe);
 
@@ -393,7 +392,8 @@ float StepParityCost::calcFootswitchCost(
   float timeScaled = elapsedTime - SLOW_FOOTSWITCH_THRESHOLD;
 
   for (int i = 0; i < columnCount; i++) {
-    if (initialState->combinedColumns[i] == NONE || columns[i] == NONE) {
+    if (initialState->combinedColumns[i] == Foot_None ||
+        columns[i] == Foot_None) {
       continue;
     }
 
@@ -412,8 +412,9 @@ float StepParityCost::calcSideswitchCost(
     int columnCount) {
   float cost = 0;
   for (auto c : layout->sideArrows) {
-    if (initialState->combinedColumns[c] != columns[c] && columns[c] != NONE &&
-        initialState->combinedColumns[c] != NONE &&
+    if (initialState->combinedColumns[c] != columns[c] &&
+        columns[c] != Foot_None &&
+        initialState->combinedColumns[c] != Foot_None &&
         !resultState->didTheFootMove[initialState->combinedColumns[c]]) {
       cost += SIDESWITCH;
     }
@@ -487,17 +488,17 @@ bool StepParityCost::didDoubleStep(
   Row& row = rows[rowIndex];
   bool doublestepped = false;
   if (movedLeft && !jackedLeft &&
-      ((initialState->didTheFootMove[LEFT_HEEL] &&
-        !initialState->isTheFootHolding[LEFT_HEEL]) ||
-       (initialState->didTheFootMove[LEFT_TOE] &&
-        !initialState->isTheFootHolding[LEFT_TOE]))) {
+      ((initialState->didTheFootMove[Foot_LeftHeel] &&
+        !initialState->isTheFootHolding[Foot_LeftHeel]) ||
+       (initialState->didTheFootMove[Foot_LeftToe] &&
+        !initialState->isTheFootHolding[Foot_LeftToe]))) {
     doublestepped = true;
   }
   if (movedRight && !jackedRight &&
-      ((initialState->didTheFootMove[RIGHT_HEEL] &&
-        !initialState->isTheFootHolding[RIGHT_HEEL]) ||
-       (initialState->didTheFootMove[RIGHT_TOE] &&
-        !initialState->isTheFootHolding[RIGHT_TOE]))) {
+      ((initialState->didTheFootMove[Foot_RightHeel] &&
+        !initialState->isTheFootHolding[Foot_RightHeel]) ||
+       (initialState->didTheFootMove[Foot_RightToe] &&
+        !initialState->isTheFootHolding[Foot_RightToe]))) {
     doublestepped = true;
   }
 
@@ -530,21 +531,21 @@ bool StepParityCost::didJackLeft(
   bool jackedLeft = false;
   if (!didJump && movedLeft) {
     if (leftHeel > INVALID_COLUMN &&
-        initialState->combinedColumns[leftHeel] == LEFT_HEEL &&
-        !resultState->isTheFootHolding[LEFT_HEEL] &&
-        ((initialState->didTheFootMove[LEFT_HEEL] &&
-          !initialState->isTheFootHolding[LEFT_HEEL]) ||
-         (initialState->didTheFootMove[LEFT_TOE] &&
-          !initialState->isTheFootHolding[LEFT_TOE]))) {
+        initialState->combinedColumns[leftHeel] == Foot_LeftHeel &&
+        !resultState->isTheFootHolding[Foot_LeftHeel] &&
+        ((initialState->didTheFootMove[Foot_LeftHeel] &&
+          !initialState->isTheFootHolding[Foot_LeftHeel]) ||
+         (initialState->didTheFootMove[Foot_LeftToe] &&
+          !initialState->isTheFootHolding[Foot_LeftToe]))) {
       jackedLeft = true;
     }
     if (leftToe > INVALID_COLUMN &&
-        initialState->combinedColumns[leftToe] == LEFT_TOE &&
-        !resultState->isTheFootHolding[LEFT_TOE] &&
-        ((initialState->didTheFootMove[LEFT_HEEL] &&
-          !initialState->isTheFootHolding[LEFT_HEEL]) ||
-         (initialState->didTheFootMove[LEFT_TOE] &&
-          !initialState->isTheFootHolding[LEFT_TOE]))) {
+        initialState->combinedColumns[leftToe] == Foot_LeftToe &&
+        !resultState->isTheFootHolding[Foot_LeftToe] &&
+        ((initialState->didTheFootMove[Foot_LeftHeel] &&
+          !initialState->isTheFootHolding[Foot_LeftHeel]) ||
+         (initialState->didTheFootMove[Foot_LeftToe] &&
+          !initialState->isTheFootHolding[Foot_LeftToe]))) {
       jackedLeft = true;
     }
   }
@@ -557,21 +558,21 @@ bool StepParityCost::didJackRight(
   bool jackedRight = false;
   if (!didJump && movedRight) {
     if (rightHeel > INVALID_COLUMN &&
-        initialState->combinedColumns[rightHeel] == RIGHT_HEEL &&
-        !resultState->isTheFootHolding[RIGHT_HEEL] &&
-        ((initialState->didTheFootMove[RIGHT_HEEL] &&
-          !initialState->isTheFootHolding[RIGHT_HEEL]) ||
-         (initialState->didTheFootMove[RIGHT_TOE] &&
-          !initialState->isTheFootHolding[RIGHT_TOE]))) {
+        initialState->combinedColumns[rightHeel] == Foot_RightHeel &&
+        !resultState->isTheFootHolding[Foot_RightHeel] &&
+        ((initialState->didTheFootMove[Foot_RightHeel] &&
+          !initialState->isTheFootHolding[Foot_RightHeel]) ||
+         (initialState->didTheFootMove[Foot_RightToe] &&
+          !initialState->isTheFootHolding[Foot_RightToe]))) {
       jackedRight = true;
     }
     if (rightToe > INVALID_COLUMN &&
-        initialState->combinedColumns[rightToe] == RIGHT_TOE &&
-        !resultState->isTheFootHolding[RIGHT_TOE] &&
-        ((initialState->didTheFootMove[RIGHT_HEEL] &&
-          !initialState->isTheFootHolding[RIGHT_HEEL]) ||
-         (initialState->didTheFootMove[RIGHT_TOE] &&
-          !initialState->isTheFootHolding[RIGHT_TOE]))) {
+        initialState->combinedColumns[rightToe] == Foot_RightToe &&
+        !resultState->isTheFootHolding[Foot_RightToe] &&
+        ((initialState->didTheFootMove[Foot_RightHeel] &&
+          !initialState->isTheFootHolding[Foot_RightHeel]) ||
+         (initialState->didTheFootMove[Foot_RightToe] &&
+          !initialState->isTheFootHolding[Foot_RightToe]))) {
       jackedRight = true;
     }
   }

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -9,9 +9,21 @@
 #include <intrin.h>
 #endif
 
+#include "EnumHelper.h"
+#include "LocalizedString.h"
+#include "LuaBinding.h"
 #include "NoteTypes.h"
 
 using namespace StepParity;
+
+static const char* FootNames[] = {
+    "None", "LeftHeel", "LeftToe", "RightHeel", "RightToe"};
+
+XToString(Foot);
+XToLocalizedString(Foot);
+LuaFunction(
+    FootToLocalizedString, FootToLocalizedString(Enum::Check<Foot>(L, 1)));
+LuaXType(Foot);
 
 bool State::operator==(const State& other) const {
   return combined_mask == other.combined_mask &&
@@ -191,7 +203,7 @@ void StageLayout::preGeneratePermutations() {
     if (bits > 4) {
       continue;
     }
-    FootPlacement blankColumns(columnCount, NONE);
+    FootPlacement blankColumns(columnCount, Foot_None);
 
     std::vector<FootPlacement> placements =
         PermuteFootPlacements(i, blankColumns, 0);
@@ -212,19 +224,19 @@ std::vector<FootPlacement> StageLayout::PermuteFootPlacements(
     int rightToeIndex = StepParity::INVALID_COLUMN;
 
     for (unsigned long i = 0; i < test_columns.size(); i++) {
-      if (test_columns[i] == NONE) {
+      if (test_columns[i] == Foot_None) {
         continue;
       }
-      if (test_columns[i] == LEFT_HEEL) {
+      if (test_columns[i] == Foot_LeftHeel) {
         leftHeelIndex = i;
       }
-      if (test_columns[i] == LEFT_TOE) {
+      if (test_columns[i] == Foot_LeftToe) {
         leftToeIndex = i;
       }
-      if (test_columns[i] == RIGHT_HEEL) {
+      if (test_columns[i] == Foot_RightHeel) {
         rightHeelIndex = i;
       }
-      if (test_columns[i] == RIGHT_TOE) {
+      if (test_columns[i] == Foot_RightToe) {
         rightToeIndex = i;
       }
     }

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -9,9 +9,21 @@
 #include <intrin.h>
 #endif
 
+#include "EnumHelper.h"
+#include "LocalizedString.h"
+#include "LuaBinding.h"
 #include "NoteTypes.h"
 
 using namespace StepParity;
+
+static const char* FootNames[] = {
+    "None", "LeftHeel", "LeftToe", "RightHeel", "RightToe"};
+
+XToString(Foot);
+XToLocalizedString(Foot);
+LuaFunction(
+    FootToLocalizedString, FootToLocalizedString(Enum::Check<Foot>(L, 1)));
+LuaXType(Foot);
 
 bool State::operator==(const State& other) const {
   return combined_mask == other.combined_mask &&
@@ -188,7 +200,7 @@ void StageLayout::preGeneratePermutations() {
     if (bits > 4) {
       continue;
     }
-    FootPlacement blankColumns(columnCount, NONE);
+    FootPlacement blankColumns(columnCount, Foot_None);
 
     std::vector<FootPlacement> placements =
         PermuteFootPlacements(i, blankColumns, 0);
@@ -209,19 +221,19 @@ std::vector<FootPlacement> StageLayout::PermuteFootPlacements(
     int rightToeIndex = StepParity::INVALID_COLUMN;
 
     for (unsigned long i = 0; i < test_columns.size(); i++) {
-      if (test_columns[i] == NONE) {
+      if (test_columns[i] == Foot_None) {
         continue;
       }
-      if (test_columns[i] == LEFT_HEEL) {
+      if (test_columns[i] == Foot_LeftHeel) {
         leftHeelIndex = i;
       }
-      if (test_columns[i] == LEFT_TOE) {
+      if (test_columns[i] == Foot_LeftToe) {
         leftToeIndex = i;
       }
-      if (test_columns[i] == RIGHT_HEEL) {
+      if (test_columns[i] == Foot_RightHeel) {
         rightHeelIndex = i;
       }
-      if (test_columns[i] == RIGHT_TOE) {
+      if (test_columns[i] == Foot_RightToe) {
         rightToeIndex = i;
       }
     }

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -16,7 +16,15 @@ const int INVALID_COLUMN = -1;
 const float CLM_SECOND_INVALID = -1;
 const int MAX_COLUMNS = 16;
 
-enum Foot { NONE = 0, LEFT_HEEL, LEFT_TOE, RIGHT_HEEL, RIGHT_TOE, NUM_Foot };
+enum Foot {
+  Foot_None = 0,
+  Foot_LeftHeel,
+  Foot_LeftToe,
+  Foot_RightHeel,
+  Foot_RightToe,
+  NUM_Foot,
+  Foot_Invalid
+};
 
 /// @brief A vector of Foot values, which represents the player's
 /// foot placement on the dance stage.
@@ -25,22 +33,17 @@ typedef std::vector<Foot> FootPlacement;
 const std::vector<uint16_t> FOOT_MASKS = {0, 1, 2, 4, 8};
 
 const int16_t FOOT_MASK_LEFT =
-    FOOT_MASKS[Foot::LEFT_HEEL] | FOOT_MASKS[Foot::LEFT_TOE];
+    FOOT_MASKS[Foot::Foot_LeftHeel] | FOOT_MASKS[Foot::Foot_LeftToe];
 const int16_t FOOT_MASK_RIGHT =
-    FOOT_MASKS[Foot::RIGHT_HEEL] | FOOT_MASKS[Foot::RIGHT_TOE];
+    FOOT_MASKS[Foot::Foot_RightHeel] | FOOT_MASKS[Foot::Foot_RightToe];
 
 const std::array<StepParity::Foot, 4> FEET = {
-    LEFT_HEEL, LEFT_TOE, RIGHT_HEEL, RIGHT_TOE};
+    Foot_LeftHeel, Foot_LeftToe, Foot_RightHeel, Foot_RightToe};
 // A map for getting the other part of the foot, when you don't actually care
 // what part it is.
 // OTHER_PART_OF_FOOT[LEFT_HEEL] == LEFT_TOE
 const std::array<StepParity::Foot, 5> OTHER_PART_OF_FOOT = {
-    NONE, LEFT_TOE, LEFT_HEEL, RIGHT_TOE, RIGHT_HEEL};
-
-const std::string FEET_LABELS[] = {"N", "L", "l", "R", "r", "5??", "6??"};
-const std::string TapNoteTypeShortNames[] = {
-    "Empty", "Tap", "Mine", "Attack", "AutoKeySound", "Fake", "", ""};
-const std::string TapNoteSubTypeShortNames[] = {"Hold", "Roll", "", ""};
+    Foot_None, Foot_LeftToe, Foot_LeftHeel, Foot_RightToe, Foot_RightHeel};
 
 enum Cost {
   COST_DOUBLESTEP = 0,
@@ -156,8 +159,8 @@ struct IntermediateNoteData {
   bool fake = false;     // Is this note fake (besides being TapNoteType_Fake)?
   float second = false;  // time into the song on which the note occurs
 
-  Foot parity =
-      NONE;  // Which foot (and which part of the foot) will most likely be used
+  Foot parity = Foot_None;  // Which foot (and which part of the foot) will most
+                            // likely be used
 };
 
 /// @brief A slightly complicated structure to encapsulate all of the data for a
@@ -200,7 +203,7 @@ struct Row {
     holds = std::vector<IntermediateNoteData>(columnCount);
     mines = std::vector<float>(columnCount, 0);
     fakeMines = std::vector<float>(columnCount, 0);
-    columns = std::vector<StepParity::Foot>(columnCount, StepParity::NONE);
+    columns = std::vector<StepParity::Foot>(columnCount, StepParity::Foot_None);
     whereTheFeetAre = std::vector<int>(StepParity::NUM_Foot, INVALID_COLUMN);
   }
 

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -16,7 +16,15 @@ const int INVALID_COLUMN = -1;
 const float CLM_SECOND_INVALID = -1;
 const int MAX_COLUMNS = 16;
 
-enum Foot { NONE = 0, LEFT_HEEL, LEFT_TOE, RIGHT_HEEL, RIGHT_TOE, NUM_Foot };
+enum Foot {
+  Foot_None = 0,
+  Foot_LeftHeel,
+  Foot_LeftToe,
+  Foot_RightHeel,
+  Foot_RightToe,
+  NUM_Foot,
+  Foot_Invalid
+};
 
 /// @brief A vector of Foot values, which represents the player's
 /// foot placement on the dance stage.
@@ -25,22 +33,17 @@ typedef std::vector<Foot> FootPlacement;
 const std::vector<uint16_t> FOOT_MASKS = {0, 1, 2, 4, 8};
 
 const int16_t FOOT_MASK_LEFT =
-    FOOT_MASKS[Foot::LEFT_HEEL] | FOOT_MASKS[Foot::LEFT_TOE];
+    FOOT_MASKS[Foot::Foot_LeftHeel] | FOOT_MASKS[Foot::Foot_LeftToe];
 const int16_t FOOT_MASK_RIGHT =
-    FOOT_MASKS[Foot::RIGHT_HEEL] | FOOT_MASKS[Foot::RIGHT_TOE];
+    FOOT_MASKS[Foot::Foot_RightHeel] | FOOT_MASKS[Foot::Foot_RightToe];
 
 const std::array<StepParity::Foot, 4> FEET = {
-    LEFT_HEEL, LEFT_TOE, RIGHT_HEEL, RIGHT_TOE};
+    Foot_LeftHeel, Foot_LeftToe, Foot_RightHeel, Foot_RightToe};
 // A map for getting the other part of the foot, when you don't actually care
 // what part it is.
 // OTHER_PART_OF_FOOT[LEFT_HEEL] == LEFT_TOE
 const std::array<StepParity::Foot, 5> OTHER_PART_OF_FOOT = {
-    NONE, LEFT_TOE, LEFT_HEEL, RIGHT_TOE, RIGHT_HEEL};
-
-const std::string FEET_LABELS[] = {"N", "L", "l", "R", "r", "5??", "6??"};
-const std::string TapNoteTypeShortNames[] = {
-    "Empty", "Tap", "Mine", "Attack", "AutoKeySound", "Fake", "", ""};
-const std::string TapNoteSubTypeShortNames[] = {"Hold", "Roll", "", ""};
+    Foot_None, Foot_LeftToe, Foot_LeftHeel, Foot_RightToe, Foot_RightHeel};
 
 enum Cost {
   COST_DOUBLESTEP = 0,
@@ -156,8 +159,8 @@ struct IntermediateNoteData {
   bool fake = false;    // Is this note fake (besides being TapNoteType_Fake)?
   float second = 0;     // time into the song on which the note occurs
 
-  Foot parity =
-      NONE;  // Which foot (and which part of the foot) will most likely be used
+  Foot parity = Foot_None;  // Which foot (and which part of the foot) will most
+                            // likely be used
 };
 
 /// @brief A slightly complicated structure to encapsulate all of the data for a
@@ -200,7 +203,7 @@ struct Row {
     holds = std::vector<IntermediateNoteData>(columnCount);
     mines = std::vector<float>(columnCount, 0);
     fakeMines = std::vector<float>(columnCount, 0);
-    columns = std::vector<StepParity::Foot>(columnCount, StepParity::NONE);
+    columns = std::vector<StepParity::Foot>(columnCount, StepParity::Foot_None);
     whereTheFeetAre = std::vector<int>(StepParity::NUM_Foot, INVALID_COLUMN);
   }
 

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -137,12 +137,12 @@ State* StepParityGenerator::initResultState(
   }
 
   for (unsigned long i = 0; i < columns.size(); i++) {
-    resultState->combinedColumns[i] = NONE;
+    resultState->combinedColumns[i] = Foot_None;
   }
 
   // I tried to condense this, but kept getting the logic messed up
   for (unsigned long i = 0; i < columns.size(); i++) {
-    if (columns[i] == NONE) {
+    if (columns[i] == Foot_None) {
       continue;
     }
     resultState->whatNoteTheFootIsHitting[columns[i]] = i;
@@ -158,7 +158,7 @@ State* StepParityGenerator::initResultState(
   }
 
   for (unsigned long i = 0; i < columns.size(); i++) {
-    if (columns[i] == NONE) {
+    if (columns[i] == Foot_None) {
       continue;
     }
 
@@ -207,32 +207,32 @@ void StepParityGenerator::mergeInitialAndResultPosition(
   for (int i = 0; i < columnCount; i++) {
     // copy in data from columns over the top which overrides it, as long as
     // it's not nothing
-    if (columns[i] != NONE) {
+    if (columns[i] != Foot_None) {
       resultState->combinedColumns[i] = columns[i];
       continue;
     }
 
     // copy in data from initialState, if it wasn't moved
-    if (initialState->combinedColumns[i] == LEFT_HEEL ||
-        initialState->combinedColumns[i] == RIGHT_HEEL) {
+    if (initialState->combinedColumns[i] == Foot_LeftHeel ||
+        initialState->combinedColumns[i] == Foot_RightHeel) {
       if (!resultState->didTheFootMove[initialState->combinedColumns[i]]) {
         resultState->combinedColumns[i] = initialState->combinedColumns[i];
       }
-    } else if (initialState->combinedColumns[i] == LEFT_TOE) {
-      if (!resultState->didTheFootMove[LEFT_TOE] &&
-          !resultState->didTheFootMove[LEFT_HEEL]) {
+    } else if (initialState->combinedColumns[i] == Foot_LeftToe) {
+      if (!resultState->didTheFootMove[Foot_LeftToe] &&
+          !resultState->didTheFootMove[Foot_LeftHeel]) {
         resultState->combinedColumns[i] = initialState->combinedColumns[i];
       }
-    } else if (initialState->combinedColumns[i] == RIGHT_TOE) {
-      if (!resultState->didTheFootMove[RIGHT_TOE] &&
-          !resultState->didTheFootMove[RIGHT_HEEL]) {
+    } else if (initialState->combinedColumns[i] == Foot_RightToe) {
+      if (!resultState->didTheFootMove[Foot_RightToe] &&
+          !resultState->didTheFootMove[Foot_RightHeel]) {
         resultState->combinedColumns[i] = initialState->combinedColumns[i];
       }
     }
   }
 
   for (int i = 0; i < columnCount; i++) {
-    if (resultState->combinedColumns[i] != NONE) {
+    if (resultState->combinedColumns[i] != Foot_None) {
       resultState->whereTheFeetAre[resultState->combinedColumns[i]] = i;
     }
     resultState->combined_mask |=

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -412,6 +412,7 @@ void Steps::CalculateTechCounts() {
   this->GetNoteData(tempNoteData);
 
   FOREACH_PlayerNumber(pn) m_CachedTechCounts[pn].Zero();
+  m_CachedNoteAnnotations.clear();
 
   const std::optional<StepParity::StageLayout> layout =
       getLayout(this->m_StepsType);
@@ -424,9 +425,16 @@ void Steps::CalculateTechCounts() {
   StepParity::StepParityGenerator gen =
       StepParity::StepParityGenerator(&*layout, timing);
   gen.analyzeNoteData(tempNoteData);
+
+  std::vector<NoteAnnotation> tempNoteAnnotations;
+
   TechCounts::CalculateTechCountsFromRows(
-      gen.rows, &*layout, m_CachedTechCounts[0]);
+      gen.rows, &*layout, m_CachedTechCounts[0], tempNoteAnnotations);
   std::fill_n(m_CachedTechCounts + 1, NUM_PLAYERS - 1, m_CachedTechCounts[0]);
+  NoteAnnotationCache cachedAnnotations;
+  cachedAnnotations.decompressed = tempNoteAnnotations;
+  cachedAnnotations.Compress();
+  m_CachedNoteAnnotations.push_back(cachedAnnotations);
 }
 
 void Steps::CalculateMeasureInfo() {
@@ -575,6 +583,10 @@ void Steps::Compress() const {
   // Don't compress data in the editor: it's still in use.
   if (GAMESTATE->m_bInStepEditor) {
     return;
+  }
+
+  for (NoteAnnotationCache annotationCache : m_CachedNoteAnnotations) {
+    annotationCache.Compress();
   }
 
   if (!m_sFilename.empty() && m_LoadedFromProfile == ProfileSlot_Invalid) {
@@ -756,6 +768,14 @@ void Steps::SetCachedTechCounts(const TechCounts ts[NUM_PLAYERS]) {
   DeAutogen();
   std::copy(ts, ts + NUM_PLAYERS, m_CachedTechCounts);
   m_bAreCachedTechCountsValuesJustLoaded = true;
+}
+
+void Steps::SetCachedNoteAnnotations(
+    std::vector<NoteAnnotationCache>& noteAnnotations) {
+  DeAutogen();
+  m_CachedNoteAnnotations.assign(
+      noteAnnotations.begin(), noteAnnotations.end());
+  m_AreCachedNoteAnnotationsJustLoaded = true;
 }
 
 void Steps::SetCachedNpsPerMeasure(
@@ -1028,6 +1048,33 @@ const std::vector<int>& Steps::GetNotesPerMeasure(PlayerNumber pn) const {
   }
 }
 
+const std::vector<NoteAnnotation>& Steps::GetNoteAnnotations(
+    PlayerNumber pn) const {
+  // m_CachedNoteAnnotations doesn't actually support couples/routine charts
+  // yet, but in the event we ever get around to implementing that, this
+  // functions the same as GetNotesPerMeasure and GetNpsPerMeasure
+
+  static const std::vector<NoteAnnotation> EMPTY_VECTOR;
+  if (Real()->m_CachedNoteAnnotations.size() == 0) {
+    return EMPTY_VECTOR;
+  } else if (Real()->m_CachedNoteAnnotations.size() <= pn) {
+    return Real()->m_CachedNoteAnnotations[PLAYER_1].GetNoteAnnotations();
+  } else {
+    return Real()->m_CachedNoteAnnotations[pn].GetNoteAnnotations();
+  }
+}
+
+const std::vector<NoteAnnotationCache>& Steps::GetNoteAnnotationCaches() const {
+  return m_CachedNoteAnnotations;
+}
+std::vector<std::vector<NoteAnnotation>> Steps::GetAllNoteAnnotations() const {
+  std::vector<std::vector<NoteAnnotation>> annotations;
+  for (NoteAnnotationCache c : m_CachedNoteAnnotations) {
+    annotations.push_back(c.GetNoteAnnotations());
+  }
+  return annotations;
+}
+
 float Steps::GetPeakNps(PlayerNumber pn) const {
   if (Real()->m_PeakNps.size() == 0) {
     return 0;
@@ -1231,6 +1278,45 @@ class LunaSteps : public Luna<Steps> {
     return 1;
   }
 
+  static int GetNoteAnnotations(T* p, lua_State* L) {
+    const std::vector<NoteAnnotation> rows = p->GetNoteAnnotations(PLAYER_1);
+
+    lua_createtable(L, static_cast<int>(rows.size()), 0);
+
+    for (unsigned i = 0; i < rows.size(); i++) {
+      lua_createtable(L, 0, 4);
+      lua_pushstring(L, "beat");
+      lua_pushnumber(L, rows[i].beat);
+      lua_settable(L, -3);
+
+      // add columns
+      lua_pushstring(L, "footPlacement");
+      lua_createtable(L, 0, 0);
+      int colIndex = 1;
+      for (StepParity::Foot f : StepParity::FEET) {
+        if (rows[i].whereTheFeetAre[f] != StepParity::INVALID_COLUMN) {
+          lua_pushnumber(L, rows[i].whereTheFeetAre[f] + 1);
+          Enum::Push(L, f);
+          lua_settable(L, -3);
+        }
+      }
+      lua_settable(L, -3);
+
+      // add tech
+      lua_pushstring(L, "tech");
+      lua_createtable(L, 0, 0);
+      int techIndex = 1;
+      for (const TechCountsCategory techVal : rows[i].tech) {
+        Enum::Push(L, techVal);
+        lua_rawseti(L, -2, techIndex++);
+      }
+      lua_settable(L, -3);
+
+      lua_rawseti(L, -2, i + 1);
+    }
+    return 1;
+  }
+
   LunaSteps() {
     ADD_METHOD(GetAuthorCredit);
     ADD_METHOD(GetChartStyle);
@@ -1266,6 +1352,7 @@ class LunaSteps : public Luna<Steps> {
     ADD_METHOD(GetPeakNps);
     ADD_METHOD(GetGrooveStatsHash);
     ADD_METHOD(GetGrooveStatsHashVersion);
+    ADD_METHOD(GetNoteAnnotations);
   }
 };
 

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -402,7 +402,7 @@ void Steps::CalculateTechCounts(const NoteData& tempNoteData) {
   TechCounts::CalculateTechCountsFromRows(
       gen.rows, &*layout, m_TechCounts[0], tempNoteAnnotations);
   std::fill_n(m_TechCounts + 1, NUM_PLAYERS - 1, m_TechCounts[0]);
-  
+
   NoteAnnotationCache cachedAnnotations;
   cachedAnnotations.decompressed = tempNoteAnnotations;
   cachedAnnotations.Compress();
@@ -712,8 +712,7 @@ void Steps::SetTechCounts(const TechCounts ts[NUM_PLAYERS]) {
 void Steps::SetNoteAnnotations(
     std::vector<NoteAnnotationCache>& noteAnnotations) {
   DeAutogen();
-  m_NoteAnnotations.assign(
-      noteAnnotations.begin(), noteAnnotations.end());
+  m_NoteAnnotations.assign(noteAnnotations.begin(), noteAnnotations.end());
 }
 
 void Steps::SetNpsPerMeasure(std::vector<std::vector<float>>& npsPerMeasure) {

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -397,8 +397,16 @@ void Steps::CalculateTechCounts(const NoteData& tempNoteData) {
   StepParity::StepParityGenerator gen =
       StepParity::StepParityGenerator(&*layout, timing);
   gen.analyzeNoteData(tempNoteData);
-  TechCounts::CalculateTechCountsFromRows(gen.rows, &*layout, m_TechCounts[0]);
+
+  std::vector<NoteAnnotation> tempNoteAnnotations;
+  TechCounts::CalculateTechCountsFromRows(
+      gen.rows, &*layout, m_TechCounts[0], tempNoteAnnotations);
   std::fill_n(m_TechCounts + 1, NUM_PLAYERS - 1, m_TechCounts[0]);
+  
+  NoteAnnotationCache cachedAnnotations;
+  cachedAnnotations.decompressed = tempNoteAnnotations;
+  cachedAnnotations.Compress();
+  m_NoteAnnotations.push_back(cachedAnnotations);
 }
 
 void Steps::CalculateMeasureInfo(const NoteData& tempNoteData) {
@@ -518,6 +526,10 @@ void Steps::Compress() const {
   // Don't compress data in the editor: it's still in use.
   if (GAMESTATE->m_bInStepEditor) {
     return;
+  }
+
+  for (NoteAnnotationCache annotationCache : m_NoteAnnotations) {
+    annotationCache.Compress();
   }
 
   if (!m_sFilename.empty() && m_LoadedFromProfile == ProfileSlot_Invalid) {
@@ -695,6 +707,13 @@ void Steps::SetRadarValues(const RadarValues v[NUM_PLAYERS]) {
 void Steps::SetTechCounts(const TechCounts ts[NUM_PLAYERS]) {
   DeAutogen();
   std::copy(ts, ts + NUM_PLAYERS, m_TechCounts);
+}
+
+void Steps::SetNoteAnnotations(
+    std::vector<NoteAnnotationCache>& noteAnnotations) {
+  DeAutogen();
+  m_NoteAnnotations.assign(
+      noteAnnotations.begin(), noteAnnotations.end());
 }
 
 void Steps::SetNpsPerMeasure(std::vector<std::vector<float>>& npsPerMeasure) {
@@ -928,7 +947,7 @@ const std::vector<float>& Steps::GetNpsPerMeasure(PlayerNumber pn) const {
 }
 
 const std::vector<int>& Steps::GetNotesPerMeasure(PlayerNumber pn) const {
-  // CachedNotesPerMeasure will only have separate sets of values per-player if
+  // m_NotesPerMeasure will only have separate sets of values per-player if
   // the steps type has different steps for each player (eg dance-couples,
   // dance-routine). Otherwise, it will only have one copy of the values (which
   // will be the case for like 99.9% of charts).
@@ -940,6 +959,33 @@ const std::vector<int>& Steps::GetNotesPerMeasure(PlayerNumber pn) const {
   } else {
     return Real()->m_NotesPerMeasure[pn];
   }
+}
+
+const std::vector<NoteAnnotation>& Steps::GetNoteAnnotations(
+    PlayerNumber pn) const {
+  // m_NoteAnnotations doesn't actually support couples/routine charts
+  // yet, but in the event we ever get around to implementing that, this
+  // functions the same as GetNotesPerMeasure and GetNpsPerMeasure
+
+  static const std::vector<NoteAnnotation> EMPTY_VECTOR;
+  if (Real()->m_NoteAnnotations.size() == 0) {
+    return EMPTY_VECTOR;
+  } else if (Real()->m_NoteAnnotations.size() <= pn) {
+    return Real()->m_NoteAnnotations[PLAYER_1].GetNoteAnnotations();
+  } else {
+    return Real()->m_NoteAnnotations[pn].GetNoteAnnotations();
+  }
+}
+
+const std::vector<NoteAnnotationCache>& Steps::GetNoteAnnotationCaches() const {
+  return m_NoteAnnotations;
+}
+std::vector<std::vector<NoteAnnotation>> Steps::GetAllNoteAnnotations() const {
+  std::vector<std::vector<NoteAnnotation>> annotations;
+  for (NoteAnnotationCache c : m_NoteAnnotations) {
+    annotations.push_back(c.GetNoteAnnotations());
+  }
+  return annotations;
 }
 
 float Steps::GetPeakNps(PlayerNumber pn) const {
@@ -1138,6 +1184,45 @@ class LunaSteps : public Luna<Steps> {
     return 1;
   }
 
+  static int GetNoteAnnotations(T* p, lua_State* L) {
+    const std::vector<NoteAnnotation> rows = p->GetNoteAnnotations(PLAYER_1);
+
+    lua_createtable(L, static_cast<int>(rows.size()), 0);
+
+    for (unsigned i = 0; i < rows.size(); i++) {
+      lua_createtable(L, 0, 4);
+      lua_pushstring(L, "beat");
+      lua_pushnumber(L, rows[i].beat);
+      lua_settable(L, -3);
+
+      // add columns
+      lua_pushstring(L, "footPlacement");
+      lua_createtable(L, 0, 0);
+      int colIndex = 1;
+      for (StepParity::Foot f : StepParity::FEET) {
+        if (rows[i].whereTheFeetAre[f] != StepParity::INVALID_COLUMN) {
+          lua_pushnumber(L, rows[i].whereTheFeetAre[f] + 1);
+          Enum::Push(L, f);
+          lua_settable(L, -3);
+        }
+      }
+      lua_settable(L, -3);
+
+      // add tech
+      lua_pushstring(L, "tech");
+      lua_createtable(L, 0, 0);
+      int techIndex = 1;
+      for (const TechCountsCategory techVal : rows[i].tech) {
+        Enum::Push(L, techVal);
+        lua_rawseti(L, -2, techIndex++);
+      }
+      lua_settable(L, -3);
+
+      lua_rawseti(L, -2, i + 1);
+    }
+    return 1;
+  }
+
   LunaSteps() {
     ADD_METHOD(GetAuthorCredit);
     ADD_METHOD(GetChartStyle);
@@ -1174,6 +1259,7 @@ class LunaSteps : public Luna<Steps> {
     ADD_METHOD(GetPeakNps);
     ADD_METHOD(GetGrooveStatsHash);
     ADD_METHOD(GetGrooveStatsHashVersion);
+    ADD_METHOD(GetNoteAnnotations);
   }
 };
 

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -9,6 +9,7 @@
 #include "Difficulty.h"
 #include "EnumHelper.h"
 #include "GameConstantsAndTypes.h"
+#include "NoteAnnotation.h"
 #include "PlayerNumber.h"
 #include "RadarValues.h"
 #include "RageUtil.h"
@@ -174,6 +175,8 @@ class Steps {
   void SetMeter(int meter);
   void SetCachedRadarValues(const RadarValues v[NUM_PLAYERS]);
   void SetCachedTechCounts(const TechCounts ts[NUM_PLAYERS]);
+  void SetCachedNoteAnnotations(
+      std::vector<NoteAnnotationCache>& noteAnnotations);
   void SetCachedNpsPerMeasure(std::vector<std::vector<float>>& npsPerMeasure);
   void SetCachedNotesPerMeasure(std::vector<std::vector<int>>& notesPerMeasure);
   void SetPeakNps(std::vector<float>& peakNps);
@@ -213,6 +216,9 @@ class Steps {
     return Real()->m_CachedTechCounts[pn];
   }
 
+  const std::vector<NoteAnnotation>& GetNoteAnnotations(PlayerNumber pn) const;
+  const std::vector<NoteAnnotationCache>& GetNoteAnnotationCaches() const;
+  std::vector<std::vector<NoteAnnotation>> GetAllNoteAnnotations() const;
   void CalculateMeasureInfo();
 
   const std::vector<std::vector<float>>& GetAllNpsPerMeasures() const {
@@ -337,6 +343,8 @@ class Steps {
   std::vector<std::vector<int>> m_CachedNotesPerMeasure;
   bool m_AreCachedNotesPerMeasureJustLoaded;
 
+  std::vector<NoteAnnotationCache> m_CachedNoteAnnotations;
+  bool m_AreCachedNoteAnnotationsJustLoaded;
   std::vector<float> m_PeakNps;
 
   bool m_bIsCachedGrooveStatsHashJustLoaded;

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -9,6 +9,7 @@
 #include "Difficulty.h"
 #include "EnumHelper.h"
 #include "GameConstantsAndTypes.h"
+#include "NoteAnnotation.h"
 #include "PlayerNumber.h"
 #include "RadarValues.h"
 #include "RageUtil.h"
@@ -178,6 +179,8 @@ class Steps {
   void SetTechCounts(const TechCounts ts[NUM_PLAYERS]);
   void SetNpsPerMeasure(std::vector<std::vector<float>>& npsPerMeasure);
   void SetNotesPerMeasure(std::vector<std::vector<int>>& notesPerMeasure);
+  void SetNoteAnnotations(
+      std::vector<NoteAnnotationCache>& noteAnnotations);
   void SetPeakNps(std::vector<float>& peakNps);
   void SetGrooveStatsHash(const std::string& key);
   void SetGrooveStatsHashVersion(int version);
@@ -217,6 +220,9 @@ class Steps {
   }
 
   void CalculateMeasureInfo(const NoteData& noteData);
+  const std::vector<NoteAnnotation>& GetNoteAnnotations(PlayerNumber pn) const;
+  const std::vector<NoteAnnotationCache>& GetNoteAnnotationCaches() const;
+  std::vector<std::vector<NoteAnnotation>> GetAllNoteAnnotations() const;
 
   const std::vector<std::vector<float>>& GetAllNpsPerMeasures() const {
     return Real()->m_NpsPerMeasure;
@@ -335,6 +341,7 @@ class Steps {
   std::vector<std::vector<float>> m_NpsPerMeasure;
   std::vector<std::vector<int>> m_NotesPerMeasure;
 
+  std::vector<NoteAnnotationCache> m_NoteAnnotations;
   std::vector<float> m_PeakNps;
 
   std::string m_sGrooveStatsHash;

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -179,8 +179,7 @@ class Steps {
   void SetTechCounts(const TechCounts ts[NUM_PLAYERS]);
   void SetNpsPerMeasure(std::vector<std::vector<float>>& npsPerMeasure);
   void SetNotesPerMeasure(std::vector<std::vector<int>>& notesPerMeasure);
-  void SetNoteAnnotations(
-      std::vector<NoteAnnotationCache>& noteAnnotations);
+  void SetNoteAnnotations(std::vector<NoteAnnotationCache>& noteAnnotations);
   void SetPeakNps(std::vector<float>& peakNps);
   void SetGrooveStatsHash(const std::string& key);
   void SetGrooveStatsHashVersion(int version);

--- a/src/TechCounts.cpp
+++ b/src/TechCounts.cpp
@@ -11,18 +11,6 @@
 #include "RageUtil.h"
 #include "StepParityDatastructs.h"
 
-static const char* TechCountsCategoryNames[] = {
-    "Crossovers",     "HalfCrossovers",   "FullCrossovers", "Footswitches",
-    "UpFootswitches", "DownFootswitches", "Sideswitches",   "Jacks",
-    "Brackets",       "Doublesteps"};
-
-XToString(TechCountsCategory);
-XToLocalizedString(TechCountsCategory);
-LuaFunction(
-    TechCountsCategoryToLocalizedString,
-    TechCountsCategoryToLocalizedString(Enum::Check<TechCountsCategory>(L, 1)));
-LuaXType(TechCountsCategory);
-
 // 0.176 ~= 1/8th at 175bpm
 // Anything slower isn't counted as a jack
 constexpr float JACK_CUTOFF = 0.176f;
@@ -72,12 +60,18 @@ void TechCounts::FromString(std::string sTechCounts) {
 
 void TechCounts::CalculateTechCountsFromRows(
     const std::vector<StepParity::Row>& rows,
-    const StepParity::StageLayout* layout, TechCounts& out) {
+    const StepParity::StageLayout* layout, TechCounts& out,
+    std::vector<NoteAnnotation>& annotations_out) {
   for (unsigned long i = 1; i < rows.size(); i++) {
+    NoteAnnotation annotation;
     const StepParity::Row& currentRow = rows[i];
     const StepParity::Row& previousRow = rows[i - 1];
 
     float elapsedTime = currentRow.second - previousRow.second;
+
+    annotation.beat = currentRow.beat;
+    annotation.whereTheFeetAre.assign(
+        currentRow.whereTheFeetAre.begin(), currentRow.whereTheFeetAre.end());
 
     // Jacks are same arrow same foot
     // Doublestep is same foot on successive arrows
@@ -99,10 +93,12 @@ void TechCounts::CalculateTechCountsFromRows(
             currentRow.whereTheFeetAre[foot]) {
           if (elapsedTime < JACK_CUTOFF) {
             out[TechCountsCategory_Jacks] += 1;
+            annotation.tech.push_back(TechCountsCategory_Jacks);
           }
         } else {
           if (elapsedTime < DOUBLESTEP_CUTOFF) {
             out[TechCountsCategory_Doublesteps] += 1;
+            annotation.tech.push_back(TechCountsCategory_Doublesteps);
           }
         }
       }
@@ -110,18 +106,20 @@ void TechCounts::CalculateTechCountsFromRows(
 
     // Check for brackets
     if (currentRow.noteCount >= 2) {
-      if (currentRow.whereTheFeetAre[StepParity::LEFT_HEEL] !=
+      if (currentRow.whereTheFeetAre[StepParity::Foot_LeftHeel] !=
               StepParity::INVALID_COLUMN &&
-          currentRow.whereTheFeetAre[StepParity::LEFT_TOE] !=
+          currentRow.whereTheFeetAre[StepParity::Foot_LeftToe] !=
               StepParity::INVALID_COLUMN) {
         out[TechCountsCategory_Brackets] += 1;
+        annotation.tech.push_back(TechCountsCategory_Brackets);
       }
 
-      if (currentRow.whereTheFeetAre[StepParity::RIGHT_HEEL] !=
+      if (currentRow.whereTheFeetAre[StepParity::Foot_RightHeel] !=
               StepParity::INVALID_COLUMN &&
-          currentRow.whereTheFeetAre[StepParity::RIGHT_TOE] !=
+          currentRow.whereTheFeetAre[StepParity::Foot_RightToe] !=
               StepParity::INVALID_COLUMN) {
         out[TechCountsCategory_Brackets] += 1;
+        annotation.tech.push_back(TechCountsCategory_Brackets);
       }
     }
 
@@ -130,6 +128,8 @@ void TechCounts::CalculateTechCountsFromRows(
       if (isFootswitch(c, currentRow, previousRow, elapsedTime)) {
         out[TechCountsCategory_UpFootswitches] += 1;
         out[TechCountsCategory_Footswitches] += 1;
+        annotation.tech.push_back(TechCountsCategory_UpFootswitches);
+        annotation.tech.push_back(TechCountsCategory_Footswitches);
       }
     }
     // Check for down footswitches
@@ -137,6 +137,8 @@ void TechCounts::CalculateTechCountsFromRows(
       if (isFootswitch(c, currentRow, previousRow, elapsedTime)) {
         out[TechCountsCategory_DownFootswitches] += 1;
         out[TechCountsCategory_Footswitches] += 1;
+        annotation.tech.push_back(TechCountsCategory_DownFootswitches);
+        annotation.tech.push_back(TechCountsCategory_Footswitches);
       }
     }
 
@@ -144,19 +146,23 @@ void TechCounts::CalculateTechCountsFromRows(
     for (int c : layout->sideArrows) {
       if (isFootswitch(c, currentRow, previousRow, elapsedTime)) {
         out[TechCountsCategory_Sideswitches] += 1;
+        annotation.tech.push_back(TechCountsCategory_Sideswitches);
       }
     }
 
     // Check for crossovers
-    int leftHeel = currentRow.whereTheFeetAre[StepParity::LEFT_HEEL];
-    int leftToe = currentRow.whereTheFeetAre[StepParity::LEFT_TOE];
-    int rightHeel = currentRow.whereTheFeetAre[StepParity::RIGHT_HEEL];
-    int rightToe = currentRow.whereTheFeetAre[StepParity::RIGHT_TOE];
+    int leftHeel = currentRow.whereTheFeetAre[StepParity::Foot_LeftHeel];
+    int leftToe = currentRow.whereTheFeetAre[StepParity::Foot_LeftToe];
+    int rightHeel = currentRow.whereTheFeetAre[StepParity::Foot_RightHeel];
+    int rightToe = currentRow.whereTheFeetAre[StepParity::Foot_RightToe];
 
-    int previousLeftHeel = previousRow.whereTheFeetAre[StepParity::LEFT_HEEL];
-    int previousLeftToe = previousRow.whereTheFeetAre[StepParity::LEFT_TOE];
-    int previousRightHeel = previousRow.whereTheFeetAre[StepParity::RIGHT_HEEL];
-    int previousRightToe = previousRow.whereTheFeetAre[StepParity::RIGHT_TOE];
+    int previousLeftHeel =
+        previousRow.whereTheFeetAre[StepParity::Foot_LeftHeel];
+    int previousLeftToe = previousRow.whereTheFeetAre[StepParity::Foot_LeftToe];
+    int previousRightHeel =
+        previousRow.whereTheFeetAre[StepParity::Foot_RightHeel];
+    int previousRightToe =
+        previousRow.whereTheFeetAre[StepParity::Foot_RightToe];
 
     // Check for the following:
     // - We moved the right foot on this row,
@@ -182,7 +188,7 @@ void TechCounts::CalculateTechCountsFromRows(
         if (i > 1) {
           const StepParity::Row& previousPreviousRow = rows[i - 2];
           int previousPreviousRightHeel =
-              previousPreviousRow.whereTheFeetAre[StepParity::RIGHT_HEEL];
+              previousPreviousRow.whereTheFeetAre[StepParity::Foot_RightHeel];
 
           if (previousPreviousRightHeel != StepParity::INVALID_COLUMN &&
               previousPreviousRightHeel != rightHeel) {
@@ -190,14 +196,19 @@ void TechCounts::CalculateTechCountsFromRows(
                 layout->columns[previousPreviousRightHeel];
             if (previousPreviousRightPos.x > leftPos.x) {
               out[TechCountsCategory_FullCrossovers] += 1;
+              annotation.tech.push_back(TechCountsCategory_FullCrossovers);
             } else {
               out[TechCountsCategory_HalfCrossovers] += 1;
+              annotation.tech.push_back(TechCountsCategory_HalfCrossovers);
             }
             out[TechCountsCategory_Crossovers] += 1;
+            annotation.tech.push_back(TechCountsCategory_Crossovers);
           }
         } else {
           out[TechCountsCategory_HalfCrossovers] += 1;
           out[TechCountsCategory_Crossovers] += 1;
+          annotation.tech.push_back(TechCountsCategory_HalfCrossovers);
+          annotation.tech.push_back(TechCountsCategory_Crossovers);
         }
       }
     }
@@ -214,32 +225,38 @@ void TechCounts::CalculateTechCountsFromRows(
         if (i > 1) {
           const StepParity::Row& previousPreviousRow = rows[i - 2];
           int previousPreviousLeftHeel =
-              previousPreviousRow.whereTheFeetAre[StepParity::LEFT_HEEL];
+              previousPreviousRow.whereTheFeetAre[StepParity::Foot_LeftHeel];
           if (previousPreviousLeftHeel != StepParity::INVALID_COLUMN &&
               previousPreviousLeftHeel != leftHeel) {
             StepParity::StagePoint previousPreviousLeftPos =
                 layout->columns[previousPreviousLeftHeel];
             if (rightPos.x > previousPreviousLeftPos.x) {
               out[TechCountsCategory_FullCrossovers] += 1;
+              annotation.tech.push_back(TechCountsCategory_FullCrossovers);
             } else {
               out[TechCountsCategory_HalfCrossovers] += 1;
+              annotation.tech.push_back(TechCountsCategory_HalfCrossovers);
             }
             out[TechCountsCategory_Crossovers] += 1;
+            annotation.tech.push_back(TechCountsCategory_Crossovers);
           }
         } else {
           out[TechCountsCategory_HalfCrossovers] += 1;
           out[TechCountsCategory_Crossovers] += 1;
+          annotation.tech.push_back(TechCountsCategory_HalfCrossovers);
+          annotation.tech.push_back(TechCountsCategory_Crossovers);
         }
       }
     }
+    annotations_out.push_back(annotation);
   }
 }
 
 bool TechCounts::isFootswitch(
     int c, const StepParity::Row& currentRow,
     const StepParity::Row& previousRow, float elapsedTime) {
-  if (currentRow.columns[c] == StepParity::NONE ||
-      previousRow.columns[c] == StepParity::NONE) {
+  if (currentRow.columns[c] == StepParity::Foot_None ||
+      previousRow.columns[c] == StepParity::Foot_None) {
     return false;
   }
 

--- a/src/TechCounts.cpp
+++ b/src/TechCounts.cpp
@@ -55,23 +55,50 @@ void TechCounts::FromString(std::string sTechCounts) {
     return;
   }
 
-  FOREACH_ENUM(RadarCategory, rc) { (*this)[rc] = StringToFloat(saValues[rc]); }
+  FOREACH_ENUM(TechCountsCategory, rc) {
+    (*this)[rc] = StringToFloat(saValues[rc]);
+  }
 }
 
 void TechCounts::CalculateTechCountsFromRows(
     const std::vector<StepParity::Row>& rows,
     const StepParity::StageLayout* layout, TechCounts& out,
     std::vector<NoteAnnotation>& annotations_out) {
-  for (unsigned long i = 1; i < rows.size(); i++) {
+  for (unsigned long i = 0; i < rows.size(); i++) {
     NoteAnnotation annotation;
     const StepParity::Row& currentRow = rows[i];
-    const StepParity::Row& previousRow = rows[i - 1];
-
-    float elapsedTime = currentRow.second - previousRow.second;
-
     annotation.beat = currentRow.beat;
     annotation.whereTheFeetAre.assign(
         currentRow.whereTheFeetAre.begin(), currentRow.whereTheFeetAre.end());
+
+    // Check for brackets
+    if (currentRow.noteCount >= 2) {
+      if (currentRow.whereTheFeetAre[StepParity::Foot_LeftHeel] !=
+              StepParity::INVALID_COLUMN &&
+          currentRow.whereTheFeetAre[StepParity::Foot_LeftToe] !=
+              StepParity::INVALID_COLUMN) {
+        out[TechCountsCategory_Brackets] += 1;
+        annotation.tech.push_back(TechCountsCategory_Brackets);
+      }
+
+      if (currentRow.whereTheFeetAre[StepParity::Foot_RightHeel] !=
+              StepParity::INVALID_COLUMN &&
+          currentRow.whereTheFeetAre[StepParity::Foot_RightToe] !=
+              StepParity::INVALID_COLUMN) {
+        out[TechCountsCategory_Brackets] += 1;
+        annotation.tech.push_back(TechCountsCategory_Brackets);
+      }
+    }
+
+    // If this is the first row, none of the other tech counts are applicable
+    if (i == 0) {
+      annotations_out.push_back(annotation);
+      continue;
+    }
+
+    const StepParity::Row& previousRow = rows[i - 1];
+
+    float elapsedTime = currentRow.second - previousRow.second;
 
     // Jacks are same arrow same foot
     // Doublestep is same foot on successive arrows
@@ -101,25 +128,6 @@ void TechCounts::CalculateTechCountsFromRows(
             annotation.tech.push_back(TechCountsCategory_Doublesteps);
           }
         }
-      }
-    }
-
-    // Check for brackets
-    if (currentRow.noteCount >= 2) {
-      if (currentRow.whereTheFeetAre[StepParity::Foot_LeftHeel] !=
-              StepParity::INVALID_COLUMN &&
-          currentRow.whereTheFeetAre[StepParity::Foot_LeftToe] !=
-              StepParity::INVALID_COLUMN) {
-        out[TechCountsCategory_Brackets] += 1;
-        annotation.tech.push_back(TechCountsCategory_Brackets);
-      }
-
-      if (currentRow.whereTheFeetAre[StepParity::Foot_RightHeel] !=
-              StepParity::INVALID_COLUMN &&
-          currentRow.whereTheFeetAre[StepParity::Foot_RightToe] !=
-              StepParity::INVALID_COLUMN) {
-        out[TechCountsCategory_Brackets] += 1;
-        annotation.tech.push_back(TechCountsCategory_Brackets);
       }
     }
 

--- a/src/TechCounts.h
+++ b/src/TechCounts.h
@@ -5,34 +5,11 @@
 #include <vector>
 
 #include "EnumHelper.h"
+#include "NoteAnnotation.h"
 #include "StepParityDatastructs.h"
-
+#include "TechCountsCategory.h"
 /** @brief Unknown radar values are given a default value. */
 #define TECHCOUNTS_VAL_UNKNOWN -1
-
-enum TechCountsCategory {
-  TechCountsCategory_Crossovers = 0,
-  TechCountsCategory_HalfCrossovers,
-  TechCountsCategory_FullCrossovers,
-  TechCountsCategory_Footswitches,
-  TechCountsCategory_UpFootswitches,
-  TechCountsCategory_DownFootswitches,
-  TechCountsCategory_Sideswitches,
-  TechCountsCategory_Jacks,
-  TechCountsCategory_Brackets,
-  TechCountsCategory_Doublesteps,
-  NUM_TechCountsCategory,
-  TechCountsCategory_Invalid
-};
-
-const std::string& TechCountsCategoryToString(TechCountsCategory cat);
-/**
- * @brief Turn the radar category into a proper localized string.
- * @param cat the radar category.
- * @return the localized string version of the radar category.
- */
-const std::string& TechCountsCategoryToLocalizedString(TechCountsCategory cat);
-LuaDeclareType(TechCountsCategory);
 
 struct lua_State;
 
@@ -72,7 +49,8 @@ struct TechCounts {
   void PushSelf(lua_State* L);
   static void CalculateTechCountsFromRows(
       const std::vector<StepParity::Row>& rows,
-      const StepParity::StageLayout* layout, TechCounts& out);
+      const StepParity::StageLayout* layout, TechCounts& out,
+      std::vector<NoteAnnotation>& annotations_out);
 
  private:
   static bool isFootswitch(

--- a/src/TechCountsCategory.cpp
+++ b/src/TechCountsCategory.cpp
@@ -1,0 +1,18 @@
+#include "TechCountsCategory.h"
+
+#include "EnumHelper.h"
+#include "LocalizedString.h"
+#include "LuaBinding.h"
+#include "global.h"
+
+static const char* TechCountsCategoryNames[] = {
+    "Crossovers",     "HalfCrossovers",   "FullCrossovers", "Footswitches",
+    "UpFootswitches", "DownFootswitches", "Sideswitches",   "Jacks",
+    "Brackets",       "Doublesteps"};
+
+XToString(TechCountsCategory);
+XToLocalizedString(TechCountsCategory);
+LuaFunction(
+    TechCountsCategoryToLocalizedString,
+    TechCountsCategoryToLocalizedString(Enum::Check<TechCountsCategory>(L, 1)));
+LuaXType(TechCountsCategory);

--- a/src/TechCountsCategory.h
+++ b/src/TechCountsCategory.h
@@ -1,0 +1,24 @@
+#ifndef TECH_COUNTS_CATEGORY_H
+#define TECH_COUNTS_CATEGORY_H
+
+#include <string>
+
+enum TechCountsCategory {
+  TechCountsCategory_Crossovers = 0,
+  TechCountsCategory_HalfCrossovers,
+  TechCountsCategory_FullCrossovers,
+  TechCountsCategory_Footswitches,
+  TechCountsCategory_UpFootswitches,
+  TechCountsCategory_DownFootswitches,
+  TechCountsCategory_Sideswitches,
+  TechCountsCategory_Jacks,
+  TechCountsCategory_Brackets,
+  TechCountsCategory_Doublesteps,
+  NUM_TechCountsCategory,
+  TechCountsCategory_Invalid
+};
+
+const std::string& TechCountsCategoryToString(TechCountsCategory tnst);
+const std::string& TechCountsCategoryToLocalizedString(TechCountsCategory tnst);
+
+#endif


### PR DESCRIPTION
(alternative to #808)
This adds a a new Lua function Steps::GetNoteAnnotations() and exposes StepParity:Foot and TechCountsCategory enums to Lua.

The data is provided as an array like:
```
[
  {
    "beat": 4.20,
    "footPlacement": {
      2: Foot_LeftHeel,
      3: Foot_LeftToe
    },
    "tech": [TechCountsCategory_Brackets]
  }
]
```
`footPlacement` is a table that maps column index to the predicted Foot (column indexes are 1-based)
`tech` is an array of TechCountsCategory predicted for the given beat.

When generating cache data, NoteAnnotations will be saved as a base64-encoded string to a `#NOTEANNOTATIONS` tag.

### A note about memory use:
The annotations are held in-memory as their base64-encoded strings, inside `NoteAnnotationCache` structs, which provide methods for getting the decompressed `NoteAnnotation` objects themselves. Storing the `NoteAnnotation` data decompressed basically doubles itgmania's memory usage, at least from my testing. Holding onto the base64 strings raises memory usage by only about 20-30%.
Any decompressed `NoteAnnotation` data is cleared when `Steps::Compress()` is called.

### Questions 

Currently I just have the base64 encoding/decoding functions sitting inside `NoteAnnotation.cpp`. It's making use of some base64 functions provided by mbedtls. These should probably live somewhere else, but now that we've finally killed RString, there's no obvious place to put these. 

- Are we fine with relying on mbedtls, or would we rather just implement our own base64 encode/decode methods?
- Where should I stick these functions?

And as far as the `NoteAnnotationCache` stuff is concerned, I'm not crazy about how this ended up, but as it is, the whole file/cache loading process in general is clunky as hell. At one point, I considered trying to make this a more generic wrapper thing for any objects that implement `FromString` and `ToString` methods. This seems like it could come in handy if we end up needing to store more data as base64-encoded, but also this could just end up being a needless abstraction.

If you can think of a less bad way to do any of this, let me know.