### PR TITLE
Avoid mutex locking and repeated searches on inputs as much as possible

### DIFF
--- a/src/ScreenDebugOverlay.cpp
+++ b/src/ScreenDebugOverlay.cpp
@@ -63,6 +63,25 @@ static RageTimer g_HaltTimer(RageZeroTimer);
 static float g_fImageScaleCurrent = 1;
 static float g_fImageScaleDestination = 1;
 
+namespace {
+bool IsPressedInInputList(
+    const DeviceInputList& input_list, const DeviceInput& device_input) {
+  const auto it =
+      std::lower_bound(input_list.begin(), input_list.end(), device_input);
+  return it != input_list.end() && *it == device_input && it->bDown;
+}
+
+bool IsEitherShiftHeld() {
+  return INPUTFILTER->IsBeingPressed(
+             DeviceInput(DEVICE_KEYBOARD, KEY_LSHIFT)) ||
+         INPUTFILTER->IsBeingPressed(DeviceInput(DEVICE_KEYBOARD, KEY_RSHIFT));
+}
+
+bool IsLeftShiftHeld() {
+  return INPUTFILTER->IsBeingPressed(DeviceInput(DEVICE_KEYBOARD, KEY_LSHIFT));
+}
+}  // namespace
+
 // This will disable the debug menu ENTIRELY - including F6 for autosync, F8 for
 // autoplay, etc
 static bool g_bEnableDebugMenu = true;
@@ -475,16 +494,14 @@ bool ScreenDebugOverlay::Input(const InputEventPlus& input) {
 
   if (input.DeviceI == g_Mappings.holdForDebug1 ||
       input.DeviceI == g_Mappings.holdForDebug2) {
-    bool bHoldingNeither =
-        (!g_Mappings.holdForDebug1.IsValid() ||
-         !INPUTFILTER->IsBeingPressed(g_Mappings.holdForDebug1)) &&
-        (!g_Mappings.holdForDebug2.IsValid() ||
-         !INPUTFILTER->IsBeingPressed(g_Mappings.holdForDebug2));
-    bool bHoldingBoth =
-        (!g_Mappings.holdForDebug1.IsValid() ||
-         INPUTFILTER->IsBeingPressed(g_Mappings.holdForDebug1)) &&
-        (!g_Mappings.holdForDebug2.IsValid() ||
-         INPUTFILTER->IsBeingPressed(g_Mappings.holdForDebug2));
+    const bool bDebug1Held =
+        !g_Mappings.holdForDebug1.IsValid() ||
+        IsPressedInInputList(input.InputList, g_Mappings.holdForDebug1);
+    const bool bDebug2Held =
+        !g_Mappings.holdForDebug2.IsValid() ||
+        IsPressedInInputList(input.InputList, g_Mappings.holdForDebug2);
+    bool bHoldingNeither = !bDebug1Held && !bDebug2Held;
+    bool bHoldingBoth = bDebug1Held && bDebug2Held;
     if (bHoldingNeither) {
       m_bForcedHidden = false;
     }
@@ -682,9 +699,7 @@ class DebugLineAutoplay : public IDebugLine {
     PlayerController pc =
         GAMESTATE->m_pPlayerState[GAMESTATE->GetMasterPlayerNumber()]
             ->m_PlayerController;
-    bool bHoldingShift =
-        INPUTFILTER->IsBeingPressed(DeviceInput(DEVICE_KEYBOARD, KEY_LSHIFT)) ||
-        INPUTFILTER->IsBeingPressed(DeviceInput(DEVICE_KEYBOARD, KEY_RSHIFT));
+    bool bHoldingShift = IsEitherShiftHeld();
     if (bHoldingShift) {
       pc = (pc == PC_CPU) ? PC_HUMAN : PC_CPU;
     } else {
@@ -720,8 +735,7 @@ class DebugLineAssist : public IDebugLine {
   }
   virtual void DoAndLog(std::string& sMessageOut) {
     ASSERT(GAMESTATE->GetMasterPlayerNumber() != PLAYER_INVALID);
-    bool bHoldingShift =
-        INPUTFILTER->IsBeingPressed(DeviceInput(DEVICE_KEYBOARD, KEY_LSHIFT));
+    bool bHoldingShift = IsLeftShiftHeld();
     bool b;
     if (bHoldingShift) {
       b = !GAMESTATE->m_SongOptions.GetSong().m_bAssistMetronome;

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -84,6 +84,58 @@
 #include "UnlockManager.h"
 #include "ver.h"
 
+namespace {
+enum KeyboardModifierMask {
+  KEY_MODIFIER_SHIFT = 1 << 0,
+  KEY_MODIFIER_CTRL = 1 << 1,
+  KEY_MODIFIER_ALT = 1 << 2,
+  KEY_MODIFIER_META = 1 << 3,
+};
+
+// Builds a modifier mask from the event snapshot in input_list.
+// Default state is "no modifiers" (0). We set bits for various modifier keys
+// (Shift, Ctrl, Alt, etc) when that key is held. The modifiers are read from
+// the InputEventPlus snapshot (input_list) so we don't have to constantly call
+// InputFilter::IsBeingPressed(). This helps us avoid unnecessary mutex locking
+// or repeated searches on the same state.
+unsigned GetKeyboardModifierMask(const DeviceInputList& input_list) {
+  unsigned modifier_mask = 0;
+  for (const auto& device_input : input_list) {
+    if (device_input.device != DEVICE_KEYBOARD || !device_input.bDown) {
+      continue;
+    }
+
+    switch (device_input.button) {
+      case KEY_LSHIFT:
+      case KEY_RSHIFT:
+        modifier_mask |= KEY_MODIFIER_SHIFT;
+        break;
+      case KEY_LCTRL:
+      case KEY_RCTRL:
+        modifier_mask |= KEY_MODIFIER_CTRL;
+        break;
+      case KEY_LALT:
+      case KEY_RALT:
+        modifier_mask |= KEY_MODIFIER_ALT;
+        break;
+      case KEY_LMETA:
+      case KEY_RMETA:
+        modifier_mask |= KEY_MODIFIER_META;
+        break;
+      default:
+        break;
+    }
+
+    if (modifier_mask == (KEY_MODIFIER_SHIFT | KEY_MODIFIER_CTRL |
+                          KEY_MODIFIER_ALT | KEY_MODIFIER_META)) {
+      break;
+    }
+  }
+
+  return modifier_mask;
+}
+}  // namespace
+
 void ShutdownGame();
 bool HandleGlobalInputs(const InputEventPlus& input);
 void HandleInputEvents(float fDeltaTime);
@@ -1158,43 +1210,44 @@ bool HandleGlobalInputs(const InputEventPlus& input) {
   /* Re-added for StepMania 3.9 theming veterans, plus it's just faster than
    * the debug menu. The Shift button only reloads the metrics, unlike in 3.9
    * (where it saved bookkeeping and machine profile). -aj */
-  bool bIsShiftHeld =
-      INPUTFILTER->IsBeingPressed(
-          DeviceInput(DEVICE_KEYBOARD, KEY_LSHIFT), &input.InputList) ||
-      INPUTFILTER->IsBeingPressed(
-          DeviceInput(DEVICE_KEYBOARD, KEY_RSHIFT), &input.InputList);
-  bool bIsCtrlHeld =
-      INPUTFILTER->IsBeingPressed(
-          DeviceInput(DEVICE_KEYBOARD, KEY_LCTRL), &input.InputList) ||
-      INPUTFILTER->IsBeingPressed(
-          DeviceInput(DEVICE_KEYBOARD, KEY_RCTRL), &input.InputList);
+  const unsigned modifier_mask = GetKeyboardModifierMask(input.InputList);
+  const bool bIsShiftHeld = (modifier_mask & KEY_MODIFIER_SHIFT) != 0;
+  const bool bIsCtrlHeld = (modifier_mask & KEY_MODIFIER_CTRL) != 0;
+  const bool bIsAltHeld = (modifier_mask & KEY_MODIFIER_ALT) != 0;
+  const bool bIsMetaHeld = (modifier_mask & KEY_MODIFIER_META) != 0;
+
   if (input.DeviceI == DeviceInput(DEVICE_KEYBOARD, KEY_F2)) {
-    if (bIsShiftHeld && !bIsCtrlHeld) {
-      // Shift+F2: refresh metrics,noteskin cache and CodeDetector cache only
-      THEME->ReloadMetrics();
-      NOTESKIN->RefreshNoteSkinData(GAMESTATE->m_pCurGame);
-      CodeDetector::RefreshCacheItems();
-      SCREENMAN->SystemMessage(RELOADED_METRICS);
-    } else if (bIsCtrlHeld && !bIsShiftHeld) {
-      // Ctrl+F2: reload scripts only
-      if (NETWORK != nullptr) {
-        NETWORK->CloseAllWebSockets();
-      }
-      THEME->UpdateLuaGlobals();
-      SCREENMAN->SystemMessage(RELOADED_SCRIPTS);
-    } else if (bIsCtrlHeld && bIsShiftHeld) {
-      // Shift+Ctrl+F2: reload overlay screens (and metrics, since themers
-      // are likely going to do this after changing metrics.)
-      THEME->ReloadMetrics();
-      SCREENMAN->ReloadOverlayScreens();
-      SCREENMAN->SystemMessage(RELOADED_OVERLAY_SCREENS);
-    } else {
-      // F2 alone: refresh metrics, textures, noteskins, codedetector cache
-      THEME->ReloadMetrics();
-      TEXTUREMAN->ReloadAll();
-      NOTESKIN->RefreshNoteSkinData(GAMESTATE->m_pCurGame);
-      CodeDetector::RefreshCacheItems();
-      SCREENMAN->SystemMessage(RELOADED_METRICS_AND_TEXTURES);
+    switch (modifier_mask & (KEY_MODIFIER_SHIFT | KEY_MODIFIER_CTRL)) {
+      case KEY_MODIFIER_SHIFT:
+        // Shift+F2: refresh metrics,noteskin cache and CodeDetector cache only
+        THEME->ReloadMetrics();
+        NOTESKIN->RefreshNoteSkinData(GAMESTATE->m_pCurGame);
+        CodeDetector::RefreshCacheItems();
+        SCREENMAN->SystemMessage(RELOADED_METRICS);
+        break;
+      case KEY_MODIFIER_CTRL:
+        // Ctrl+F2: reload scripts only
+        if (NETWORK != nullptr) {
+          NETWORK->CloseAllWebSockets();
+        }
+        THEME->UpdateLuaGlobals();
+        SCREENMAN->SystemMessage(RELOADED_SCRIPTS);
+        break;
+      case KEY_MODIFIER_SHIFT | KEY_MODIFIER_CTRL:
+        // Shift+Ctrl+F2: reload overlay screens (and metrics, since themers
+        // are likely going to do this after changing metrics.)
+        THEME->ReloadMetrics();
+        SCREENMAN->ReloadOverlayScreens();
+        SCREENMAN->SystemMessage(RELOADED_OVERLAY_SCREENS);
+        break;
+      default:
+        // F2 alone: refresh metrics, textures, noteskins, codedetector cache
+        THEME->ReloadMetrics();
+        TEXTUREMAN->ReloadAll();
+        NOTESKIN->RefreshNoteSkinData(GAMESTATE->m_pCurGame);
+        CodeDetector::RefreshCacheItems();
+        SCREENMAN->SystemMessage(RELOADED_METRICS_AND_TEXTURES);
+        break;
     }
 
     return true;
@@ -1208,21 +1261,14 @@ bool HandleGlobalInputs(const InputEventPlus& input) {
 
 #if !defined(MACOSX)
   if (input.DeviceI == DeviceInput(DEVICE_KEYBOARD, KEY_F4)) {
-    if (INPUTFILTER->IsBeingPressed(
-            DeviceInput(DEVICE_KEYBOARD, KEY_RALT), &input.InputList) ||
-        INPUTFILTER->IsBeingPressed(
-            DeviceInput(DEVICE_KEYBOARD, KEY_LALT), &input.InputList)) {
+    if (bIsAltHeld) {
       // pressed Alt+F4
       ArchHooks::SetUserQuit();
       return true;
     }
   }
 #else
-  if (input.DeviceI == DeviceInput(DEVICE_KEYBOARD, KEY_Cq) &&
-      (INPUTFILTER->IsBeingPressed(
-           DeviceInput(DEVICE_KEYBOARD, KEY_LMETA), &input.InputList) ||
-       INPUTFILTER->IsBeingPressed(
-           DeviceInput(DEVICE_KEYBOARD, KEY_RMETA), &input.InputList))) {
+  if (input.DeviceI == DeviceInput(DEVICE_KEYBOARD, KEY_Cq) && bIsMetaHeld) {
     /* The user quit is handled by the menu item so we don't need to set it
      * here; however, we do want to return that it has been handled since
      * this will happen first. */
@@ -1235,41 +1281,25 @@ bool HandleGlobalInputs(const InputEventPlus& input) {
       // Notebooks don't have F13. Use cmd-F12 as well.
       input.DeviceI == DeviceInput(DEVICE_KEYBOARD, KEY_PRTSC) ||
       input.DeviceI == DeviceInput(DEVICE_KEYBOARD, KEY_F13) ||
-      (input.DeviceI == DeviceInput(DEVICE_KEYBOARD, KEY_F12) &&
-       (INPUTFILTER->IsBeingPressed(
-            DeviceInput(DEVICE_KEYBOARD, KEY_LMETA), &input.InputList) ||
-        INPUTFILTER->IsBeingPressed(
-            DeviceInput(DEVICE_KEYBOARD, KEY_RMETA), &input.InputList)));
+      (input.DeviceI == DeviceInput(DEVICE_KEYBOARD, KEY_F12) && bIsMetaHeld);
 #else
       /* The default Windows message handler will capture the desktop window
        * upon pressing PrntScrn, or will capture the foreground with focus upon
        * pressing Alt+PrntScrn. Windows will do this whether or not we save a
        * screenshot ourself by dumping the frame buffer. */
       // "if pressing PrintScreen and not pressing Alt"
-      input.DeviceI == DeviceInput(DEVICE_KEYBOARD, KEY_PRTSC) &&
-      !INPUTFILTER->IsBeingPressed(
-          DeviceInput(DEVICE_KEYBOARD, KEY_LALT), &input.InputList) &&
-      !INPUTFILTER->IsBeingPressed(
-          DeviceInput(DEVICE_KEYBOARD, KEY_RALT), &input.InputList);
+      input.DeviceI == DeviceInput(DEVICE_KEYBOARD, KEY_PRTSC) && !bIsAltHeld;
 #endif
   if (bDoScreenshot) {
     // If holding Shift save uncompressed, else save compressed
-    bool bHoldingShift =
-        (INPUTFILTER->IsBeingPressed(
-             DeviceInput(DEVICE_KEYBOARD, KEY_LSHIFT)) ||
-         INPUTFILTER->IsBeingPressed(DeviceInput(DEVICE_KEYBOARD, KEY_RSHIFT)));
-    bool bSaveCompressed = !bHoldingShift;
+    bool bSaveCompressed = !bIsShiftHeld;
     RageTimer timer;
     StepMania::SaveScreenshot("Screenshots/", bSaveCompressed, false, "", "");
     LOG->Trace("Screenshot took %f seconds.", timer.GetDeltaTime());
     return true;  // handled
   }
 
-  if (input.DeviceI == DeviceInput(DEVICE_KEYBOARD, KEY_ENTER) &&
-      (INPUTFILTER->IsBeingPressed(
-           DeviceInput(DEVICE_KEYBOARD, KEY_RALT), &input.InputList) ||
-       INPUTFILTER->IsBeingPressed(
-           DeviceInput(DEVICE_KEYBOARD, KEY_LALT), &input.InputList))) {
+  if (input.DeviceI == DeviceInput(DEVICE_KEYBOARD, KEY_ENTER) && bIsAltHeld) {
     // alt-enter
     /* In macOS, this is a menu item and will be handled as such. This will
      * happen first and then the lower priority GUI thread will happen second,

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1212,7 +1212,6 @@ bool HandleGlobalInputs(const InputEventPlus& input) {
    * (where it saved bookkeeping and machine profile). -aj */
   const unsigned modifier_mask = GetKeyboardModifierMask(input.InputList);
   const bool bIsShiftHeld = (modifier_mask & KEY_MODIFIER_SHIFT) != 0;
-  const bool bIsCtrlHeld = (modifier_mask & KEY_MODIFIER_CTRL) != 0;
   const bool bIsAltHeld = (modifier_mask & KEY_MODIFIER_ALT) != 0;
   const bool bIsMetaHeld = (modifier_mask & KEY_MODIFIER_META) != 0;
 


### PR DESCRIPTION
Last night I was reading the more recent changes to 1.2.0 I was not familiar with and was inspired to implement this after reading d00fad2d3ce5966b994845d602dd735e7f5fa718. This is a change I have been meaning to implement and finally got around to making the change & testing it. This change was largely inspired by DeadSync, where masking is used much more heavily than it is in SM/ITGm to prevent branching while possible.

When I noticed the amount of chained `IsBeingPressed()` calls, I thought the code was a bit messy and could stand to be consolidated / optimized. I was also worried because each of these incurs a [mutex lock](https://github.com/itgmania/itgmania/blob/5c737928d93778c2c9f68e276052b220b43a468f/src/InputFilter.cpp#L388-L397), and the expense of so many concurrent `IsBeingPressed()` calls can add up.

A design choice in DeadSync which I appreciated was the use of masking where possible to avoid lots of branching or repeated searches on the same object, as is common in SM/ITGm.

This gives us a few benefits:

- In ScreenDebugOverlay, it can generally be considered a cleanup, as the shift holding logic is consolidated into a single place for better readability and clarity. Readability is greatly improved as the reader does not have to keep track of each individual IsBeingPressed call, and the state is more easily understood.
- In HandleGlobalInputs, clearly labeled booleans/masks are easier to read and understand and can greatly simplify the code. For example, we can reduce the following to a simple `!bIsAltHeld`:

```
      !INPUTFILTER->IsBeingPressed(
          DeviceInput(DEVICE_KEYBOARD, KEY_LALT), &input.InputList) &&
      !INPUTFILTER->IsBeingPressed(
          DeviceInput(DEVICE_KEYBOARD, KEY_RALT), &input.InputList);
``` 


I tested all varieties of inputs and input combinations on all affected code and have not found any regression; everything was continuing to work as expected, including all F2 behavior.