### PR TITLE
Write SSC timing tags with 6 digits of precision

### DIFF
--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -208,37 +208,37 @@ static void WriteTimingTags(
     RageFile& f, const TimingData& timing, bool bIsSong = false) {
   f.PutLine(ssprintf(
       "#BPMS:%s;",
-      join(",\r\n", timing.ToVectorString(SEGMENT_BPM, 3)).c_str()));
+      join(",\r\n", timing.ToVectorString(SEGMENT_BPM, 6)).c_str()));
   f.PutLine(ssprintf(
       "#STOPS:%s;",
-      join(",\r\n", timing.ToVectorString(SEGMENT_STOP, 3)).c_str()));
+      join(",\r\n", timing.ToVectorString(SEGMENT_STOP, 6)).c_str()));
   f.PutLine(ssprintf(
       "#DELAYS:%s;",
-      join(",\r\n", timing.ToVectorString(SEGMENT_DELAY, 3)).c_str()));
+      join(",\r\n", timing.ToVectorString(SEGMENT_DELAY, 6)).c_str()));
   f.PutLine(ssprintf(
       "#WARPS:%s;",
-      join(",\r\n", timing.ToVectorString(SEGMENT_WARP, 3)).c_str()));
+      join(",\r\n", timing.ToVectorString(SEGMENT_WARP, 6)).c_str()));
   f.PutLine(ssprintf(
       "#TIMESIGNATURES:%s;",
-      join(",\r\n", timing.ToVectorString(SEGMENT_TIME_SIG, 3)).c_str()));
+      join(",\r\n", timing.ToVectorString(SEGMENT_TIME_SIG, 6)).c_str()));
   f.PutLine(ssprintf(
       "#TICKCOUNTS:%s;",
-      join(",\r\n", timing.ToVectorString(SEGMENT_TICKCOUNT, 3)).c_str()));
+      join(",\r\n", timing.ToVectorString(SEGMENT_TICKCOUNT, 6)).c_str()));
   f.PutLine(ssprintf(
       "#COMBOS:%s;",
-      join(",\r\n", timing.ToVectorString(SEGMENT_COMBO, 3)).c_str()));
+      join(",\r\n", timing.ToVectorString(SEGMENT_COMBO, 6)).c_str()));
   f.PutLine(ssprintf(
       "#SPEEDS:%s;",
-      join(",\r\n", timing.ToVectorString(SEGMENT_SPEED, 3)).c_str()));
+      join(",\r\n", timing.ToVectorString(SEGMENT_SPEED, 6)).c_str()));
   f.PutLine(ssprintf(
       "#SCROLLS:%s;",
-      join(",\r\n", timing.ToVectorString(SEGMENT_SCROLL, 3)).c_str()));
+      join(",\r\n", timing.ToVectorString(SEGMENT_SCROLL, 6)).c_str()));
   f.PutLine(ssprintf(
       "#FAKES:%s;",
-      join(",\r\n", timing.ToVectorString(SEGMENT_FAKE, 3)).c_str()));
+      join(",\r\n", timing.ToVectorString(SEGMENT_FAKE, 6)).c_str()));
   f.PutLine(ssprintf(
       "#LABELS:%s;",
-      join(",\r\n", timing.ToVectorString(SEGMENT_LABEL, 3)).c_str()));
+      join(",\r\n", timing.ToVectorString(SEGMENT_LABEL, 6)).c_str()));
 }
 
 /**


### PR DESCRIPTION
This updates `NotesWriterSSC` to output several tags with 6 digits of precision, up from 3. 
The following tags are affected:
```
#BPMS
#STOPS
#DELAYS
#WARPS
#TIMESIGNATURES
#TICKCOUNTS
#COMBOS
#SPEEDS
#SCROLLS
#FAKES
#LABELS
```

This is mainly meant to fix some remaining differences in tech counts calculation that happen when calling `Steps::CalculateTechCounts()` on a chart that's been loaded directly from the sm/ssc file vs loaded from cache. The loss in precision seems to very subtly affect the tech counts calculated for songs that make use of any of these tags, and happen to have more than 3 decimal places written (eg `#STOPS:133.500000=0.370370` vs `#STOPS:133.500=0.370;`).

And to make it painfully clear, these changes don't just affect the cache files, but any ssc files that are written by itgmania going forward.

The history of this is kind of interesting, in the way that things like this are.

The first iteration of NotesWriterSSC wrote these tags out as 6 decimals: 
[Bring from sandbox to new branch - 02/10/2011](https://github.com/itgmania/itgmania/commit/d6511c103444b479e0e97331dfe3e97483d7c29c)
[We should write 6 for consistency - 06/29/2011](https://github.com/itgmania/itgmania/commit/4aa404d38ebfd1d02079f6f9db2e62bc77a4284f)

But then a few months later, it seems to have been decided to write everything out with 3 decimals:
[back to 3 digits for .ssc files - 09/07/2011](https://github.com/itgmania/itgmania/commit/e06c7d334f731b9800da5c7f881a15a9bfc6e71d#diff-dd5cea9efc6a794e656c077b8f84f7ba6c2ce1c6f2e8d6882c98cdd494ce28b1)
[Finish the 3 decimal write out - 09/23/2011](https://github.com/itgmania/itgmania/commit/c6fff6099847e9a76f3bf4d712de0e73d3bc2159)

A few years later, though, there was an attempt to switch things back to using 6 decimal places: 
[Restore storing to 6 decimals - 01/06/2013](https://github.com/itgmania/itgmania/commit/ada0c3cdd0adaad271243bbf9d44bab15b852b71#diff-dd5cea9efc6a794e656c077b8f84f7ba6c2ce1c6f2e8d6882c98cdd494ce28b1) 
It seems that the author maybe have done a find-replace on "%.3f", and ended up missing the tags that were written using `timing.ToVectorString()`