### PR TITLE
Remove dead lights autogen code

### DIFF
--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -1393,8 +1393,7 @@ void Song::AddAutoGenNotes() {
       continue;
     }
 
-    // If m_bAutogenSteps is disabled, only autogen lights.
-    if (!PREFSMAN->m_bAutogenSteps && stMissing != StepsType_lights_cabinet) {
+    if (!PREFSMAN->m_bAutogenSteps) {
       continue;
     }
     if (!GAMEMAN->GetStepsTypeInfo(stMissing).bAllowAutogen) {

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -473,14 +473,10 @@ void Steps::Decompress() {
 
     int iNewTracks = GAMEMAN->GetStepsTypeInfo(m_StepsType).iNumTracks;
 
-    if (this->m_StepsType == StepsType_lights_cabinet) {
-      NoteDataUtil::LoadTransformedLights(notedata, *m_pNoteData, iNewTracks);
-    } else {
-      NoteDataUtil::LoadTransformedSlidingWindow(
-          notedata, *m_pNoteData, iNewTracks);
+    NoteDataUtil::LoadTransformedSlidingWindow(
+        notedata, *m_pNoteData, iNewTracks);
 
-      NoteDataUtil::RemoveStretch(*m_pNoteData, m_StepsType);
-    }
+    NoteDataUtil::RemoveStretch(*m_pNoteData, m_StepsType);
     return;
   }
 


### PR DESCRIPTION
Lights is specifically not allowed to be autogen'd (see g_StepsTypeInfos).

Lights does actually get autogen'd at runtime, but it's a different codepath in ScreenGameplay::LoadLights.