### PR TITLE
Remove problematic frame timing function

### DIFF
--- a/src/GameSoundManager.cpp
+++ b/src/GameSoundManager.cpp
@@ -490,43 +490,6 @@ GameSoundManager::~GameSoundManager() {
   RageUtil::SafeDelete(g_Mutex);
 }
 
-float GameSoundManager::GetFrameTimingAdjustment(float fDeltaTime) {
-  /*
-   * We get one update per frame, and we're updated early, almost immediately
-   * after vsync, near the beginning of the game loop.  However, it's very
-   * likely that we'll lose the scheduler while waiting for vsync, and some
-   * other thread will be working.  Especially with a low-resolution scheduler
-   * (Linux 2.4, Win9x), we may not get the scheduler back immediately after the
-   * vsync; there may be up to a ~10ms delay.  This can cause jitter in the
-   * rendered arrows.
-   *
-   * Compensate.  If vsync is enabled, and we're maintaining the refresh rate
-   * consistently, we should have a very precise game loop interval.  If we have
-   * that, but we're off by a small amount (less than the interval), adjust the
-   * time to line it up.  As long as we adjust both the sound time and the
-   * timestamp, this won't adversely affect input timing. If we're off by more
-   * than that, we probably had a frame skip, in which case we have bigger skip
-   * problems, so don't adjust.
-   */
-  static int iLastFPS = 0;
-  int iThisFPS = DISPLAY->GetFPS();
-
-  if (iThisFPS != DISPLAY->GetActualVideoModeParams().rate ||
-      iThisFPS != iLastFPS) {
-    iLastFPS = iThisFPS;
-    return 0;
-  }
-
-  const float fExpectedDelay = 1.0f / iThisFPS;
-  const float fExtraDelay = fDeltaTime - fExpectedDelay;
-  if (std::abs(fExtraDelay) >= fExpectedDelay / 2) {
-    return 0;
-  }
-
-  /* Subtract the extra delay. */
-  return std::min(-fExtraDelay, 0.0f);
-}
-
 void GameSoundManager::Update(float fDeltaTime) {
   {
     g_Mutex->Lock();
@@ -603,7 +566,6 @@ void GameSoundManager::Update(float fDeltaTime) {
     return;
   }
 
-  const float fAdjust = GetFrameTimingAdjustment(fDeltaTime);
   if (!g_Playing->m_Music->IsPlaying()) {
     /* There's no song playing.  Fake it. */
     CHECKPOINT_M(ssprintf(
@@ -660,8 +622,7 @@ void GameSoundManager::Update(float fDeltaTime) {
         GAMESTATE->m_Position.m_fMusicSeconds + fDeltaTime,
         g_Playing->m_Timing);
   } else {
-    GAMESTATE->UpdateSongPosition(
-        fSeconds + fAdjust, g_Playing->m_Timing, tm + fAdjust);
+    GAMESTATE->UpdateSongPosition(fSeconds, g_Playing->m_Timing, tm);
   }
 
   // Send crossed messages

--- a/src/GameSoundManager.h
+++ b/src/GameSoundManager.h
@@ -58,7 +58,6 @@ class GameSoundManager {
   void PlayOnceFromAnnouncer(std::string sFolderName);
 
   void HandleSongTimer(bool on = true);
-  float GetFrameTimingAdjustment(float fDeltaTime);
 
   static float GetPlayerBalance(PlayerNumber pn);
 

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1640,9 +1640,9 @@ void ScreenGameplay::UpdateSongPosition(float fDeltaTime) {
 
   RageTimer tm;
   const float fSeconds = m_pSoundMusic->GetPositionSeconds(&tm);
-  const float fAdjust = SOUND->GetFrameTimingAdjustment(fDeltaTime);
+
   GAMESTATE->UpdateSongPosition(
-      fSeconds + fAdjust, GAMESTATE->m_pCurSong->m_SongTiming, tm + fAdjust);
+      fSeconds, GAMESTATE->m_pCurSong->m_SongTiming, tm);
 }
 
 void ScreenGameplay::BeginScreen() {


### PR DESCRIPTION
Per the comment, this exists to compensate for low-resolution schedulers such as those found in Linux 2.x or Windows 9X.  We do not support such platforms anymore and specifically use monotonic clocks with high precision and OS's with reliable schedulers, so this code should be removed as it is counterproductive rather than helpful for us currently.

In testing, on a fairly low end PC (AMD A12-9800 using integrated graphics), with a 125hz keyboard, I could easily 97% a tech 7 or get a low white/yellow count score on 150bpm stam, timing feels very good with this patch and vsync enabled.