### PR TITLE
Separate XML workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,15 +55,3 @@ jobs:
         run: ${{ matrix.configure }}
       - name: Build
         run: ${{ matrix.build }}
-
-  validate-xml-docs:
-    name: Validate Lua.xml, LuaDocumentation.xml
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
-      - name: Validate Lua.xml
-        run: xmllint --noout Docs/Luadoc/Lua.xml
-      - name: Validate LuaDocumentation.xml
-        run: xmllint --noout Docs/Luadoc/LuaDocumentation.xml

--- a/.github/workflows/validate-xml.yml
+++ b/.github/workflows/validate-xml.yml
@@ -1,0 +1,24 @@
+name: Validate XML Docs
+
+on:
+  push:
+    paths:
+      - 'Docs/Luadoc/Lua.xml'
+      - 'Docs/Luadoc/LuaDocumentation.xml'
+  pull_request:
+    paths:
+      - 'Docs/Luadoc/Lua.xml'
+      - 'Docs/Luadoc/LuaDocumentation.xml'
+
+jobs:
+  validate-xml-docs:
+    name: Validate Lua.xml, LuaDocumentation.xml
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+      - name: Validate Lua.xml
+        run: xmllint --noout Docs/Luadoc/Lua.xml
+      - name: Validate LuaDocumentation.xml
+        run: xmllint --noout Docs/Luadoc/LuaDocumentation.xml


### PR DESCRIPTION
Splits out the XML validation step into a separate workflow that only runs when the two files are modified, and runs on https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/.