### PR TITLE
Remove compiler macros to their own header

### DIFF
--- a/src/Compiler.h
+++ b/src/Compiler.h
@@ -1,0 +1,12 @@
+#ifndef COMPILER_H
+#define COMPILER_H
+
+#if defined(__GNUC__)
+#define PRINTF(a, b) __attribute__((format(__printf__, a, b)))
+#define CONST_FUNCTION __attribute__((const))
+#else
+#define PRINTF(a, b)
+#define CONST_FUNCTION
+#endif
+
+#endif

--- a/src/RageException.h
+++ b/src/RageException.h
@@ -3,6 +3,7 @@
 
 #include <string>
 
+#include "Compiler.h"
 #include "config.hpp"
 
 /**

--- a/src/RageLog.h
+++ b/src/RageLog.h
@@ -5,6 +5,7 @@
 
 #include <string>
 
+#include "Compiler.h"
 #include "config.hpp"
 
 class RageLog {

--- a/src/RageMath.h
+++ b/src/RageMath.h
@@ -5,6 +5,7 @@
 
 #include <vector>
 
+#include "Compiler.h"
 #include "config.hpp"
 
 constexpr float PI = 3.1415926536f;

--- a/src/RageUtil.h
+++ b/src/RageUtil.h
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+#include "Compiler.h"
 #include "config.hpp"
 #include "global.h"
 

--- a/src/config.hpp.in
+++ b/src/config.hpp.in
@@ -38,17 +38,6 @@
 /* Defined to 1 if logging timing segment additions and removals. */
 #cmakedefine WITH_LOGGING_TIMING_DATA 1
 
-#if defined(__GNUC__)
-/** @brief Define a macro to tell the compiler that a function has printf()
- * semantics, to aid warning output. */
-#define PRINTF(a, b) __attribute__((format(__printf__, a, b)))
-#define CONST_FUNCTION __attribute__((const))
-#else
-/** @brief A dummy define to keep things going smoothly. */
-#define PRINTF(a, b)
-/** @brief A dummy define to keep things going smoothly. */
-#define CONST_FUNCTION
-#endif
 
 /* Ensure we have a function that acts like a size limited sprintf. */
 #if defined(HAVE_SNPRINTF)


### PR DESCRIPTION
They're not really a "config" that can be specified.