### PR TITLE
Small Improvements to macOS crash handling

### DIFF
--- a/src/archutils/Darwin/Crash.h
+++ b/src/archutils/Darwin/Crash.h
@@ -4,7 +4,7 @@
 
 namespace CrashHandler {
 std::string GetLogsDirectory();
-void InformUserOfCrash(const std::string& sPath);
+void InformUserOfCrash(const std::string& sCrashInfoPath);
 bool IsDebuggerPresent();
 void DebugBreak();
 }  // namespace CrashHandler

--- a/src/archutils/Darwin/Crash.mm
+++ b/src/archutils/Darwin/Crash.mm
@@ -14,14 +14,15 @@
 #endif
 #include <sys/sysctl.h>
 
+#import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
 
 std::string CrashHandler::GetLogsDirectory() {
   NSFileManager* fileManager = [NSFileManager defaultManager];
-  
+
   NSString* bundleParent = [[[NSBundle mainBundle] bundlePath] stringByDeletingLastPathComponent];
   NSString* portablePath = [bundleParent stringByAppendingPathComponent:@"Portable.ini"];
-  
+
   BOOL isPortable = [fileManager fileExistsAtPath:portablePath];
   if (isPortable) {
     return std::string([bundleParent UTF8String]) + "/Logs";
@@ -43,7 +44,7 @@ std::string CrashHandler::GetLogsDirectory() {
 // XXX Can we use LocalizedString here instead?
 #define LSTRING(b, x) CFBundleCopyLocalizedString((b), CFSTR(x), nullptr, CFSTR("Localizable"))
 
-void CrashHandler::InformUserOfCrash(const std::string& sPath) {
+void CrashHandler::InformUserOfCrash(const std::string& sCrashInfoPath) {
   CFBundleRef bundle = CFBundleGetMainBundle();
   CFStringRef sAlternate = LSTRING(bundle, "Quit " PRODUCT_FAMILY);
   /* XXX Translate these and remove the redefine of LSTRING. Another way to do this
@@ -59,7 +60,7 @@ void CrashHandler::InformUserOfCrash(const std::string& sPath) {
                              "Debugging information has been output to\n\n%s\n\n"
                              "Please file a bug report at\n\n%s");
   CFStringRef sBody = CFStringCreateWithFormat(
-      kCFAllocatorDefault, nullptr, sFormat, sPath.c_str(), REPORT_BUG_URL);
+      kCFAllocatorDefault, nullptr, sFormat, sCrashInfoPath.c_str(), REPORT_BUG_URL);
   CFOptionFlags response = kCFUserNotificationCancelResponse;
   CFTimeInterval timeout = 0.0;  // Should we ever time out?
 
@@ -68,11 +69,20 @@ void CrashHandler::InformUserOfCrash(const std::string& sPath) {
       sDefault, sAlternate, sOther, &response);
 
   switch (response) {
-    case kCFUserNotificationDefaultResponse:
-      // Fall through.
-    case kCFUserNotificationOtherResponse:
-      // Open the file with the default application (probably TextEdit). [unimplemented]
+    case kCFUserNotificationDefaultResponse: {
+      NSURL* bugURL = [NSURL URLWithString:@REPORT_BUG_URL];
+      [[NSWorkspace sharedWorkspace] openURL:bugURL];
       break;
+    }
+    case kCFUserNotificationOtherResponse: {
+      NSString* nsPath = [NSString stringWithUTF8String:sCrashInfoPath.c_str()];
+      NSURL* fileURL = [NSURL fileURLWithPath:nsPath];
+      BOOL opened = [[NSWorkspace sharedWorkspace] openURL:fileURL];
+      if (!opened) {
+        [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:@[ fileURL ]];
+      }
+      break;
+    }
   }
   CFRelease(sBody);
   CFRelease(sFormat);

--- a/src/archutils/Darwin/Crash.mm
+++ b/src/archutils/Darwin/Crash.mm
@@ -18,6 +18,15 @@
 
 std::string CrashHandler::GetLogsDirectory() {
   NSFileManager* fileManager = [NSFileManager defaultManager];
+  
+  NSString* bundleParent = [[[NSBundle mainBundle] bundlePath] stringByDeletingLastPathComponent];
+  NSString* portablePath = [bundleParent stringByAppendingPathComponent:@"Portable.ini"];
+  
+  BOOL isPortable = [fileManager fileExistsAtPath:portablePath];
+  if (isPortable) {
+    return std::string([bundleParent UTF8String]) + "/Logs";
+  }
+
   NSURL* url = [fileManager URLForDirectory:NSLibraryDirectory
                                    inDomain:NSUserDomainMask
                           appropriateForURL:nil

--- a/src/archutils/Darwin/DarwinThreadHelpers.cpp
+++ b/src/archutils/Darwin/DarwinThreadHelpers.cpp
@@ -53,6 +53,18 @@ bool GetThreadBacktraceContext(uint64_t iID, BacktraceContext* ctx) {
   ctx->bp = (void*)state.__rbp;
   ctx->sp = (void*)state.__rsp;
   return true;
+#elif defined(__aarch64__)
+  arm_thread_state64_t state;
+  mach_msg_type_number_t count = ARM_THREAD_STATE64_COUNT;
+  if (thread_get_state(
+          thread, ARM_THREAD_STATE64, thread_state_t(&state), &count)) {
+    return false;
+  }
+
+  ctx->ip = (void*)arm_thread_state64_get_pc(state);
+  ctx->bp = (void*)arm_thread_state64_get_fp(state);
+  ctx->sp = (void*)arm_thread_state64_get_sp(state);
+  return true;
 #else
   return false;
 #endif


### PR DESCRIPTION
3 small changes in here.

- The first, in [src/archutils/Darwin/Crash.mm](https://github.com/itgmania/itgmania/compare/beta...mjvotaw:macos-crash-info-arm64?expand=1#diff-83f12e3e7105133d0766181e88517857f4ea8ebab21cb124b3545d97eb205313), updates `CrashHandler::GetLogsDirectory` to return the expected path to "/Logs" when the application is running in portable mode. 

Without this check, it will try to save crashinfo.txt to `/Users/<username>/Library/Logs/ITGmania/crashinfo.txt`, but this fails with the error `Couldn't open /Users/<username>/Library/Logs/ITGmania/crashinfo.txt: No such file or directory`, because the  `ITGmania` folder doesn't exist.

Instead of importing `RageFileManager` and using `DoesFileExist`, it just directly checks that `Portable.ini` exists in the same dir as the application. I went with this approach partly because that's what the Windows version of CrashHandlerChild does. Since we're dealing with the application in a crashing state, it seems like a good idea to avoid calling engine code.


- Second change, in [src/archutils/Darwin/DarwinThreadHelpers.cpp](https://github.com/itgmania/itgmania/compare/beta...mjvotaw:macos-crash-info-arm64?expand=1#diff-7e75d6d6c7c70282a42bcd6e2e7653765e7faceba40b277a57707aeb86bc3bbb), adds a new case to `GetThreadBacktraceContext` for getting backtrace info on arm64 devices.

From what I can tell, `GetThreadBacktraceContext` gets called through calling `CrashHandler::ForceDeadlock`, which is only called when either RageSemaphore::Wait or RageMutex::Lock run into a problem.

- And third, also in Crash.mm, finishes implementing `InformUserOfCrash`, so that now the "File Bug Report" and "Open crashinfo.txt" buttons actually do what you'd expect them to.