### PR TITLE
Include DisplayName on Profile Directories

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -2741,6 +2741,7 @@
 			<EnumValue name='&apos;ProfileSortOrder_Priority&apos;' value='0'/>
 			<EnumValue name='&apos;ProfileSortOrder_Recent&apos;' value='1'/>
 			<EnumValue name='&apos;ProfileSortOrder_Alphabetical&apos;' value='2'/>
+			<EnumValue name='&apos;ProfileSortOrder_CreationTime&apos;' value='3'/>
 		</Enum>
 		<Enum name='ProfileType'>
 			<EnumValue name='&apos;ProfileType_Guest&apos;' value='0'/>

--- a/Themes/_fallback/Languages/en.ini
+++ b/Themes/_fallback/Languages/en.ini
@@ -752,6 +752,7 @@ Courses Only=Courses Only
 CoverDistort=Cover Distort
 CoverPreserve=Cover Preserve
 Create New=Create New
+CreationTime=Creation Time
 Cross=Cross
 Custom=Custom
 Dance Points=Dance Points

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -119,7 +119,11 @@ StringToX(BackgroundFitMode);
 LuaXType(BackgroundFitMode);
 
 static const char* ProfileSortOrderNames[] = {
-    "Priority", "Recent", "Alphabetical"};
+    "Priority",
+    "Recent",
+    "Alphabetical",
+    "CreationTime",
+};
 XToString(ProfileSortOrder);
 StringToX(ProfileSortOrder);
 LuaXType(ProfileSortOrder);

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -106,6 +106,7 @@ enum ProfileSortOrder {
                                   // profile's Type.ini
   ProfileSortOrder_Recent,        // Sorts profiles by most recently used.
   ProfileSortOrder_Alphabetical,  // Sorts profiles alphabetically.
+  ProfileSortOrder_CreationTime,  // Sorts profiles by creation time.
   NUM_ProfileSortOrder,
   ProfileSortOrder_Invalid
 };

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -989,6 +989,7 @@ void Profile::swap(Profile& other) {
   SWAP_GENERAL(m_bNewProfile);
   SWAP_STR_MEMBER(m_UnlockedEntryIDs);
   SWAP_STR_MEMBER(m_sLastPlayedMachineGuid);
+  SWAP_GENERAL(m_CreationTime);
   SWAP_GENERAL(m_LastPlayedDate);
   SWAP_ARRAY(m_iNumSongsPlayedByPlayMode, NUM_PlayMode);
   SWAP_STR_MEMBER(m_iNumSongsPlayedByStyle);
@@ -1338,6 +1339,8 @@ ProfileLoadResult Profile::LoadStatsFromDir(
 void Profile::LoadTypeFromDir(std::string dir) {
   m_Type = ProfileType_Normal;
   m_ListPriority = 0;
+  m_CreationTime.Init();
+  m_LastPlayedDate.Init();
   std::string fn = dir + TYPE_INI;
   if (FILEMAN->DoesFileExist(fn)) {
     IniFile ini;
@@ -1352,9 +1355,18 @@ void Profile::LoadTypeFromDir(std::string dir) {
           }
         }
         data->GetAttrValue("Priority", m_ListPriority);
+        std::string creation_date_str;
+        if (data->GetAttrValue("CreationTime", creation_date_str)) {
+          m_CreationTime.FromString(creation_date_str);
+        }
         std::string date_str;
         if (data->GetAttrValue("LastPlayedDate", date_str)) {
           m_LastPlayedDate.FromString(date_str);
+        }
+        // Backward compatibility for profiles created before CreationTime
+        // existed in Type.ini.
+        if (m_CreationTime == DateTime()) {
+          m_CreationTime = m_LastPlayedDate;
         }
       }
     }
@@ -1527,8 +1539,12 @@ bool Profile::SaveStatsXmlToDir(std::string sDir, bool bSignData) const {
 
 void Profile::SaveTypeToDir(std::string dir) const {
   IniFile ini;
+  if (m_CreationTime == DateTime()) {
+    m_CreationTime = DateTime::GetNowDateTime();
+  }
   ini.SetValue("ListPosition", "Type", ProfileTypeToString(m_Type));
   ini.SetValue("ListPosition", "Priority", m_ListPriority);
+  ini.SetValue("ListPosition", "CreationTime", m_CreationTime.GetString());
   ini.SetValue(
       "ListPosition", "LastPlayedDate", DateTime::GetNowDateTime().GetString());
   ini.WriteFile(dir + TYPE_INI);

--- a/src/Profile.h
+++ b/src/Profile.h
@@ -135,6 +135,7 @@ class Profile {
         m_bNewProfile(false),
         m_UnlockedEntryIDs(),
         m_sLastPlayedMachineGuid(""),
+        m_CreationTime(),
         m_LastPlayedDate(),
         m_iNumSongsPlayedByStyle(),
         m_iNumTotalSongsPlayed(0),
@@ -146,6 +147,7 @@ class Profile {
     m_lastSong.Unset();
     m_lastCourse.Unset();
 
+    m_CreationTime.Init();
     m_LastPlayedDate.Init();
 
     FOREACH_ENUM(PlayMode, i)
@@ -273,6 +275,7 @@ class Profile {
    * const everywhere else. It was decided to keep const on the whole
    * save chain and keep this mutable. -Chris */
   mutable std::string m_sLastPlayedMachineGuid;
+    mutable DateTime m_CreationTime;
   mutable DateTime m_LastPlayedDate;
   /* These stats count twice in the machine profile if two players are playing;
    * that's the only approach that makes sense for ByDifficulty and ByMeter. */

--- a/src/Profile.h
+++ b/src/Profile.h
@@ -275,7 +275,7 @@ class Profile {
    * const everywhere else. It was decided to keep const on the whole
    * save chain and keep this mutable. -Chris */
   mutable std::string m_sLastPlayedMachineGuid;
-    mutable DateTime m_CreationTime;
+  mutable DateTime m_CreationTime;
   mutable DateTime m_LastPlayedDate;
   /* These stats count twice in the machine profile if two players are playing;
    * that's the only approach that makes sense for ByDifficulty and ByMeter. */

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <cctype>
 #include <cstddef>
+#include <cstdint>
+#include <limits>
 #include <map>
 #include <string>
 #include <vector>
@@ -70,7 +72,7 @@ static std::string LocalProfileIDToDir(const std::string& sProfileID) {
 }
 
 // Sanitize a display name so it is safe to embed in a directory name.
-static const size_t MAX_DISPLAY_NAME_IN_DIR = 32;
+constexpr size_t MAX_DISPLAY_NAME_IN_DIR = 32;
 static std::string SanitizeForDirName(const std::string& name) {
   std::string result;
 
@@ -740,7 +742,7 @@ bool ProfileManager::CreateLocalProfile(
   // attempt to append an incrementing number until we find a name that doesn't
   // exist.
   if (base_exists) {
-    int suffix = 1;
+    int16_t suffix = 1;
     while (true) {
       std::string candidate = ssprintf("%s_%d", base.c_str(), suffix);
       bool candidate_exists = false;
@@ -757,6 +759,11 @@ bool ProfileManager::CreateLocalProfile(
         break;
       }
 
+      // Bail before overflow
+      if (suffix < 0 || suffix == std::numeric_limits<int16_t>::max()) {
+        sProfileIDOut = "";
+        return false;
+      }
       ++suffix;
     }
   }

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -462,6 +462,9 @@ void ProfileManager::RefreshLocalProfilesFromDisk() {
     case ProfileSortOrder_Recent:
       LoadLocalProfilesByRecent();
       break;
+    case ProfileSortOrder_CreationTime:
+      LoadLocalProfilesByCreationTime();
+      break;
     default:
       LoadLocalProfilesByPriority();
       break;
@@ -642,6 +645,62 @@ void ProfileManager::LoadLocalProfilesByRecent() {
   }
 }
 
+// This function is used within RefreshLocalProfilesFromDisk() to sort the
+// profiles by creation time.
+void ProfileManager::LoadLocalProfilesByCreationTime() {
+  std::vector<std::string> profile_ids;
+  GetDirListing(USER_PROFILES_DIR "*", profile_ids, true, true);
+
+  std::vector<DirAndProfile> guestProfiles;
+  std::vector<DirAndProfile> normalProfiles;
+  std::vector<DirAndProfile> testProfiles;
+
+  for (const std::string& id : profile_ids) {
+    DirAndProfile derp;
+    derp.sDir = id "/";
+    derp.profile.LoadTypeFromDir(derp.sDir);
+    switch (derp.profile.m_Type) {
+      case ProfileType_Guest:
+        guestProfiles.push_back(derp);
+        break;
+      case ProfileType_Normal:
+        normalProfiles.push_back(derp);
+        break;
+      case ProfileType_Test:
+        testProfiles.push_back(derp);
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (PREFSMAN->m_bProfileSortOrderAscending) {
+    auto creationAscending = [](const DirAndProfile& a,
+                                const DirAndProfile& b) {
+      return a.profile.m_CreationTime > b.profile.m_CreationTime;
+    };
+    std::sort(guestProfiles.begin(), guestProfiles.end(), creationAscending);
+    std::sort(normalProfiles.begin(), normalProfiles.end(), creationAscending);
+    std::sort(testProfiles.begin(), testProfiles.end(), creationAscending);
+  } else {
+    auto creationDescending = [](const DirAndProfile& a,
+                                 const DirAndProfile& b) {
+      return a.profile.m_CreationTime < b.profile.m_CreationTime;
+    };
+    std::sort(guestProfiles.begin(), guestProfiles.end(), creationDescending);
+    std::sort(normalProfiles.begin(), normalProfiles.end(), creationDescending);
+    std::sort(testProfiles.begin(), testProfiles.end(), creationDescending);
+  }
+
+  add_category_to_global_list(guestProfiles);
+  add_category_to_global_list(normalProfiles);
+  add_category_to_global_list(testProfiles);
+
+  for (DirAndProfile& curr : g_vLocalProfile) {
+    curr.profile.LoadAllFromDir(curr.sDir, PREFSMAN->m_bSignProfileData);
+  }
+}
+
 const Profile* ProfileManager::GetLocalProfile(
     const std::string& sProfileID) const {
   std::string sDir = LocalProfileIDToDir(sProfileID);
@@ -709,6 +768,7 @@ bool ProfileManager::CreateLocalProfile(
   Profile* pProfile = new Profile;
   pProfile->m_sDisplayName = sName;
   pProfile->m_sCharacterID = CHARMAN->GetRandomCharacter()->m_sCharacterID;
+  pProfile->m_CreationTime = DateTime::GetNowDateTime();
 
   // Save it to disk.
   std::string sProfileDir = LocalProfileIDToDir(profile_id);

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -1,6 +1,7 @@
 #include "ProfileManager.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cstddef>
 #include <map>
 #include <string>
@@ -67,6 +68,33 @@ static Preference<std::string> g_sMemoryCardProfileImportSubdirs(
 static std::string LocalProfileIDToDir(const std::string& sProfileID) {
   return USER_PROFILES_DIR + sProfileID + "/";
 }
+
+// Sanitize a display name so it is safe to embed in a directory name.
+static const size_t MAX_DISPLAY_NAME_IN_DIR = 32;
+static std::string SanitizeForDirName(const std::string& name) {
+  std::string result;
+
+  result.reserve(name.size());
+  for (unsigned char c : name) {
+    // Allow only alphanumeric characters, underscore, and dash.
+    if (std::isalnum(c) || c == '_' || c == '-') {
+      result += static_cast<char>(c);
+    } else {
+      result += '_';
+    }
+  }
+  // Cap length.
+  if (result.size() > MAX_DISPLAY_NAME_IN_DIR) {
+    result.resize(MAX_DISPLAY_NAME_IN_DIR);
+  }
+  // If the result is all underscores (e.g. the name was only spaces/periods),
+  // treat it as empty so the caller falls back to the number-only format.
+  if (result.find_first_not_of('_') == std::string::npos) {
+    return "";
+  }
+  return result;
+}
+
 static std::string LocalProfileDirToID(const std::string& sDir) {
   return Basename(sDir);
 }
@@ -663,7 +691,12 @@ bool ProfileManager::CreateLocalProfile(
   ASSERT_M(
       profile_number >= 0 && profile_number <= MAX_ID,
       "Too many profiles, cannot assign ID to new profile.");
-  std::string profile_id = ssprintf("%0" ID_DIGITS_STR "d", profile_number);
+  std::string sanitized_name = SanitizeForDirName(sName);
+  std::string profile_id =
+      sanitized_name.empty() ? ssprintf("%0" ID_DIGITS_STR "d", profile_number)
+                             : ssprintf(
+                                   "%0" ID_DIGITS_STR "d_%s", profile_number,
+                                   sanitized_name.c_str());
 
   // make sure this id doesn't already exist
   ASSERT_M(

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -737,7 +737,8 @@ bool ProfileManager::CreateLocalProfile(
   }
 
   // If a profile with the same name already exists..
-  // attempt to append an incrementing number until we find a name that doesn't exist.
+  // attempt to append an incrementing number until we find a name that doesn't
+  // exist.
   if (base_exists) {
     int suffix = 1;
     while (true) {

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -649,7 +649,7 @@ void ProfileManager::LoadLocalProfilesByRecent() {
 // profiles by creation time.
 void ProfileManager::LoadLocalProfilesByCreationTime() {
   std::vector<std::string> profile_ids;
-  GetDirListing(USER_PROFILES_DIR "*", profile_ids, true, true);
+  GetDirListing(USER_PROFILES_DIR + "*", profile_ids, true, true);
 
   std::vector<DirAndProfile> guestProfiles;
   std::vector<DirAndProfile> normalProfiles;
@@ -657,7 +657,7 @@ void ProfileManager::LoadLocalProfilesByCreationTime() {
 
   for (const std::string& id : profile_ids) {
     DirAndProfile derp;
-    derp.sDir = id "/";
+    derp.sDir = id + "/";
     derp.profile.LoadTypeFromDir(derp.sDir);
     switch (derp.profile.m_Type) {
       case ProfileType_Guest:
@@ -718,44 +718,47 @@ bool ProfileManager::CreateLocalProfile(
     std::string sName, std::string& sProfileIDOut) {
   ASSERT(!sName.empty());
 
-  // Find a directory directory name that's a number greater than all
-  // existing numbers.  This preserves the "order by create date".
-  // Profile IDs are actually the directory names, so they can be any string,
-  // and we have to handle the case where the user renames one.
-  // Since the user can rename them, they might have any number, wrapping our
-  // counter or setting it to a ridiculous value.  That case must also be
-  // handled. -Kyz
-  int max_profile_number = -1;
-  int first_free_number = 0;
   std::vector<std::string> profile_ids;
   GetLocalProfileIDs(profile_ids);
+
+  std::string base = SanitizeForDirName(sName);
+  if (base.empty()) {
+    base = "Profile";
+  }
+
+  std::string profile_id = base;
+  bool base_exists = false;
   for (std::vector<std::string>::const_iterator id = profile_ids.begin();
        id != profile_ids.end(); ++id) {
-    int tmp = 0;
-    if ((*id) >> tmp) {
-      // The profile ids are already in order, so we don't have to handle the
-      // case where 5 is encountered before 3.
-      if (tmp == first_free_number) {
-        ++first_free_number;
-      }
-      max_profile_number = std::max(tmp, max_profile_number);
+    if (CompareNoCase(*id, base) == 0) {
+      base_exists = true;
+      break;
     }
   }
 
-  int profile_number = max_profile_number + 1;
-  // Prevent profiles from going over the 8 digit limit.
-  if (profile_number > MAX_ID || profile_number < 0) {
-    profile_number = first_free_number;
+  // If a profile with the same name already exists..
+  // attempt to append an incrementing number until we find a name that doesn't exist.
+  if (base_exists) {
+    int suffix = 1;
+    while (true) {
+      std::string candidate = ssprintf("%s_%d", base.c_str(), suffix);
+      bool candidate_exists = false;
+      for (std::vector<std::string>::const_iterator id = profile_ids.begin();
+           id != profile_ids.end(); ++id) {
+        if (CompareNoCase(*id, candidate) == 0) {
+          candidate_exists = true;
+          break;
+        }
+      }
+
+      if (!candidate_exists) {
+        profile_id = candidate;
+        break;
+      }
+
+      ++suffix;
+    }
   }
-  ASSERT_M(
-      profile_number >= 0 && profile_number <= MAX_ID,
-      "Too many profiles, cannot assign ID to new profile.");
-  std::string sanitized_name = SanitizeForDirName(sName);
-  std::string profile_id =
-      sanitized_name.empty() ? ssprintf("%0" ID_DIGITS_STR "d", profile_number)
-                             : ssprintf(
-                                   "%0" ID_DIGITS_STR "d_%s", profile_number,
-                                   sanitized_name.c_str());
 
   // make sure this id doesn't already exist
   ASSERT_M(

--- a/src/ProfileManager.h
+++ b/src/ProfileManager.h
@@ -34,6 +34,7 @@ class ProfileManager {
   void LoadLocalProfilesByPriority();
   void LoadLocalProfilesByRecent();
   void LoadLocalProfilesByName();
+  void LoadLocalProfilesByCreationTime();
 
   const Profile* GetLocalProfile(const std::string& sProfileID) const;
   Profile* GetLocalProfile(const std::string& sProfileID) {

--- a/src/ScreenOptionsManageProfiles.cpp
+++ b/src/ScreenOptionsManageProfiles.cpp
@@ -1,6 +1,7 @@
 #include "ScreenOptionsManageProfiles.h"
 
 #include <algorithm>
+#include <cctype>
 #include <string>
 #include <vector>
 
@@ -97,6 +98,28 @@ static bool ValidateLocalProfileName(
     return false;
   }
 
+  return true;
+}
+
+// Strip disallowed characters before they are appended to the profile name.
+static const std::string kProfileNameBlockedChars = "'\"";
+static bool ValidateAppendProfileName(
+    const std::string& /*sAnswerBeforeChar*/, std::string& sAppend) {
+  std::string sFiltered;
+  sFiltered.reserve(sAppend.size());
+  for (unsigned char c : sAppend) {
+    if (c < 0x20 || c > 0x7E) {
+      continue;  // non-printable or non-ASCII
+    }
+    if (kProfileNameBlockedChars.find(static_cast<char>(c)) !=
+        std::string::npos) {
+      continue;  // explicitly blocked
+    }
+    sFiltered += static_cast<char>(c);
+  }
+  sAppend = sFiltered;
+  // Return true even if we stripped everything; an empty append is fine
+  // (ValidateAppend returning false would abort the whole input).
   return true;
 }
 
@@ -314,7 +337,8 @@ void ScreenOptionsManageProfiles::HandleScreenMessage(const ScreenMessage SM) {
         case ProfileAction_Rename: {
           ScreenTextEntry::TextEntry(
               SM_BackFromRename, ENTER_PROFILE_NAME, pProfile->m_sDisplayName,
-              PROFILE_MAX_DISPLAY_NAME_LENGTH, ValidateLocalProfileName);
+              PROFILE_MAX_DISPLAY_NAME_LENGTH, ValidateLocalProfileName,
+              nullptr, nullptr, false, ValidateAppendProfileName);
         } break;
         case ProfileAction_Delete: {
           std::string sTitle = pProfile->m_sDisplayName;
@@ -416,7 +440,8 @@ void ScreenOptionsManageProfiles::ProcessMenuStart(const InputEventPlus&) {
     }
     ScreenTextEntry::TextEntry(
         SM_BackFromEnterNameForNew, ENTER_PROFILE_NAME, sPotentialName,
-        PROFILE_MAX_DISPLAY_NAME_LENGTH, ValidateLocalProfileName);
+        PROFILE_MAX_DISPLAY_NAME_LENGTH, ValidateLocalProfileName,
+        nullptr, nullptr, false, ValidateAppendProfileName);
   } else if (row.GetRowType() == OptionRow::RowType_Exit) {
     SCREENMAN->PlayStartSound();
     this->BeginFadingOut();

--- a/src/ScreenOptionsManageProfiles.cpp
+++ b/src/ScreenOptionsManageProfiles.cpp
@@ -105,19 +105,16 @@ static bool ValidateLocalProfileName(
 static const std::string kProfileNameBlockedChars = "'\"";
 static bool ValidateAppendProfileName(
     const std::string& /*sAnswerBeforeChar*/, std::string& sAppend) {
-  std::string sFiltered;
-  sFiltered.reserve(sAppend.size());
-  for (unsigned char c : sAppend) {
-    if (c < 0x20 || c > 0x7E) {
-      continue;  // non-printable or non-ASCII
-    }
-    if (kProfileNameBlockedChars.find(static_cast<char>(c)) !=
-        std::string::npos) {
-      continue;  // explicitly blocked
-    }
-    sFiltered += static_cast<char>(c);
-  }
-  sAppend = sFiltered;
+  sAppend.erase(
+      std::remove_if(
+          sAppend.begin(), sAppend.end(),
+          [](unsigned char c) {
+            // Drop non-printables, non ascii, & explicitly blocked chars
+            return c < 0x20 || c > 0x7E ||
+                   kProfileNameBlockedChars.find(static_cast<char>(c)) !=
+                       std::string::npos;
+          }),
+      sAppend.end());
   // Return true even if we stripped everything; an empty append is fine
   // (ValidateAppend returning false would abort the whole input).
   return true;

--- a/src/ScreenOptionsManageProfiles.cpp
+++ b/src/ScreenOptionsManageProfiles.cpp
@@ -440,8 +440,8 @@ void ScreenOptionsManageProfiles::ProcessMenuStart(const InputEventPlus&) {
     }
     ScreenTextEntry::TextEntry(
         SM_BackFromEnterNameForNew, ENTER_PROFILE_NAME, sPotentialName,
-        PROFILE_MAX_DISPLAY_NAME_LENGTH, ValidateLocalProfileName,
-        nullptr, nullptr, false, ValidateAppendProfileName);
+        PROFILE_MAX_DISPLAY_NAME_LENGTH, ValidateLocalProfileName, nullptr,
+        nullptr, false, ValidateAppendProfileName);
   } else if (row.GetRowType() == OptionRow::RowType_Exit) {
     SCREENMAN->PlayStartSound();
     this->BeginFadingOut();

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -960,7 +960,7 @@ static void InitializeConfOptions() {
   g_ConfOptions.back().m_iEffects = OPT_APPLY_PROFILES;
   ADD(ConfOption(
       "ProfileSortOrder", MovePref<ProfileSortOrder>, "Priority", "Recent",
-      "Alphabetical"));
+      "Alphabetical", "CreationTime"));
   g_ConfOptions.back().m_sPrefName = "ProfileSortOrder";
   g_ConfOptions.back().m_iEffects = OPT_APPLY_PROFILES;
 


### PR DESCRIPTION
## What's the point of this PR?
I figured we could first demonstrate the problem it aims to solve with a bit of a game:

I have a lengthy list of profiles on my machine as shown below. Tallying all of the active and 'preserved' profiles at The Space, we've a total of 149. It's quite the list to sift through when searching for 1 profile in particular!

<img width="537" height="580" alt="image" src="https://github.com/user-attachments/assets/c45e924b-52f3-4688-8f51-4b1348db77f9" />

### Exercise
Dora and Boots are trying to find Crash Cringle's profile so they can give the profile an Avatar and add a few personal playlists. But they need **your** help.
<img width="450" height="338" alt="image" src="https://github.com/user-attachments/assets/1e587f15-a043-4083-8f46-157956cd10df" />


<details>
  <summary>🔵Help Me Find Crash Cringle! 🔉</summary>
  <video src="https://github.com/user-attachments/assets/a1c08e6a-acb0-426a-80af-131c8201da26" controls></video>
</details>

### Solutions?
If you guessed correctly, congratulations haha. In any case, generally speaking there is no way of knowing which profile directory belongs to which profile without either:
- Opening profiles systematically (or at random, whichever you fancy) then opening up Editable.ini until you find the profile you seek.
- Manually renaming your folders (requires out of game modification and needs to be repeated for every new profile)
- Remembering the profile id of every profile by heart.
- Running a script or command that searches the directories for a specific string identifier
- Placing a file in each directory with the name of the profile (Requires manually opening profiles until you find the right one)

All of these require some level of manual procedure.


### Proposal
My proposal is that we maintain most of the same naming convention we already do with numbering the profiles, but we append the display name at the time of creation to the end of the dir. So instead of the above list of ambiguious profiles we have a list like:
<img width="552" height="812" alt="image" src="https://github.com/user-attachments/assets/dad53c6d-a1a9-48da-95a5-46817a9476a9" />

A display name is already passed in and required for creating a profile so this change doesn't modify the structure of any existing methods.
Notes:
- I wanted to preserve existing functionality of incrementing profiles so that the change works seamlessly with present lists of profiles. That is, the next profile that's created will continue the already existing chain (if your last profile was 00000074, the next one created would be 00000075_{NAME}.
- We perform some sanitation on the username to prevent any non alphanumeric characters in the name. This is just to wholesale avoid OS parsing issues (like periods at the end of a file). Any nonalphanumeric character is just converted to an underscore.
- The profile folders are still static in the sense that their dir names are not being dynamically updated. This behavior is "preserved." So we're not updating the name any time a user's name changes. I think in any case having the initial name there is better than previous behavior as you can still identify the profiles.
- You can still rename profiles to whatever you want they work. I _did_ discover a separate bug unrelated to this PR where the game crashes if you try to manage profiles that contain certain nonalphanumeric characters in their title. I'll tackle that in a separate issue/PR, but for clarity this PR does **not** enable a means of causing that bug in-game.
- If there are other suggestions lmk, open to feedback for this