### PR TITLE
Close web socket connections when reloading scripts

### DIFF
--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -116,7 +116,21 @@ NetworkManager::~NetworkManager() {
 
   this->StopWorkers();
 
-  // Close all WebSocket connections
+  this->CloseAllWebSockets();
+
+  // Set the status to uninitialized.
+  ix::uninitNetSystem();
+}
+
+void NetworkManager::CloseAllWebSockets() {
+  // Drop queued websocket starts so no new connections come up after cleanup.
+  {
+    std::lock_guard<std::mutex> lock(this->webSocketWorkerMutex);
+    std::queue<std::function<void()>> empty;
+    std::swap(this->webSocketWorkerQueue, empty);
+  }
+
+  // Stop all active websocket connections without aggressively clearing.
   std::vector<WebSocketHandlePtr> webSocketHandlesCopy;
   {
     std::lock_guard<std::mutex> lock(this->webSocketHandlesMutex);
@@ -124,11 +138,9 @@ NetworkManager::~NetworkManager() {
   }
 
   for (auto& handle : webSocketHandlesCopy) {
+    handle->webSocket.disableAutomaticReconnection();
     handle->webSocket.stop();
   }
-
-  // Set the status to uninitialized.
-  ix::uninitNetSystem();
 }
 
 void NetworkManager::RunHttpWorker() {

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -126,8 +126,7 @@ void NetworkManager::CloseAllWebSockets() {
   // Drop queued websocket starts so no new connections come up after cleanup.
   {
     std::lock_guard<std::mutex> lock(this->webSocketWorkerMutex);
-    std::queue<std::function<void()>> empty;
-    std::swap(this->webSocketWorkerQueue, empty);
+    this->webSocketWorkerQueue = {};
   }
 
   // Stop all active websocket connections without aggressively clearing.

--- a/src/NetworkManager.h
+++ b/src/NetworkManager.h
@@ -131,6 +131,7 @@ class NetworkManager {
   bool IsUrlAllowed(const std::string& url);
   HttpRequestFuturePtr HttpRequest(const HttpRequestArgs& args);
   WebSocketHandlePtr WebSocket(const WebSocketArgs& args);
+  void CloseAllWebSockets();
   void Update();
   void EnqueueMainThreadTask(std::function<void()> task);
   std::string UrlEncode(const std::string& value);

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1177,6 +1177,9 @@ bool HandleGlobalInputs(const InputEventPlus& input) {
       SCREENMAN->SystemMessage(RELOADED_METRICS);
     } else if (bIsCtrlHeld && !bIsShiftHeld) {
       // Ctrl+F2: reload scripts only
+      if (NETWORK != nullptr) {
+        NETWORK->CloseAllWebSockets();
+      }
       THEME->UpdateLuaGlobals();
       SCREENMAN->SystemMessage(RELOADED_SCRIPTS);
     } else if (bIsCtrlHeld && bIsShiftHeld) {


### PR DESCRIPTION
This is to close socket connections when reloading scripts as this seemed to cause an issue where you could still be in a lobby despite all references in-game being gone or stale