### PR TITLE
Control disabled OptionRow visibility with bHideDisabledRows parameter

### DIFF
--- a/Docs/Themerdocs/Examples/Example_Screens/ScreenOptionsExample.ini
+++ b/Docs/Themerdocs/Examples/Example_Screens/ScreenOptionsExample.ini
@@ -111,6 +111,7 @@ Linen="gamecommand;name,ExampleCommand"
 #   "default":  Sets the default choice.  Takes one argument, the number of the choice.  "default,2" makes the second choice the default.
 #   "reloadrowmessages":  Sets the messages that will cause the row to be reloaded.  Arguments are the messages.
 #   "enabledforplayers":  Sets which players are allowed to use the row.  Arguments are numbers.
+#   "hideondisable": Sets whether rows that are not enabled for any player are hidden.
 #   "exportonchange":  Sets whether the option is exported every time it changes.
 #   "broadcastonexport":  Sets the messages that are broadcast when the row is exported.  Arguments are the messages.
 # Example line using all flags:

--- a/Docs/Themerdocs/Examples/OptionRowHandlerLua.lua
+++ b/Docs/Themerdocs/Examples/OptionRowHandlerLua.lua
@@ -58,6 +58,10 @@ function FooMods()
 			-- Leave out PLAYER_1 just for example.
 			return {PLAYER_2}
 		end,
+		-- Optional boolean.  If true, rows that are not enabled for any player
+		-- will be hidden.  If false, they will be shown but faded out. "Enabled
+		-- rows" are controlled by EnabledForPlayers above
+		HideOnDisable= false,
 
 		-- Optional function. If non-nil, this function must return the string representation
 		-- of a member of the ReloadChanged enum. This function is called in response to a message

--- a/Docs/Themerdocs/ThemePrefsRows.txt
+++ b/Docs/Themerdocs/ThemePrefsRows.txt
@@ -78,6 +78,9 @@ ExportOnChange (bool): currently disabled in the source, but available to
 EnabledForPlayers (function): has 'self' as an argument, returns a table of
 	PlayerNumbers who are allowed to select stuff. Not important yet.
 
+HideOnDisable (bool): controls whether if we should hide the row if it is
+    not enabled for any player. 
+
 ReloadRowMessages (table): contains an indexed array of strings. Whenever 
 	any of the messages in this table are broadcast, the Load function
 	(which loads the list of possible options and sets the selected

--- a/src/OptionRowHandler.cpp
+++ b/src/OptionRowHandler.cpp
@@ -221,8 +221,8 @@ class OptionRowHandlerList : public OptionRowHandler {
           }
         } else if (sName == "exportonchange") {
           m_Def.m_bExportOnChange = true;
-        } else if (sName == "hidedisabledrows") {
-          m_Def.m_bHideDisabledRows = true;
+        } else if (sName == "hideondisable") {
+          m_Def.m_bHideOnDisable = true;
         } else if (sName == "broadcastonexport") {
           for (unsigned j = 1; j < cmd.m_vsArgs.size(); j++) {
             m_vsBroadcastOnExport.push_back(cmd.m_vsArgs[j]);
@@ -1081,8 +1081,8 @@ class OptionRowHandlerLua : public OptionRowHandler {
     m_Def.m_bExportOnChange = lua_toboolean(L, -1) > 0;
     lua_pop(L, 1);
 
-    lua_getfield(L, -1, "HideDisabledRows");
-    m_Def.m_bHideDisabledRows = lua_toboolean(L, -1) > 0;
+    lua_getfield(L, -1, "HideOnDisable");
+    m_Def.m_bHideOnDisable = lua_toboolean(L, -1) > 0;
     lua_pop(L, 1);
 
     // TODO:  Change these to use the proper enum strings like everything

--- a/src/OptionRowHandler.cpp
+++ b/src/OptionRowHandler.cpp
@@ -221,6 +221,8 @@ class OptionRowHandlerList : public OptionRowHandler {
           }
         } else if (sName == "exportonchange") {
           m_Def.m_bExportOnChange = true;
+        } else if (sName == "hidedisabledrows") {
+          m_Def.m_bHideDisabledRows = true;
         } else if (sName == "broadcastonexport") {
           for (unsigned j = 1; j < cmd.m_vsArgs.size(); j++) {
             m_vsBroadcastOnExport.push_back(cmd.m_vsArgs[j]);
@@ -1077,6 +1079,10 @@ class OptionRowHandlerLua : public OptionRowHandler {
 
     lua_getfield(L, -1, "ExportOnChange");
     m_Def.m_bExportOnChange = lua_toboolean(L, -1) > 0;
+    lua_pop(L, 1);
+
+    lua_getfield(L, -1, "HideDisabledRows");
+    m_Def.m_bHideDisabledRows = lua_toboolean(L, -1) > 0;
     lua_pop(L, 1);
 
     // TODO:  Change these to use the proper enum strings like everything

--- a/src/OptionRowHandler.h
+++ b/src/OptionRowHandler.h
@@ -63,7 +63,7 @@ struct OptionRowDefinition {
                                                 // change focus to this row
   int m_iDefault;
   bool m_bExportOnChange;
-  bool m_bHideDisabledRows;
+  bool m_bHideOnDisable;
   /**
    * @brief Are theme items allowed here?
    *
@@ -102,7 +102,7 @@ struct OptionRowDefinition {
         m_vEnabledForPlayers(),
         m_iDefault(-1),
         m_bExportOnChange(false),
-        m_bHideDisabledRows(false),
+        m_bHideOnDisable(false),
         m_bAllowThemeItems(true),
         m_bAllowThemeTitle(true),
         m_bAllowExplanation(true),
@@ -120,7 +120,7 @@ struct OptionRowDefinition {
     FOREACH_PlayerNumber(pn) m_vEnabledForPlayers.insert(pn);
     m_iDefault = -1;
     m_bExportOnChange = false;
-    m_bHideDisabledRows = false;
+    m_bHideOnDisable = false;
     m_bAllowThemeItems = true;
     m_bAllowThemeTitle = true;
     m_bAllowExplanation = true;
@@ -147,7 +147,7 @@ struct OptionRowDefinition {
         m_vEnabledForPlayers(),
         m_iDefault(-1),
         m_bExportOnChange(false),
-        m_bHideDisabledRows(false),
+        m_bHideOnDisable(false),
         m_bAllowThemeItems(true),
         m_bAllowThemeTitle(true),
         m_bAllowExplanation(true),

--- a/src/OptionRowHandler.h
+++ b/src/OptionRowHandler.h
@@ -63,6 +63,7 @@ struct OptionRowDefinition {
                                                 // change focus to this row
   int m_iDefault;
   bool m_bExportOnChange;
+  bool m_bHideDisabledRows;
   /**
    * @brief Are theme items allowed here?
    *
@@ -101,6 +102,7 @@ struct OptionRowDefinition {
         m_vEnabledForPlayers(),
         m_iDefault(-1),
         m_bExportOnChange(false),
+        m_bHideDisabledRows(false),
         m_bAllowThemeItems(true),
         m_bAllowThemeTitle(true),
         m_bAllowExplanation(true),
@@ -118,6 +120,7 @@ struct OptionRowDefinition {
     FOREACH_PlayerNumber(pn) m_vEnabledForPlayers.insert(pn);
     m_iDefault = -1;
     m_bExportOnChange = false;
+    m_bHideDisabledRows = false;
     m_bAllowThemeItems = true;
     m_bAllowThemeTitle = true;
     m_bAllowExplanation = true;
@@ -144,6 +147,7 @@ struct OptionRowDefinition {
         m_vEnabledForPlayers(),
         m_iDefault(-1),
         m_bExportOnChange(false),
+        m_bHideDisabledRows(false),
         m_bAllowThemeItems(true),
         m_bAllowThemeTitle(true),
         m_bAllowExplanation(true),

--- a/src/ScreenOptions.cpp
+++ b/src/ScreenOptions.cpp
@@ -614,8 +614,14 @@ void ScreenOptions::PositionRows(bool bTween) {
   }
 
   std::vector<int> visibleRows;
+
   for (int i = 0; i < (int)Rows.size(); i++) {
-    if (!Rows[i]->GetRowDef().m_vEnabledForPlayers.empty()) {
+    const OptionRowDefinition& def = Rows[i]->GetRowDef();
+    // We only hide rows if HideDisabledRows is true, and the row is not enabled
+    // for any player. If HideDisabledRows is false, we show all rows, even if
+    // they are not enabled for any player. Disabled rows show up faded out if
+    // they are not enabled
+    if (!def.m_vEnabledForPlayers.empty() || !def.m_bHideDisabledRows) {
       visibleRows.push_back(i);
     }
   }
@@ -718,24 +724,27 @@ void ScreenOptions::PositionRows(bool bTween) {
   for (int i = 0; i < (int)Rows.size(); i++)  // foreach row
   {
     OptionRow& row = *Rows[i];
+    const OptionRowDefinition& def = row.GetRowDef();
 
-    bool bRowEnabled =
-        bTreatAllRowsVisible || !row.GetRowDef().m_vEnabledForPlayers.empty();
+    const bool bRowEnabled = !def.m_vEnabledForPlayers.empty();
+    const bool bHideDisabled = def.m_bHideDisabledRows;
+    const bool bRowVisible =
+        bRowEnabled || !bHideDisabled || bTreatAllRowsVisible;
     int thisVisibleIndex = -1;
-    if (bRowEnabled) {
+    if (bRowVisible) {
       thisVisibleIndex = visibleIndex;
       visibleIndex++;
     }
 
     float fPos = (float)pos;
 
-    if (bRowEnabled && thisVisibleIndex < first_start) {
+    if (bRowVisible && thisVisibleIndex < first_start) {
       fPos = -0.5f;
     } else if (
-        bRowEnabled && thisVisibleIndex >= first_end &&
+        bRowVisible && thisVisibleIndex >= first_end &&
         thisVisibleIndex < second_start) {
       fPos = ((int)NUM_ROWS_SHOWN) / 2 - 0.5f;
-    } else if (bRowEnabled && thisVisibleIndex >= second_end) {
+    } else if (bRowVisible && thisVisibleIndex >= second_end) {
       fPos = ((int)NUM_ROWS_SHOWN) - 0.5f;
     }
 
@@ -743,14 +752,14 @@ void ScreenOptions::PositionRows(bool bTween) {
         m_exprRowPositionTransformFunction.GetTransformCached(
             fPos, i, std::min((int)Rows.size(), (int)NUM_ROWS_SHOWN));
 
-    bool bHidden = !bRowEnabled;
-    if (bRowEnabled) {
+    bool bHidden = !bRowVisible;
+    if (bRowVisible) {
       bHidden =
           thisVisibleIndex < first_start ||
           (thisVisibleIndex >= first_end && thisVisibleIndex < second_start) ||
           thisVisibleIndex >= second_end;
     }
-    if (!bRowEnabled) {
+    if (!bRowEnabled && bHideDisabled) {
       bHidden = true;
       row.SetVisible(false);
     } else {
@@ -1455,10 +1464,12 @@ void ScreenOptions::SetOptionRowVisible(
 
   OptionRowDefinition& def = pOptRow->GetRowDef();
   if (visible) {
+    def.m_bHideDisabledRows = false;
     if (def.m_vEnabledForPlayers.empty()) {
       FOREACH_PlayerNumber(pn) def.m_vEnabledForPlayers.insert(pn);
     }
   } else {
+    def.m_bHideDisabledRows = true;
     def.m_vEnabledForPlayers.clear();
   }
 

--- a/src/ScreenOptions.cpp
+++ b/src/ScreenOptions.cpp
@@ -617,11 +617,12 @@ void ScreenOptions::PositionRows(bool bTween) {
 
   for (int i = 0; i < (int)Rows.size(); i++) {
     const OptionRowDefinition& def = Rows[i]->GetRowDef();
-    // We only hide rows if HideDisabledRows is true, and the row is not enabled
-    // for any player. If HideDisabledRows is false, we show all rows, even if
+    // We only hide rows if HideOnDisable is true, and the row is not enabled
+    // for any player. If HideOnDisable is false, we show all rows, even if
     // they are not enabled for any player. Disabled rows show up faded out if
     // they are not enabled
-    if (!def.m_vEnabledForPlayers.empty() || !def.m_bHideDisabledRows) {
+    if (!def.m_vEnabledForPlayers.empty() ||
+        !Rows[i]->GetRowDef().m_bHideOnDisable) {
       visibleRows.push_back(i);
     }
   }
@@ -727,7 +728,7 @@ void ScreenOptions::PositionRows(bool bTween) {
     const OptionRowDefinition& def = row.GetRowDef();
 
     const bool bRowEnabled = !def.m_vEnabledForPlayers.empty();
-    const bool bHideDisabled = def.m_bHideDisabledRows;
+    const bool bHideDisabled = def.m_bHideOnDisable;
     const bool bRowVisible =
         bRowEnabled || !bHideDisabled || bTreatAllRowsVisible;
     int thisVisibleIndex = -1;
@@ -1464,12 +1465,12 @@ void ScreenOptions::SetOptionRowVisible(
 
   OptionRowDefinition& def = pOptRow->GetRowDef();
   if (visible) {
-    def.m_bHideDisabledRows = false;
+    def.m_bHideOnDisable = false;
     if (def.m_vEnabledForPlayers.empty()) {
       FOREACH_PlayerNumber(pn) def.m_vEnabledForPlayers.insert(pn);
     }
   } else {
-    def.m_bHideDisabledRows = true;
+    def.m_bHideOnDisable = true;
     def.m_vEnabledForPlayers.clear();
   }
 


### PR DESCRIPTION
Follow up to: https://github.com/itgmania/itgmania/pull/1240

The previous fix resolved the crashing, but some option rows were unintentionally hidden in Edit Mode. This is because Edit Mode leverages an empty m_vEnabledForPlayers vector to create read-only menus AND read only rows for displaying information. 

This commit adds a bool parameter ``bHideOnDisable`` which controls whether optionrows hide or not when it is not enabled for any players (empty m_vEnabledForPlayers). By default this is false in order to maintain read-only menu behavior in Edit Mode for disabled rows.

OptionRows can still be outright hidden on the fly using SetOptionRowVisibility irregardless of this setting.
