### PR TITLE
Move SM_UNIQUE_NAME out of global.h

### DIFF
--- a/src/LuaManager.h
+++ b/src/LuaManager.h
@@ -198,6 +198,12 @@ class LuaThreadVariable {
   LuaThreadVariable& operator=(const LuaThreadVariable& rhs);
 };
 
+/* Use SM_UNIQUE_NAME to get the line number concatenated to x. This is useful
+ * for generating unique identifiers in other macros.  */
+#define SM_UNIQUE_NAME3(x, line) x##line
+#define SM_UNIQUE_NAME2(x, line) SM_UNIQUE_NAME3(x, line)
+#define SM_UNIQUE_NAME(x) SM_UNIQUE_NAME2(x, __LINE__)
+
 /**
  * @brief Iterate over all elements in the table.
  *
@@ -207,6 +213,7 @@ class LuaThreadVariable {
  * Once the loop exits normally, the top of the stack will be where it was
  * before. If you break out of the loop early, you need to handle that
  * explicitly. */
+
 #define FOREACH_LUATABLE(L, index)                                       \
   for (const int SM_UNIQUE_NAME(tab) = LuaHelpers::AbsIndex(L, index),   \
                  SM_UNIQUE_NAME(top) = (lua_pushnil(L), lua_gettop(L));  \

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -1524,7 +1524,7 @@ bool MusicWheel::NextSort()  // return true if change successful
   {
     Lua* L = LUA->Get();
     SORT_ORDERS.PushSelf(L);
-    FOREACH_LUATABLEI(L, -1, i) {
+    FOREACH_LUATABLE(L, -1) {
       SortOrder so = Enum::Check<SortOrder>(L, -1, true);
       aSortOrders.push_back(so);
     }

--- a/src/RageThreads.h
+++ b/src/RageThreads.h
@@ -162,7 +162,7 @@ class LockMutex {
   LockMutex& operator=(const LockMutex& rhs);
 };
 
-#define LockMut(m) LockMutex SM_UNIQUE_NAME(LocalLock)(m, __FILE__, __LINE__)
+#define LockMut(m) LockMutex LocalLock(m, __FILE__, __LINE__)
 
 class EventImpl;
 class RageEvent : public RageMutex {

--- a/src/arch/LowLevelWindow/LowLevelWindow_MacOSX.mm
+++ b/src/arch/LowLevelWindow/LowLevelWindow_MacOSX.mm
@@ -38,8 +38,6 @@ class AutoreleasePool {
   ~AutoreleasePool() { [m_Pool release]; }
 };
 
-#define POOL AutoreleasePool SM_UNIQUE_NAME(pool)
-
 // Window delegate class
 @interface SMWindowDelegate : NSObject {
  @public
@@ -197,7 +195,7 @@ RenderTarget_MacOSX::RenderTarget_MacOSX(id shareContext) {
 }
 
 RenderTarget_MacOSX::~RenderTarget_MacOSX() {
-  POOL;
+  AutoreleasePool pool;
   [m_PBufferContext release];
   if (m_iTexHandle) {
     glDeleteTextures(1, &m_iTexHandle);
@@ -206,7 +204,7 @@ RenderTarget_MacOSX::~RenderTarget_MacOSX() {
 
 void RenderTarget_MacOSX::Create(
     const RenderTargetParam& param, int& iTextureWidthOut, int& iTextureHeightOut) {
-  POOL;
+  AutoreleasePool pool;
   m_iWidth = param.iWidth;
   m_iHeight = param.iHeight;
 
@@ -282,7 +280,7 @@ void RenderTarget_MacOSX::FinishRenderingTo() {
 
 LowLevelWindow_MacOSX::LowLevelWindow_MacOSX()
     : m_Context(nil), m_BGContext(nil), m_CurrentDisplayMode(nil), m_DisplayID(0) {
-  POOL;
+  AutoreleasePool pool;
   m_WindowDelegate = [[SMWindowDelegate alloc] init];
   [m_WindowDelegate performSelectorOnMainThread:@selector(setupWindow)
                                      withObject:nil
@@ -297,7 +295,7 @@ LowLevelWindow_MacOSX::LowLevelWindow_MacOSX()
 }
 
 LowLevelWindow_MacOSX::~LowLevelWindow_MacOSX() {
-  POOL;
+  AutoreleasePool pool;
   ShutDownFullScreen();
 
   [m_Context clearDrawable];
@@ -339,7 +337,7 @@ std::string LowLevelWindow_MacOSX::TryVideoMode(const VideoModeParams& p, bool& 
     return std::string();
   }
 
-  POOL;
+  AutoreleasePool pool;
   newDeviceOut = false;
 
   ASSERT(p.bpp == 16 || p.bpp == 32);

--- a/src/global.h
+++ b/src/global.h
@@ -102,12 +102,6 @@ void ShowWarningOrTrace(
 #define DEBUG_ASSERT_M(x, y)
 #endif
 
-/* Use SM_UNIQUE_NAME to get the line number concatenated to x. This is useful
- * for generating unique identifiers in other macros.  */
-#define SM_UNIQUE_NAME3(x, line) x##line
-#define SM_UNIQUE_NAME2(x, line) SM_UNIQUE_NAME3(x, line)
-#define SM_UNIQUE_NAME(x) SM_UNIQUE_NAME2(x, __LINE__)
-
 /* Don't include our own headers here, since they tend to change often. */
 
 #endif


### PR DESCRIPTION
All uses are local variables so it doesn't matter.

It's only needed in FOREACH_LUATABLE since that's used nested and MSVC complains about shadowed variables.
