### PR TITLE
Small fixes for fake notes in step parity calculation

### DIFF
--- a/src/StepParityCost.cpp
+++ b/src/StepParityCost.cpp
@@ -96,13 +96,14 @@ float StepParityCost::getActionCost(
 // 0100 <- no cost
 float StepParityCost::calcMineCost(
     State* resultState, Row& row, int columnCount) {
-  if (row.mine_mask == 0) {
+  if (row.mine_mask == 0 && row.fake_mine_mask == 0) {
     return 0.0f;
   }
   float cost = 0;
 
   for (int i = 0; i < columnCount; i++) {
-    if (resultState->combinedColumns[i] != NONE && row.mines[i] != 0) {
+    if (resultState->combinedColumns[i] != NONE &&
+        (row.mines[i] != 0 || row.fakeMines[i] != 0)) {
       cost += MINE;
       break;
     }

--- a/src/StepParityDatastructs.h
+++ b/src/StepParityDatastructs.h
@@ -150,11 +150,11 @@ struct IntermediateNoteData {
   int row = 0;     // row on which the note occurs
   float beat = 0;  // beat on which the note occurs
   float hold_length =
-      0;  // If type is TapNoteType_HoldTail, length of hold, in beats
+      0;  // If type is TapNoteType_HoldHead, length of hold, in beats
 
-  bool warped = false;   // Is this note warped?
-  bool fake = false;     // Is this note fake (besides being TapNoteType_Fake)?
-  float second = false;  // time into the song on which the note occurs
+  bool warped = false;  // Is this note warped?
+  bool fake = false;    // Is this note fake (besides being TapNoteType_Fake)?
+  float second = 0;     // time into the song on which the note occurs
 
   Foot parity =
       NONE;  // Which foot (and which part of the foot) will most likely be used

--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -314,7 +314,7 @@ void StepParityGenerator::CreateIntermediateNoteData(
     note.beat = NoteRowToBeat(curr_note.Row());
     note.second = timing->GetElapsedTimeFromBeat(note.beat);
 
-    note.fake = note.type == TapNoteType_Fake || timing->IsFakeAtBeat(note.row);
+    note.fake = note.type == TapNoteType_Fake || timing->IsFakeAtRow(note.row);
     note.warped = timing->IsWarpAtRow(note.row);
 
     if (note.type == TapNoteType_HoldHead) {


### PR DESCRIPTION
Two problems fixed in this:
- `StepParityGenerator::CreateIntermediateNoteData` was calling `timing->IsFakeAtBeat(note.row);` instead of `timing->IsFakeAtRow(note.row);`
- `StepParityCost::calcMineCost` should take fake mines into account

And then a couple of small typos noticed along the way.

A quick test on ITL 2025 charts doesn't show any changes in tech counts, which is a little surprising. But I think this has more to do with the fact that all of these charts seem to use `#FAKES` just to prevent mines from being hittable.