### PR TITLE
Ignore race conditions between readdir and stat (lower priority but still helpful IMO)

### DIFF
--- a/src/RageFileDriverDirectHelpers.cpp
+++ b/src/RageFileDriverDirectHelpers.cpp
@@ -278,6 +278,12 @@ void DirectFilenameDB::PopulateFileSet(FileSet& fs, const std::string& path) {
     struct stat st;
     if (DoStat((root + sPath + "/" + pEnt->d_name).c_str(), &st) == -1) {
       int iError = errno;
+      // Files can disappear between readdir and stat (e.g. temp files used
+      // during atomic cache writes).  Treat these as expected races.
+      if (iError == ENOENT || iError == ENOTDIR) {
+        continue;
+      }
+
       /* If it's a broken symlink, ignore it.  Otherwise, warn. */
       if (lstat((root + sPath + "/" + pEnt->d_name).c_str(), &st) == 0) {
         continue;


### PR DESCRIPTION
Prevents rare but occasional warnings when building the cache such as 


/////////////////////////////////////////
WARNING: RageFileDriverDirectHelpers.cpp:287: Got file 'new.(file name).cache.new' in '/Cache/Songs/' from list, but can't stat? (No such file or directory)
/////////////////////////////////////////


as the RageFile loading mechanism wasn't designed for atomicity or modern I/O speeds.  This warning would occasionally show up in user logs too and really we shouldn't be so overzealous about trying to catch the `new.*.new` files RageFile itself creates. We know we're creating transient temp files during atomic cache writes, so we can continue instead of warning.

To be honest, the entire function should be re-evaluated in light of the new threaded loading changes.