### PR TITLE
Add YAML linter to CI

### DIFF
--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -1,0 +1,21 @@
+name: Lint YAML
+
+on:
+    pull_request:
+        paths:
+            - ".github/**"
+    push:
+        paths:
+            - ".github/**"
+jobs:
+    yamllint:
+        # note: ubuntu-slim is container-based, rather than being a full VM
+        runs-on: ubuntu-slim
+        steps:
+            - uses: actions/checkout@v6
+            - run: |
+                  sudo apt-get update
+                  sudo apt-get install -y yamllint
+            - run: |
+                  set -e
+                  yamllint -d "{extends: relaxed, rules: {line-length: disable}}" .github


### PR DESCRIPTION
Runs **yamllint** in a containerized session, sets a failure if there are errors, but forgives `line-length` warnings. Super basic.