### PR TITLE
Use timestamp of input events on Mac

### DIFF
--- a/src/arch/InputHandler/InputHandler_MacOSX_HID.mm
+++ b/src/arch/InputHandler/InputHandler_MacOSX_HID.mm
@@ -9,17 +9,24 @@
 #include "archutils/Darwin/PumpDevice.h"
 #include "global.h"
 
+#include <mach/mach_time.h>
 #include <vector>
 
 #include <Carbon/Carbon.h>
 #include <IOKit/IOMessage.h>
+
+static double GetTimebaseFactor() {
+  mach_timebase_info_data_t timeBase;
+  mach_timebase_info(&timeBase);
+  return timeBase.numer / (1000.0 * timeBase.denom);
+}
+static const double g_fTimebaseFactor = GetTimebaseFactor();
 
 REGISTER_INPUT_HANDLER_CLASS2(HID, MacOSX_HID);
 
 void InputHandler_MacOSX_HID::QueueCallback(void* target, int result, void* refcon, void* sender) {
   // The result seems useless as you can't actually return anything...
 
-  RageTimer now;
   InputHandler_MacOSX_HID* This = (InputHandler_MacOSX_HID*)target;
   IOHIDQueueInterface** queue = (IOHIDQueueInterface**)sender;
   IOHIDEventStruct event;
@@ -32,8 +39,10 @@ void InputHandler_MacOSX_HID::QueueCallback(void* target, int result, void* refc
       free(event.longValue);
       continue;
     }
-    // LOG->Trace( "Got event with cookie %p, value %d", event.elementCookie, int(event.value) );
-    dev->GetButtonPresses(vPresses, event.elementCookie, event.value, now);
+    uint64_t absoluteTimeVal = ((uint64_t)event.timestamp.hi << 32) | event.timestamp.lo;
+    uint64_t usecs = uint64_t(absoluteTimeVal * g_fTimebaseFactor);
+    RageTimer eventTime(usecs / 1000000ULL, usecs % 1000000ULL);
+    dev->GetButtonPresses(vPresses, event.elementCookie, event.value, eventTime);
   }
   for (DeviceInput& i : vPresses) {
     INPUTFILTER->ButtonPressed(i);

--- a/src/arch/InputHandler/InputHandler_NSEvent.mm
+++ b/src/arch/InputHandler/InputHandler_NSEvent.mm
@@ -157,14 +157,15 @@ void InputHandler_NSEvent::HandleEvent(NSEvent* e) {
     return;
   }
 
-  RageTimer now;
+  uint64_t usecs = uint64_t([e timestamp] * 1000000.0);
+  RageTimer eventTime(usecs / 1000000ULL, usecs % 1000000ULL);
   unsigned short keyCode = [e keyCode];
   float zval = (type == NSEventTypeKeyDown ? 1.0 : 0.0);
 
   switch (type) {
     case NSEventTypeKeyUp:
     case NSEventTypeKeyDown:
-      ButtonPressed(DeviceInput(DEVICE_KEYBOARD, m_NSKeyCodeMap[keyCode], zval, now));
+      ButtonPressed(DeviceInput(DEVICE_KEYBOARD, m_NSKeyCodeMap[keyCode], zval, eventTime));
       break;
 
     case NSEventTypeFlagsChanged: {
@@ -173,36 +174,36 @@ void InputHandler_NSEvent::HandleEvent(NSEvent* e) {
         case kVK_CapsLock:
           ButtonPressed(DeviceInput(
               DEVICE_KEYBOARD, m_NSKeyCodeMap[keyCode],
-              DownOrUp(flags & NSEventModifierFlagCapsLock), now));
+              DownOrUp(flags & NSEventModifierFlagCapsLock), eventTime));
           break;
         case kVK_Shift:
         case kVK_RightShift:
           ButtonPressed(DeviceInput(
               DEVICE_KEYBOARD, m_NSKeyCodeMap[keyCode], DownOrUp(flags & NSEventModifierFlagShift),
-              now));
+              eventTime));
           break;
         case kVK_Control:
         case kVK_RightControl:
           ButtonPressed(DeviceInput(
               DEVICE_KEYBOARD, m_NSKeyCodeMap[keyCode],
-              DownOrUp(flags & NSEventModifierFlagControl), now));
+              DownOrUp(flags & NSEventModifierFlagControl), eventTime));
           break;
         case kVK_Option:
         case kVK_RightOption:
           ButtonPressed(DeviceInput(
               DEVICE_KEYBOARD, m_NSKeyCodeMap[keyCode], DownOrUp(flags & NSEventModifierFlagOption),
-              now));
+              eventTime));
           break;
         case kVK_Command:
         case kVK_RightCommand:
           ButtonPressed(DeviceInput(
               DEVICE_KEYBOARD, m_NSKeyCodeMap[keyCode],
-              DownOrUp(flags & NSEventModifierFlagCommand), now));
+              DownOrUp(flags & NSEventModifierFlagCommand), eventTime));
           break;
         case kVK_Function:
           ButtonPressed(DeviceInput(
               DEVICE_KEYBOARD, m_NSKeyCodeMap[keyCode],
-              DownOrUp(flags & NSEventModifierFlagFunction), now));
+              DownOrUp(flags & NSEventModifierFlagFunction), eventTime));
           break;
       }
     } break;


### PR DESCRIPTION
that the OS provides, instead of relying on getting the current time.

Only affects MacOSX_HID and NSEvent input handlers.