### PR TITLE
[work-in-progress] macOS mouse support via NSEvent

### DIFF
--- a/src/arch/InputHandler/InputHandler_NSEvent.mm
+++ b/src/arch/InputHandler/InputHandler_NSEvent.mm
@@ -6,6 +6,7 @@
 //
 
 #include "InputHandler_NSEvent.hpp"
+#include "InputFilter.h"
 #include "archutils/Darwin/CocoaEventDispatcher.h"
 #include "global.h"
 
@@ -149,6 +150,13 @@ void InputHandler_NSEvent::InitKeyCodeMap() {
 
 void InputHandler_NSEvent::HandleEvent(NSEvent* e) {
   NSEventType type = [e type];
+
+  if (type == NSEventTypeMouseMoved) {
+    NSPoint mouseLocation = [e locationInWindow];
+    INPUTFILTER->UpdateCursorLocation(mouseLocation.x, mouseLocation.y);
+    return;
+  }
+
   if (type != NSEventTypeKeyDown && type != NSEventTypeKeyUp && type != NSEventTypeFlagsChanged) {
     return;
   }


### PR DESCRIPTION
# mouse support in ITGmania
ITGmania already offers rudimentary mouse support on Windows and Linux, though not macOS.  As far as I can tell, the macOS `MouseDevice` driver was never finished.

Some themes like Digital Dance and Simply-Love-SM5-v4.9.1 use mouse input via `INPUTFILTER`, so it'd be nice to support on macOS.

This PR attempts to add it to the NSEvent driver, but it's not ready to merge.  My hope is that someone who knows macOS's APIs better than I will see this and be able to help. :)

## how to test in a theme

I tested these changes by adding this Lua to Simply Love's *./BGAnimations/ScreenWithMenuElements background.lua*:
```lua
local update = function()
  SM( ("mouse x: %f\nmouse y: %f"):format(INPUTFILTER:GetMouseX(), INPUTFILTER:GetMouseY()))
end

local t = Def.ActorFrame{}
t.InitCommand=function(self) self:SetUpdateFunction(update) end

return t
```

## existing Windows implementation

On Windows, the implementation is such that mouse `[0,0]` is top-left of the window, and bringing your mouse cursor beyond the left-edge or top-edge of the window will return negative x and y coordinates respectively.

https://github.com/user-attachments/assets/89d3f310-7686-4117-b887-c53180520ea4


## this PR: not-quite-ready macOS implementation

With this PR, macOS mouse behavior has `[0,0]` at the **bottom-left** of the window, and bringing your mouse cursor beyond the left-edge or bottom-edge will (seemingly) cause the mouse's coordinates to be **relative to the screen**, rather than to ITGmania window.

https://github.com/user-attachments/assets/441c327b-5854-4cae-9d84-69d624a88b6a

## What Would Need To Be Done
So this PR is a start, but there's two issues to fix before it could be considered for merge:
1. y-axis coordinates within the window need to be flipped.  `[0,0]` should be top-left of the window to match Windows and Linux.
2. Mouse coordinates should report as negative values when ITGmania is windowed and the cursor goes higher-than or to-the-left-of the window.

## what I've tried

I experimented with creating a boolean `mouseInWindow` owned by InputHandler_NSEvent.mm, setting it based on NSEvent's `mouseEntered` and `mouseExited` events, and using it to only call `INPUTFILTER->UpdateCursorLocation()` when the cursor was within window bounds, but in practice I found it too flaky to be usable.  Sometimes `mouseEntered` and `mousedExited` didn't seem to fire.

I don't know macOS's APIs well enough to take this PR further, but maybe someone reading does.