### PR TITLE
Pass C(XX)_COMPILER(_FLAGS/_COMPILER_LAUNCHER) to sub-CMake invocations

### DIFF
--- a/CMake/CMakeMacros.cmake
+++ b/CMake/CMakeMacros.cmake
@@ -66,3 +66,20 @@ macro(check_compile_features
     endif()
   endif()
 endmacro()
+
+# To be passed to ExternalProject_Add to ensure sub-CMake projects use the right
+# compiler. Must specify `LIST_SEPARATOR "|"`.
+function(sm_get_forwarded_toolchain_args out_var)
+  set(toolchain_args
+      "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
+      "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+      "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}"
+      "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
+  foreach(lang C CXX)
+    if(CMAKE_${lang}_COMPILER_LAUNCHER)
+      string(REPLACE ";" "|" launcher "${CMAKE_${lang}_COMPILER_LAUNCHER}")
+      list(APPEND toolchain_args "-DCMAKE_${lang}_COMPILER_LAUNCHER=${launcher}")
+    endif()
+  endforeach()
+  set(${out_var} "${toolchain_args}" PARENT_SCOPE)
+endfunction()

--- a/extern/CMakeProject-libjpeg-turbo.cmake
+++ b/extern/CMakeProject-libjpeg-turbo.cmake
@@ -15,16 +15,22 @@ if(APPLE)
   )
 endif()
 
+sm_get_forwarded_toolchain_args(JPEG_FORWARD_ARGS)
+
 include(ExternalProject)
 ExternalProject_Add(
   libjpeg_turbo_project
 
   SOURCE_DIR ${SM_EXTERN_DIR}/libjpeg-turbo
   INSTALL_DIR ${INSTALL_DIR}
+  LIST_SEPARATOR "|"
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}
              -DCMAKE_INSTALL_LIBDIR=${LIB_DIR}
              -DENABLE_SHARED=OFF
              -DENABLE_STATIC=ON
+             -DWITH_TOOLS=OFF
+             -DWITH_TESTS=OFF
+             ${JPEG_FORWARD_ARGS}
              ${ARCH_FLAGS}
   BUILD_IN_SOURCE OFF
   CONFIGURE_HANDLED_BY_BUILD ON

--- a/extern/CMakeProject-libusb.cmake
+++ b/extern/CMakeProject-libusb.cmake
@@ -8,12 +8,17 @@ endif()
 
 set(LIBUSB_SOURCE_DIR "${SM_EXTERN_DIR}/libusb")
 
+sm_get_forwarded_toolchain_args(LIBUSB_FORWARD_ARGS)
+
 include(ExternalProject)
 ExternalProject_Add(
   libusb
 
   SOURCE_DIR "${LIBUSB_SOURCE_DIR}"
+  LIST_SEPARATOR "|"
+  CMAKE_ARGS ${LIBUSB_FORWARD_ARGS}
   INSTALL_COMMAND ""
+  BUILD_BYPRODUCTS "<BINARY_DIR>/libusb-1.0.a"
 )
 
 ExternalProject_Get_Property(libusb SOURCE_DIR BINARY_DIR)


### PR DESCRIPTION
Also pass `-DWITH_TOOLS=OFF -DWITH_TESTS=OFF` to libjpeg-turbo to build fewer things we don't use.