### PR TITLE
Added SampleMusicStartsImmediately themepref

### DIFF
--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -2134,6 +2134,7 @@ DefaultSort=GAMESTATE:IsCourseMode() and "Group" or "AllCourses"
 #
 SampleMusicPreviewMode='SampleMusicPreviewMode_Normal'
 SampleMusicLoops=true
+SampleMusicStartsImmediately=true
 SampleMusicFallbackFadeInSeconds=0
 SampleMusicFadeOutSeconds=1.5
 #

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -112,6 +112,7 @@ void ScreenSelectMusic::Init() {
   SAMPLE_MUSIC_DELAY_INIT.Load(m_sName, "SampleMusicDelayInit");
   SAMPLE_MUSIC_DELAY.Load(m_sName, "SampleMusicDelay");
   SAMPLE_MUSIC_LOOPS.Load(m_sName, "SampleMusicLoops");
+  SAMPLE_MUSIC_STARTS_IMMEDIATELY.Load(m_sName, "SampleMusicStartsImmediately");
   SAMPLE_MUSIC_PREVIEW_MODE.Load(m_sName, "SampleMusicPreviewMode");
   SAMPLE_MUSIC_FALLBACK_FADE_IN_SECONDS.Load(
       m_sName, "SampleMusicFallbackFadeInSeconds");
@@ -139,6 +140,8 @@ void ScreenSelectMusic::Init() {
   CHANGE_STEPS_WITH_GAME_BUTTONS.Load(m_sName, "ChangeStepsWithGameButtons");
   CHANGE_GROUPS_WITH_GAME_BUTTONS.Load(m_sName, "ChangeGroupsWithGameButtons");
   CONFIRM_EXIT.Load(m_sName, "ConfirmExit");
+
+  m_bPreviewDisabled = !SAMPLE_MUSIC_STARTS_IMMEDIATELY;
 
   m_GameButtonPreviousSong = INPUTMAPPER->GetInputScheme()->ButtonNameToIndex(
       THEME->GetMetric(m_sName, "PreviousSongButton"));
@@ -408,6 +411,12 @@ void ScreenSelectMusic::CheckBackgroundRequests(bool bForce) {
   // Nothing else is going.  Start the music, if we haven't yet.
   if (g_bSampleMusicWaiting) {
     if (g_ScreenStartedLoadingAt.Ago() < SAMPLE_MUSIC_DELAY_INIT) {
+      return;
+    }
+
+    if (m_bPreviewDisabled) {
+      m_bPreviewDisabled = false;
+      g_bSampleMusicWaiting = false;
       return;
     }
 

--- a/src/ScreenSelectMusic.h
+++ b/src/ScreenSelectMusic.h
@@ -95,6 +95,7 @@ class ScreenSelectMusic : public ScreenWithMenuElements {
   ThemeMetric<float> SAMPLE_MUSIC_DELAY_INIT;
   ThemeMetric<float> SAMPLE_MUSIC_DELAY;
   ThemeMetric<bool> SAMPLE_MUSIC_LOOPS;
+  ThemeMetric<bool> SAMPLE_MUSIC_STARTS_IMMEDIATELY;
   ThemeMetric<SampleMusicPreviewMode> SAMPLE_MUSIC_PREVIEW_MODE;
   ThemeMetric<float> SAMPLE_MUSIC_FALLBACK_FADE_IN_SECONDS;
   ThemeMetric<float> SAMPLE_MUSIC_FADE_OUT_SECONDS;
@@ -174,6 +175,8 @@ class ScreenSelectMusic : public ScreenWithMenuElements {
   bool m_bAllowOptionsMenu, m_bAllowOptionsMenuRepeat;
   bool m_bSelectIsDown[NUM_PLAYERS];
   bool m_bAcceptSelectRelease[NUM_PLAYERS];
+
+  bool m_bPreviewDisabled;
 
   RageSound m_soundStart;
   RageSound m_soundDifficultyEasier;


### PR DESCRIPTION
solves https://github.com/itgmania/itgmania/issues/1253
goes with https://github.com/Simply-Love/Simply-Love-SM5/pull/725

When set to off the preview music doesn't play until you move the MusicWheel