### PR TITLE
Ensure ARCH_MEMORY_CARD_DRIVER is included

### DIFF
--- a/src/arch/MemoryCard/MemoryCardDriver.cpp
+++ b/src/arch/MemoryCard/MemoryCardDriver.cpp
@@ -11,11 +11,13 @@
 #include "ProfileManager.h"
 #include "RageFileManager.h"
 #include "RageLog.h"
+// Provides platform-specific ARCH_MEMORY_CARD_DRIVER selection.
+#include "arch/arch_default.h"
 
 static const std::string TEMP_MOUNT_POINT = "/@mctemptimeout/";
 
 enum MemoryCardDriverType {
-  MemoryCardDriverType_Usb,
+  MemoryCardDriverType_USB,
   MemoryCardDriverType_Directory,
   NUM_MemoryCardDriverType,
   MemoryCardDriverType_Invalid
@@ -27,7 +29,7 @@ StringToX(MemoryCardDriverType);
 LuaXType(MemoryCardDriverType);
 
 Preference<MemoryCardDriverType> g_MemoryCardDriver(
-    "MemoryCardDriver", MemoryCardDriverType_Usb, nullptr,
+    "MemoryCardDriver", MemoryCardDriverType_USB, nullptr,
     PreferenceType::Immutable);
 
 bool UsbStorageDevice::operator==(const UsbStorageDevice& other) const {
@@ -152,9 +154,13 @@ MemoryCardDriver* MemoryCardDriver::Create() {
     case MemoryCardDriverType_Directory:
       ret = new MemoryCardDriverThreaded_Folder;
       break;
-    case MemoryCardDriverType_Usb:
+    case MemoryCardDriverType_USB:
 #ifdef ARCH_MEMORY_CARD_DRIVER
       ret = new ARCH_MEMORY_CARD_DRIVER;
+#else
+      LOG->Warn(
+          "MemoryCardDriverType_USB was selected, "
+          "but no driver was compiled in.");
 #endif
       break;
     default:
@@ -162,6 +168,7 @@ MemoryCardDriver* MemoryCardDriver::Create() {
   }
 
   if (!ret) {
+    LOG->Info("MemoryCardDriver_Null is loaded.");
     ret = new MemoryCardDriver_Null;
   }
 

--- a/src/arch/MemoryCard/MemoryCardDriverThreaded_Linux.h
+++ b/src/arch/MemoryCard/MemoryCardDriverThreaded_Linux.h
@@ -1,5 +1,5 @@
 #ifndef MemoryCardDriverThreaded_Linux_H
-#define MemoryCardDriverThreaded_Linux_H 1
+#define MemoryCardDriverThreaded_Linux_H
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
- ARCH_MEMORY_CARD_DRIVER determines which driver to use for USBs (arch dependent). This PR #includes "arch/arch_default.h" which should pull in the correct headers for the platform
- Also rename MemoryCardDriverType_Usb -> MemoryCardDriverType_USB which is how the preference gets loaded
- Finally added some logging to help surface this in the future