### PR TITLE
Use uint64_t for popcount and replace inline assembly.

### DIFF
--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -164,8 +164,6 @@ void StageLayout::preCalculateStuff() {
 inline int popcount(unsigned int x) {
 #if defined(__GNUC__) || defined(__clang__)
   return __builtin_popcount(x);
-#elif defined(_MSC_VER)
-  return __popcnt(x);
 #else
   // Fallback implementation
   int count = 0;

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -166,13 +166,17 @@ inline int popcount(uint64_t x) {
 #if defined(__clang__) || defined(__GNUC__)
   return __builtin_popcountll(x);
 #else
-  // Fallback implementation
-  int count = 0;
-  while (x) {
-    x &= x - 1;  // Clear the lowest set bit
-    count++;
-  }
-  return count;
+  // popcount64b from https://en.wikipedia.org/wiki/Hamming_weight
+  constexpr uint64_t m1 = 0x5555555555555555;  // binary: 0101...
+  constexpr uint64_t m2 = 0x3333333333333333;  // binary: 00110011..
+  constexpr uint64_t m4 = 0x0f0f0f0f0f0f0f0f;  // binary:  4 zeros,  4 ones ...
+  x -= (x >> 1) & m1;              // put count of each 2 bits into those 2 bits
+  x = (x & m2) + ((x >> 2) & m2);  // put count of each 4 bits into those 4 bits
+  x = (x + (x >> 4)) & m4;         // put count of each 8 bits into those 8 bits
+  x += x >> 8;   // put count of each 16 bits into their lowest 8 bits
+  x += x >> 16;  // put count of each 32 bits into their lowest 8 bits
+  x += x >> 32;  // put count of each 64 bits into their lowest 8 bits
+  return x & 0x7f;
 #endif
 }
 

--- a/src/StepParityDatastructs.cpp
+++ b/src/StepParityDatastructs.cpp
@@ -161,9 +161,10 @@ void StageLayout::preCalculateStuff() {
 
 // Counts the number of ones in the binary representation
 // of the given `x`.
-inline int popcount(unsigned int x) {
-#if defined(__GNUC__) || defined(__clang__)
-  return __builtin_popcount(x);
+// TODO: use std::popcount if we upgrade to C++20.
+inline int popcount(uint64_t x) {
+#if defined(__clang__) || defined(__GNUC__)
+  return __builtin_popcountll(x);
 #else
   // Fallback implementation
   int count = 0;


### PR DESCRIPTION
The SSE4 __popcnt is not actually available on all 64-bit x86 CPU's, and was causing the game to fail immediately upon song loading on CPU's without this instruction. I've replaced it with one of the faster pure-C implementations ("popcount64b" from https://en.wikipedia.org/wiki/Hamming_weight). The game now launches and runs on older CPU's.

I was able to confirm this patch resolves the issue on a Pentium E2160 running Win 7 64-bit.