### PR TITLE
Add WASAPI sound driver

### DIFF
--- a/src/CMakeData-arch.cmake
+++ b/src/CMakeData-arch.cmake
@@ -37,12 +37,14 @@ if(WIN32)
               "arch/Sound/DSoundHelpers.cpp"
               "arch/Sound/RageSoundDriver_DSound_Software.cpp"
               "arch/Sound/RageSoundDriver_WaveOut.cpp"
-              "arch/Sound/RageSoundDriver_WDMKS.cpp")
+              "arch/Sound/RageSoundDriver_WDMKS.cpp"
+              "arch/Sound/RageSoundDriver_WASAPI.cpp")
   list(APPEND SMDATA_ARCH_SOUND_HPP
               "arch/Sound/DSoundHelpers.h"
               "arch/Sound/RageSoundDriver_DSound_Software.h"
               "arch/Sound/RageSoundDriver_WaveOut.h"
-              "arch/Sound/RageSoundDriver_WDMKS.h")
+              "arch/Sound/RageSoundDriver_WDMKS.h"
+              "arch/Sound/RageSoundDriver_WASAPI.h")
 elseif(APPLE)
   list(APPEND SMDATA_ARCH_SOUND_SRC "arch/Sound/RageSoundDriver_AU.mm")
   list(APPEND SMDATA_ARCH_SOUND_HPP "arch/Sound/RageSoundDriver_AU.h")

--- a/src/arch/Sound/RageSoundDriver_WASAPI.cpp
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.cpp
@@ -1,0 +1,324 @@
+#include "RageSoundDriver_WASAPI.h"
+
+// clang-format off
+#include <windows.h>
+#include <audioclient.h>
+#include <ksmedia.h>
+#include <mmdeviceapi.h>
+// clang-format on
+
+#include "PrefsManager.h"
+#include "RageLog.h"
+#include "RageUtil.h"
+#include "archutils/Win32/DirectXHelpers.h"
+#include "archutils/Win32/ErrorStrings.h"
+#include "global.h"
+
+REGISTER_SOUND_DRIVER_CLASS2("WASAPI", WASAPI);
+
+RageSoundDriver_WASAPI::RageSoundDriver_WASAPI()
+    : m_iSampleRate(0),
+      m_iBufferSizeFrames(0),
+      m_bFloat(true),
+      m_pAudioClient(nullptr),
+      m_pRenderClient(nullptr),
+      m_pAudioClock(nullptr),
+      m_iAudioClockFreq(0),
+      m_hAudioEvent(INVALID_HANDLE_VALUE),
+      m_bShutdownMixerThread(false),
+      m_bOwnsComInit(false) {}
+
+RageSoundDriver_WASAPI::~RageSoundDriver_WASAPI() {
+  if (m_MixingThread.IsCreated()) {
+    m_bShutdownMixerThread = true;
+    if (m_hAudioEvent != INVALID_HANDLE_VALUE) {
+      SetEvent(m_hAudioEvent);  // Wake up thread
+    }
+    m_MixingThread.Wait();
+  }
+
+  FreeWASAPI();
+
+  if (m_hAudioEvent != INVALID_HANDLE_VALUE) {
+    CloseHandle(m_hAudioEvent);
+  }
+}
+
+void RageSoundDriver_WASAPI::FreeWASAPI() {
+  if (m_pAudioClient) {
+    m_pAudioClient->Stop();
+  }
+  if (m_pAudioClock) {
+    m_pAudioClock->Release();
+    m_pAudioClock = nullptr;
+  }
+  if (m_pRenderClient) {
+    m_pRenderClient->Release();
+    m_pRenderClient = nullptr;
+  }
+  if (m_pAudioClient) {
+    m_pAudioClient->Release();
+    m_pAudioClient = nullptr;
+  }
+  if (m_bOwnsComInit) {
+    CoUninitialize();
+    m_bOwnsComInit = false;
+  }
+}
+
+bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
+  HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+  if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
+    sError = hr_ssprintf(hr, "CoInitializeEx failed");
+    return false;
+  }
+  m_bOwnsComInit = SUCCEEDED(hr);
+
+  IMMDeviceEnumerator* pEnumerator = nullptr;
+  hr = CoCreateInstance(
+      __uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+      IID_PPV_ARGS(&pEnumerator));
+  if (FAILED(hr)) {
+    sError = hr_ssprintf(hr, "CoCreateInstance(MMDeviceEnumerator) failed");
+    FreeWASAPI();
+    return false;
+  }
+
+  IMMDevice* pDevice = nullptr;
+  hr = pEnumerator->GetDefaultAudioEndpoint(eRender, eConsole, &pDevice);
+  pEnumerator->Release();
+  if (FAILED(hr)) {
+    sError = hr_ssprintf(hr, "GetDefaultAudioEndpoint failed");
+    FreeWASAPI();
+    return false;
+  }
+
+  hr = pDevice->Activate(
+      __uuidof(IAudioClient), CLSCTX_ALL, nullptr, (void**)&m_pAudioClient);
+  pDevice->Release();
+  if (FAILED(hr)) {
+    sError = hr_ssprintf(hr, "Activate(IAudioClient) failed");
+    FreeWASAPI();
+    return false;
+  }
+
+  WAVEFORMATEX* pwfx = nullptr;
+  hr = m_pAudioClient->GetMixFormat(&pwfx);
+  if (FAILED(hr)) {
+    sError = hr_ssprintf(hr, "GetMixFormat failed");
+    FreeWASAPI();
+    return false;
+  }
+
+  m_iSampleRate = pwfx->nSamplesPerSec;
+  int iChannels = pwfx->nChannels;
+
+  if (pwfx->wFormatTag != WAVE_FORMAT_EXTENSIBLE) {
+    sError = ssprintf("Unsupported format tag: %d", pwfx->wFormatTag);
+    CoTaskMemFree(pwfx);
+    FreeWASAPI();
+    return false;
+  }
+
+  WAVEFORMATEXTENSIBLE* pEx = (WAVEFORMATEXTENSIBLE*)pwfx;
+  if (pEx->SubFormat == KSDATAFORMAT_SUBTYPE_IEEE_FLOAT) {
+    m_bFloat = true;
+  } else if (
+      pEx->SubFormat == KSDATAFORMAT_SUBTYPE_PCM &&
+      pEx->Format.wBitsPerSample == 16) {
+    m_bFloat = false;
+  } else {
+    sError = "Unsupported format (expected float or 16-bit PCM)";
+    CoTaskMemFree(pwfx);
+    FreeWASAPI();
+    return false;
+  }
+
+  REFERENCE_TIME hnsRequestedDuration = 0;
+  if (PREFSMAN->m_iSoundWriteAhead) {
+    // WriteAhead is in frames. Convert to 100-nanosecond units.
+    hnsRequestedDuration = (REFERENCE_TIME)PREFSMAN->m_iSoundWriteAhead *
+                           10000000ULL / m_iSampleRate;
+  }
+
+  hr = m_pAudioClient->Initialize(
+      AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
+      hnsRequestedDuration, 0, pwfx, nullptr);
+
+  CoTaskMemFree(pwfx);
+
+  if (FAILED(hr)) {
+    sError = hr_ssprintf(hr, "Initialize(IAudioClient) failed");
+    FreeWASAPI();
+    return false;
+  }
+
+  m_hAudioEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+  if (m_hAudioEvent == NULL) {
+    sError = werr_ssprintf(GetLastError(), "CreateEvent failed");
+    FreeWASAPI();
+    return false;
+  }
+
+  hr = m_pAudioClient->SetEventHandle(m_hAudioEvent);
+  if (FAILED(hr)) {
+    sError = hr_ssprintf(hr, "SetEventHandle failed");
+    FreeWASAPI();
+    return false;
+  }
+
+  hr = m_pAudioClient->GetBufferSize(&m_iBufferSizeFrames);
+  if (FAILED(hr)) {
+    sError = hr_ssprintf(hr, "GetBufferSize failed");
+    FreeWASAPI();
+    return false;
+  }
+
+  hr = m_pAudioClient->GetService(IID_PPV_ARGS(&m_pRenderClient));
+  if (FAILED(hr)) {
+    sError = hr_ssprintf(hr, "GetService(IAudioRenderClient) failed");
+    FreeWASAPI();
+    return false;
+  }
+
+  hr = m_pAudioClient->GetService(IID_PPV_ARGS(&m_pAudioClock));
+  if (FAILED(hr)) {
+    sError = hr_ssprintf(hr, "GetService(IAudioClock) failed");
+    FreeWASAPI();
+    return false;
+  }
+
+  hr = m_pAudioClock->GetFrequency(&m_iAudioClockFreq);
+  if (FAILED(hr)) {
+    sError = hr_ssprintf(hr, "GetFrequency failed");
+    FreeWASAPI();
+    return false;
+  }
+
+  LOG->Info(
+      "WASAPI: Shared mode, %d channels, %d Hz, %s, buffer size %d frames",
+      iChannels, m_iSampleRate, m_bFloat ? "Float" : "Int16",
+      m_iBufferSizeFrames);
+
+  return true;
+}
+
+std::string RageSoundDriver_WASAPI::Init() {
+  std::string sError;
+  if (!InitWASAPI(sError)) {
+    return sError;
+  }
+
+  // Set decode buffer size.
+  // We want it to be at least as big as the WASAPI buffer.
+  SetDecodeBufferSize(m_iBufferSizeFrames * 3 / 2);
+  StartDecodeThread();
+
+  m_MixingThread.SetName("WASAPI Mixer Thread");
+  m_MixingThread.Create(MixerThread_start, this);
+
+  return "";
+}
+
+int RageSoundDriver_WASAPI::MixerThread_start(void* p) {
+  ((RageSoundDriver_WASAPI*)p)->MixerThread();
+  return 0;
+}
+
+void RageSoundDriver_WASAPI::MixerThread() {
+  if (!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL)) {
+    if (!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL)) {
+      LOG->Warn(
+          werr_ssprintf(
+              GetLastError(), "Failed to set WASAPI sound thread priority")
+              .c_str());
+    }
+  }
+
+  HRESULT hr = m_pAudioClient->Start();
+  if (FAILED(hr)) {
+    LOG->Warn(hr_ssprintf(hr, "Failed to start IAudioClient").c_str());
+    return;
+  }
+
+  int64_t iHardwareFrame = 0;  // Total frames played/mixed so far
+
+  while (!m_bShutdownMixerThread) {
+    DWORD waitResult =
+        WaitForSingleObject(m_hAudioEvent, 2000);  // 2 second timeout safety
+    if (waitResult == WAIT_TIMEOUT) {
+      LOG->Warn("WASAPI: Timeout waiting for audio event");
+      m_pAudioClient->Stop();
+      m_pAudioClient->Start();
+      continue;
+    }
+
+    if (m_bShutdownMixerThread) {
+      break;
+    }
+
+    UINT32 padding = 0;
+    hr = m_pAudioClient->GetCurrentPadding(&padding);
+    if (FAILED(hr)) {
+      LOG->Warn(hr_ssprintf(hr, "GetCurrentPadding failed").c_str());
+      continue;
+    }
+
+    UINT32 framesAvailable = m_iBufferSizeFrames - padding;
+    if (framesAvailable == 0) {
+      continue;
+    }
+
+    BYTE* pData = nullptr;
+    hr = m_pRenderClient->GetBuffer(framesAvailable, &pData);
+    if (FAILED(hr)) {
+      LOG->Warn(hr_ssprintf(hr, "GetBuffer failed").c_str());
+      continue;
+    }
+
+    int64_t iCurrentFrame = GetPosition();
+
+    if (m_bFloat) {
+      this->Mix((float*)pData, framesAvailable, iHardwareFrame, iCurrentFrame);
+    } else {
+      this->Mix(
+          (int16_t*)pData, framesAvailable, iHardwareFrame, iCurrentFrame);
+    }
+
+    hr = m_pRenderClient->ReleaseBuffer(framesAvailable, 0);
+    if (FAILED(hr)) {
+      LOG->Warn(hr_ssprintf(hr, "ReleaseBuffer failed").c_str());
+    }
+
+    iHardwareFrame += framesAvailable;
+  }
+
+  m_pAudioClient->Stop();
+}
+
+int64_t RageSoundDriver_WASAPI::GetPosition() const {
+  UINT64 position = 0;
+  if (FAILED(m_pAudioClock->GetPosition(&position, nullptr))) {
+    return 0;
+  }
+  return (int64_t)(position * (UINT64)m_iSampleRate / m_iAudioClockFreq);
+}
+
+float RageSoundDriver_WASAPI::GetPlayLatency() const {
+  REFERENCE_TIME latency = 0;
+  if (FAILED(m_pAudioClient->GetStreamLatency(&latency))) {
+    return 0.0f;
+  }
+  return (float)latency / 10000000.0f;
+}
+
+int RageSoundDriver_WASAPI::GetSampleRate() const { return m_iSampleRate; }
+
+void RageSoundDriver_WASAPI::SetupDecodingThread() {
+  if (!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL)) {
+    LOG->Warn(
+        werr_ssprintf(
+            GetLastError(), "Failed to set WASAPI decoding thread priority")
+            .c_str());
+  }
+}

--- a/src/arch/Sound/RageSoundDriver_WASAPI.h
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.h
@@ -1,0 +1,53 @@
+#ifndef RAGE_SOUND_WASAPI_H
+#define RAGE_SOUND_WASAPI_H
+
+// clang-format off
+#include <windows.h>
+// clang-format on
+
+#include <atomic>
+
+#include "RageSoundDriver.h"
+#include "RageThreads.h"
+
+struct IAudioClient;
+struct IAudioRenderClient;
+struct IAudioClock;
+
+class RageSoundDriver_WASAPI : public RageSoundDriver {
+ public:
+  RageSoundDriver_WASAPI();
+  virtual ~RageSoundDriver_WASAPI();
+  std::string Init() override;
+
+  int64_t GetPosition() const override;
+  float GetPlayLatency() const override;
+  int GetSampleRate() const override;
+
+ protected:
+  void SetupDecodingThread() override;
+
+ private:
+  int m_iSampleRate;
+  UINT32 m_iBufferSizeFrames;
+  bool m_bFloat;  // true if we are using float, false if 16-bit PCM
+
+  IAudioClient* m_pAudioClient;
+  IAudioRenderClient* m_pRenderClient;
+  IAudioClock* m_pAudioClock;
+  UINT64 m_iAudioClockFreq;  // device units per second, from GetFrequency
+
+  HANDLE m_hAudioEvent;
+
+  std::atomic<bool> m_bShutdownMixerThread;
+  bool m_bOwnsComInit;
+
+  static int MixerThread_start(void* p);
+  void MixerThread();
+  RageThread m_MixingThread;
+
+  bool InitWASAPI(std::string& sError);
+  void FreeWASAPI();
+};
+
+#endif

--- a/src/arch/arch_default.h
+++ b/src/arch/arch_default.h
@@ -24,7 +24,7 @@ inline const std::vector<std::string>& GetDefaultMovieDriverList() {
 
 inline const std::vector<std::string>& GetDefaultSoundDriverList() {
   static const std::vector<std::string> soundDriverList = {
-      "DirectSound-sw", "WaveOut", "WDMKS", "Null"};
+      "DirectSound-sw", "WASAPI", "WaveOut", "WDMKS", "Null"};
   return soundDriverList;
 }
 


### PR DESCRIPTION
Enable with `SoundDrivers=WASAPI` in Preferences.ini.

DirectSound is a super legacy sound driver that's actually emulated on top of WASAPI. Add a WASAPI sound driver so we can use a more modern sound driver and also potentially avoid issues (e.g. maybe sync) with DirectSound.

WASAPI is supported back to Vista.