### PR TITLE
Lua debugger: Performance improvement and fixes

### DIFF
--- a/Docs/LuaDebugging.md
+++ b/Docs/LuaDebugging.md
@@ -30,13 +30,13 @@ configuration examples for specific clients below.
 1. Install the [nvim-dap](https://github.com/mfussenegger/nvim-dap) plugin.
 2. Add the following to your Neovim configuration:
 ```lua
-dap.adapters.itgmania_lua = {
+require('dap').adapters.itgmania_lua = {
     type = 'server',
     host = '127.0.0.1',
     port = 8173,
 }
 
-dap.configurations.lua = {
+require('dap').configurations.lua = {
     {
         type = 'itgmania_lua',
         request = 'attach',

--- a/src/LuaDebugBreakpoint.cpp
+++ b/src/LuaDebugBreakpoint.cpp
@@ -81,24 +81,51 @@ bool Breakpoint::IsHit(lua_State* L, lua_Debug& debug) {
   if ((m_eventMask & (1 << debug.event)) == 0) {
     return false;
   }
+
   if (m_thread != nullptr && m_thread != L) {
     return false;
   }
-  if (!m_functionName.empty() &&
-      (debug.name == nullptr || m_functionName != debug.name)) {
-    return false;
+
+  if (m_lineNumber >= 0) {
+    if (debug.currentline == INT_MIN) {
+      lua_getinfo(L, "l", &debug);
+    }
+    if (m_lineNumber != debug.currentline) {
+      return false;
+    }
   }
-  if (!m_fileName.empty() &&
-      (debug.source == nullptr || m_fileName != debug.source)) {
-    return false;
+
+  if (!m_functionName.empty()) {
+    if (debug.name == nullptr) {
+      lua_getinfo(L, "n", &debug);
+      if (debug.name == nullptr) {
+        debug.name = "";
+        return false;
+      }
+    }
+    if (m_functionName != debug.name) {
+      return false;
+    }
   }
-  if (m_lineNumber >= 0 && m_lineNumber != debug.currentline) {
-    return false;
+
+  if (!m_fileName.empty()) {
+    if (debug.source == nullptr) {
+      lua_getinfo(L, "S", &debug);
+      if (debug.source == nullptr) {
+        debug.source = "";
+        return false;
+      }
+    }
+    if (m_fileName != debug.source) {
+      return false;
+    }
   }
+
   lua_Debug tmp;
   if (m_maxStackDepth >= 0 && lua_getstack(L, m_maxStackDepth, &tmp)) {
     return false;
   }
+
   return true;
 }
 

--- a/src/LuaDebugBreakpoint.cpp
+++ b/src/LuaDebugBreakpoint.cpp
@@ -114,6 +114,14 @@ bool Breakpoint::IsHit(lua_State* L, lua_Debug& debug) {
       if (debug.source == nullptr) {
         debug.source = "";
         return false;
+      } else {
+        // Ignore leading "@/".
+        if (debug.source[0] == '@') {
+          debug.source++;
+        }
+        if (debug.source[0] == '/') {
+          debug.source++;
+        }
       }
     }
     if (m_fileName != debug.source) {

--- a/src/LuaDebugBreakpoint.cpp
+++ b/src/LuaDebugBreakpoint.cpp
@@ -5,6 +5,7 @@
 #include "LuaDebugHelpers.h"
 #include "LuaDebuggeeState.h"
 #include "LuaManager.h"
+#include "StdString.h"
 
 namespace LuaDebug {
 namespace {
@@ -124,7 +125,7 @@ bool Breakpoint::IsHit(lua_State* L, lua_Debug& debug) {
         }
       }
     }
-    if (m_fileName != debug.source) {
+    if (!EqualsNoCase(m_fileName, debug.source)) {
       return false;
     }
   }

--- a/src/LuaDebugBreakpoint.h
+++ b/src/LuaDebugBreakpoint.h
@@ -23,6 +23,9 @@ class Breakpoint {
   static Breakpoint Line(
       BreakpointId id, const std::string& fileName, int lineNumber);
 
+  /* Checks if the breakpoint is hit, ignoring condition and hit count
+   * condition. Fills in debug.source, debug.currentline, and debug.name as
+   * needed. */
   bool IsHit(lua_State* L, lua_Debug& debug);
   bool EvaluateConditions(
       DebuggeeState& stackFrame, std::string& evaluationError);
@@ -32,6 +35,8 @@ class Breakpoint {
   BreakpointId GetId() const { return m_id; }
   int GetEventMask() const { return m_eventMask; }
   const std::string& GetFileName() const { return m_fileName; }
+  int GetLineNumber() const { return m_lineNumber; }
+  int GetMaxStackDepth() const { return m_maxStackDepth; }
   const std::string& GetFunctionName() const { return m_functionName; }
   const lua_State* GetThread() const { return m_thread; }
   const std::string& GetReason() const { return m_reason; }

--- a/src/LuaDebugHelpers.cpp
+++ b/src/LuaDebugHelpers.cpp
@@ -277,7 +277,10 @@ std::vector<std::string> UnresolvePath(const std::string& absolutePath) {
     }
 
     std::string path = Right(absPath, absPath.size() - root.size());
-    std::string luaPath = "@" + mount.MountPoint + path;
+    std::string luaPath = mount.MountPoint + path;
+    if (Left(luaPath, 1) == "/") {
+      luaPath = luaPath.substr(1);
+    }
     result.push_back(luaPath);
   }
 

--- a/src/LuaDebugger.cpp
+++ b/src/LuaDebugger.cpp
@@ -1,7 +1,10 @@
 #include "LuaDebugger.h"
 
+#include <atomic>
+#include <mutex>
 #include <queue>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -14,6 +17,23 @@
 #include "global.h"
 
 namespace LuaDebug {
+
+class Spinlock {
+ public:
+  bool try_lock() { return !m_locked.test_and_set(std::memory_order_acquire); }
+
+  void lock() {
+    while (!try_lock()) {
+      std::this_thread::yield();
+    }
+  }
+
+  void unlock() { m_locked.clear(std::memory_order_release); }
+
+ private:
+  std::atomic_flag m_locked = ATOMIC_FLAG_INIT;
+};
+
 class Debugger::Impl {
  public:
   Impl() : m_luaDebugMutex("LuaDebug"), m_debuggeeState(DebuggeeState::Root{}) {
@@ -63,6 +83,7 @@ class Debugger::Impl {
 
   void DeactivateState(lua_State* lua) {
     LockMutex lock(m_luaDebugMutex);
+    std::lock_guard lock2(m_breakpointsLock);
 
     lua_sethook(lua, nullptr, 0, 0);
 
@@ -151,6 +172,12 @@ class Debugger::Impl {
   // Locks access to the shared data. Signaled when m_toLuaThread or
   // m_toServerThread is available for reading.
   RageEvent m_luaDebugMutex;
+
+  // Access to m_breakpoints is synchronized by locking
+  //  1. m_luaDebugMutex AND m_breakpointsLock on the server thread
+  //  2. m_luaDebugMutex OR m_breakpointsLock on the Lua thread.
+  // When locking both, m_luaDebugMutex is locked first to prevent deadlocks.
+  Spinlock m_breakpointsLock;
 
   // Kept across client sessions
   std::vector<LuaThread> m_threads;
@@ -802,12 +829,16 @@ class Debugger::Impl {
 
   void AddBreakpoint(Breakpoint breakpoint) {
     LockMutex lock(m_luaDebugMutex);
+    std::lock_guard lock2(m_breakpointsLock);
+
     m_breakpoints.push_back(breakpoint);
     UpdateHook();
   }
 
   void DeleteBreakpointsInSource(std::string source) {
     LockMutex lock(m_luaDebugMutex);
+    std::lock_guard lock2(m_breakpointsLock);
+
     bool anyDeleted = false;
     for (int i = m_breakpoints.size() - 1; i >= 0; i--) {
       if (m_breakpoints[i].GetFileName() == source) {
@@ -822,6 +853,8 @@ class Debugger::Impl {
 
   void DeleteAllFunctionBreakpoints() {
     LockMutex lock(m_luaDebugMutex);
+    std::lock_guard lock2(m_breakpointsLock);
+
     bool anyDeleted = false;
     for (int i = m_breakpoints.size() - 1; i >= 0; i--) {
       if (!m_breakpoints[i].GetFunctionName().empty()) {
@@ -836,22 +869,49 @@ class Debugger::Impl {
 
   void DeleteAllBreakpoints() {
     LockMutex lock(m_luaDebugMutex);
+    std::lock_guard lock2(m_breakpointsLock);
+
     m_breakpoints.clear();
     UpdateHook();
   }
 
   void LuaHook(lua_State* L, lua_Debug* ar) {
+    // These are set to arbitrary values before calling lua_getinfo. Clear them
+    // so that Breakpoint::IsHit can set them as needed.
+    ar->source = nullptr;
+    ar->currentline = INT_MIN;
+    ar->name = nullptr;
+
+    // Locking the m_luaDebugMutex mutex is slow, so try with only
+    // m_breakpointsLock first. Only try to lock it once to avoid excessive
+    // spinning if the server thread holds it for a long time.
+    bool isAnyHit = false;
+    if (m_breakpointsLock.try_lock()) {
+      for (Breakpoint& bp : m_breakpoints) {
+        if (bp.IsHit(L, *ar)) {
+          isAnyHit = true;
+          break;
+        }
+      }
+      m_breakpointsLock.unlock();
+      if (!isAnyHit) {
+        return;
+      }
+    }
+
     LockMutex lock(m_luaDebugMutex);
 
-    lua_getinfo(L, "lnS", ar);
-    bool anyHit = false;
+    // Check again after acquiring m_luaDebugMutex. The breakpoints could have
+    // changed between releasing m_breakpointsLock and acquiring
+    // m_luaDebugMutex, or if we failed to acquire m_breakpointsLock at all.
+    isAnyHit = false;
     for (Breakpoint& bp : m_breakpoints) {
       if (bp.IsHit(L, *ar)) {
-        anyHit = true;
+        isAnyHit = true;
         break;
       }
     }
-    if (!anyHit) {
+    if (!isAnyHit) {
       return;
     }
 


### PR DESCRIPTION
- Optimizes the debug hook for 90 % lower overhead by avoiding locking a mutex, avoiding loading unnecessary data with `lua_getinfo`, and moving the line number comparison before the file name.

- Fixes breakpoints not working in some Lua files in note skins and songs because of a mismatch when comparing the paths.
  
  For note skin code, the path passed to `luaL_loadbuffer` doesn't contain a `/` at the beginning, but it is included when setting a breakpoint.
  
  For song code, the filenames are changed to lowercase before being passed to `luaL_loadbuffer`, but are not when setting a breakpoint.

- Fixes a missing require in the docs for Neovim.