### PR TITLE
DirectSound formatting fix

### DIFF
--- a/src/arch/Sound/RageSoundDriver.h
+++ b/src/arch/Sound/RageSoundDriver.h
@@ -223,10 +223,10 @@ class RageSoundDriver : public RageDriver {
 // Can't use Create##name because many of these have -sw suffixes.
 #define REGISTER_SOUND_DRIVER_CLASS2(name, x) \
   static RegisterRageDriver register_##x(     \
-      &RageSoundDriver::m_pDriverList, #name, \
+      &RageSoundDriver::m_pDriverList, name,  \
       CreateClass<RageSoundDriver_##x, RageDriver>)
 #define REGISTER_SOUND_DRIVER_CLASS(name) \
-  REGISTER_SOUND_DRIVER_CLASS2(name, name)
+  REGISTER_SOUND_DRIVER_CLASS2(#name, name)
 
 /*
  * (c) 2002-2004 Glenn Maynard

--- a/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
@@ -16,9 +16,7 @@
 #include "archutils/Unix/GetSysInfo.h"
 #include "global.h"
 
-// clang-format off
-REGISTER_SOUND_DRIVER_CLASS2(ALSA-sw, ALSA9_Software);
-// clang-format on
+REGISTER_SOUND_DRIVER_CLASS2("ALSA-sw", ALSA9_Software);
 
 static const int channels = 2;
 static const int samples_per_frame = channels;

--- a/src/arch/Sound/RageSoundDriver_AU.mm
+++ b/src/arch/Sound/RageSoundDriver_AU.mm
@@ -11,7 +11,7 @@
 #include <CoreAudio/CoreAudio.h>
 #include <CoreServices/CoreServices.h>
 
-REGISTER_SOUND_DRIVER_CLASS2(AudioUnit, AU);
+REGISTER_SOUND_DRIVER_CLASS2("AudioUnit", AU);
 
 static const UInt32 kFramesPerPacket = 1;
 static const UInt32 kChannelsPerFrame = 2;

--- a/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
@@ -11,7 +11,7 @@
 #include "archutils/Win32/ErrorStrings.h"
 #include "global.h"
 
-REGISTER_SOUND_DRIVER_CLASS2(DirectSound - sw, DSound_Software);
+REGISTER_SOUND_DRIVER_CLASS2("DirectSound-sw", DSound_Software);
 
 static const int channels = 2;
 static const int bytes_per_frame = channels * 2; /* 16-bit */

--- a/src/arch/Sound/RageSoundDriver_PulseAudio.cpp
+++ b/src/arch/Sound/RageSoundDriver_PulseAudio.cpp
@@ -21,7 +21,7 @@
 #include "ver.h"
 
 /* Register the RageSoundDriver_Pulseaudio class as sound driver "Pulse" */
-REGISTER_SOUND_DRIVER_CLASS2(Pulse, PulseAudio);
+REGISTER_SOUND_DRIVER_CLASS2("Pulse", PulseAudio);
 
 /* Constructor */
 RageSoundDriver_PulseAudio::RageSoundDriver_PulseAudio()


### PR DESCRIPTION
Same as the ALSA-sw issue (https://github.com/itgmania/itgmania/pull/1198), this is why users with a SoundDriver value of DirectSound-sw got the error of no sound device available.