### PR TITLE
Pool-allocate StepParity States and nodes

### DIFF
--- a/src/StepParityGenerator.cpp
+++ b/src/StepParityGenerator.cpp
@@ -49,7 +49,7 @@ bool StepParityGenerator::analyzeGraph() {
 void StepParityGenerator::buildStateGraph() {
   // The first node of the graph is beginningState, which represents the time
   // before the first note (and so it's roIndex is considered -1)
-  beginningState = new State();
+  beginningState = allocState();
   startNode = addNode(beginningState, rows[0].second - 1, -1);
 
   std::vector<StepParityNode*> previousNodes;
@@ -103,7 +103,7 @@ void StepParityGenerator::buildStateGraph() {
 
   // at this point, previousStates holds all of the states for the very last
   // row, which just get connected to the endState
-  endingState = new State();
+  endingState = allocState();
   endNode = addNode(endingState, rows[rows.size() - 1].second + 1, rows.size());
   endNode->totalCost = FLT_MAX;
 
@@ -118,7 +118,7 @@ void StepParityGenerator::buildStateGraph() {
 State* StepParityGenerator::initResultState(
     State* initialState, Row& row, const FootPlacement& columns) {
   if (tmpState == nullptr) {
-    tmpState = new State();
+    tmpState = allocState();
   }
 
   State* resultState = tmpState;
@@ -485,7 +485,8 @@ std::uint64_t StepParityGenerator::getStateCacheKey(State* state) {
 
 StepParityNode* StepParityGenerator::addNode(
     State* state, float second, int rowIndex) {
-  StepParityNode* newNode = new StepParityNode(state, second, rowIndex);
+  nodePool.emplace_back(state, second, rowIndex);
+  StepParityNode* newNode = &nodePool.back();
   newNode->id = int(nodes.size());
   nodes.push_back(newNode);
   return newNode;

--- a/src/StepParityGenerator.h
+++ b/src/StepParityGenerator.h
@@ -2,6 +2,7 @@
 #define STEP_PARITY_GENERATOR_H
 
 #include <cstdint>
+#include <deque>
 #include <unordered_map>
 #include <vector>
 
@@ -24,6 +25,14 @@ class StepParityGenerator {
   StepParity::StepParityNode* endNode = nullptr;
   StepParity::State* tmpState = nullptr;
 
+  std::deque<StepParity::State> statePool;
+  std::deque<StepParity::StepParityNode> nodePool;
+
+  StepParity::State* allocState() {
+    statePool.emplace_back();
+    return &statePool.back();
+  }
+
  public:
   std::unordered_map<std::uint64_t, StepParity::State*> stateCache;
   std::vector<StepParity::StepParityNode*> nodes;
@@ -33,25 +42,6 @@ class StepParityGenerator {
 
   StepParityGenerator(const StageLayout* l, TimingData* t) : layout(l) {
     timing = t;
-  }
-
-  ~StepParityGenerator() {
-    for (auto s : stateCache) {
-      delete s.second;
-    }
-    for (auto n : nodes) {
-      delete n;
-    }
-    if (beginningState != nullptr) {
-      delete beginningState;
-    }
-
-    if (endingState != nullptr) {
-      delete endingState;
-    }
-    if (tmpState != nullptr) {
-      delete tmpState;
-    }
   }
   /// @brief Analyzes the given NoteData to generate a vector of
   /// StepParity::Rows, with each step annotated with a foot placement.


### PR DESCRIPTION
Instead of allocating them individually.

~4.7% reduction in cold song-load time.