### PR TITLE
Modify release attestation to use actions/attest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
           name: ITGmania-${{ github.sha }}-${{ matrix.name }}
           path: ${{ matrix.path }}
           archive: false
-      - uses: actions/attest-build-provenance@v3
+      - uses: actions/attest@v4
         with:
           subject-name: ITGmania-${{ github.sha }}-${{ matrix.name }}
           subject-digest: sha256:${{ steps.upload.outputs.artifact-digest }}


### PR DESCRIPTION
Noted in the latest release of the current action https://github.com/actions/attest-build-provenance?tab=readme-ov-file#usage-

> `actions/attest-build-provenance` is simply a wrapper on top of [actions/attest](https://github.com/actions/attest)

Modifying to instead use https://github.com/actions/attest.