### PR TITLE
Change NoteData from using std::map to std::deque

### DIFF
--- a/src/NoteData.cpp
+++ b/src/NoteData.cpp
@@ -35,7 +35,7 @@ void NoteData::SetNumTracks(int iNewNumTracks) {
 
 bool NoteData::IsComposite() const {
   for (int track = 0; track < GetNumTracks(); ++track) {
-    for (const std::pair<const int, TapNote>& tn : m_TapNotes[track]) {
+    for (const RowTapNote& tn : m_TapNotes[track]) {
       if (tn.second.pn != PLAYER_INVALID) {
         return true;
       }
@@ -320,14 +320,7 @@ void NoteData::AddHoldNote(int iTrack, int iStartRow, int iEndRow, TapNote tn) {
   tn.iDuration = iEndRow - iStartRow;
 
   // Remove everything in the range.
-  while (lBegin != lEnd) {
-    iterator next = lBegin;
-    ++next;
-
-    RemoveTapNote(iTrack, lBegin);
-
-    lBegin = next;
-  }
+  m_TapNotes[iTrack].erase(lBegin, lEnd);
 
   /* Additionally, if there's a tap note lying at the end of our range,
    * remove it too. */
@@ -935,17 +928,20 @@ void NoteData::SetTapNote(int track, int row, const TapNote& t) {
     return;
   }
 
-  // There's no point in inserting empty notes into the map.
-  // Any blank space in the map is defined to be empty.
-  // If we're trying to insert an empty at a spot where another note
-  // already exists, then we're really deleting from the map.
+  TrackMap& trackMap = m_TapNotes[track];
+  auto it = lower_bound(track, row);
+  bool found = (it != trackMap.end() && it->first == row);
+
   if (t == TAP_EMPTY) {
-    TrackMap& trackMap = m_TapNotes[track];
-    // remove the element at this position (if any).
-    // This will return either 0 or 1.
-    trackMap.erase(row);
+    if (found) {
+      trackMap.erase(it);
+    }
   } else {
-    m_TapNotes[track][row] = t;
+    if (found) {
+      it->second = t;
+    } else {
+      trackMap.insert(it, {row, t});
+    }
   }
 }
 
@@ -975,8 +971,7 @@ bool NoteData::GetNextTapNoteRowForTrack(
   // upper_bound "finds the first element whose key greater than k".  They don't
   // have the same effect, but lower_bound(row+1) should equal upper_bound(row).
   // -glenn
-  TrackMap::const_iterator iter = mapTrack.lower_bound(
-      rowInOut + 1);  // "find the first note for which row+1 < key == false"
+  TrackMap::const_iterator iter = lower_bound(track, rowInOut + 1);
   if (iter == mapTrack.end()) {
     return false;
   }
@@ -1000,7 +995,7 @@ bool NoteData::GetPrevTapNoteRowForTrack(int track, int& rowInOut) const {
   const TrackMap& mapTrack = m_TapNotes[track];
 
   // Find the first note >= rowInOut.
-  TrackMap::const_iterator iter = mapTrack.lower_bound(rowInOut);
+  TrackMap::const_iterator iter = lower_bound(track, rowInOut);
 
   // If we're at the beginning, we can't move back any more.
   if (iter == mapTrack.begin()) {
@@ -1030,7 +1025,7 @@ void NoteData::GetTapNoteRange(
   } else if (iStartRow >= MAX_NOTE_ROW) {
     lBegin = mapTrack.end();  // optimization
   } else {
-    lBegin = mapTrack.lower_bound(iStartRow);
+    lBegin = lower_bound(iTrack, iStartRow);
   }
 
   if (iEndRow <= 0) {
@@ -1038,7 +1033,7 @@ void NoteData::GetTapNoteRange(
   } else if (iEndRow >= MAX_NOTE_ROW) {
     lEnd = mapTrack.end();  // optimization
   } else {
-    lEnd = mapTrack.lower_bound(iEndRow);
+    lEnd = lower_bound(iTrack, iEndRow);
   }
 }
 
@@ -1441,6 +1436,51 @@ NoteData::_all_tracks_iterator<ND, iter, TN> NoteData::_all_tracks_iterator<ND, 
 	return ret;
 }
 #endif
+
+NoteData::iterator NoteData::lower_bound(int iTrack, int iRow) {
+  return std::lower_bound(
+      m_TapNotes[iTrack].begin(), m_TapNotes[iTrack].end(), iRow,
+      [](const RowTapNote& a, int b) { return a.first < b; });
+}
+
+NoteData::const_iterator NoteData::lower_bound(int iTrack, int iRow) const {
+  return std::lower_bound(
+      m_TapNotes[iTrack].begin(), m_TapNotes[iTrack].end(), iRow,
+      [](const RowTapNote& a, int b) { return a.first < b; });
+}
+
+NoteData::iterator NoteData::upper_bound(int iTrack, int iRow) {
+  return std::upper_bound(
+      m_TapNotes[iTrack].begin(), m_TapNotes[iTrack].end(), iRow,
+      [](int a, const RowTapNote& b) { return a < b.first; });
+}
+
+NoteData::const_iterator NoteData::upper_bound(int iTrack, int iRow) const {
+  return std::upper_bound(
+      m_TapNotes[iTrack].begin(), m_TapNotes[iTrack].end(), iRow,
+      [](int a, const RowTapNote& b) { return a < b.first; });
+}
+
+NoteData::iterator NoteData::FindTapNote(unsigned iTrack, int iRow) {
+  auto it = lower_bound(iTrack, iRow);
+  if (it != m_TapNotes[iTrack].end() && it->first == iRow) {
+    return it;
+  }
+  return m_TapNotes[iTrack].end();
+}
+
+NoteData::const_iterator NoteData::FindTapNote(
+    unsigned iTrack, int iRow) const {
+  auto it = lower_bound(iTrack, iRow);
+  if (it != m_TapNotes[iTrack].end() && it->first == iRow) {
+    return it;
+  }
+  return m_TapNotes[iTrack].end();
+}
+
+NoteData::iterator NoteData::RemoveTapNote(unsigned iTrack, iterator it) {
+  return m_TapNotes[iTrack].erase(it);
+}
 
 // Explicit instantiation.
 template class NoteData::_all_tracks_iterator<

--- a/src/NoteData.h
+++ b/src/NoteData.h
@@ -1,7 +1,7 @@
 #ifndef NOTE_DATA_H
 #define NOTE_DATA_H
 
-#include <map>
+#include <deque>
 #include <set>
 #include <utility>
 #include <vector>
@@ -35,11 +35,12 @@
 /** @brief Holds data about the notes that the player is supposed to hit. */
 class NoteData {
  public:
-  typedef std::map<int, TapNote> TrackMap;
-  typedef std::map<int, TapNote>::iterator iterator;
-  typedef std::map<int, TapNote>::const_iterator const_iterator;
-  typedef std::map<int, TapNote>::reverse_iterator reverse_iterator;
-  typedef std::map<int, TapNote>::const_reverse_iterator const_reverse_iterator;
+  typedef std::pair<int, TapNote> RowTapNote;
+  typedef std::deque<RowTapNote> TrackMap;
+  typedef TrackMap::iterator iterator;
+  typedef TrackMap::const_iterator const_iterator;
+  typedef TrackMap::reverse_iterator reverse_iterator;
+  typedef TrackMap::const_reverse_iterator const_reverse_iterator;
 
   NoteData() : m_TapNotes() {}
 
@@ -55,18 +56,10 @@ class NoteData {
   const_reverse_iterator rend(int iTrack) const {
     return m_TapNotes[iTrack].rend();
   }
-  iterator lower_bound(int iTrack, int iRow) {
-    return m_TapNotes[iTrack].lower_bound(iRow);
-  }
-  const_iterator lower_bound(int iTrack, int iRow) const {
-    return m_TapNotes[iTrack].lower_bound(iRow);
-  }
-  iterator upper_bound(int iTrack, int iRow) {
-    return m_TapNotes[iTrack].upper_bound(iRow);
-  }
-  const_iterator upper_bound(int iTrack, int iRow) const {
-    return m_TapNotes[iTrack].upper_bound(iRow);
-  }
+  iterator lower_bound(int iTrack, int iRow);
+  const_iterator lower_bound(int iTrack, int iRow) const;
+  iterator upper_bound(int iTrack, int iRow);
+  const_iterator upper_bound(int iTrack, int iRow) const;
   void swap(NoteData& nd) {
     m_TapNotes.swap(nd.m_TapNotes);
     m_atis.swap(nd.m_atis);
@@ -220,24 +213,17 @@ class NoteData {
   /* Return the note at the given track and row.  Row may be out of
    * range; pretend the song goes on with TAP_EMPTYs indefinitely. */
   inline const TapNote& GetTapNote(unsigned track, int row) const {
-    const TrackMap& mapTrack = m_TapNotes[track];
-    TrackMap::const_iterator iter = mapTrack.find(row);
-    if (iter != mapTrack.end()) {
+    const_iterator iter = FindTapNote(track, row);
+    if (iter != end(track)) {
       return iter->second;
     } else {
       return TAP_EMPTY;
     }
   }
 
-  inline iterator FindTapNote(unsigned iTrack, int iRow) {
-    return m_TapNotes[iTrack].find(iRow);
-  }
-  inline const_iterator FindTapNote(unsigned iTrack, int iRow) const {
-    return m_TapNotes[iTrack].find(iRow);
-  }
-  void RemoveTapNote(unsigned iTrack, iterator it) {
-    m_TapNotes[iTrack].erase(it);
-  }
+  iterator FindTapNote(unsigned iTrack, int iRow);
+  const_iterator FindTapNote(unsigned iTrack, int iRow) const;
+  iterator RemoveTapNote(unsigned iTrack, iterator it);
 
   /**
    * @brief Return an iterator range for [rowBegin,rowEnd).

--- a/src/NoteDataUtil.cpp
+++ b/src/NoteDataUtil.cpp
@@ -281,21 +281,18 @@ static void LoadFromSMNoteDataStringWithPlayer(
   // Make sure we don't have any hold notes that didn't find a tail.
   for (int t = 0; t < out.GetNumTracks(); t++) {
     NoteData::iterator begin = out.begin(t);
-    NoteData::iterator lEnd = out.end(t);
-    while (begin != lEnd) {
-      NoteData::iterator next = Increment(begin);
+    while (begin != out.end(t)) {
       const TapNote& tn = begin->second;
       if (tn.type == TapNoteType_HoldHead && tn.iDuration == MAX_NOTE_ROW) {
-        int iRow = begin->first;
         LOG->UserLog(
             "", "",
             "While loading .sm/.ssc note data, there was an unmatched 2 at "
             "beat %f",
-            NoteRowToBeat(iRow));
-        out.RemoveTapNote(t, begin);
+            NoteRowToBeat(begin->first));
+        begin = out.RemoveTapNote(t, begin);
+      } else {
+        ++begin;
       }
-
-      begin = next;
     }
   }
   out.RevalidateATIs(std::vector<int>(), false);
@@ -356,11 +353,12 @@ void NoteDataUtil::LoadFromSMNoteDataString(
 
 void NoteDataUtil::InsertHoldTails(NoteData& inout) {
   for (int t = 0; t < inout.GetNumTracks(); t++) {
-    NoteData::iterator begin = inout.begin(t), end = inout.end(t);
-
-    for (; begin != end; ++begin) {
-      int iRow = begin->first;
-      const TapNote& tn = begin->second;
+    /* Collect the tails to insert in a first pass. We can't insert while
+     * iterating, since inserting into the track invalidates our iterators. */
+    std::vector<std::pair<int, TapNote>> tails;
+    for (NoteData::iterator it = inout.begin(t); it != inout.end(t); ++it) {
+      int iRow = it->first;
+      const TapNote& tn = it->second;
       if (tn.type != TapNoteType_HoldHead) {
         continue;
       }
@@ -368,11 +366,15 @@ void NoteDataUtil::InsertHoldTails(NoteData& inout) {
       TapNote tail = tn;
       tail.type = TapNoteType_HoldTail;
 
-      /* If iDuration is 0, we'd end up overwriting the head with the tail
-       * (and invalidating our iterator). Empty hold notes aren't valid. */
+      /* If iDuration is 0, we'd end up overwriting the head with the tail.
+       * Empty hold notes aren't valid. */
       ASSERT(tn.iDuration != 0);
 
-      inout.SetTapNote(t, iRow + tn.iDuration, tail);
+      tails.push_back({iRow + tn.iDuration, tail});
+    }
+
+    for (const std::pair<int, TapNote>& tail : tails) {
+      inout.SetTapNote(t, tail.first, tail.second);
     }
   }
 }
@@ -1201,7 +1203,7 @@ void NoteDataUtil::RemoveAllButPlayer(NoteData& inout, PlayerNumber pn) {
 
     while (i != inout.end(track)) {
       if (i->second.pn != pn && i->second.pn != PLAYER_INVALID) {
-        inout.RemoveTapNote(track, i++);
+        i = inout.RemoveTapNote(track, i);
       } else {
         ++i;
       }
@@ -2944,7 +2946,7 @@ void NoteDataUtil::RemoveAllTapsOfType(
   for (int t = 0; t < ndInOut.GetNumTracks(); t++) {
     for (NoteData::iterator iter = ndInOut.begin(t); iter != ndInOut.end(t);) {
       if (iter->second.type == typeToRemove) {
-        ndInOut.RemoveTapNote(t, iter++);
+        iter = ndInOut.RemoveTapNote(t, iter);
       } else {
         ++iter;
       }
@@ -2959,7 +2961,7 @@ void NoteDataUtil::RemoveAllTapsExceptForType(
   for (int t = 0; t < ndInOut.GetNumTracks(); t++) {
     for (NoteData::iterator iter = ndInOut.begin(t); iter != ndInOut.end(t);) {
       if (iter->second.type != typeToKeep) {
-        ndInOut.RemoveTapNote(t, iter++);
+        iter = ndInOut.RemoveTapNote(t, iter);
       } else {
         ++iter;
       }


### PR DESCRIPTION
std::map is terribly inefficient. Instead use std::deque containing notes sorted by row.

Lookup is still log(n). The problem with std::deque is that it makes arbitrary insertion/deletion O(n). However, this is fairly uncommon in practice. I tried editing XS project full in the editor and this change doesn't make a noticeable difference.

Change some places to take advantage of std::deque iteration being much faster.

Speeds up uncached load time by ~10%.