### PR TITLE
add static assert for linux leds

### DIFF
--- a/src/arch/Lights/LightsDriver_Linux_ITGIO.cpp
+++ b/src/arch/Lights/LightsDriver_Linux_ITGIO.cpp
@@ -15,7 +15,7 @@ REGISTER_LIGHTS_DRIVER_CLASS2(ITGIO, Linux_ITGIO);
 namespace {
 const int coin_counter_index = 14;
 
-const int cabinet_lights[NUM_CabinetLight] = {
+const int cabinet_lights[] = {
     8,   // LIGHT_MARQUEE_UP_LEFT
     10,  // LIGHT_MARQUEE_UP_RIGHT
     9,   // LIGHT_MARQUEE_LR_LEFT
@@ -24,7 +24,7 @@ const int cabinet_lights[NUM_CabinetLight] = {
     15,  // LIGHT_BASS_RIGHT
 };
 
-const int player1_lights[NUM_GameButton] = {
+const int player1_lights[] = {
     -1,  // GAME_BUTTON_MENULEFT
     -1,  // GAME_BUTTON_MENURIGHT
     -1,  // GAME_BUTTON_MENUUP
@@ -58,7 +58,7 @@ const int player1_lights[NUM_GameButton] = {
     -1,  // GAME_BUTTON_CUSTOM_19
 };
 
-const int player2_lights[NUM_GameButton] = {
+const int player2_lights[] = {
     -1,  // GAME_BUTTON_MENULEFT
     -1,  // GAME_BUTTON_MENURIGHT
     -1,  // GAME_BUTTON_MENUUP
@@ -91,6 +91,16 @@ const int player2_lights[NUM_GameButton] = {
     -1,  // GAME_BUTTON_CUSTOM_18
     -1,  // GAME_BUTTON_CUSTOM_19
 };
+
+static_assert(
+    ARRAYLEN(cabinet_lights) == NUM_CabinetLight,
+    "LightsDriver_Linux_ITGIO ARRAYLEN(cabinet_lights) != NUM_CabinetLight");
+static_assert(
+    ARRAYLEN(player1_lights) == NUM_GameButton,
+    "LightsDriver_Linux_ITGIO ARRAYLEN(player1_lights) != NUM_GameButton");
+static_assert(
+    ARRAYLEN(player2_lights) == NUM_GameButton,
+    "LightsDriver_Linux_ITGIO ARRAYLEN(player2_lights) != NUM_GameButton");
 
 }  // namespace
 

--- a/src/arch/Lights/LightsDriver_Linux_PIUIOBTN_Leds.cpp
+++ b/src/arch/Lights/LightsDriver_Linux_PIUIOBTN_Leds.cpp
@@ -13,7 +13,7 @@
 REGISTER_LIGHTS_DRIVER_CLASS2(PIUIOBTN_Leds, Linux_PIUIOBTN_Leds);
 
 namespace {
-const int player1_lights[NUM_GameButton] = {
+const int player1_lights[] = {
     6,   // GAME_BUTTON_MENULEFT
     5,   // GAME_BUTTON_MENURIGHT
     -1,  // GAME_BUTTON_MENUUP
@@ -47,7 +47,7 @@ const int player1_lights[NUM_GameButton] = {
     -1,  // GAME_BUTTON_CUSTOM_19
 };
 
-const int player2_lights[NUM_GameButton] = {
+const int player2_lights[] = {
     2,   // GAME_BUTTON_MENULEFT
     1,   // GAME_BUTTON_MENURIGHT
     -1,  // GAME_BUTTON_MENUUP
@@ -80,6 +80,16 @@ const int player2_lights[NUM_GameButton] = {
     -1,  // GAME_BUTTON_CUSTOM_18
     -1,  // GAME_BUTTON_CUSTOM_19
 };
+
+static_assert(
+    ARRAYLEN(player1_lights) == NUM_GameButton,
+    "LightsDriver_Linux_PIUIOBTN_Leds ARRAYLEN(player1_lights) != "
+    "NUM_GameButton");
+static_assert(
+    ARRAYLEN(player2_lights) == NUM_GameButton,
+    "LightsDriver_Linux_PIUIOBTN_Leds ARRAYLEN(player2_lights) != "
+    "NUM_GameButton");
+
 }  // namespace
 
 void LightsDriver_Linux_PIUIOBTN_Leds::Set(const LightsState* ls) {

--- a/src/arch/Lights/LightsDriver_Linux_PIUIO_Leds.cpp
+++ b/src/arch/Lights/LightsDriver_Linux_PIUIO_Leds.cpp
@@ -18,7 +18,7 @@ REGISTER_LIGHTS_DRIVER_CLASS2(PIUIO_Leds, Linux_PIUIO_Leds);
 namespace {
 const int coin_counter_index = 28;
 
-const int cabinet_lights[NUM_CabinetLight] = {
+const int cabinet_lights[] = {
     23,  // LIGHT_MARQUEE_UP_LEFT
     26,  // LIGHT_MARQUEE_UP_RIGHT
     25,  // LIGHT_MARQUEE_LR_LEFT
@@ -27,7 +27,7 @@ const int cabinet_lights[NUM_CabinetLight] = {
     10,  // LIGHT_BASS_RIGHT
 };
 
-const int player1_dance_lights[NUM_GameButton] = {
+const int player1_dance_lights[] = {
     -1,  // GAME_BUTTON_MENULEFT
     -1,  // GAME_BUTTON_MENURIGHT
     -1,  // GAME_BUTTON_MENUUP
@@ -61,7 +61,7 @@ const int player1_dance_lights[NUM_GameButton] = {
     -1,  // GAME_BUTTON_CUSTOM_19
 };
 
-const int player2_dance_lights[NUM_GameButton] = {
+const int player2_dance_lights[] = {
     -1,  // GAME_BUTTON_MENULEFT
     -1,  // GAME_BUTTON_MENURIGHT
     -1,  // GAME_BUTTON_MENUUP
@@ -95,7 +95,7 @@ const int player2_dance_lights[NUM_GameButton] = {
     -1,  // GAME_BUTTON_CUSTOM_19
 };
 
-const int player1_pump_lights[NUM_GameButton] = {
+const int player1_pump_lights[] = {
     -1,  // GAME_BUTTON_MENULEFT
     -1,  // GAME_BUTTON_MENURIGHT
     -1,  // GAME_BUTTON_MENUUP
@@ -129,7 +129,7 @@ const int player1_pump_lights[NUM_GameButton] = {
     -1,  // GAME_BUTTON_CUSTOM_19
 };
 
-const int player2_pump_lights[NUM_GameButton] = {
+const int player2_pump_lights[] = {
     -1,  // GAME_BUTTON_MENULEFT
     -1,  // GAME_BUTTON_MENURIGHT
     -1,  // GAME_BUTTON_MENUUP
@@ -162,6 +162,27 @@ const int player2_pump_lights[NUM_GameButton] = {
     -1,  // GAME_BUTTON_CUSTOM_18
     -1,  // GAME_BUTTON_CUSTOM_19
 };
+
+static_assert(
+    ARRAYLEN(cabinet_lights) == NUM_CabinetLight,
+    "LightsDriver_Linux_PIUIO_Leds ARRAYLEN(cabinet_lights) != "
+    "NUM_CabinetLight");
+static_assert(
+    ARRAYLEN(player1_dance_lights) == NUM_GameButton,
+    "LightsDriver_Linux_PIUIO_Leds ARRAYLEN(player1_dance_lights) != "
+    "NUM_GameButton");
+static_assert(
+    ARRAYLEN(player2_dance_lights) == NUM_GameButton,
+    "LightsDriver_Linux_PIUIO_Leds ARRAYLEN(player2_dance_lights) != "
+    "NUM_GameButton");
+static_assert(
+    ARRAYLEN(player1_pump_lights) == NUM_GameButton,
+    "LightsDriver_Linux_PIUIO_Leds ARRAYLEN(player1_pump_lights) != "
+    "NUM_GameButton");
+static_assert(
+    ARRAYLEN(player2_pump_lights) == NUM_GameButton,
+    "LightsDriver_Linux_PIUIO_Leds ARRAYLEN(player2_pump_lights) != "
+    "NUM_GameButton");
 
 }  // namespace
 


### PR DESCRIPTION
realized this was never addressed the last time a new `GAME_BUTTON` was added and the piuio lighting order was messed up.

This will prevent the compile in the event the sizes don't match.