### PR TITLE
release.yml fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
 
 name: Release
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
         with:
           msbuild-architecture: x64
 
+      - name: Configure
+        run: ${{ matrix.configure }}
       - name: Create nightly release
         if: github.ref_name == 'beta'
         run: >


### PR DESCRIPTION
First of all msbuild@v2, which we use, is going away this summer, so we need it changed by the time ITGm 1.3.0 rolls around. So 7fd32e6cd36c7bff019a5155ba98ad1843a19653 updates msbuild v2 to v3 and also appends the recommended opt-in for Node.js 24 support. We have no reason keeping us from upgrading so might as well IMO.


Lastly, I'm adding an explicit configure step to the release.yml. For whatever reason, it's causing [all my release build runs on my fork to fail](https://github.com/sukibaby/itgmania-testing/actions/runs/23494131840) that it isn't here. It seems like we rely on the “Create nightly release” / “Create full release” steps to act as configure steps, but this behavior apparently isn't guaranteed, as evidenced in [the necessity of me adding it for my own workflows to succeed](https://github.com/sukibaby/itgmania-testing/actions/runs/23494514677). 