### PR TITLE
Cap network task processing per frame

### DIFF
--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -24,6 +24,7 @@
 #include "RageFile.h"
 #include "RageFileManager.h"
 #include "RageLog.h"
+#include "RageTimer.h"
 #include "RageUtil.h"
 #include "SpecialFiles.h"
 #include "StdString.h"
@@ -72,6 +73,10 @@ static const char* WebSocketMessageTypeNames[] = {
     "Close",
     "Error",
 };
+
+static constexpr int kMaxMainThreadTasksPerUpdate = 32;
+static constexpr float kMaxMainThreadTaskSecondsPerUpdate = 0.001f;
+
 XToString(WebSocketMessageType);
 StringToX(WebSocketMessageType);
 LuaXType(WebSocketMessageType);
@@ -212,15 +217,27 @@ void NetworkManager::EnqueueMainThreadTask(std::function<void()> task) {
 }
 
 void NetworkManager::Update() {
-  std::queue<std::function<void()>> tasks;
-  {
-    std::lock_guard<std::mutex> lock(this->mainThreadTaskMutex);
-    std::swap(tasks, this->mainThreadTaskQueue);
-  }
+  RageTimer timer;
+  int tasksProcessed = 0;
 
-  while (!tasks.empty()) {
-    tasks.front()();
-    tasks.pop();
+  while (tasksProcessed < kMaxMainThreadTasksPerUpdate) {
+    std::function<void()> task;
+    {
+      std::lock_guard<std::mutex> lock(this->mainThreadTaskMutex);
+      if (this->mainThreadTaskQueue.empty()) {
+        break;
+      }
+
+      task = std::move(this->mainThreadTaskQueue.front());
+      this->mainThreadTaskQueue.pop();
+    }
+
+    task();
+    ++tasksProcessed;
+
+    if (timer.Ago() >= kMaxMainThreadTaskSecondsPerUpdate) {
+      break;
+    }
   }
 }
 


### PR DESCRIPTION
Prevents long blocking on the main thread by capping work done each frame in the main game loop. As it is, a burst of network events could cause the game to stutter if we receive them in chunks (e.g. slow network). Changes processing from swapping and executing the whole queue each time to popping and executing tasks one-by-one while honoring the limitations defined within this diff. This keeps the mutex held for a small, predictable amount of time, and allows larger network queues to pop over multiple frames (which should not be noticeable in practice).


This commit is made to address the 1.2.0 stuttering issue (#1245). I have the `NETWORK->Update()` refactored so that it can't hang the main game loop if it takes longer than expected because it is a blocking call.  In order to leave the GameLoop implementation unchanged, we can easily refactor the actual Update function itself to not let itself run for an excessively long time.

It simply leaves the existing functionality intact, but takes care to not block if we still have more stuff in the queue by the time we have to move onto the next frame.

My aging AMD A8 7600 was very noticeably affected by this stutter issue, presumably because its long pipeline exacerbates issues such as branch misprediction and mutex locking as it'll deal with such things less gracefully than short pipeline CPU designs. With this change I don't see the same stuttering that's very noticeable in 1.2.0.

Note the maximum queue processing value of 32 is kinda a guess. But, in testing,  nobody reported stuttering, and my most affected machine doesn't have stuttering i can notice, so i think it works.