### PR TITLE
Resolve "maybe uninitialized" warning in RageFileBasic

### DIFF
--- a/src/RageFileBasic.cpp
+++ b/src/RageFileBasic.cpp
@@ -28,7 +28,20 @@ RageFileObj::RageFileObj() {
   m_iCRC32 = 0;
 }
 
-RageFileObj::RageFileObj(const RageFileObj& cpy) : RageFileBasic(cpy) {
+RageFileObj::RageFileObj(const RageFileObj& cpy)
+    : RageFileBasic(cpy),
+      m_sError(cpy.m_sError),
+      m_bEOF(cpy.m_bEOF),
+      m_iFilePos(cpy.m_iFilePos),
+      m_pReadBuffer(nullptr),
+      m_pReadBuf(nullptr),
+      m_iReadBufAvail(cpy.m_iReadBufAvail),
+      m_pWriteBuffer(nullptr),
+      m_iWriteBufferPos(cpy.m_iWriteBufferPos),
+      m_iWriteBufferSize(cpy.m_iWriteBufferSize),
+      m_iWriteBufferUsed(cpy.m_iWriteBufferUsed),
+      m_bCRC32Enabled(cpy.m_bCRC32Enabled),
+      m_iCRC32(cpy.m_iCRC32) {
   /* If the original file has a buffer, copy it. */
   if (cpy.m_pReadBuffer != nullptr) {
     m_pReadBuffer = new char[BSIZE];
@@ -41,20 +54,9 @@ RageFileObj::RageFileObj(const RageFileObj& cpy) : RageFileBasic(cpy) {
   }
 
   if (cpy.m_pWriteBuffer != nullptr) {
-    m_pWriteBuffer = new char[cpy.m_iWriteBufferSize];
+    m_pWriteBuffer = new char[m_iWriteBufferSize];
     memcpy(m_pWriteBuffer, cpy.m_pWriteBuffer, m_iWriteBufferUsed);
-  } else {
-    m_pWriteBuffer = nullptr;
   }
-
-  m_iReadBufAvail = cpy.m_iReadBufAvail;
-  m_bEOF = cpy.m_bEOF;
-  m_iFilePos = cpy.m_iFilePos;
-  m_iWriteBufferPos = cpy.m_iWriteBufferPos;
-  m_iWriteBufferSize = cpy.m_iWriteBufferSize;
-  m_iWriteBufferUsed = cpy.m_iWriteBufferUsed;
-  m_bCRC32Enabled = cpy.m_bCRC32Enabled;
-  m_iCRC32 = cpy.m_iCRC32;
 }
 
 RageFileObj::~RageFileObj() {


### PR DESCRIPTION
We get a memcpy warning that m_iWriteBufferUsed may be uninitialized. This patch ensures m_iWriteBufferUsed is read before assigning it from cpy, so we can be sure the object is initialized into a valid state before we operate on it. Functionality isn't changed in with this patch.