### PR TITLE
Skip emitting measure comments instead of regex-stripping them

### DIFF
--- a/src/NoteDataUtil.cpp
+++ b/src/NoteDataUtil.cpp
@@ -377,7 +377,8 @@ void NoteDataUtil::InsertHoldTails(NoteData& inout) {
   }
 }
 
-void NoteDataUtil::GetSMNoteDataString(const NoteData& in, std::string& sRet) {
+void NoteDataUtil::GetSMNoteDataString(
+    const NoteData& in, std::string& sRet, bool bIncludeMeasureComments) {
   // Get note data
   std::vector<NoteData> parts;
   float fLastBeat = -1.0f;
@@ -402,7 +403,9 @@ void NoteDataUtil::GetSMNoteDataString(const NoteData& in, std::string& sRet) {
       if (m) {
         sRet.append(1, ',');
       }
-      sRet += ssprintf("  // measure %d\n", m);
+      if (bIncludeMeasureComments) {
+        sRet += ssprintf("  // measure %d\n", m);
+      }
 
       NoteType nt = GetSmallestNoteTypeForMeasure(nd, m);
       int iRowSpacing;

--- a/src/NoteDataUtil.h
+++ b/src/NoteDataUtil.h
@@ -32,7 +32,8 @@ NoteType GetSmallestNoteTypeInRange(
     const NoteData& nd, int iStartIndex, int iEndIndex);
 void LoadFromSMNoteDataString(
     NoteData& out, const std::string& sSMNoteData, bool bComposite);
-void GetSMNoteDataString(const NoteData& in, std::string& notes_out);
+void GetSMNoteDataString(
+    const NoteData& in, std::string& notes_out, bool bIncludeMeasureComments);
 void SplitCompositeNoteData(const NoteData& in, std::vector<NoteData>& out);
 void CombineCompositeNoteData(NoteData& out, const std::vector<NoteData>& in);
 /**

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -16,7 +16,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <optional>
-#include <regex>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -146,7 +145,8 @@ unsigned Steps::GetHash() const {
     if (!m_bNoteDataIsFilled) {
       return 0;  // No data, no hash.
     }
-    NoteDataUtil::GetSMNoteDataString(*m_pNoteData, m_sNoteDataCompressed);
+    NoteDataUtil::GetSMNoteDataString(
+        *m_pNoteData, m_sNoteDataCompressed, /*bIncludeMeasureComments=*/true);
   }
   m_iHash = GetHashForString(m_sNoteDataCompressed);
   return m_iHash;
@@ -253,7 +253,8 @@ void Steps::GetSMNoteData(std::string& notes_comp_out) const {
       return;
     }
 
-    NoteDataUtil::GetSMNoteDataString(*m_pNoteData, m_sNoteDataCompressed);
+    NoteDataUtil::GetSMNoteDataString(
+        *m_pNoteData, m_sNoteDataCompressed, /*bIncludeMeasureComments=*/true);
   }
 
   notes_comp_out = m_sNoteDataCompressed;
@@ -549,7 +550,8 @@ void Steps::Compress() const {
     if (!m_bNoteDataIsFilled) {
       return; /* no data is no data */
     }
-    NoteDataUtil::GetSMNoteDataString(*m_pNoteData, m_sNoteDataCompressed);
+    NoteDataUtil::GetSMNoteDataString(
+        *m_pNoteData, m_sNoteDataCompressed, /*bIncludeMeasureComments=*/true);
   }
 
   m_pNoteData->Init();
@@ -772,23 +774,19 @@ std::string Steps::MinimizedChartString() {
   std::string smNoteData = "";
   NoteData noteData;
   this->GetNoteData(noteData);
-  NoteDataUtil::GetSMNoteDataString(noteData, smNoteData);
+  NoteDataUtil::GetSMNoteDataString(
+      noteData, smNoteData, /*bIncludeMeasureComments=*/false);
 
   if (smNoteData == "") {
     return "";
   }
-
-  // Strip any comments from smNoteData
-  std::regex commentRegex("//[^\n]*");
-  std::string deCommentedNoteData =
-      std::regex_replace(smNoteData, commentRegex, "");
 
   std::string minimizedNoteData = "";
 
   std::vector<std::string> measures;
   Regex anyNote("[^0]");
 
-  split(deCommentedNoteData, ",", measures, true);
+  split(smNoteData, ",", measures, true);
   for (unsigned m = 0; m < measures.size(); m++) {
     Trim(measures[m]);
     bool allZeroes = true;


### PR DESCRIPTION
Regexes are expensive.

~7.4% reduction in cold song-load time.