### PR TITLE
Reserve a larger buffer for the playback position

### DIFF
--- a/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_Generic_Software.cpp
@@ -59,7 +59,7 @@ void RageSoundDriver::Sound::Allocate(int iFrames) {
   const int iFramesPerBlock = samples_per_block / channels;
   const int iBlocksToPrebuffer = iFrames / iFramesPerBlock;
   m_Buffer.reserve(iBlocksToPrebuffer + 1);
-  m_MixedPositionQueue.reserve(32);
+  m_MixedPositionQueue.reserve(64);
   m_PlaybackHistory.clear();
 }
 


### PR DESCRIPTION
We can definitely afford the extra blocks here to store a bit more position history.