### PR TITLE
macOS user data migration helpers

### DIFF
--- a/Installer/mac/Migrate_Save_Data.sh
+++ b/Installer/mac/Migrate_Save_Data.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+PREFDIR="$HOME/Library/Preferences/ITGmania"
+LOGDIR="$HOME/Library/Logs/ITGmania"
+CACHEDIR="$HOME/Library/Caches/ITGmania"
+SCREENSHOTDIR="$HOME/Pictures/ITGmania Screenshots"
+DEST_ROOT="$HOME/Library/Application Support/ITGmania"
+DEST_SAVE="$DEST_ROOT/Save"
+DEST_LOGS="$DEST_ROOT/Logs"
+DEST_SCREENSHOTS="$DEST_ROOT/Screenshots"
+
+has_content=false
+for src in "$PREFDIR" "$LOGDIR" "$CACHEDIR" "$SCREENSHOTDIR"; do
+  if [[ -d "$src" ]] && find "$src" -mindepth 1 -print -quit >/dev/null 2>&1; then
+    has_content=true
+  fi
+done
+
+if ! $has_content; then
+  echo "No ITGmania data found to migrate."
+  exit 0
+fi
+
+echo "ITGmania data for version 1.1.0 or below was found."
+for src in "$DEST_SAVE" "$DEST_LOGS" "$DEST_SCREENSHOTS"; do
+  if [[ -d "$src" ]] && find "$src" -mindepth 1 -print -quit >/dev/null 2>&1; then
+    echo ""
+    echo " --- Note ---"
+    echo "ITGmania data for version 1.2.0 or above seems to"
+    echo "exist already!"
+    echo ""
+    echo "Migration may overwrite newer data, so please double"
+    echo "check before moving or copying anything if you're"
+    echo "concerned about possibly losing any data!"
+    echo ""
+  fi
+done
+
+echo ""
+echo "Choose action: [m]ove (recommended), [c]opy, [x] cancel:"
+read -r choice
+case "$choice" in
+  m|M) action="move" ;;
+  c|C) action="copy" ;;
+  x|X) echo "Cancelled."; exit 0 ;;
+  *) echo "Invalid choice - please enter m, c, or x."; exit 1 ;;
+esac
+
+mkdir -p "$DEST_SAVE" "$DEST_LOGS" "$DEST_SCREENSHOTS"
+
+copy_or_move() {
+  local src=$1 dest=$2
+  local op=$3
+  [[ -d "$src" ]] || return 0
+  if ! find "$src" -mindepth 1 -print -quit >/dev/null 2>&1; then
+    return 0
+  fi
+  if [[ "$op" == "move" ]]; then
+    echo "Moving from $src to $dest"
+    # macOS comes with rsync so this is safe
+    rsync -a --remove-source-files --prune-empty-dirs "$src"/ "$dest"/
+    find "$src" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} + >/dev/null 2>&1 || true
+  else
+    echo "Copying from $src to $dest"
+    rsync -a "$src"/ "$dest"/
+  fi
+}
+
+copy_or_move "$PREFDIR" "$DEST_SAVE" "$action"
+echo "Save data now located at $DEST_SAVE"
+
+copy_or_move "$LOGDIR" "$DEST_LOGS" "$action"
+echo "Old logs now located at $DEST_LOGS"
+
+copy_or_move "$SCREENSHOTDIR" "$DEST_SCREENSHOTS" "$action"
+echo "Old screenshots now located at $DEST_SCREENSHOTS"
+
+# No need to bring over old cache, just remove it.
+if [[ -d "$CACHEDIR" ]]; then
+  echo "Removing old cache at $CACHEDIR"
+  rm -rf "$CACHEDIR"
+fi
+
+echo
+echo "Done!"

--- a/Installer/mac/guide.rtf
+++ b/Installer/mac/guide.rtf
@@ -1,0 +1,187 @@
+{\rtf1\ansi\deff3\adeflang1025
+{\fonttbl{\f0\froman\fprq2\fcharset0 Times New Roman;}{\f1\froman\fprq2\fcharset2 Symbol;}{\f2\fswiss\fprq2\fcharset0 Arial;}{\f3\froman\fprq2\fcharset0 Liberation Serif{\*\falt Times New Roman};}{\f4\froman\fprq2\fcharset0 Liberation Mono{\*\falt Courier New};}{\f5\froman\fprq2\fcharset0 Liberation Sans{\*\falt Arial};}{\f6\froman\fprq2\fcharset0 Helvetica{\*\falt Arial};}{\f7\fswiss\fprq0\fcharset128 Helvetica{\*\falt Arial};}{\f8\fnil\fprq2\fcharset0 Liberation Mono{\*\falt Courier New};}{\f9\fnil\fprq2\fcharset0 DejaVu Sans;}{\f10\fnil\fprq2\fcharset0 OpenSymbol{\*\falt Arial Unicode MS};}{\f11\fnil\fprq2\fcharset0 FreeSans;}}
+{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red91\green39\blue125;\red85\green48\blue141;}
+{\stylesheet{\s0\snext0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033 Normal;}
+{\*\cs15\snext15\rtlch\af8\ltrch\hich\af4\dbch\af8\loch\f4 Source Text;}
+{\*\cs16\snext16\rtlch\af10\ltrch ListLabel 1;}
+{\*\cs17\snext17\rtlch\af10\ltrch ListLabel 2;}
+{\*\cs18\snext18\rtlch\af10\ltrch ListLabel 3;}
+{\*\cs19\snext19\rtlch\af10\ltrch ListLabel 4;}
+{\*\cs20\snext20\rtlch\af10\ltrch ListLabel 5;}
+{\*\cs21\snext21\rtlch\af10\ltrch ListLabel 6;}
+{\*\cs22\snext22\rtlch\af10\ltrch ListLabel 7;}
+{\*\cs23\snext23\rtlch\af10\ltrch ListLabel 8;}
+{\*\cs24\snext24\rtlch\af10\ltrch ListLabel 9;}
+{\*\cs25\snext25 ListLabel 10;}
+{\*\cs26\snext26 ListLabel 11;}
+{\*\cs27\snext27 ListLabel 12;}
+{\*\cs28\snext28 ListLabel 13;}
+{\*\cs29\snext29 ListLabel 14;}
+{\*\cs30\snext30 ListLabel 15;}
+{\*\cs31\snext31 ListLabel 16;}
+{\*\cs32\snext32 ListLabel 17;}
+{\*\cs33\snext33 ListLabel 18;}
+{\*\cs34\snext34\rtlch\af10\ltrch ListLabel 19;}
+{\*\cs35\snext35\rtlch\af10\ltrch ListLabel 20;}
+{\*\cs36\snext36\rtlch\af10\ltrch ListLabel 21;}
+{\*\cs37\snext37\rtlch\af10\ltrch ListLabel 22;}
+{\*\cs38\snext38\rtlch\af10\ltrch ListLabel 23;}
+{\*\cs39\snext39\rtlch\af10\ltrch ListLabel 24;}
+{\*\cs40\snext40\rtlch\af10\ltrch ListLabel 25;}
+{\*\cs41\snext41\rtlch\af10\ltrch ListLabel 26;}
+{\*\cs42\snext42\rtlch\af10\ltrch ListLabel 27;}
+{\*\cs43\snext43 ListLabel 28;}
+{\*\cs44\snext44 ListLabel 29;}
+{\*\cs45\snext45 ListLabel 30;}
+{\*\cs46\snext46 ListLabel 31;}
+{\*\cs47\snext47 ListLabel 32;}
+{\*\cs48\snext48 ListLabel 33;}
+{\*\cs49\snext49 ListLabel 34;}
+{\*\cs50\snext50 ListLabel 35;}
+{\*\cs51\snext51 ListLabel 36;}
+{\*\cs52\snext52\rtlch\af10\ltrch ListLabel 37;}
+{\*\cs53\snext53\rtlch\af10\ltrch ListLabel 38;}
+{\*\cs54\snext54\rtlch\af10\ltrch ListLabel 39;}
+{\*\cs55\snext55\rtlch\af10\ltrch ListLabel 40;}
+{\*\cs56\snext56\rtlch\af10\ltrch ListLabel 41;}
+{\*\cs57\snext57\rtlch\af10\ltrch ListLabel 42;}
+{\*\cs58\snext58\rtlch\af10\ltrch ListLabel 43;}
+{\*\cs59\snext59\rtlch\af10\ltrch ListLabel 44;}
+{\*\cs60\snext60\rtlch\af10\ltrch ListLabel 45;}
+{\*\cs61\snext61 ListLabel 46;}
+{\*\cs62\snext62 ListLabel 47;}
+{\*\cs63\snext63 ListLabel 48;}
+{\*\cs64\snext64 ListLabel 49;}
+{\*\cs65\snext65 ListLabel 50;}
+{\*\cs66\snext66 ListLabel 51;}
+{\*\cs67\snext67 ListLabel 52;}
+{\*\cs68\snext68 ListLabel 53;}
+{\*\cs69\snext69 ListLabel 54;}
+{\*\cs70\snext70\ulc0\cf9\ul Hyperlink;}
+{\s71\sbasedon0\snext72\sb240\sa120\keepn\rtlch\af11\afs28\ltrch\hich\af5\afs28\dbch\af9\loch\f5\fs28 Heading;}
+{\s72\sbasedon0\snext72\sl276\slmult1\sb0\sa140 Body Text;}
+{\s73\sbasedon72\snext73\sl240\slmult1\sb0\sa0\rtlch\af11\ltrch List;}
+{\s74\sbasedon0\snext74\sb120\sa120\rtlch\af11\afs24\ai\ltrch\fs24\i caption;}
+{\s75\sbasedon0\snext75\rtlch\af11\ltrch Index;}
+}{\*\listtable{\list\listtemplateid1
+{\listlevel\levelnfc23\leveljc0\levelstartat1\levelfollow0{\leveltext \'01\u8226 ?;}{\levelnumbers;}\f10\rtlch\af10\ltrch\fi-360\li720}
+{\listlevel\levelnfc23\leveljc0\levelstartat1\levelfollow0{\leveltext \'01\u9702 ?;}{\levelnumbers;}\f10\rtlch\af10\ltrch\fi-360\li1080}
+{\listlevel\levelnfc23\leveljc0\levelstartat1\levelfollow0{\leveltext \'01\u9642 ?;}{\levelnumbers;}\f10\rtlch\af10\ltrch\fi-360\li1440}
+{\listlevel\levelnfc23\leveljc0\levelstartat1\levelfollow0{\leveltext \'01\u8226 ?;}{\levelnumbers;}\f10\rtlch\af10\ltrch\fi-360\li1800}
+{\listlevel\levelnfc23\leveljc0\levelstartat1\levelfollow0{\leveltext \'01\u9702 ?;}{\levelnumbers;}\f10\rtlch\af10\ltrch\fi-360\li2160}
+{\listlevel\levelnfc23\leveljc0\levelstartat1\levelfollow0{\leveltext \'01\u9642 ?;}{\levelnumbers;}\f10\rtlch\af10\ltrch\fi-360\li2520}
+{\listlevel\levelnfc23\leveljc0\levelstartat1\levelfollow0{\leveltext \'01\u8226 ?;}{\levelnumbers;}\f10\rtlch\af10\ltrch\fi-360\li2880}
+{\listlevel\levelnfc23\leveljc0\levelstartat1\levelfollow0{\leveltext \'01\u9702 ?;}{\levelnumbers;}\f10\rtlch\af10\ltrch\fi-360\li3240}
+{\listlevel\levelnfc23\leveljc0\levelstartat1\levelfollow0{\leveltext \'01\u9642 ?;}{\levelnumbers;}\f10\rtlch\af10\ltrch\fi-360\li3600}\listid1}
+{\list\listtemplateid2
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}\listid2}
+}{\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}{\listoverride\listid2\listoverridecount0\ls2}}{\*\generator LibreOffice/26.2.1.2$Linux_X86_64 LibreOffice_project/620$Build-2}{\info{\creatim\yr2026\mo3\dy8\hr23\min14}{\revtim\yr2026\mo3\dy9\hr2\min14}{\printim\yr0\mo0\dy0\hr0\min0}}{\*\userprops}\deftab709
+\hyphauto1\viewscale100\formshade\nobrkwrptbl\paperh15840\paperw12240\margl1134\margr1134\margt1134\margb1134\sectd\sbknone\sftnnar\saftnnrlc\sectunlocked1\pgwsxn12240\pghsxn15840\marglsxn1134\margrsxn1134\margtsxn1134\margbsxn1134\ftnbj\ftnstart1\ftnrstcont\ftnnar\fet\aftnrstcont\aftnstart1\aftnnrlc
+{\*\ftnsep\chftnsep}\pgndec\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql{\f6
+Beginning with ITGmania 1.2.0 for macOS, the layout for user custom content has been consolidated into a single location. }{\f6
+This makes it easier for users to find their}{\f6
+ ITGmania data!}
+{\f6\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\qc\rtlch\ab\ltrch\f6\b
+
+{\rtlch\ab\ltrch\hich\af6\ab\dbch\ab\loch\f6\b\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\qc{\rtlch\ab\ltrch\f6\b
+All user data will now be located at}
+{\rtlch\ab\ltrch\hich\af6\ab\dbch\ab\loch\f6\b\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\qc{\cf18\rtlch\ab\ltrch\f7\b
+~/Library/Application Support/ITGmania}
+{\cf18\rtlch\ab\ltrch\hich\af7\ab\dbch\ab\loch\f7\b\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\qc\rtlch\ab\ltrch\f6\b
+
+{\rtlch\ab\ltrch\hich\af6\ab\dbch\ab\loch\f6\b\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql{\rtlch\ai0\ab0\ltrch\f6\i0\b0
+Below are instructions of various ways you can migrate your user data.}
+{\rtlch\ai0\ab0\ltrch\hich\af6\ai0\ab0\dbch\ai0\ab0\loch\f6\i0\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\qc\rtlch\ab\ltrch\f6\b
+
+{\rtlch\ab\ltrch\hich\af6\ab\dbch\ab\loch\f6\b\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql{\ulc0\rtlch\afs30\ab\ltrch\f6\fs30\ul\b
+Option 1\u8211\'96 Manual migration (easy)}
+{\rtlch\ab\ltrch\hich\af6\ab\dbch\ab\loch\f6\b\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql\rtlch\ab0\ltrch\f6\b0
+
+{\rtlch\ab0\ltrch\hich\af6\ab0\dbch\ab0\loch\f6\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql{\rtlch\ab0\ltrch\f6\b0
+We provided a script to help you migrate your files safely, called }{\cf17\rtlch\ab\ltrch\f6\b
+Migrate_Save_Data.sh}{\rtlch\ab0\ltrch\f6\b0
+.}
+{\rtlch\ab0\ltrch\hich\af6\ab0\dbch\ab0\loch\f6\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql\rtlch\ab0\ltrch\f6\b0
+
+{\rtlch\ab0\ltrch\hich\af6\ab0\dbch\ab0\loch\f6\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql{\rtlch\ab0\ltrch\f6\b0
+To run this, you\u8217\'92ll need to open the }{\rtlch\ab\ltrch\f6\b
+Terminal}{\rtlch\ab0\ltrch\f6\b0
+ (one way to get here is to click the }{\rtlch\ab\ltrch\f6\b
+Go}{\rtlch\ab0\ltrch\f6\b0
+ menu in Finder, and then click }{\rtlch\ab\ltrch\f6\b
+Utilities}{\rtlch\ab0\ltrch\f6\b0
+ near the bottom of the menu).}
+{\rtlch\ab0\ltrch\hich\af6\ab0\dbch\ab0\loch\f6\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql\rtlch\ab0\ltrch\f6\b0
+
+{\rtlch\ab0\ltrch\hich\af6\ab0\dbch\ab0\loch\f6\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql{\rtlch\ab0\ltrch\f6\b0
+First, type zsh, and then a space, and then drag }{\cf17\rtlch\ab\ltrch\f6\b
+Migrate_Save_Data.sh}{\cf0\rtlch\ab0\ltrch\f6\b0
+ onto the Terminal window. It should look like this:}
+{\cf0\rtlch\ab0\ltrch\hich\af6\ab0\dbch\ab0\loch\f6\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql\cf0\rtlch\ab0\ltrch\f6\b0
+
+{\cf0\rtlch\ab0\ltrch\hich\af6\ab0\dbch\ab0\loch\f6\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql{\cf0\rtlch\ab0\ltrch\f6\b0
+\tab me@My-Mac ~ % zsh /Volumes/ITGmania (version)/Migrate_Save_Data.sh}
+{\cf0\rtlch\ab0\ltrch\hich\af6\ab0\dbch\ab0\loch\f6\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql\rtlch\ab0\ltrch\f6\b0
+
+{\rtlch\ab0\ltrch\hich\af6\ab0\dbch\ab0\loch\f6\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql{\rtlch\ab0\ltrch\f6\b0
+Then, press Enter, and you will be prompted if you would like to move or copy your old data. See the note at the end of the document if you were unable to run }{\cf17\rtlch\ab\ltrch\f6\b
+Migrate_Save_Data.sh}{\rtlch\ab0\ltrch\f6\b0
+.}
+{\rtlch\ab0\ltrch\hich\af6\ab0\dbch\ab0\loch\f6\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql\rtlch\ab0\ltrch\f6\b0
+
+{\rtlch\ab0\ltrch\hich\af6\ab0\dbch\ab0\loch\f6\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql{\ulc0\rtlch\afs30\ab\ltrch\f6\fs30\ul\b
+Option 2 \u8211\'96 Manual migration (more involved)}
+{\ulc0\rtlch\afs30\ab\ltrch\hich\af6\afs30\aul\ab\dbch\afs30\ab\loch\f6\fs30\ul\b\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql\rtlch\ab0\ltrch\f6\b0
+
+{\rtlch\ab0\ltrch\hich\af6\ab0\dbch\ab0\loch\f6\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql{\rtlch\ab0\ltrch\f6\b0
+You can easily access the ITGmania data folder by clicking the }{\rtlch\ab\ltrch\f6\b
+Go}{\rtlch\ab0\ltrch\f6\b0
+ menu in Finder, selecting }{\rtlch\ab\ltrch\f6\b
+Go to Folder\u8230\'85}{\rtlch\ab0\ltrch\f6\b0
+, and then pasting in the following path (beginning with the tilde)}
+{\rtlch\ab0\ltrch\hich\af6\ab0\dbch\ab0\loch\f6\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql\rtlch\ab0\ltrch\f6\b0
+
+{\rtlch\ab0\ltrch\hich\af6\ab0\dbch\ab0\loch\f6\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\qc{\cf6\rtlch\ab\ltrch\f6\b
+~/Library/Application Support/ITGmania}
+{\cf6\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql\rtlch\ab0\ltrch\f6\b0
+
+{\rtlch\ab0\ltrch\hich\af6\ab0\dbch\ab0\loch\f6\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql{\rtlch\ab0\ltrch\f6\b0
+To manually move your content, your old user data will be stored in the following locations.}
+{\f6\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql\f6
+
+{\f6\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033{\listtext\pard\plain \rtlch\af10\ltrch \u8226\'95\tab}\ilvl0\ls1 \fi-360\li720\lin720\ql{\rtlch\ab\ltrch\f6\b
+~/Library/Preferences/ITGmania}{\f6
+ contains the content that needs to be in the Save directory }{\rtlch\ab0\ltrch\f6\b0
+(~/Library/Preferences/ITGmania/Save)}
+{\f6\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033{\listtext\pard\plain \rtlch\af10\ltrch \u8226\'95\tab}\ilvl0\ls1 \fi-360\li720\lin720\ql{\rtlch\ab\ltrch\f6\b
+~/Library/Logs/ITGmania}{\rtlch\ab0\ltrch\f6\b0
+ contains your log files. It is not important to move these, but you can if you\u8217\'92d like to.}
+{\rtlch\ab\ltrch\hich\af6\ab\dbch\ab\loch\f6\b\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033{\listtext\pard\plain \rtlch\af10\ltrch \u8226\'95\tab}\ilvl0\ls1 \fi-360\li720\lin720\ql{\rtlch\ab\ltrch\f6\b
+~/Library/Caches/ITGmania}{\f6
+ - do not move your old cache in, as it will be found to be invalid and rebuilt;  simply delete this to make space.}
+{\f6\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033{\listtext\pard\plain \rtlch\af10\ltrch \u8226\'95\tab}\ilvl0\ls1 \fi-360\li720\lin720\ql{\rtlch\ab\ltrch\f6\b
+~/Pictures/ITGmania Screenshots}{\rtlch\ab0\ltrch\f6\b0
+ contents will now be in ~/Library/Preferences/ITGmania/Screenshots}
+{\f6\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql\rtlch\ab0\ltrch\f6\b0
+
+{\f6\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql{\ulc0\rtlch\afs20\ai\ab\ltrch\f6\fs20\i\ul\b
+If the script did not run as expected}
+{\ulc0\rtlch\afs20\ai\ab\ltrch\hich\af6\afs20\ai\aul\ab\dbch\afs20\ai\ab\loch\f6\fs20\i\ul\b\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql{\rtlch\afs20\ab0\ltrch\f6\fs20\b0
+This way of running the script should ensure the script runs as expected. However, if you get a }{\rtlch\afs20\ai\ab0\ltrch\f6\fs20\i\b0
+zsh: permission denied}{\rtlch\afs20\ai0\ab0\ltrch\f6\fs20\i0\b0
+ error, you will need to run the command }{\rtlch\afs20\ai\ab0\ltrch\f6\fs20\i\b0
+chmod +x}{\rtlch\afs20\ai0\ab0\ltrch\f6\fs20\i0\b0
+ on Migrate_Save_Data.sh, as shown below:}
+{\rtlch\afs20\ab0\ltrch\hich\af6\afs20\ab0\dbch\afs20\ab0\loch\f6\fs20\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql\rtlch\afs20\ai0\ab0\ltrch\f6\fs20\i0\b0
+
+{\rtlch\afs20\ai0\ab0\ltrch\hich\af6\afs20\ai0\ab0\dbch\afs20\ai0\ab0\loch\f6\fs20\i0\b0\par}\pard\plain \s0\widctlpar\hyphpar0\ltrpar\kerning1\cf0\rtlch\af11\afs24\alang1033\ltrch\hich\af3\afs24\alang1033\dbch\af9\langfe2052\loch\f3\fs24\lang1033\ql{\rtlch\afs20\ai0\ab0\ltrch\f6\fs20\i0\b0
+\tab me@My-Mac ~ % chmod +x /Volumes/ITGmania (version)/Migrate_Save_Data.sh}
+{\rtlch\afs20\ai0\ab0\ltrch\hich\af6\afs20\ai0\ab0\dbch\afs20\ai0\ab0\loch\f6\fs20\i0\b0\par}}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -510,6 +510,14 @@ if(WIN32)
 elseif(APPLE)
   # On macOS, just install the .app bundle - resources are already inside it
   install(TARGETS "${SM_EXE_NAME}" BUNDLE DESTINATION ".")
+  
+  # ITGm v1.1.0 -> v1.2.0 migration extras
+  set(MAC_EXTRAS_DIR "${SM_INSTALLER_DIR}/mac")
+  install(FILES "${MAC_EXTRAS_DIR}/guide.rtf"
+          DESTINATION "."
+          RENAME "Important Notes about Save Data.rtf")
+  install(PROGRAMS "${MAC_EXTRAS_DIR}/Migrate_Save_Data.sh"
+          DESTINATION ".")
 else()
   install(TARGETS "${SM_EXE_NAME}" DESTINATION "${SM_INSTALL_DESTINATION}")
   if(LINUX)


### PR DESCRIPTION
We still needed a way to help macOS users migrate their content & save data from the ITGm 1.1.0 and below locations to the new locations.  So, I have here a zsh script and a corresponding readme so Mac users will be well equipped to handle the migration on their own. It will appear alongside the .app in the installer disk image.