### PR TITLE
Fix hovering over first edit chart after playing any edit chart

### DIFF
--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -263,7 +263,7 @@ void MusicWheel::BeginScreen() {
       bool bStepsIsPossible =
           find(
               vpPossibleSteps.begin(), vpPossibleSteps.end(),
-              GAMESTATE->m_pCurSteps[p]) == vpPossibleSteps.end();
+              GAMESTATE->m_pCurSteps[p]) != vpPossibleSteps.end();
       if (!bStepsIsPossible) {
         GAMESTATE->m_pCurSteps[p].Set(nullptr);
       }


### PR DESCRIPTION
Instead of hovering over the edit chart you just played.