### PR TITLE
Ensure helper strings are cleared before use in Song::LoadFromSongDir

### DIFF
--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -306,6 +306,10 @@ bool Song::LoadFromSongDir(
   }
 
   if (use_cache) {
+    m_sMainTitle.clear();
+    m_sMusicFile.clear();
+    m_vsKeysoundFile.clear();
+
     /*
     LOG->Trace("Loading '%s' from cache file '%s'.",
                        m_sSongDir.c_str(),


### PR DESCRIPTION
Note this is not actually fixing the underlying linux bug reported in #1201 , but I think this is improved behavior in this function IMO offered by this PR.  It is the code I tested with, anyway. Just ensures these strings are cleared before reading from the cache .