### PR TITLE
ffmpeg-w32.yml: Update zlib 1.3.1 -> 1.3.2

### DIFF
--- a/.github/workflows/ffmpeg-w32.yml
+++ b/.github/workflows/ffmpeg-w32.yml
@@ -37,9 +37,9 @@ jobs:
         
         # We need to custom build zlib and bzip2 for mingw.
         # Build zlib
-        wget https://zlib.net/zlib-1.3.1.tar.gz
-        tar -xzf zlib-1.3.1.tar.gz
-        cd zlib-1.3.1
+        wget https://github.com/madler/zlib/releases/download/v1.3.2/zlib-1.3.2.tar.gz
+        tar -xzf zlib-1.3.2.tar.gz
+        cd zlib-1.3.2
         make -f win32/Makefile.gcc PREFIX=x86_64-w64-mingw32- SHARED_MODE=1
         sudo make -f win32/Makefile.gcc install DESTDIR=/usr/x86_64-w64-mingw32/ INCLUDE_PATH=/include LIBRARY_PATH=/lib BINARY_PATH=/bin SHARED_MODE=1
         cd ..


### PR DESCRIPTION
Really the main reason for the change is to point the download link to the GitHub repo for zlib rather than to stress the zlib server, which is not always available, to prevent that from failing the CI run. Plus just faster to get it from GitHub's own servers.