### PR TITLE
Fix ninja build on Linux

### DIFF
--- a/CMake/SetupFfmpeg.cmake
+++ b/CMake/SetupFfmpeg.cmake
@@ -65,7 +65,7 @@ externalproject_add("ffmpeg"
                     UPDATE_COMMAND ""
                     INSTALL_COMMAND ""
                     TEST_COMMAND ""
-                    BYPRODUCTS
+                    BUILD_BYPRODUCTS
                       "<BINARY_DIR>/dest/lib/libavformat.a"
                       "<BINARY_DIR>/dest/lib/libavcodec.a"
                       "<BINARY_DIR>/dest/lib/libswscale.a"

--- a/extern/CMakeProject-libusb.cmake
+++ b/extern/CMakeProject-libusb.cmake
@@ -14,6 +14,7 @@ ExternalProject_Add(
 
   SOURCE_DIR "${LIBUSB_SOURCE_DIR}"
   INSTALL_COMMAND ""
+  BUILD_BYPRODUCTS "<BINARY_DIR>/libusb-1.0.a"
 )
 
 ExternalProject_Get_Property(libusb SOURCE_DIR BINARY_DIR)


### PR DESCRIPTION
Need to declare libusb output.

Standardize on BUILD_BYPRODUCTS in ffmpeg as well since that looks like what the official documentation uses.