### PR TITLE
ALSA fix

### DIFF
--- a/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
@@ -16,7 +16,7 @@
 #include "archutils/Unix/GetSysInfo.h"
 #include "global.h"
 
-REGISTER_SOUND_DRIVER_CLASS2(ALSA - sw, ALSA9_Software);
+REGISTER_SOUND_DRIVER_CLASS2(ALSA-sw, ALSA9_Software);
 
 static const int channels = 2;
 static const int samples_per_frame = channels;

--- a/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
@@ -16,7 +16,9 @@
 #include "archutils/Unix/GetSysInfo.h"
 #include "global.h"
 
+// clang-format off
 REGISTER_SOUND_DRIVER_CLASS2(ALSA-sw, ALSA9_Software);
+// clang-format on
 
 static const int channels = 2;
 static const int samples_per_frame = channels;


### PR DESCRIPTION
Typo that was a victim of the formatting change.

Prevented the use of the ALSA backend as `SoundDrivers=ALSA - sw,Null` was also invalid parsing for some reason.