### PR TITLE
Cache thread id in TLS on Linux

### DIFF
--- a/src/RageThreads.cpp
+++ b/src/RageThreads.cpp
@@ -22,10 +22,6 @@
 #include "archutils/Unix/CrashHandler.h"
 #endif
 
-/* Assume TLS doesn't work until told otherwise.  It's ArchHooks's job to set
- * this. */
-bool RageThread::s_bSystemSupportsTLS = false;
-
 // Set in Dialog.cpp via SetIsShowingDialog, but read in RageThread.cpp.
 std::atomic<bool> RageThread::s_bIsShowingDialog(false);
 

--- a/src/RageThreads.h
+++ b/src/RageThreads.h
@@ -36,12 +36,6 @@ class RageThread {
   int Wait();
   bool IsCreated() const { return m_pSlot != nullptr; }
 
-  /* A system can define HAVE_TLS, indicating that it can compile thread_local
-   * code, but an individual environment may not actually have functional TLS.
-   * If this returns false, thread_local variables are considered undefined. */
-  static bool GetSupportsTLS() { return s_bSystemSupportsTLS; }
-  static void SetSupportsTLS(bool b) { s_bSystemSupportsTLS = b; }
-
   static bool GetIsShowingDialog() { return s_bIsShowingDialog.load(); }
   static void SetIsShowingDialog(bool b) { s_bIsShowingDialog.store(b); }
   static uint64_t GetInvalidThreadID();
@@ -50,7 +44,6 @@ class RageThread {
   ThreadSlot* m_pSlot;
   std::string m_sName;
 
-  static bool s_bSystemSupportsTLS;
   static std::atomic<bool> s_bIsShowingDialog;
 
   // Swallow up warnings. If they must be used, define them.

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -864,10 +864,6 @@ int sm_main(int argc, char* argv[]) {
    * that to appear delayed. */
   HOOKS->DumpDebugInfo();
 
-#if defined(HAVE_TLS)
-  LOG->Info("TLS is %savailable", RageThread::GetSupportsTLS() ? "" : "not ");
-#endif
-
   std::string luaDebugServerAddress;
   if (GetCommandlineArgument("lua-debugger", &luaDebugServerAddress)) {
     LUADEBUG = new LuaDebugManager();

--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -83,35 +83,6 @@ static bool EmergencyShutdown(int signal, siginfo_t* si, const ucontext_t* uc) {
   return false;
 }
 
-#if defined(HAVE_TLS)
-static thread_local int g_iTestTLS = 0;
-
-static int TestTLSThread(void* p) {
-  g_iTestTLS = 2;
-  return 0;
-}
-
-static void TestTLS() {
-#if defined(LINUX)
-  /* TLS won't work on older threads libraries, and may crash. */
-  if (!UsingNPTL()) {
-    return;
-  }
-#endif
-  /* TLS won't work on older Linux kernels.  Do a simple check. */
-  g_iTestTLS = 1;
-
-  RageThread TestThread;
-  TestThread.SetName("TestTLS");
-  TestThread.Create(TestTLSThread, nullptr);
-  TestThread.Wait();
-
-  if (g_iTestTLS == 1) {
-    RageThread::SetSupportsTLS(true);
-  }
-}
-#endif
-
 #if 1
 /* If librt is available, use CLOCK_MONOTONIC to implement
  * GetSystemTimeInMicroseconds, if supported, so changes to the system clock
@@ -201,10 +172,6 @@ void ArchHooks_Unix::Init() {
   SignalHandler::OnClose(EmergencyShutdown);
 
   InstallExceptionHandler();
-
-#if defined(HAVE_TLS) && !defined(BSD)
-  TestTLS();
-#endif
 }
 
 #ifndef _CS_GNU_LIBC_VERSION

--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -9,7 +9,6 @@
 #include "RageFileManager.h"
 #include "RageLog.h"
 #include "RageUtil.h"
-#include "archutils/Common/PthreadHelpers.h"
 #include "archutils/Unix/AssertionHandler.h"
 #include "archutils/Unix/EmergencyShutdown.h"
 #include "archutils/Unix/GetSysInfo.h"
@@ -201,7 +200,6 @@ void ArchHooks_Unix::DumpDebugInfo() {
 #endif
 
   LOG->Info("Runtime library: %s", LibcVersion().c_str());
-  LOG->Info("Threads library: %s", ThreadsVersion().c_str());
   LOG->Info("libavcodec: %#x (%u)", avcodec_version(), avcodec_version());
 }
 

--- a/src/archutils/Common/PthreadHelpers.cpp
+++ b/src/archutils/Common/PthreadHelpers.cpp
@@ -158,21 +158,13 @@ static uint64_t GetCurrentThreadIdInternal() {
 }
 
 uint64_t GetCurrentThreadId() {
-#if defined(HAVE_TLS)
-  /* This is called each time we lock a mutex, and gettid() is a little slow, so
-   * cache the result if we support TLS. */
-  if (RageThread::GetSupportsTLS()) {
-    static thread_local uint64_t cached_tid = 0;
-    static thread_local bool cached = false;
-    if (!cached) {
-      cached_tid = GetCurrentThreadIdInternal();
-      cached = true;
-    }
-    return cached_tid;
+  static thread_local uint64_t cached_tid = 0;
+  static thread_local bool cached = false;
+  if (!cached) {
+    cached_tid = GetCurrentThreadIdInternal();
+    cached = true;
   }
-#endif
-
-  return GetCurrentThreadIdInternal();
+  return cached_tid;
 }
 
 int SuspendThread(uint64_t ThreadID) {

--- a/src/archutils/Common/PthreadHelpers.cpp
+++ b/src/archutils/Common/PthreadHelpers.cpp
@@ -2,20 +2,16 @@
  */
 #include "PthreadHelpers.h"
 
-#include "RageUtil.h"
-#include "archutils/Unix/Backtrace.h"  // HACK: This should be platform-agnosticized
-#include "global.h"
-
-#if defined(UNIX)
-#include "archutils/Unix/RunningUnderValgrind.h"
-#endif
-
 #include <pthread.h>
 #include <semaphore.h>
 
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
+
+#include "RageUtil.h"
+#include "archutils/Unix/Backtrace.h"  // HACK: This should be platform-agnosticized
+#include "global.h"
 
 #if defined(LINUX)
 #if defined(HAVE_UNISTD_H)
@@ -32,51 +28,6 @@
 #define _LINUX_PTRACE_H  // hack to prevent broken linux/ptrace.h from
                          // conflicting with sys/ptrace.h
 #include <sys/user.h>
-
-/* In Linux, we might be using PID-based or TID-based threads.  With PID-based
- * threads, getpid() returns a unique value for each thread; each thread is a
- * separate process.  Newer kernels using NPTL return the same PID for all
- * threads; these systems support a gettid() call to get a unique TID for each
- * thread. */
-
-static bool g_bUsingNPTL = false;
-
-#define gettid() syscall(SYS_gettid)
-
-#ifndef _CS_GNU_LIBPTHREAD_VERSION
-#define _CS_GNU_LIBPTHREAD_VERSION 3
-#endif
-
-std::string ThreadsVersion() {
-  char buf[1024] = "(error)";
-  int ret = confstr(_CS_GNU_LIBPTHREAD_VERSION, buf, sizeof(buf));
-  if (ret == -1) {
-    return "(unknown)";
-  }
-
-  return buf;
-}
-
-/* Crash-conditions-safe: */
-bool UsingNPTL() {
-  char buf[1024] = "";
-  int ret = confstr(_CS_GNU_LIBPTHREAD_VERSION, buf, sizeof(buf));
-  if (ret == -1) {
-    return false;
-  }
-
-  return !strncmp(buf, "NPTL", 4);
-}
-/* Crash-conditions-safe: */
-void InitializePidThreadHelpers() {
-  static bool bInitialized = false;
-  if (bInitialized) {
-    return;
-  }
-  bInitialized = true;
-
-  g_bUsingNPTL = UsingNPTL();
-}
 
 /* waitpid(); ThreadID can be a PID or (in NPTL) a TID; doesn't care if the ID
  * is a clone() or not. */
@@ -125,44 +76,10 @@ static int PtraceDetach(int ThreadID) {
   return ptrace(PTRACE_DETACH, ThreadID, nullptr, nullptr);
 }
 
-/* Get this thread's ID (this may be a TID or a PID). */
-static uint64_t GetCurrentThreadIdInternal() {
-  /* If we're under Valgrind, neither the PID nor the TID is associated with the
-   * thread.  Return the pthread ID.  This can't be used to kill threads, etc.,
-   * but that only happens under error conditions anyway.  If we don't return a
-   * usable, unique ID, then mutexes won't work. */
-  if (RunningUnderValgrind()) {
-    return (int)pthread_self();
-  }
-
-  InitializePidThreadHelpers();  // for g_bUsingNPTL
-
-  /* Don't keep calling gettid() if it's not supported; it'll make valgrind spam
-   * us. */
-  static bool GetTidUnsupported = 0;
-  if (!GetTidUnsupported) {
-    pid_t ret = gettid();
-
-    /* If this fails with ENOSYS, we're on a kernel before gettid, or we're
-     * under valgrind.  If we don't have NPTL, then just use getpid().  If
-     * we're on NPTL and don't have gettid(), something's wrong. */
-    if (ret != -1) {
-      return ret;
-    }
-
-    ASSERT(!g_bUsingNPTL);
-    GetTidUnsupported = true;
-  }
-
-  return getpid();
-}
-
 uint64_t GetCurrentThreadId() {
   static thread_local uint64_t cached_tid = 0;
-  static thread_local bool cached = false;
-  if (!cached) {
-    cached_tid = GetCurrentThreadIdInternal();
-    cached = true;
+  if (!cached_tid) {
+    cached_tid = gettid();
   }
   return cached_tid;
 }
@@ -183,16 +100,8 @@ int ResumeThread(uint64_t ThreadID) {
 }
 
 /* Get a BacktraceContext for a thread.  ThreadID must not be the current
- * thread.
- *
- * tid() is a PID (from getpid) or a TID (from gettid).  Note that this may have
- * kernel compatibility problems, because NPTL is new and its interactions with
- * ptrace() aren't well-defined. If we're on a non-NPTL system, tid is a regular
- * PID.
- *
- * This call leaves the given thread suspended, so the returned context doesn't
- * become invalid. ResumeThread() can be used to resume a thread after this
- * call. */
+ * thread. This call leaves the given thread suspended; use ResumeThread() to
+ * resume it after. */
 bool GetThreadBacktraceContext(uint64_t ThreadID, BacktraceContext* ctx) {
   /* Can't GetThreadBacktraceContext the current thread. */
   ASSERT(ThreadID != GetCurrentThreadId());
@@ -251,8 +160,6 @@ bool GetThreadBacktraceContext(uint64_t ThreadID, BacktraceContext* ctx) {
 #elif defined(UNIX)
 #include <pthread.h>
 #include <signal.h>
-
-std::string ThreadsVersion() { return "(unknown)"; }
 
 uint64_t GetCurrentThreadId() { return uint64_t(pthread_self()); }
 

--- a/src/archutils/Common/PthreadHelpers.h
+++ b/src/archutils/Common/PthreadHelpers.h
@@ -2,15 +2,9 @@
 #define PID_THREAD_HELPERS_H
 
 #include <cstdint>
-#include <string>
-
-std::string ThreadsVersion();
 
 /* Get the current thread's ThreadID. */
 uint64_t GetCurrentThreadId();
-
-/* Return true if NPTL libraries are in use, false if linuxthreads. */
-bool UsingNPTL();
 
 int SuspendThread(uint64_t ThreadID);
 int ResumeThread(uint64_t ThreadID);

--- a/src/archutils/Unix/SignalHandler.cpp
+++ b/src/archutils/Unix/SignalHandler.cpp
@@ -151,9 +151,8 @@ void SignalHandler::OnClose(handler h) {
 
 #if defined(LINUX)
     /* Linuxthreads (pre-NPTL) sigaltstack is broken. */
-    if (!UsingNPTL()) {
-      bUseAltSigStack = false;
-    }
+    // TODO: check if this is still necessary
+    bUseAltSigStack = false;
 #endif
 
     /* Allocate a separate signal stack.  This makes the crash handler work

--- a/src/tests/test_threads.cpp
+++ b/src/tests/test_threads.cpp
@@ -286,8 +286,6 @@ int main(int argc, char* argv[]) {
 
   InitializeBacktrace();
 
-  printf("'%s'\n", ThreadsVersion().c_str());
-
   go();
 
   test_deinit();


### PR DESCRIPTION
Drops GetThisThreadId from 3.8% of a profile to 0.06%.

This calls into the kernel so was causing an insane number of context switches for any locking.

HAVE_TLS wasn't defined anywhere. thread_local has been required everywhere for a long time.

NPTL has been dead for a very long time, delete that code.