### PR TITLE
Support forcing a song reload from the song wheel

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -1853,6 +1853,7 @@
 			<Function name='MusicLengthSeconds'/>
 			<Function name='NormallyDisplayed'/>
 			<Function name='ReloadFromSongDir'/>
+			<Function name='ForceReloadFromSongDir'/>
 			<Function name='ShowInDemonstrationAndRanking'/>
 		</Class>
 		<Class name='SongManager'>

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -496,7 +496,7 @@ bool ScreenSelectMusic::Input(const InputEventPlus& input) {
       // Reload the currently selected song. -Kyz
       Song* to_reload = m_MusicWheel.GetSelectedSong();
       if (to_reload) {
-        to_reload->ReloadFromSongDir();
+        to_reload->ForceReloadFromSongDir();
         AfterMusicChange();
         return true;
       }

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -446,6 +446,8 @@ bool Song::LoadFromSongDir(
 /* This function feels EXTREMELY hacky - copying things on top of pointers so
  * they don't break elsewhere.  Maybe it could be rewritten to politely ask the
  * Song/Steps objects to reload themselves. -- djpohly */
+// This is now only used by Edit Mode now to preserve its existing reload
+// behavior - song wheel now uses ForceReloadFromSongDir. -sukibaby
 bool Song::ReloadFromSongDir(std::string sDir) {
   // Remove the cache file to force the song to reload from its dir instead
   // of loading from the cache. -Kyz

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -559,6 +559,68 @@ bool Song::ReloadFromSongDir(std::string sDir) {
   return true;
 }
 
+bool Song::ForceReloadFromSongDir(std::string sDir) {
+  FILEMAN->Remove(GetCacheFilePath());
+
+  // Clear all existing steps and AutoGen notes since we're doing a full reload
+  RemoveAutoGenNotes();
+  m_vpSteps.clear();
+  FOREACH_ENUM(StepsType, i)
+  m_vpStepsByType[i].clear();
+
+  // Load everything fresh from the song directory (follows LoadFromSongDir's
+  // structure but without any pointer reuse logic)
+  if (!LoadFromSongDir(sDir)) {
+    return false;
+  }
+
+  // Reload all images associated with the song code from ReloadFromSongDir.
+  // Would be good to consolidate this into a helper function.
+  std::vector<std::string> to_reload;
+  to_reload.reserve(7);
+  to_reload.push_back(m_sBannerFile);
+  to_reload.push_back(m_sJacketFile);
+  to_reload.push_back(m_sCDFile);
+  to_reload.push_back(m_sDiscFile);
+  to_reload.push_back(m_sBackgroundFile);
+  to_reload.push_back(m_sCDTitleFile);
+  to_reload.push_back(m_sPreviewVidFile);
+  for (std::vector<std::string>::iterator file = to_reload.begin();
+       file != to_reload.end(); ++file) {
+    RageTextureID id(*file);
+    if (TEXTUREMAN->IsTextureRegistered(id)) {
+      RageTexture* tex = TEXTUREMAN->LoadTexture(id);
+      if (tex) {
+        tex->Reload();
+      }
+    }
+  }
+
+  // Regenerate cached images from disk for low-res preload.
+  // We remove the cached image first to get the desired behavior from
+  // CacheImage(). Otherwise FastLoad will prevent this reload.
+  // If we don't do this, the old lowres preload will persist until
+  // cache is manually cleared.
+  // The changes don't show until the existing textures have been
+  // invalidated, which requires moving on the song wheel a bit.
+  // Not sure it's possible yet with the current state of the code to
+  // signal an immediate texture reload for just the banner and cdtitle
+  // art and guarantee it was updated instantaneously.
+  if (PREFSMAN->m_ImageCache == IMGCACHE_LOW_RES_PRELOAD) {
+    for (std::string Image : ImageDir) {
+      const std::string source_image_path = GetCacheFile(Image);
+      if (source_image_path.empty()) {
+        continue;
+      }
+      FILEMAN->Remove(
+          SongCacheIndex::GetCacheFilePath(Image, source_image_path));
+      IMAGECACHE->CacheImage(Image, source_image_path);
+    }
+  }
+
+  return true;
+}
+
 void Song::LoadEditsFromSongDir(std::string dir) {
   // Load any .edit files in the song folder.
   // Doing this BEFORE setting up AutoGen just in case.

--- a/src/Song.h
+++ b/src/Song.h
@@ -99,6 +99,11 @@ class Song {
   bool ReloadFromSongDir() { return ReloadFromSongDir(GetSongDir()); }
   void LoadEditsFromSongDir(std::string dir);
 
+  // This one explicitly does not reuse any Steps pointers, it is a full reload
+  // of simfile and assets.
+  bool ForceReloadFromSongDir(std::string sDir);
+  bool ForceReloadFromSongDir() { return ForceReloadFromSongDir(GetSongDir()); }
+
   bool HasAutosaveFile();
   bool LoadAutosaveFile();
 


### PR DESCRIPTION
This PR was edited and is no longer taking the "double check hash before reloading" approach.

I decided to go with the "force a reload when requested" approach as i feel it's more correct. 

It does not however address the underlying bug causing #1201 .


Previous PR text is below.

<details>

# Background

This is based on a previously-approved change which was, at the time, requested to be brought out to its own PR (however, I did not yet open said PR until now). It was previously discussed and accepted to be generally favorable to use our existing CRC32 hashes when possible to improve cache staleness checks in Song.cpp.  It has been determined that the existing checks are not fully reliable on their own, and a CRC32 validation would be preferable to the current method which is heavy on disk I/O and comparisons which may not be fully reliable.


While this doesn't solve #1201 I think it's a step in the right direction of ensuring correctness here.


<details>


### [Add various note loader includes to Song.cpp](https://github.com/itgmania/itgmania/commit/38935961be8ff8cabb8cb2f817dbd2c8ae6e9a6a), [Add methods within Song.cpp to allow for CRC32 determination](https://github.com/itgmania/itgmania/commit/5a2198ab367b34f743de908b8c35aa0a53a86a3b), [Implement a method to get the simfile path](https://github.com/itgmania/itgmania/commit/286c9bb76b32817a9cf229b7cb9532baa950ad4e)

- Adds various CRC32 helpers local to Song.cpp.  Methods we use in Song.cpp already make use of CRC32 of the cached simfle, but the new helpers allow us to determine the CRC32 of the file on disk at the the time of the function call, so we can now easily get the CRC32 of the actual file on disk at that point in time to compare against the cached simfile. 
- The method to determine the primary simfile path ensures the correct file in the Songs directory itself is used for the comparison.

### [Compare current simfile CRC32 against the cached value for the use_cache decision in LoadFromSongDir](https://github.com/itgmania/itgmania/commit/499bed1617f34f97cade7fd371e78d14ca41971d)

- Uses our new helpers alongside the existing `SONGINDEX->GetCacheHash` and `GetHashForDirectory` calls to implement the CRC32 based comparison


</details>

</details>