### PR TITLE
Save crashinfo.txt to appropriate directory on macOS when in portable mode

### DIFF
--- a/src/archutils/Darwin/Crash.mm
+++ b/src/archutils/Darwin/Crash.mm
@@ -18,6 +18,15 @@
 
 std::string CrashHandler::GetLogsDirectory() {
   NSFileManager* fileManager = [NSFileManager defaultManager];
+
+  NSString* bundleParent = [[[NSBundle mainBundle] bundlePath] stringByDeletingLastPathComponent];
+  NSString* portablePath = [bundleParent stringByAppendingPathComponent:@"Portable.ini"];
+
+  BOOL isPortable = [fileManager fileExistsAtPath:portablePath];
+  if (isPortable) {
+    return std::string([bundleParent UTF8String]) + "/Logs";
+  }
+
   NSURL* url = [fileManager URLForDirectory:NSLibraryDirectory
                                    inDomain:NSUserDomainMask
                           appropriateForURL:nil


### PR DESCRIPTION
This PR updates `CrashHandler::GetLogsDirectory` to return the expected path to "/Logs" when the application is running in portable mode.

Without this check, it will try to save crashinfo.txt to `/Users/<username>/Library/Logs/ITGmania/crashinfo.txt`, but this fails with the error `Couldn't open /Users/<username>/Library/Logs/ITGmania/crashinfo.txt: No such file or directory`, because the ITGmania folder doesn't exist.

Instead of importing `RageFileManager` and using `DoesFileExist`, it just directly checks that Portable.ini exists in the same dir as the application. I went with this approach partly because that's what the Windows version of `CrashHandlerChild` does. Since we're dealing with the application in a crashing state, it seems like a good idea to avoid calling engine code.