### PR TITLE
Kill legacy chart hash

### DIFF
--- a/src/NotesLoaderJson.cpp
+++ b/src/NotesLoaderJson.cpp
@@ -133,7 +133,6 @@ static void Deserialize(Steps& o, const Json::Value& root) {
   NoteData nd;
   Deserialize(o.m_StepsType, nd, root["NoteData"]);
   o.SetNoteData(nd);
-  // o.SetHash( root["Hash"].asInt() );
   o.SetDescription(root["Description"].asString());
   o.SetDifficulty(StringToDifficulty(root["Difficulty"].asString()));
   o.SetMeter(root["Meter"].asInt());

--- a/src/NotesWriterJson.cpp
+++ b/src/NotesWriterJson.cpp
@@ -115,7 +115,6 @@ static void Serialize(const Steps& o, Json::Value& root) {
   NoteData nd;
   o.GetNoteData(nd);
   Serialize(nd, root["NoteData"]);
-  root["Hash"] = o.GetHash();
   root["Description"] = o.GetDescription();
   root["Difficulty"] = DifficultyToString(o.GetDifficulty());
   root["Meter"] = o.GetMeter();

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -3146,9 +3146,6 @@ void ScreenGameplay::SaveReplay() {
       StepsID stepsID;
       stepsID.FromSteps(GAMESTATE->m_pCurSteps[pn]);
       XNode* pStepsInfoNode = stepsID.CreateNode();
-      // hashing = argh
-      // pStepsInfoNode->AppendChild("StepsHash",
-      // stepsID.ToSteps(GAMESTATE->m_pCurSong,false)->GetHash());
       p->AppendChild(pStepsInfoNode);
 
       // player information node (rival data sup)

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -1936,7 +1936,7 @@ bool Song::IsEditAlreadyLoaded(Steps* pSteps) const {
     Steps* pOther = m_vpSteps[i];
     if (pOther->GetDifficulty() == Difficulty_Edit &&
         pOther->m_StepsType == pSteps->m_StepsType &&
-        pOther->GetHash() == pSteps->GetHash()) {
+        pOther->GetDescription() == pSteps->GetDescription()) {
       return true;
     }
   }

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -177,7 +177,7 @@ void SongUtil::GetSteps(
     const Song* pSong, std::vector<Steps*>& arrayAddTo, StepsType st,
     Difficulty dc, int iMeterLow, int iMeterHigh,
     const std::string& sDescription, const std::string& sCredit,
-    bool bIncludeAutoGen, unsigned uHash, int iMaxToGet) {
+    bool bIncludeAutoGen, int iMaxToGet) {
   if (!iMaxToGet) {
     return;
   }
@@ -204,9 +204,6 @@ void SongUtil::GetSteps(
     if (sCredit.size() && sCredit != pSteps->GetCredit()) {
       continue;
     }
-    if (uHash != 0 && uHash != pSteps->GetHash()) {
-      continue;
-    }
     if (!bIncludeAutoGen && pSteps->IsAutogen()) {
       continue;
     }
@@ -225,11 +222,11 @@ void SongUtil::GetSteps(
 Steps* SongUtil::GetOneSteps(
     const Song* pSong, StepsType st, Difficulty dc, int iMeterLow,
     int iMeterHigh, const std::string& sDescription, const std::string& sCredit,
-    unsigned uHash, bool bIncludeAutoGen) {
+    bool bIncludeAutoGen) {
   std::vector<Steps*> vpSteps;
   GetSteps(
       pSong, vpSteps, st, dc, iMeterLow, iMeterHigh, sDescription, sCredit,
-      bIncludeAutoGen, uHash, 1);  // get max 1
+      bIncludeAutoGen, 1);  // get max 1
   if (vpSteps.empty()) {
     return nullptr;
   } else {

--- a/src/SongUtil.h
+++ b/src/SongUtil.h
@@ -118,12 +118,12 @@ void GetSteps(
     StepsType st = StepsType_Invalid, Difficulty dc = Difficulty_Invalid,
     int iMeterLow = -1, int iMeterHigh = -1,
     const std::string& sDescription = "", const std::string& sCredit = "",
-    bool bIncludeAutoGen = true, unsigned uHash = 0, int iMaxToGet = -1);
+    bool bIncludeAutoGen = true, int iMaxToGet = -1);
 Steps* GetOneSteps(
     const Song* pSong, StepsType st = StepsType_Invalid,
     Difficulty dc = Difficulty_Invalid, int iMeterLow = -1, int iMeterHigh = -1,
     const std::string& sDescription = "", const std::string& sCredit = "",
-    unsigned uHash = 0, bool bIncludeAutoGen = true);
+    bool bIncludeAutoGen = true);
 Steps* GetStepsByDifficulty(
     const Song* pSong, StepsType st, Difficulty dc,
     bool bIncludeAutoGen = true);

--- a/src/StatsManager.cpp
+++ b/src/StatsManager.cpp
@@ -336,9 +336,7 @@ void StatsManager::SavePadmissScore(const StageStats* pSS, PlayerNumber pn) {
 
   Steps* steps = playerStats->m_vpPossibleSteps[0];  // XXX Courses and such
   Song* song = steps->m_pSong;
-  steps->Decompress();  // Hashing won't work unless the steps are decompressed
   XNode* stepdata = xml->AppendChild("Steps");
-  stepdata->AppendChild("Hash", steps->GetHash());
   stepdata->AppendChild("Meter", steps->GetMeter());
   stepdata->AppendChild("StepArtist", steps->GetCredit());
   stepdata->AppendChild("StepsType", steps->m_StepsTypeStr);

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -106,7 +106,6 @@ Steps::Steps(Song* song)
       m_sFilename(""),
       m_bSavedToDisk(false),
       m_LoadedFromProfile(ProfileSlot_Invalid),
-      m_iHash(0),
       m_sDescription(""),
       m_sChartStyle(""),
       m_Difficulty(Difficulty_Invalid),
@@ -133,24 +132,6 @@ void Steps::GetDisplayBpms(DisplayBpms& AddTo) const {
 }
 
 bool Steps::HasAttacks() const { return !this->m_Attacks.empty(); }
-
-unsigned Steps::GetHash() const {
-  if (parent) {
-    return parent->GetHash();
-  }
-  if (m_iHash) {
-    return m_iHash;
-  }
-  if (m_sNoteDataCompressed.empty()) {
-    if (!m_bNoteDataIsFilled) {
-      return 0;  // No data, no hash.
-    }
-    NoteDataUtil::GetSMNoteDataString(
-        *m_pNoteData, m_sNoteDataCompressed, /*bIncludeMeasureComments=*/true);
-  }
-  m_iHash = GetHashForString(m_sNoteDataCompressed);
-  return m_iHash;
-}
 
 bool Steps::IsNoteDataEmpty() const {
   return this->m_sNoteDataCompressed.empty();
@@ -216,7 +197,6 @@ void Steps::SetNoteData(const NoteData& noteDataNew) {
   m_bNoteDataIsFilled = true;
 
   m_sNoteDataCompressed = std::string();
-  m_iHash = 0;
 }
 
 void Steps::GetNoteData(NoteData& noteDataOut) const {
@@ -241,7 +221,6 @@ void Steps::SetSMNoteData(const std::string& notes_comp_) {
   m_bNoteDataIsFilled = false;
 
   m_sNoteDataCompressed = notes_comp_;
-  m_iHash = 0;
 }
 
 /* XXX: this function should pull data from m_sFilename, like Decompress() */
@@ -1040,10 +1019,6 @@ class LunaSteps : public Luna<Steps> {
     p->GetTimingData()->PushSelf(L);
     return 1;
   }
-  static int GetHash(T* p, lua_State* L) {
-    lua_pushnumber(L, p->GetHash());
-    return 1;
-  }
   // untested
   /*
   static int GetSMNoteData( T* p, lua_State *L )
@@ -1148,7 +1123,6 @@ class LunaSteps : public Luna<Steps> {
     ADD_METHOD(GetDescription);
     ADD_METHOD(GetDifficulty);
     ADD_METHOD(GetFilename);
-    ADD_METHOD(GetHash);
     ADD_METHOD(GetMeter);
     ADD_METHOD(HasSignificantTimingChanges);
     ADD_METHOD(HasAttacks);

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -183,7 +183,6 @@ class Steps {
   void SetGrooveStatsHashVersion(int version);
   float PredictMeter() const;
 
-  unsigned GetHash() const;
   void GetNoteData(NoteData& noteDataOut) const;
   NoteData GetNoteData() const;
   void SetNoteData(const NoteData& noteDataNew);
@@ -314,8 +313,6 @@ class Steps {
   ProfileSlot m_LoadedFromProfile;
 
   /* These values are pulled from the autogen source first, if there is one. */
-  /** @brief The hash of the steps. This is used only for Edit Steps. */
-  mutable unsigned m_iHash;
   /** @brief The name of the edit, or some other useful description.
    This used to also contain the step author's name. */
   std::string m_sDescription;

--- a/src/StepsUtil.cpp
+++ b/src/StepsUtil.cpp
@@ -293,17 +293,10 @@ void StepsID::FromSteps(const Steps* p) {
     st = StepsType_Invalid;
     dc = Difficulty_Invalid;
     sDescription = "";
-    uHash = 0;
   } else {
     st = p->m_StepsType;
     dc = p->GetDifficulty();
-    if (dc == Difficulty_Edit) {
-      sDescription = p->GetDescription();
-      uHash = p->GetHash();
-    } else {
-      sDescription = "";
-      uHash = 0;
-    }
+    sDescription = (dc == Difficulty_Edit) ? p->GetDescription() : "";
   }
 }
 
@@ -327,10 +320,9 @@ Steps* StepsID::ToSteps(const Song* p, bool bAllowNull) const {
 
   Steps* pRet = nullptr;
   if (dc == Difficulty_Edit) {
-    pRet =
-        SongUtil::GetOneSteps(p, st, dc, -1, -1, sDescription, "", uHash, true);
+    pRet = SongUtil::GetOneSteps(p, st, dc, -1, -1, sDescription, "", true);
   } else {
-    pRet = SongUtil::GetOneSteps(p, st, dc, -1, -1, "", "", 0, true);
+    pRet = SongUtil::GetOneSteps(p, st, dc, -1, -1, "", "", true);
   }
 
   if (!bAllowNull && pRet == nullptr) {
@@ -347,7 +339,6 @@ XNode* StepsID::CreateNode() const {
   pNode->AppendAttr("Difficulty", DifficultyToString(dc));
   if (dc == Difficulty_Edit) {
     pNode->AppendAttr("Description", sDescription);
-    pNode->AppendAttr("Hash", uHash);
   }
 
   return pNode;
@@ -366,10 +357,8 @@ void StepsID::LoadFromNode(const XNode* pNode) {
 
   if (dc == Difficulty_Edit) {
     pNode->GetAttrValue("Description", sDescription);
-    pNode->GetAttrValue("Hash", uHash);
   } else {
     sDescription = "";
-    uHash = 0;
   }
 }
 
@@ -378,7 +367,6 @@ std::string StepsID::ToString() const {
   s += " " + DifficultyToString(dc);
   if (dc == Difficulty_Edit) {
     s += " " + sDescription;
-    s += ssprintf(" %u", uHash);
   }
   return s;
 }
@@ -394,10 +382,6 @@ bool StepsID::operator<(const StepsID& rhs) const {
   COMP(st);
   COMP(dc);
   COMP(sDescription);
-  // See explanation in class declaration. -Kyz
-  if (uHash != 0 && rhs.uHash != 0) {
-    COMP(uHash);
-  }
 #undef COMP
   return false;
 }
@@ -408,10 +392,6 @@ bool StepsID::operator==(const StepsID& rhs) const {
   COMP(st);
   COMP(dc);
   COMP(sDescription);
-  // See explanation in class declaration. -Kyz
-  if (uHash != 0 && rhs.uHash != 0) {
-    COMP(uHash);
-  }
 #undef COMP
   return true;
 }

--- a/src/StepsUtil.h
+++ b/src/StepsUtil.h
@@ -191,7 +191,6 @@ class StepsID {
   StepsType st;
   Difficulty dc;
   std::string sDescription;
-  unsigned uHash;
 
  public:
   /**
@@ -199,32 +198,13 @@ class StepsID {
    *
    * This used to call Unset(), which set the variables to
    * the same thing. */
-  StepsID()
-      : st(StepsType_Invalid),
-        dc(Difficulty_Invalid),
-        sDescription(""),
-        uHash(0) {}
+  StepsID() : st(StepsType_Invalid), dc(Difficulty_Invalid), sDescription("") {}
   void Unset() { FromSteps(nullptr); }
   void FromSteps(const Steps* p);
   Steps* ToSteps(const Song* p, bool bAllowNull) const;
-  // FIXME: (interferes with unlimited charts per song)
-  // When performing comparisons, the hash value 0 is considered equal to
-  // all other values.  This is because the hash value for a Steps is
-  // discarded immediately after loading and figuring out a way to preserve
-  // and cache it turned into a mess that still didn't work.
-  // When scores are looked up by the theme, the theme passes in a Steps
-  // which is transformed into a StepsID, which is then used to index into a
-  // map.  So when the theme goes to look up the scores for a Steps, the
-  // Steps has a hash value of 0, unless it has been played.  But when the
-  // scores are saved, the Steps has a correct hash value.  So before a
-  // Steps is played, the scores could not be correctly accessed.  This was
-  // only visible on Edit charts because scores on all other difficulties
-  // are saved without a hash value.
-  // Making operator< and operator== treat 0 as equal to all other hash
-  // values allows the theme to fetch the scores even though the Steps has
-  // a cleared hash value, but is not a good long term solution because the
-  // description field isn't always going to be unique.
-  // -Kyz
+  // Edits share the Edit difficulty slot, so they are distinguished by their
+  // description. This assumes edits for a song have unique descriptions; edits
+  // that share a description are treated as the same chart.
   bool operator<(const StepsID& rhs) const;
   bool operator==(const StepsID& rhs) const;
   bool MatchesStepsType(StepsType s) const { return st == s; }


### PR DESCRIPTION
This was only used to distinguish edits with the same description, which I've actually never seen in the wild.

As evidenced in the comments, this was inconsistently available. The reason is that you need to load the original NOTES data and hash that. Can't recreate this from the NoteData data structure since it'll get rid of redundancies in NOTES.

The better way to do this is to use the groovestats hash anyway.