### PR TITLE
Unix: use single writable root mount in portable mode

### DIFF
--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -345,26 +345,8 @@ void ArchHooks::MountInitialFilesystems(const std::string& sDirOfExecutable) {
 
   bool portable = DoesFileExist("/Portable.ini");
   if (portable) {
-    FILEMAN->Mount("dir", sDirOfExecutable + "/Announcers", "/Announcers");
-    FILEMAN->Mount("dir", sDirOfExecutable + "/BGAnimations", "/BGAnimations");
-    FILEMAN->Mount(
-        "dir", sDirOfExecutable + "/BackgroundEffects", "/BackgroundEffects");
-    FILEMAN->Mount(
-        "dir", sDirOfExecutable + "/BackgroundTransitions",
-        "/BackgroundTransitions");
-    FILEMAN->Mount("dir", sDirOfExecutable + "/Cache", "/Cache");
-    FILEMAN->Mount("dir", sDirOfExecutable + "/CDTitles", "/CDTitles");
-    FILEMAN->Mount("dir", sDirOfExecutable + "/Characters", "/Characters");
-    FILEMAN->Mount("dir", sDirOfExecutable + "/Courses", "/Courses");
-    FILEMAN->Mount("dir", sDirOfExecutable + "/Downloads", "/Downloads");
-    FILEMAN->Mount("dir", sDirOfExecutable + "/Logs", "/Logs");
-    FILEMAN->Mount("dir", sDirOfExecutable + "/NoteSkins", "/NoteSkins");
-    FILEMAN->Mount("dir", sDirOfExecutable + "/Packages", "/Packages");
-    FILEMAN->Mount("dir", sDirOfExecutable + "/Save", "/Save");
-    FILEMAN->Mount("dir", sDirOfExecutable + "/Screenshots", "/Screenshots");
-    FILEMAN->Mount("dir", sDirOfExecutable + "/Songs", "/Songs");
-    FILEMAN->Mount("dir", sDirOfExecutable + "/RandomMovies", "/RandomMovies");
-    FILEMAN->Mount("dir", sDirOfExecutable + "/Themes", "/Themes");
+    FILEMAN->Unmount("dirro", sDirOfExecutable, "/");
+    FILEMAN->Mount("dir", sDirOfExecutable, "/");
   }
 }
 


### PR DESCRIPTION
In portable mode, an oversight (presumably) caused us to mount writable sub-mounts on top of a read-only root.  This would cause duplicate virtual exposure of the same files (notably /Songs and /Cache). Typically, TidyUpData would be called on to fix this when it happened, but this is just a heuristic fix instead of a true full reload.  It seems like TidyUpData traditionally did the job here, but the changed behavior following threaded song loading has exposed this bug AFAICT.

I tested here by building a fresh cache on my Linux portable install and everything I could try (edit mode, playing songs, reloading from song wheel or settings menu) all worked as expected so I believe this is working as it should.