### PR TITLE
Refactor VSync logic to use actual video mode parameters

### DIFF
--- a/src/GameSoundManager.cpp
+++ b/src/GameSoundManager.cpp
@@ -603,7 +603,6 @@ void GameSoundManager::Update(float fDeltaTime) {
     return;
   }
 
-  const float fAdjust = GetFrameTimingAdjustment(fDeltaTime);
   if (!g_Playing->m_Music->IsPlaying()) {
     /* There's no song playing.  Fake it. */
     CHECKPOINT_M(ssprintf(
@@ -660,8 +659,7 @@ void GameSoundManager::Update(float fDeltaTime) {
         GAMESTATE->m_Position.m_fMusicSeconds + fDeltaTime,
         g_Playing->m_Timing);
   } else {
-    GAMESTATE->UpdateSongPosition(
-        fSeconds + fAdjust, g_Playing->m_Timing, tm + fAdjust);
+    GAMESTATE->UpdateSongPosition(fSeconds, g_Playing->m_Timing, tm);
   }
 
   // Send crossed messages

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -835,13 +835,16 @@ void RageDisplay::DrawCircle(const RageSpriteVertex& v, float radius) {
   this->DrawCircleInternal(v, radius);
 }
 
-void RageDisplay::FrameLimitBeforeVsync(int iFPS) {
-  ASSERT(iFPS != 0);
+int GetFrameLimitIntervalAsMicroseconds(
+    const ActualVideoModeParams& vm) noexcept {
+  const bool noValidFrameTimingHistoryOrVsync =
+      !vm.vsync && vm.rate > 0 && g_fFrameLimitPercent.Get() > 0.0f &&
+      !g_LastFrameEndedAt.IsZero();
 
   int iDelayMicroseconds = 0;
-  if (g_fFrameLimitPercent.Get() > 0.0f && !g_LastFrameEndedAt.IsZero()) {
+  if (noValidFrameTimingHistoryOrVsync) {
     float fFrameTime = g_LastFrameEndedAt.GetDeltaTime();
-    float fExpectedTime = 1.0f / iFPS;
+    float fExpectedTime = 1.0f / vm.rate;
 
     /* This is typically used to turn some of the delay that would normally
      * be waiting for vsync and turn it into a usleep, to make sure we give
@@ -860,6 +863,8 @@ void RageDisplay::FrameLimitBeforeVsync(int iFPS) {
         10000);  // give some time to other processes and threads
   }
 
+  return iDelayMicroseconds;
+}
   if (iDelayMicroseconds > 0) {
     usleep(iDelayMicroseconds);
   }

--- a/src/RageDisplay.cpp
+++ b/src/RageDisplay.cpp
@@ -865,18 +865,16 @@ int GetFrameLimitIntervalAsMicroseconds(
 
   return iDelayMicroseconds;
 }
+
+void RageDisplay::FrameLimitBeforeVsync() {
+  const int iDelayMicroseconds =
+      GetFrameLimitIntervalAsMicroseconds(GetActualVideoModeParams());
   if (iDelayMicroseconds > 0) {
     usleep(iDelayMicroseconds);
   }
 }
 
-void RageDisplay::FrameLimitAfterVsync() {
-  if (g_fFrameLimitPercent.Get() == 0.0f) {
-    return;
-  }
-
-  g_LastFrameEndedAt.Touch();
-}
+void RageDisplay::FrameLimitAfterVsync() { g_LastFrameEndedAt.Touch(); }
 
 RageCompiledGeometry::~RageCompiledGeometry() { m_bNeedsNormals = false; }
 

--- a/src/RageDisplay.h
+++ b/src/RageDisplay.h
@@ -492,9 +492,10 @@ class RageDisplay {
   const RageMatrix* GetWorldTop() const;
   const RageMatrix* GetTextureTop() const;
 
-  // To limit the framerate, call FrameLimitBeforeVsync before waiting
-  // for vsync and FrameLimitAfterVsync after.
-  void FrameLimitBeforeVsync(int iFPS);
+  // Call immediately before and after the backend-specific present routine.
+  // When vsync is enabled, the present call itself provides the pacing.
+  // When it is disabled, these helpers apply any manual frame limiting.
+  void FrameLimitBeforeVsync();
   void FrameLimitAfterVsync();
 };
 

--- a/src/RageDisplay_D3D.cpp
+++ b/src/RageDisplay_D3D.cpp
@@ -602,11 +602,10 @@ bool RageDisplay_D3D::BeginFrame() {
   return RageDisplay::BeginFrame();
 }
 
-static RageTimer g_LastFrameEndedAt(RageZeroTimer);
 void RageDisplay_D3D::EndFrame() {
   g_pd3dDevice->EndScene();
 
-  FrameLimitBeforeVsync(GetActualVideoModeParams().rate);
+  FrameLimitBeforeVsync();
   g_pd3dDevice->Present(0, 0, 0, 0);
   FrameLimitAfterVsync();
 

--- a/src/RageDisplay_GLES2.cpp
+++ b/src/RageDisplay_GLES2.cpp
@@ -413,7 +413,7 @@ void RageDisplay_GLES2::EndFrame() {
   glFlush();
 
   // XXX: This is broken on NVidia, as their xrandr sucks.
-  FrameLimitBeforeVsync(g_pWind->GetActualVideoModeParams().rate);
+  FrameLimitBeforeVsync();
   g_pWind->SwapBuffers();
   FrameLimitAfterVsync();
 

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -905,7 +905,7 @@ void RageDisplay_Legacy::EndFrame() {
     CameraPopMatrix();
   }
 
-  FrameLimitBeforeVsync(g_pWind->GetActualVideoModeParams().rate);
+  FrameLimitBeforeVsync();
   g_pWind->SwapBuffers();
   FrameLimitAfterVsync();
 

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1640,9 +1640,8 @@ void ScreenGameplay::UpdateSongPosition(float fDeltaTime) {
 
   RageTimer tm;
   const float fSeconds = m_pSoundMusic->GetPositionSeconds(&tm);
-  const float fAdjust = SOUND->GetFrameTimingAdjustment(fDeltaTime);
   GAMESTATE->UpdateSongPosition(
-      fSeconds + fAdjust, GAMESTATE->m_pCurSong->m_SongTiming, tm + fAdjust);
+      fSeconds, GAMESTATE->m_pCurSong->m_SongTiming, tm);
 }
 
 void ScreenGameplay::BeginScreen() {


### PR DESCRIPTION
The existing VSync implementation has its responsibilities split between RageDisplay, GameSoundManager, ScreenGameplay, and the various RageDisplay drivers (D3D, GLES2, OpenGL).

The drivers are only tied in themselves to pass along the framerate indirectly, so their responsibility is removed from the drivers and we instead directly get the video parameters within RageDisplay.

To improve correctness of the frame limiting timer, we now unequivocally update the timer in `FrameLimitAfterVsync` rather than gating that update behind a check against `g_fFrameLimitPercent.Get()`. It is not expensive to store the timer value continually, and this allows us to remove responsibility to update this timer from ScreenGameplay and GameSoundManager.