### PR TITLE
Make sure we only calculate chart stats once

### DIFF
--- a/src/NotesLoaderJson.cpp
+++ b/src/NotesLoaderJson.cpp
@@ -140,7 +140,7 @@ static void Deserialize(Steps& o, const Json::Value& root) {
 
   RadarValues rv[NUM_PLAYERS];
   FOREACH_PlayerNumber(pn) { Deserialize(rv[pn], root["RadarValues"]); }
-  o.SetCachedRadarValues(rv);
+  o.SetRadarValues(rv);
 }
 
 static void Deserialize(Song& out, const Json::Value& root) {

--- a/src/NotesLoaderSM.cpp
+++ b/src/NotesLoaderSM.cpp
@@ -1324,7 +1324,7 @@ void SMLoader::TidyUpData(Song& song, bool bFromCache) {
     }
   }
   if (bFromCache) {
-    song.TidyUpData(bFromCache, true);
+    song.TidyUpData(bFromCache);
   }
 }
 

--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -333,7 +333,7 @@ void SetRadarValues(StepsTagInfo& info) {
         v[pn][i] = StringToFloat(values[pn * cats_per_player + i]);
       }
     }
-    info.steps->SetCachedRadarValues(v);
+    info.steps->SetRadarValues(v);
   } else {
     // just recalc at time.
   }
@@ -351,7 +351,7 @@ void SetTechCounts(StepsTagInfo& info) {
         v[pn][i] = StringToFloat(values[pn * cats_per_player + i]);
       }
     }
-    info.steps->SetCachedTechCounts(v);
+    info.steps->SetTechCounts(v);
   } else {
     // just recalc at time.
   }
@@ -382,7 +382,7 @@ void SetNpsPerMeasure(StepsTagInfo& info) {
       }
       npsPerMeasures.push_back(npsPerMeasure);
     }
-    info.steps->SetCachedNpsPerMeasure(npsPerMeasures);
+    info.steps->SetNpsPerMeasure(npsPerMeasures);
   } else {
     // just recalc at time.
   }
@@ -413,7 +413,7 @@ void SetNotesPerMeasure(StepsTagInfo& info) {
       }
       notesPerMeasures.push_back(notesPerMeasure);
     }
-    info.steps->SetCachedNotesPerMeasure(notesPerMeasures);
+    info.steps->SetNotesPerMeasure(notesPerMeasures);
   } else {
     // just recalc at time.
   }
@@ -447,7 +447,7 @@ void SetPeakNps(StepsTagInfo& info) {
 void SetGrooveStatsHash(StepsTagInfo& info) {
   if (info.from_cache || info.for_load_edit) {
     std::string value = (*info.params)[1];
-    info.steps->SetCachedGrooveStatsHash(value);
+    info.steps->SetGrooveStatsHash(value);
   }
   info.ssc_format = true;
 }
@@ -456,7 +456,7 @@ void SetGrooveStatsHashVersion(StepsTagInfo& info) {
   if (info.from_cache || info.for_load_edit) {
     std::string value = (*info.params)[1];
     int hashVersion = StringToInt(value);
-    info.steps->SetCachedGrooveStatsHashVersion(hashVersion);
+    info.steps->SetGrooveStatsHashVersion(hashVersion);
   }
   info.ssc_format = true;
 }

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -3940,7 +3940,7 @@ void ScreenEdit::TransitionEditState(EditState em) {
         Steps* pSteps = GAMESTATE->m_pCurSteps[main_player_];
         ASSERT(pSteps != nullptr);
         pSteps->SetNoteData(m_NoteDataEdit);
-        m_pSong->ReCalculateStepStatsAndLastSecond();
+        m_pSong->ReCalculateStepStatsAndLastSecond(false);
 
         // TODO: Background videos don't support seeking, when they do, make
         // sure to load the appropriate part of the video.

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -342,7 +342,7 @@ bool Song::LoadFromSongDir(
           m_sSongDir.c_str());
       // Tell TidyUpData that it's not loaded from the cache because it needs
       // to hit the song folder to find the files that weren't found. -Kyz
-      TidyUpData(false, false);
+      TidyUpData(false);
     }
   }
 
@@ -380,7 +380,7 @@ bool Song::LoadFromSongDir(
     // loading time. -Kyz
     LoadEditsFromSongDir(sDir);
 
-    TidyUpData(false, true, blacklistedImages);
+    TidyUpData(false, blacklistedImages);
     // Don't save a cache file if the autosave is being loaded, because the
     // cache file would contain the autosave filename. -Kyz
     // Songs loaded from removable profile are never cached, on the
@@ -642,14 +642,13 @@ void FixupPath(std::string& path, const std::string& sSongPath) {
   Trim(path);
 }
 
-void Song::TidyUpData(bool from_cache, bool duringCache) {
-  Song::TidyUpData(from_cache, duringCache, std::set<std::string>());
+void Song::TidyUpData(bool from_cache) {
+  Song::TidyUpData(from_cache, std::set<std::string>());
 }
 
 // Songs in BlacklistImages will never be autodetected as song images.
 void Song::TidyUpData(
-    bool from_cache, bool /* duringCache */,
-    const std::set<std::string>& blacklistedImages) {
+    bool from_cache, const std::set<std::string>& blacklistedImages) {
   // We need to do this before calling any of HasMusic, HasHasCDTitle, etc.
   ASSERT_M(Left(m_sSongDir, 3) != "../", m_sSongDir);  // meaningless
   FixupPath(m_sSongDir, "");
@@ -1124,8 +1123,11 @@ void Song::TidyUpData(
   }
 
   /* Generate these before we autogen notes, so the new notes can inherit
-   * their source's values. */
-  ReCalculateStepStatsAndLastSecond(from_cache, true);
+   * their source's values. On cache loads the stats and first/last second
+   * already came from the cache file -- nothing to recalculate. */
+  if (!from_cache) {
+    ReCalculateStepStatsAndLastSecond(true);
+  }
   // If the music length is suspiciously shorter than the last second, adjust
   // the length.  This prevents the ogg patch from setting a false length. -Kyz
   if (m_fMusicLengthSeconds < lastSecond - 10.0f) {
@@ -1146,16 +1148,7 @@ void Song::TranslateTitles() {
       m_sSubTitleTranslit, m_sArtistTranslit);
 }
 
-void Song::ReCalculateStepStatsAndLastSecond(bool fromCache, bool duringCache) {
-  if (fromCache && this->GetFirstSecond() >= 0 && this->GetLastSecond() > 0) {
-    // this is loaded from cache, then we just have to calculate the radar
-    // values.
-    for (unsigned i = 0; i < m_vpSteps.size(); i++) {
-      m_vpSteps[i]->CalculateStepStats(m_fMusicLengthSeconds);
-    }
-    return;
-  }
-
+void Song::ReCalculateStepStatsAndLastSecond(bool wipeNoteData) {
   float localFirst = FLT_MAX;  // inf
   // Make sure we're at least as long as the specified amount below.
   float localLast = this->specifiedLastSecond;
@@ -1194,7 +1187,7 @@ void Song::ReCalculateStepStatsAndLastSecond(bool fromCache, bool duringCache) {
     }
 
     // Wipe NoteData
-    if (duringCache) {
+    if (wipeNoteData) {
       NoteData dummy;
       dummy.SetNumTracks(tempNoteData.GetNumTracks());
       pSteps->SetNoteData(dummy);
@@ -1222,7 +1215,7 @@ bool Song::HasStepsTypeAndDifficulty(StepsType st, Difficulty dc) const {
 void Song::Save(bool autosave) {
   LOG->Trace("Song::SaveToSongFile()");
 
-  ReCalculateStepStatsAndLastSecond();
+  ReCalculateStepStatsAndLastSecond(false);
   TranslateTitles();
 
   // Save the new files. These calls make backups on their own.

--- a/src/Song.h
+++ b/src/Song.h
@@ -104,17 +104,15 @@ class Song {
 
   /**
    * @brief Call this after loading a song to clean up invalid data.
-   * @param fromCache was this data loaded from the cache file?
-   * @param duringCache was this data loaded during the cache process? */
-  void TidyUpData(bool fromCache = false, bool duringCache = false);
+   * @param fromCache was this data loaded from the cache file? */
+  void TidyUpData(bool fromCache = false);
 
   /**
    * @brief Get the new step stats, and determine the last second at the same
    * time. This is called by TidyUpData, after saving the Song.
-   * @param fromCache was this data loaded from the cache file?
-   * @param duringCache was this data loaded during the cache process? */
-  void ReCalculateStepStatsAndLastSecond(
-      bool fromCache = false, bool duringCache = false);
+   * @param wipeNoteData release each chart's decompressed NoteData after
+   * computing its stats. */
+  void ReCalculateStepStatsAndLastSecond(bool wipeNoteData);
   /**
    * @brief Translate any titles that aren't in english.
    * This is called by TidyUpData. */
@@ -352,8 +350,7 @@ class Song {
       const std::vector<BackgroundChange>& changes) const;
 
   void TidyUpData(
-      bool fromCache, bool duringCache,
-      const std::set<std::string>& blacklistedImages);
+      bool fromCache, const std::set<std::string>& blacklistedImages);
 
  public:
   const std::vector<BackgroundChange>& GetBackgroundChanges(

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -114,11 +114,6 @@ Steps::Steps(Song* song)
       m_sChartStyle(""),
       m_Difficulty(Difficulty_Invalid),
       m_iMeter(0),
-      m_bAreCachedRadarValuesJustLoaded(false),
-      m_bAreCachedTechCountsValuesJustLoaded(false),
-      m_AreCachedNpsPerMeasureJustLoaded(false),
-      m_AreCachedNotesPerMeasureJustLoaded(false),
-      m_bIsCachedGrooveStatsHashJustLoaded(false),
       m_sGrooveStatsHash(""),
       m_iGrooveStatsHashVersion(0),
       m_sCredit(""),
@@ -347,11 +342,6 @@ void Steps::CalculateRadarValues(float fMusicLengthSeconds) {
     return;
   }
 
-  if (m_bAreCachedRadarValuesJustLoaded) {
-    m_bAreCachedRadarValuesJustLoaded = false;
-    return;
-  }
-
   // Do write radar values, and leave it up to the reading app whether they want
   // to trust the cached values without recalculating them.
   /*
@@ -363,7 +353,7 @@ void Steps::CalculateRadarValues(float fMusicLengthSeconds) {
   NoteData tempNoteData;
   this->GetNoteData(tempNoteData);
 
-  FOREACH_PlayerNumber(pn) m_CachedRadarValues[pn].Zero();
+  FOREACH_PlayerNumber(pn) m_RadarValues[pn].Zero();
 
   TimingData* timing = this->GetTimingData();
   if (tempNoteData.IsComposite()) {
@@ -373,7 +363,7 @@ void Steps::CalculateRadarValues(float fMusicLengthSeconds) {
     for (size_t pn = 0; pn < std::min(vParts.size(), size_t(NUM_PLAYERS));
          ++pn) {
       NoteDataUtil::CalculateRadarValues(
-          vParts[pn], fMusicLengthSeconds, timing, m_CachedRadarValues[pn]);
+          vParts[pn], fMusicLengthSeconds, timing, m_RadarValues[pn]);
     }
   } else if (
       GAMEMAN->GetStepsTypeInfo(this->m_StepsType).m_StepsTypeCategory ==
@@ -383,18 +373,16 @@ void Steps::CalculateRadarValues(float fMusicLengthSeconds) {
     const int tracks = tempNoteData.GetNumTracks() / 2;
     p1.SetNumTracks(tracks);
     NoteDataUtil::CalculateRadarValues(
-        p1, fMusicLengthSeconds, timing, m_CachedRadarValues[PLAYER_1]);
+        p1, fMusicLengthSeconds, timing, m_RadarValues[PLAYER_1]);
     // at this point, p2 is tempNoteData.
     NoteDataUtil::ShiftTracks(tempNoteData, tracks);
     tempNoteData.SetNumTracks(tracks);
     NoteDataUtil::CalculateRadarValues(
-        tempNoteData, fMusicLengthSeconds, timing,
-        m_CachedRadarValues[PLAYER_2]);
+        tempNoteData, fMusicLengthSeconds, timing, m_RadarValues[PLAYER_2]);
   } else {
     NoteDataUtil::CalculateRadarValues(
-        tempNoteData, fMusicLengthSeconds, timing, m_CachedRadarValues[0]);
-    std::fill_n(
-        m_CachedRadarValues + 1, NUM_PLAYERS - 1, m_CachedRadarValues[0]);
+        tempNoteData, fMusicLengthSeconds, timing, m_RadarValues[0]);
+    std::fill_n(m_RadarValues + 1, NUM_PLAYERS - 1, m_RadarValues[0]);
   }
 }
 
@@ -403,15 +391,10 @@ void Steps::CalculateTechCounts() {
     return;
   }
 
-  if (m_bAreCachedTechCountsValuesJustLoaded) {
-    m_bAreCachedTechCountsValuesJustLoaded = false;
-    return;
-  }
-
   NoteData tempNoteData;
   this->GetNoteData(tempNoteData);
 
-  FOREACH_PlayerNumber(pn) m_CachedTechCounts[pn].Zero();
+  FOREACH_PlayerNumber(pn) m_TechCounts[pn].Zero();
 
   const std::optional<StepParity::StageLayout> layout =
       getLayout(this->m_StepsType);
@@ -424,18 +407,12 @@ void Steps::CalculateTechCounts() {
   StepParity::StepParityGenerator gen =
       StepParity::StepParityGenerator(&*layout, timing);
   gen.analyzeNoteData(tempNoteData);
-  TechCounts::CalculateTechCountsFromRows(
-      gen.rows, &*layout, m_CachedTechCounts[0]);
-  std::fill_n(m_CachedTechCounts + 1, NUM_PLAYERS - 1, m_CachedTechCounts[0]);
+  TechCounts::CalculateTechCountsFromRows(gen.rows, &*layout, m_TechCounts[0]);
+  std::fill_n(m_TechCounts + 1, NUM_PLAYERS - 1, m_TechCounts[0]);
 }
 
 void Steps::CalculateMeasureInfo() {
   if (parent != nullptr) {
-    return;
-  }
-
-  if (m_AreCachedNpsPerMeasureJustLoaded) {
-    m_AreCachedNpsPerMeasureJustLoaded = false;
     return;
   }
 
@@ -474,13 +451,13 @@ void Steps::CalculateMeasureInfo() {
         tempNoteData, timing, measureInfoPerPlayer[0]);
   }
 
-  m_CachedNotesPerMeasure.clear();
-  m_CachedNpsPerMeasure.clear();
+  m_NotesPerMeasure.clear();
+  m_NpsPerMeasure.clear();
   m_PeakNps.clear();
 
   for (MeasureInfo& mi : measureInfoPerPlayer) {
-    m_CachedNotesPerMeasure.push_back(mi.notesPerMeasure);
-    m_CachedNpsPerMeasure.push_back(mi.npsPerMeasure);
+    m_NotesPerMeasure.push_back(mi.notesPerMeasure);
+    m_NpsPerMeasure.push_back(mi.npsPerMeasure);
     m_PeakNps.push_back(mi.peakNps);
   }
 }
@@ -621,18 +598,15 @@ void Steps::DeAutogen(bool bCopyNoteData) {
   m_Difficulty = Real()->m_Difficulty;
   m_iMeter = Real()->m_iMeter;
   std::copy(
-      Real()->m_CachedRadarValues, Real()->m_CachedRadarValues + NUM_PLAYERS,
-      m_CachedRadarValues);
+      Real()->m_RadarValues, Real()->m_RadarValues + NUM_PLAYERS,
+      m_RadarValues);
   std::copy(
-      Real()->m_CachedTechCounts, Real()->m_CachedTechCounts + NUM_PLAYERS,
-      m_CachedTechCounts);
+      Real()->m_TechCounts, Real()->m_TechCounts + NUM_PLAYERS, m_TechCounts);
 
-  m_CachedNpsPerMeasure.assign(
-      Real()->m_CachedNpsPerMeasure.begin(),
-      Real()->m_CachedNpsPerMeasure.end());
-  m_CachedNotesPerMeasure.assign(
-      Real()->m_CachedNotesPerMeasure.begin(),
-      Real()->m_CachedNotesPerMeasure.end());
+  m_NpsPerMeasure.assign(
+      Real()->m_NpsPerMeasure.begin(), Real()->m_NpsPerMeasure.end());
+  m_NotesPerMeasure.assign(
+      Real()->m_NotesPerMeasure.begin(), Real()->m_NotesPerMeasure.end());
 
   m_sCredit = Real()->m_sCredit;
   parent = nullptr;
@@ -746,31 +720,24 @@ const std::string& Steps::GetMusicFile() const { return m_MusicFile; }
 
 void Steps::SetMusicFile(const std::string& file) { m_MusicFile = file; }
 
-void Steps::SetCachedRadarValues(const RadarValues v[NUM_PLAYERS]) {
+void Steps::SetRadarValues(const RadarValues v[NUM_PLAYERS]) {
   DeAutogen();
-  std::copy(v, v + NUM_PLAYERS, m_CachedRadarValues);
-  m_bAreCachedRadarValuesJustLoaded = true;
+  std::copy(v, v + NUM_PLAYERS, m_RadarValues);
 }
 
-void Steps::SetCachedTechCounts(const TechCounts ts[NUM_PLAYERS]) {
+void Steps::SetTechCounts(const TechCounts ts[NUM_PLAYERS]) {
   DeAutogen();
-  std::copy(ts, ts + NUM_PLAYERS, m_CachedTechCounts);
-  m_bAreCachedTechCountsValuesJustLoaded = true;
+  std::copy(ts, ts + NUM_PLAYERS, m_TechCounts);
 }
 
-void Steps::SetCachedNpsPerMeasure(
-    std::vector<std::vector<float>>& npsPerMeasure) {
+void Steps::SetNpsPerMeasure(std::vector<std::vector<float>>& npsPerMeasure) {
   DeAutogen();
-  m_CachedNpsPerMeasure.assign(npsPerMeasure.begin(), npsPerMeasure.end());
-  m_AreCachedNpsPerMeasureJustLoaded = true;
+  m_NpsPerMeasure.assign(npsPerMeasure.begin(), npsPerMeasure.end());
 }
 
-void Steps::SetCachedNotesPerMeasure(
-    std::vector<std::vector<int>>& notesPerMeasure) {
+void Steps::SetNotesPerMeasure(std::vector<std::vector<int>>& notesPerMeasure) {
   DeAutogen();
-  m_CachedNotesPerMeasure.assign(
-      notesPerMeasure.begin(), notesPerMeasure.end());
-  m_AreCachedNotesPerMeasureJustLoaded = true;
+  m_NotesPerMeasure.assign(notesPerMeasure.begin(), notesPerMeasure.end());
 }
 
 void Steps::SetPeakNps(std::vector<float>& peakNps) {
@@ -786,17 +753,6 @@ int Steps::GetGrooveStatsHashVersion() const {
 }
 
 void Steps::CalculateGrooveStatsHash() {
-  // When the game first boots up, it will load the GrooveStatsHash from the
-  // cache.
-  // This should keep the initial boot snappy, especially since hashes should
-  // almost never change.
-  // If this function is then called again (say in ScreenEval), we can
-  // recalculate the hash and use that for submission.
-  if (m_iGrooveStatsHashVersion == CURRENT_GROOVE_STATS_HASH_VERSION &&
-      m_bIsCachedGrooveStatsHashJustLoaded == true) {
-    m_bIsCachedGrooveStatsHashJustLoaded = false;
-    return;
-  }
   this->Decompress();
 
   std::string smNoteData = this->MinimizedChartString();
@@ -909,12 +865,11 @@ std::string Steps::MinimizedChartString() {
   return minimizedNoteData;
 }
 
-void Steps::SetCachedGrooveStatsHash(const std::string& key) {
+void Steps::SetGrooveStatsHash(const std::string& key) {
   m_sGrooveStatsHash = key;
-  m_bIsCachedGrooveStatsHashJustLoaded = true;
 }
 
-void Steps::SetCachedGrooveStatsHashVersion(int version) {
+void Steps::SetGrooveStatsHashVersion(int version) {
   m_iGrooveStatsHashVersion = version;
 }
 
@@ -1004,12 +959,12 @@ const std::vector<float>& Steps::GetNpsPerMeasure(PlayerNumber pn) const {
   // will be the case for like 99.9% of charts).
 
   static const std::vector<float> EMPTY_VECTOR;
-  if (Real()->m_CachedNpsPerMeasure.size() == 0) {
+  if (Real()->m_NpsPerMeasure.size() == 0) {
     return EMPTY_VECTOR;
-  } else if (Real()->m_CachedNpsPerMeasure.size() <= pn) {
-    return Real()->m_CachedNpsPerMeasure[PLAYER_1];
+  } else if (Real()->m_NpsPerMeasure.size() <= pn) {
+    return Real()->m_NpsPerMeasure[PLAYER_1];
   } else {
-    return Real()->m_CachedNpsPerMeasure[pn];
+    return Real()->m_NpsPerMeasure[pn];
   }
 }
 
@@ -1019,12 +974,12 @@ const std::vector<int>& Steps::GetNotesPerMeasure(PlayerNumber pn) const {
   // dance-routine). Otherwise, it will only have one copy of the values (which
   // will be the case for like 99.9% of charts).
   static const std::vector<int> EMPTY_VECTOR;
-  if (Real()->m_CachedNotesPerMeasure.size() == 0) {
+  if (Real()->m_NotesPerMeasure.size() == 0) {
     return EMPTY_VECTOR;
-  } else if (Real()->m_CachedNotesPerMeasure.size() <= pn) {
-    return Real()->m_CachedNotesPerMeasure[PLAYER_1];
+  } else if (Real()->m_NotesPerMeasure.size() <= pn) {
+    return Real()->m_NotesPerMeasure[PLAYER_1];
   } else {
-    return Real()->m_CachedNotesPerMeasure[pn];
+    return Real()->m_NotesPerMeasure[pn];
   }
 }
 
@@ -1084,14 +1039,7 @@ class LunaSteps : public Luna<Steps> {
   }
 
   static int CalculateTechCounts(T* p, lua_State* L) {
-    p->CalculateTechCounts();
-    PlayerNumber pn = PLAYER_1;
-    if (!lua_isnil(L, 1)) {
-      pn = Enum::Check<PlayerNumber>(L, 1);
-    }
-    TechCounts& ts = const_cast<TechCounts&>(p->GetTechCounts(pn));
-    ts.PushSelf(L);
-    return 1;
+    return GetTechCounts(p, L);
   }
 
   static int GetNpsPerMeasure(T* p, lua_State* L) {
@@ -1243,6 +1191,7 @@ class LunaSteps : public Luna<Steps> {
     ADD_METHOD(HasAttacks);
     ADD_METHOD(GetRadarValues);
     ADD_METHOD(GetTechCounts);
+    // TODO: remove CalculateTechCounts
     ADD_METHOD(CalculateTechCounts);
     ADD_METHOD(GetTimingData);
     ADD_METHOD(GetChartName);

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -29,7 +29,9 @@ const int MAX_STEPS_DESCRIPTION_LENGTH = 255;
 
 /**
  * @brief Current version of GrooveStats hash.
- * Increment this to invalidate previously cached values
+ * Increment this to invalidate previously cached values.
+ * If this is incremented, FILE_CACHE_VERSION must also be incremented so that
+ * existing cache files are regenerated.
  */
 const int CURRENT_GROOVE_STATS_HASH_VERSION = 3;
 
@@ -114,7 +116,7 @@ class Steps {
    */
   int GetMeter() const { return Real()->m_iMeter; }
   const RadarValues& GetRadarValues(PlayerNumber pn) const {
-    return Real()->m_CachedRadarValues[pn];
+    return Real()->m_RadarValues[pn];
   }
   /**
    * @brief Retrieve the author credit used for this edit.
@@ -172,13 +174,13 @@ class Steps {
 
   void SetLoadedFromProfile(ProfileSlot slot) { m_LoadedFromProfile = slot; }
   void SetMeter(int meter);
-  void SetCachedRadarValues(const RadarValues v[NUM_PLAYERS]);
-  void SetCachedTechCounts(const TechCounts ts[NUM_PLAYERS]);
-  void SetCachedNpsPerMeasure(std::vector<std::vector<float>>& npsPerMeasure);
-  void SetCachedNotesPerMeasure(std::vector<std::vector<int>>& notesPerMeasure);
+  void SetRadarValues(const RadarValues v[NUM_PLAYERS]);
+  void SetTechCounts(const TechCounts ts[NUM_PLAYERS]);
+  void SetNpsPerMeasure(std::vector<std::vector<float>>& npsPerMeasure);
+  void SetNotesPerMeasure(std::vector<std::vector<int>>& notesPerMeasure);
   void SetPeakNps(std::vector<float>& peakNps);
-  void SetCachedGrooveStatsHash(const std::string& key);
-  void SetCachedGrooveStatsHashVersion(int version);
+  void SetGrooveStatsHash(const std::string& key);
+  void SetGrooveStatsHashVersion(int version);
   float PredictMeter() const;
 
   unsigned GetHash() const;
@@ -210,17 +212,17 @@ class Steps {
 
   void CalculateTechCounts();
   const TechCounts& GetTechCounts(PlayerNumber pn) const {
-    return Real()->m_CachedTechCounts[pn];
+    return Real()->m_TechCounts[pn];
   }
 
   void CalculateMeasureInfo();
 
   const std::vector<std::vector<float>>& GetAllNpsPerMeasures() const {
-    return Real()->m_CachedNpsPerMeasure;
+    return Real()->m_NpsPerMeasure;
   }
   const std::vector<float>& GetNpsPerMeasure(PlayerNumber pn) const;
   const std::vector<std::vector<int>>& GetAllNotesPerMeasures() const {
-    return Real()->m_CachedNotesPerMeasure;
+    return Real()->m_NotesPerMeasure;
   };
   const std::vector<int>& GetNotesPerMeasure(PlayerNumber pn) const;
 
@@ -324,22 +326,16 @@ class Steps {
    * MAX_METER. */
   int m_iMeter;
   /** @brief The radar values used for each player. */
-  RadarValues m_CachedRadarValues[NUM_PLAYERS];
-  bool m_bAreCachedRadarValuesJustLoaded;
+  RadarValues m_RadarValues[NUM_PLAYERS];
 
   /** @brief The tech stats used for each player */
-  mutable TechCounts m_CachedTechCounts[NUM_PLAYERS];
-  bool m_bAreCachedTechCountsValuesJustLoaded;
+  TechCounts m_TechCounts[NUM_PLAYERS];
 
-  std::vector<std::vector<float>> m_CachedNpsPerMeasure;
-  bool m_AreCachedNpsPerMeasureJustLoaded;
-
-  std::vector<std::vector<int>> m_CachedNotesPerMeasure;
-  bool m_AreCachedNotesPerMeasureJustLoaded;
+  std::vector<std::vector<float>> m_NpsPerMeasure;
+  std::vector<std::vector<int>> m_NotesPerMeasure;
 
   std::vector<float> m_PeakNps;
 
-  bool m_bIsCachedGrooveStatsHashJustLoaded;
   std::string m_sGrooveStatsHash;
   int m_iGrooveStatsHashVersion;
 


### PR DESCRIPTION
Upon initial load, then stats are stored into the cache and never recalculated.

Also fixes a bug where we'd decompress songs with a first second < 0 during load even if they were already cached. Now startup doesn't decompress any note data if everything is cached.