### PR TITLE
Ignore build directories of both casings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ CPackSourceConfig.cmake
 # The following are generated from CMake, and thus should be stopped.
 ITGmania.project
 ITGmania.workspace
+build/
 Build/
 !Build/INSTALL.md
 !Build/README.md


### PR DESCRIPTION
To save me from having to stash the build dir every time I build to `build` instead of `Build`.