### PR TITLE
menu lights fix

### DIFF
--- a/src/LightsManager.cpp
+++ b/src/LightsManager.cpp
@@ -471,7 +471,8 @@ void LightsManager::Update(float fDeltaTime) {
       FOREACH_ENUM(GameController, gc) {
         FOREACH_GameButton_Custom(gb) {
           bool bOn = INPUTMAPPER->IsBeingPressed(GameInput(gc, gb));
-          m_LightsState.m_bGameButtonLights[gc][gb] = bOn;
+          // or them in the event the game wants to turn them on too.
+          m_LightsState.m_bGameButtonLights[gc][gb] |= bOn;
         }
       }
 
@@ -481,7 +482,8 @@ void LightsManager::Update(float fDeltaTime) {
       FOREACH_ENUM(GameController, gc) {
         FOREACH_GameButton_Menu(gb) {
           bool bOn = INPUTMAPPER->IsBeingPressed(GameInput(gc, gb));
-          m_LightsState.m_bGameButtonLights[gc][gb] = bOn;
+          // or them in the event the game wants to turn them on too.
+          m_LightsState.m_bGameButtonLights[gc][gb] |= bOn;
         }
       }
 


### PR DESCRIPTION
menu lights were being turned off by the reactive code i originally wrote

this logically or's the menu lights and gameplay lights by the time it gets to the fall through switch statement so that either the gameplay engine's decision or the player's decision will illuminate the lighting.