### PR TITLE
Create .cmake-format.yaml

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,0 +1,39 @@
+# .cmake-format.yaml
+---
+format:
+  disable: false
+  line_width: 80
+  tab_size: 4
+  use_tabchars: false
+  fractional_tab_policy: use-space
+  line_ending: unix
+  command_case: canonical
+  keyword_case: unchanged
+  max_pargs_hwrap: 6
+  max_subgroups_hwrap: 2
+  max_rows_cmdline: 2
+  max_lines_hwrap: 2
+  dangle_parens: false
+  dangle_align: prefix
+  separate_ctrl_name_with_space: false
+  separate_fn_name_with_space: false
+  min_prefix_chars: 4
+  max_prefix_chars: 10
+  always_wrap: []
+  enable_sort: true
+  autosort: false
+  require_valid_layout: false
+  layout_passes: {}
+markup:
+  enable_markup: true
+  first_comment_is_literal: true
+  literal_comment_pattern: '(?s).*(Arguments:|Example usage:|Note:).*'
+  fence_pattern: '^\\s*([`~]{3}[`~]*)(.*)$'
+  ruler_pattern: '^\\s*[^\\w\\s]{3}.*[^\\w\\s]{3}$'
+  explicit_trailing_pattern: '#<'
+  hashruler_min_length: 10
+  canonicalize_hashrulers: true
+encode:
+  input_encoding: utf-8
+  output_encoding: utf-8
+  emit_byteorder_mark: false


### PR DESCRIPTION
This rules can be used by cmake-format.

The cmake-format rules at https://github.com/NVIDIA/aerial-framework/blob/main/.cmake-format.yaml were used as a basis for this configuration.