### PR TITLE
Allow mouse-mapped Start to open options after song selection

### DIFF
--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -468,7 +468,8 @@ bool ScreenSelectMusic::Input(const InputEventPlus& input) {
       mouse_evt = true;
     }
   }
-  if (mouse_evt) {
+  if (mouse_evt && !(m_SelectionState == SelectionState_Finalized &&
+                     input.MenuI == GAME_BUTTON_START)) {
     return ScreenWithMenuElements::Input(input);
   }
   //	LOG->Trace( "ScreenSelectMusic::Input()" );


### PR DESCRIPTION
This fixes a crash on ScreenSelectMusic when Start is mapped to a mouse button.

After selecting a song, pressing that mouse-mapped Start input again during the “Press Start again for options” window can crash the game, because mouse events are forwarded before the finalized-selection Start handling is reached.

This lets that input follow the same finalized-selection Start path as other Start bindings, while leaving the rest of the mouse behavior unchanged.