### PR TITLE
Set ccache directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ name: Continuous integration
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_BASEDIR: ${{ github.workspace }}
     strategy:
       fail-fast: false
       matrix:
@@ -44,6 +47,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+      - name: Prepare ccache directory
+        shell: bash
+        run: mkdir -p .ccache
       - name: Install dependencies
         run: ${{ matrix.install }}
       - name: ccache


### PR DESCRIPTION
Resolves cache misses on runs e.g. https://github.com/itgmania/itgmania/actions/runs/26106627647/job/76772181512#step:13:2
> Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.

Hits on my fork - https://github.com/ScottBrenner/itgmania/actions/runs/26140811599/job/76885764860#step:5:16