### PR TITLE
Increment counter in code for preserving difficulty in the EditMenu

### DIFF
--- a/src/EditMenu.cpp
+++ b/src/EditMenu.cpp
@@ -533,6 +533,7 @@ void EditMenu::OnRowValueChanged(EditMenuRow row) {
             m_iSelection[ROW_STEPS] = i;
             break;
           }
+          i++;
         }
         rage_clamp(m_iSelection[ROW_STEPS], 0, m_vpSteps.size() - 1);
       }


### PR DESCRIPTION
Issue as reported by freyja:
<img width="772" height="301" alt="image" src="https://github.com/user-attachments/assets/6ca72e94-308e-488a-9f22-6662f353a852" />


In short, when navigating through the edit menu to select a song to edit...it would always reset the currently active Difficulty. It was never preserved so you would always return to Novice when you changed anything.

Upon deeper inspection looks like the code to preserve difficulty was there...the counter just wasn't getting incremented. i was always 0 so we'd always get set to Novice.