### PR TITLE
Remove cron schedule from CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,8 +17,6 @@ on:
             - "**.c"
             - "**.cpp"
             - "**.mm"
-  schedule:
-    - cron: '43 2 * * 5'
 
 jobs:
   analyze:


### PR DESCRIPTION
Following https://github.com/itgmania/itgmania/commit/4a52b588756ccb540218f809a44ba2ab2332c80e the CodeQL workflow is failing with `You have an error in your yaml syntax on line 19`, as the other sections have additional indentation but `schedule` does not. Rather than fixing, proposing removing as unneeded since it runs on every commit.