### PR TITLE
Fix global offset at song loading

### DIFF
--- a/src/NotesLoaderSSC.cpp
+++ b/src/NotesLoaderSSC.cpp
@@ -258,12 +258,12 @@ void SetSongFakes(SongTagInfo& info) {
 }
 void SetFirstSecond(SongTagInfo& info) {
   if (info.from_cache) {
-    info.song->SetFirstSecond(StringToFloat((*info.params)[1]));
+    info.song->SetFirstSecondNoOffset(StringToFloat((*info.params)[1]));
   }
 }
 void SetLastSecond(SongTagInfo& info) {
   if (info.from_cache) {
-    info.song->SetLastSecond(StringToFloat((*info.params)[1]));
+    info.song->SetLastSecondNoOffset(StringToFloat((*info.params)[1]));
   }
 }
 void SetSongFilename(SongTagInfo& info) {

--- a/src/NotesWriterSSC.cpp
+++ b/src/NotesWriterSSC.cpp
@@ -580,8 +580,8 @@ bool NotesWriterSSC::Write(
 
   if (bSavingCache) {
     f.PutLine(ssprintf("// cache tags:"));
-    f.PutLine(ssprintf("#FIRSTSECOND:%.6f;", out.GetFirstSecond()));
-    f.PutLine(ssprintf("#LASTSECOND:%.6f;", out.GetLastSecond()));
+    f.PutLine(ssprintf("#FIRSTSECOND:%.6f;", out.GetFirstSecondNoOffset()));
+    f.PutLine(ssprintf("#LASTSECOND:%.6f;", out.GetLastSecondNoOffset()));
     f.PutLine(
         ssprintf("#SONGFILENAME:%s;", SmEscape(out.m_sSongFileName).c_str()));
     f.PutLine(ssprintf("#HASMUSIC:%i;", out.m_bHasMusic));

--- a/src/ScreenEdit.cpp
+++ b/src/ScreenEdit.cpp
@@ -6099,7 +6099,8 @@ void ScreenEdit::HandleAreaMenuChoice(
     case last_second_at_beat: {
       const TimingData& timing = GetAppropriateTiming();
       Song& s = *GAMESTATE->m_pCurSong;
-      s.SetSpecifiedLastSecond(timing.GetElapsedTimeFromBeat(GetBeat()));
+      s.SetSpecifiedLastSecond(
+          timing.GetElapsedTimeFromBeatNoOffset(GetBeat()));
       break;
     }
     case undo:

--- a/src/Song.cpp
+++ b/src/Song.cpp
@@ -21,6 +21,7 @@
 #include "EnumHelper.h"
 #include "GameConstantsAndTypes.h"
 #include "GameManager.h"
+#include "GameState.h"
 #include "Group.h"
 #include "ImageCache.h"
 #include "LuaManager.h"
@@ -65,7 +66,7 @@
  * @brief The internal version of the cache for StepMania.
  *
  * Increment this value to invalidate the current cache. */
-const int FILE_CACHE_VERSION = 231;
+const int FILE_CACHE_VERSION = 232;
 
 /** @brief How long does a song sample last by default? */
 const float DEFAULT_MUSIC_SAMPLE_LENGTH = 12.f;
@@ -131,27 +132,40 @@ void Song::DetachSteps() {
   m_UnknownStyleSteps.clear();
 }
 
-float Song::GetFirstSecond() const { return this->firstSecond; }
+float Song::GetFirstSecond() const {
+  return GetFirstSecondNoOffset() -
+         GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate *
+             PREFSMAN->m_fGlobalOffsetSeconds;
+}
 
 float Song::GetFirstBeat() const {
-  return this->m_SongTiming.GetBeatFromElapsedTime(this->firstSecond);
+  return this->m_SongTiming.GetBeatFromElapsedTimeNoOffset(this->firstSecond);
 }
 
-float Song::GetLastSecond() const { return this->lastSecond; }
+float Song::GetLastSecond() const {
+  return GetLastSecondNoOffset() -
+         GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate *
+             PREFSMAN->m_fGlobalOffsetSeconds;
+}
 
 float Song::GetLastBeat() const {
-  return this->m_SongTiming.GetBeatFromElapsedTime(this->lastSecond);
+  return this->m_SongTiming.GetBeatFromElapsedTimeNoOffset(this->lastSecond);
 }
+
+float Song::GetSpecifiedLastBeat() const {
+  return this->m_SongTiming.GetBeatFromElapsedTimeNoOffset(
+      this->specifiedLastSecond);
+}
+
+float Song::GetFirstSecondNoOffset() const { return this->firstSecond; }
+
+float Song::GetLastSecondNoOffset() const { return this->lastSecond; }
 
 float Song::GetSpecifiedLastSecond() const { return this->specifiedLastSecond; }
 
-float Song::GetSpecifiedLastBeat() const {
-  return this->m_SongTiming.GetBeatFromElapsedTime(this->specifiedLastSecond);
-}
+void Song::SetFirstSecondNoOffset(const float f) { this->firstSecond = f; }
 
-void Song::SetFirstSecond(const float f) { this->firstSecond = f; }
-
-void Song::SetLastSecond(const float f) { this->lastSecond = f; }
+void Song::SetLastSecondNoOffset(const float f) { this->lastSecond = f; }
 
 void Song::SetSpecifiedLastSecond(const float f) {
   this->specifiedLastSecond = f;
@@ -854,17 +868,18 @@ void Song::TidyUpData(
           m_fMusicSampleStartSeconds + m_fMusicSampleLengthSeconds >
               this->m_fMusicLengthSeconds) {
         const TimingData& timing = this->m_SongTiming;
-        m_fMusicSampleStartSeconds = timing.GetElapsedTimeFromBeat(100);
+        m_fMusicSampleStartSeconds = timing.GetElapsedTimeFromBeatNoOffset(100);
 
         if (m_fMusicSampleStartSeconds + m_fMusicSampleLengthSeconds >
             this->m_fMusicLengthSeconds) {
           // Attempt to get a reasonable default.
           int iBeat = std::lrint(
-              this->m_SongTiming.GetBeatFromElapsedTime(this->GetLastSecond()) /
+              this->m_SongTiming.GetBeatFromElapsedTimeNoOffset(
+                  this->GetLastSecondNoOffset()) /
               2);
           iBeat -= iBeat % 4;
           m_fMusicSampleStartSeconds =
-              timing.GetElapsedTimeFromBeat((float)iBeat);
+              timing.GetElapsedTimeFromBeatNoOffset((float)iBeat);
         }
       }
 
@@ -1169,10 +1184,10 @@ void Song::ReCalculateStepStatsAndLastSecond(bool wipeNoteData) {
        * don't force the first beat of the whole song to 0. */
       if (tempNoteData.GetLastRow() != 0) {
         localFirst = std::min(
-            localFirst, pSteps->GetTimingData()->GetElapsedTimeFromBeat(
+            localFirst, pSteps->GetTimingData()->GetElapsedTimeFromBeatNoOffset(
                             tempNoteData.GetFirstBeat()));
         localLast = std::max(
-            localLast, pSteps->GetTimingData()->GetElapsedTimeFromBeat(
+            localLast, pSteps->GetTimingData()->GetElapsedTimeFromBeatNoOffset(
                            tempNoteData.GetLastBeat()));
       }
     }
@@ -1976,7 +1991,7 @@ bool Song::HasSignificantBpmChangesOrStops() const {
 }
 
 float Song::GetStepsSeconds() const {
-  return this->GetLastSecond() - this->GetFirstSecond();
+  return this->GetLastSecondNoOffset() - this->GetFirstSecondNoOffset();
 }
 
 bool Song::IsLong() const {

--- a/src/Song.h
+++ b/src/Song.h
@@ -313,14 +313,17 @@ class Song {
   TimingData m_SongTiming;
 
   float GetFirstBeat() const;
+  float GetFirstSecondNoOffset() const;
   float GetFirstSecond() const;
   float GetLastBeat() const;
+  float GetLastSecondNoOffset() const;
   float GetLastSecond() const;
   float GetSpecifiedLastBeat() const;
+
   float GetSpecifiedLastSecond() const;
 
-  void SetFirstSecond(const float f);
-  void SetLastSecond(const float f);
+  void SetFirstSecondNoOffset(const float f);
+  void SetLastSecondNoOffset(const float f);
   void SetSpecifiedLastSecond(const float f);
 
   typedef std::vector<BackgroundChange> VBackgroundChange;


### PR DESCRIPTION
Song::ReCalculateStepStatsAndLastSecond used the current value of the global offset when setting the first second and last second of the song during song loading. On subsequent launches, the values are loaded from the song cache. The values are not updated when the global offset is changed, so they will be wrong if the offset is modified afterwards.

This caused the following problems:
- Song cache files have extra differences if the global offset is changed, which is annoying when making changes to the song loading code and diffing the cache as a sanity check.
- The delay before the music starts in gameplay is different if the global offset is changed after loading the songs. That's not noticeable for normal use, but was a problem when trying to get two machines synchronized.

Related fixes:
- ScreenEdit: Global offset was added to the last second hint when setting it from the area menu.
- Song: Global offset was added when determining the sample start second when not specified in the file.