### PR TITLE
Restrict submodule updates to extern directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
       interval: "weekly"
   # Enable version updates for gitsubmodules
   - package-ecosystem: "gitsubmodule"
-    directory: "/"
+    directory: "/extern"
     # Raise pull requests for version updates
     # against the `beta` branch
     target-branch: "beta"


### PR DESCRIPTION
Not sure why Dependabot failed to update Simply Love - https://github.com/itgmania/itgmania/actions/runs/23325889577/job/67846885433#step:3:243 - but as updates to this submodule are controlled as part of the development workflow, restricting automated submodule updates to the `extern` directory.