### PR TITLE
Include guards

### DIFF
--- a/src/ActorMultiVertex.h
+++ b/src/ActorMultiVertex.h
@@ -1,3 +1,6 @@
+#ifndef ACTORMULTIVERTEX_H
+#define ACTORMULTIVERTEX_H
+
 /** @brief ActorMultiVertex - An actor with mutiple vertices. Can be used to
  * create shapes that quads can't. */
 
@@ -225,3 +228,4 @@ class ActorMultiVertex : public Actor {
  * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  * PERFORMANCE OF THIS SOFTWARE.
  */
+#endif

--- a/src/EditModePlayerManager.h
+++ b/src/EditModePlayerManager.h
@@ -1,3 +1,5 @@
+#ifndef EDITMODEPLAYERMANAGER_H
+#define EDITMODEPLAYERMANAGER_H
 
 #include <memory>
 #include <unordered_map>
@@ -49,3 +51,4 @@ class EditModePlayerManager {
   std::unordered_map<PlayerNumber, std::shared_ptr<PlayerPlus>> players_;
   bool center_;
 };
+#endif

--- a/src/GameplayHelpers.h
+++ b/src/GameplayHelpers.h
@@ -1,3 +1,6 @@
+#ifndef GAMEPLAYHELPERS_H
+#define GAMEPLAYHELPERS_H
+
 #include <vector>
 
 // A very simple pair floats that represent the pixels of the left and right
@@ -15,3 +18,4 @@ struct NotefieldMargins {
 // By default points to GameplayMargins in Themes/_fallback/Scripts/03
 // Gameplay.lua
 std::vector<NotefieldMargins> GetNotefieldMargins();
+#endif

--- a/src/arch/Sound/ALSA9Dynamic.h
+++ b/src/arch/Sound/ALSA9Dynamic.h
@@ -1,4 +1,5 @@
 #ifndef ALSA9_DYNAMIC_H
+#define ALSA9_DYNAMIC_H
 
 #include <alsa/asoundlib.h>
 

--- a/src/arch/Sound/ALSA9Functions.h
+++ b/src/arch/Sound/ALSA9Functions.h
@@ -1,5 +1,9 @@
 #include <cstddef>
 
+#ifndef FUNC
+#error "Improper use of FUNC X-macro in ALSA9Functions.h"
+#endif
+
 FUNC(size_t, snd_pcm_hw_params_sizeof, (void));
 FUNC(size_t, snd_pcm_sw_params_sizeof, (void));
 FUNC(size_t, snd_pcm_info_sizeof, (void));

--- a/src/archutils/SpecialDirs.h
+++ b/src/archutils/SpecialDirs.h
@@ -1,3 +1,6 @@
+#ifndef SPECIALDIRS_H
+#define SPECIALDIRS_H
+
 #if defined(ANDROID)
 #include "Android/SpecialDirs.h"
 #elif defined(_WIN32)
@@ -31,3 +34,4 @@
  * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  * PERFORMANCE OF THIS SOFTWARE.
  */
+#endif


### PR DESCRIPTION
A bit of maintenance on our include guards:

1. Add include guards to header files which were missing them
2. Fix broken ALSA include header, and add ifndef guard to X-macro list (ALSA9Functions.h)
3. Swap from include guards to pragma once across the codebase.