### PR TITLE
Add missing pTimestamp->Touch() in GetHardwareFrame()

### DIFF
--- a/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
@@ -525,6 +525,7 @@ int64_t RageSoundDriver::GetHardwareFrame(
   do {
     iStartTime = RageTimer::GetTimeSinceStartMicroseconds();
     iPositionFrames = GetPosition();
+    pTimestamp->Touch();
     uint64_t elapsedTime =
         RageTimer::GetTimeSinceStartMicroseconds() - iStartTime;
     if (elapsedTime <= iThreshold) {


### PR DESCRIPTION
Callers of this are expecting pTimestamp to be the timestamp of when we get the audio time. pTimestamp wasn't getting modified before at all.