### PR TITLE
Send a ScrollSong lua command in EditMode / PracticeMode.

### DIFF
--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -1697,6 +1697,9 @@ void ScreenEdit::Init() {
 
   GAMESTATE->m_bIsUsingStepTiming = false;
   GAMESTATE->m_bInStepEditor = true;
+  // Is already zero if going into EditMode, but not always zero upon entering
+  // PracticeMode
+  GAMESTATE->m_Position.m_fMusicSeconds = 0.0;
 
   SubscribeToMessage("Judgment");
   main_player_ = GAMESTATE->GetMasterPlayerNumber();
@@ -4075,8 +4078,11 @@ void ScreenEdit::ScrollTo(float fDestinationBeat) {
       }
     }
   }
-
+  GAMESTATE->m_Position.m_fMusicSeconds =
+      GetAppropriateTiming().GetElapsedTimeFromBeat(fDestinationBeat);
   m_soundChangeLine.Play(true);
+  m_sprOverlay->PlayCommand("ScrollSong");
+  m_sprUnderlay->PlayCommand("ScrollSong");
 }
 
 static LocalizedString NEW_KEYSOUND_FILE(


### PR DESCRIPTION
Companion PR for SL: https://github.com/Simply-Love/Simply-Love-SM5/pull/705

There's two small changes to EditMode / PracticeMode here. One is accurately tracking the `MusicSeconds` when we move around the song (and when we init it), and the other is sending the `ScrollSong` command to the overlay and underlay.

The `MusicSeconds` is set when we actually playback in the modes, but this makes it so if we call `GAMESTATE:GetCurMusicSeconds` in the lua that it's accurate, even if we didn't hit play yet. For the ScrollSong command, I'm happy to use a system message if it makes more sense here.