### PR TITLE
gettid() -> syscall(SYS_gettid)

### DIFF
--- a/src/archutils/Common/PthreadHelpers.cpp
+++ b/src/archutils/Common/PthreadHelpers.cpp
@@ -75,7 +75,9 @@ static int PtraceDetach(int ThreadID) {
 uint64_t GetCurrentThreadId() {
   static thread_local uint64_t cached_tid = 0;
   if (!cached_tid) {
-    cached_tid = gettid();
+    // TODO: Replace syscall(SYS_gettid) with gettid() once Ubuntu 18 is no
+    // longer supported.
+    cached_tid = syscall(SYS_gettid);
   }
   return cached_tid;
 }


### PR DESCRIPTION
We still support Ubuntu 18 which doesn't have gettid(). Just call the syscall for now, it does the same thing.