### PR TITLE
Remove Vblank early return logic from UpdateAllButDraw

### DIFF
--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -236,7 +236,7 @@ void DoChangeGame() {
 }
 }  // namespace
 
-void GameLoop::UpdateAllButDraw(bool bRunningFromVBLANK) {
+void GameLoop::UpdateAllButDraw() {
   // If the constant update delta is set, use that value. Otherwise, use the
   // delta time from the gameplay timer.
   float fDeltaTime = (g_fConstantUpdateDeltaSeconds > 0)
@@ -297,7 +297,7 @@ void GameLoop::RunGameLoop() {
       ArchHooks::SetUserQuit();
     }
 
-    UpdateAllButDraw(false);
+    UpdateAllButDraw();
 
     CallEveryNFrames(500, CheckInputDevices);
 

--- a/src/GameLoop.cpp
+++ b/src/GameLoop.cpp
@@ -237,26 +237,6 @@ void DoChangeGame() {
 }  // namespace
 
 void GameLoop::UpdateAllButDraw(bool bRunningFromVBLANK) {
-  // Flag to indicate whether an update has been processed during the VBLANK
-  // period.
-  static bool m_bUpdatedDuringVBLANK = false;
-
-  // If we're running from VBLANK, and we've already updated during the VBLANK
-  // period, don't update again. This is to prevent multiple updates during the
-  // same VBLANK period.
-  if (!bRunningFromVBLANK && m_bUpdatedDuringVBLANK) {
-    m_bUpdatedDuringVBLANK = false;
-    return;
-  }
-
-  // If we're running from VBLANK, indicate we've updated during the VBLANK
-  // period. Otherwise, make sure the flag is cleared.
-  if (bRunningFromVBLANK) {
-    m_bUpdatedDuringVBLANK = true;
-  } else {
-    m_bUpdatedDuringVBLANK = false;
-  }
-
   // If the constant update delta is set, use that value. Otherwise, use the
   // delta time from the gameplay timer.
   float fDeltaTime = (g_fConstantUpdateDeltaSeconds > 0)

--- a/src/GameLoop.h
+++ b/src/GameLoop.h
@@ -5,7 +5,7 @@
 /** @brief Main rendering and update loop. */
 namespace GameLoop {
 void RunGameLoop();
-void UpdateAllButDraw(bool bRunningFromVBLANK);
+void UpdateAllButDraw();
 void SetUpdateRate(float fUpdateRate);
 float GetUpdateRate();
 void ChangeTheme(const std::string& sNewTheme);


### PR DESCRIPTION
Removes the early return logic in UpdateAllButDraw to allow for the implementation of automatic drawing management when VSync is enabled. #1379  was tested with this commit to allow for RageDisplay to maintain exclusive responsibility of the VSync implementation.