### PR TITLE
Upload non-zipped artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,11 +81,11 @@ jobs:
           ${{ matrix.package }}
       - name: Upload artifacts
         id: upload
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ITGmania-${{ github.sha }}-${{ matrix.name }}
           path: ${{ matrix.path }}
-          compression-level: 0
+          archive: false
       - uses: actions/attest-build-provenance@v3
         with:
           subject-name: ITGmania-${{ github.sha }}-${{ matrix.name }}


### PR DESCRIPTION
Modifying the release workflow to upload non-zipped artifacts, new in https://github.com/actions/upload-artifact/releases/tag/v7.0.0. With the artifact being a single file, there is not much benefit to having it zipped.

Reference https://github.blog/changelog/2026-02-26-github-actions-now-supports-uploading-and-downloading-non-zipped-artifacts/

Example output on my fork - https://github.com/ScottBrenner/itgmania/actions/runs/22533825018#artifacts