### PR TITLE
Check for NSIS before attempting the Windows release build

### DIFF
--- a/Utils/build-release-windows.bat
+++ b/Utils/build-release-windows.bat
@@ -1,4 +1,14 @@
-cd %~dp0..
+@echo off
+setlocal
+cd /d "%~dp0.."
+
+where makensis >nul 2>&1
+if errorlevel 1 (
+    echo "Error: NSIS not found in PATH. Ensure it is installed and part of the system PATH."
+    exit /b 1
+)
+
+echo "NSIS detected."
 
 cmake -B Build\release -DWITH_FULL_RELEASE=On -DWITH_CLUB_FANTASTIC=On || exit /b
 cmake --build Build\release --config Release -j %NUMBER_OF_PROCESSORS% || exit /b


### PR DESCRIPTION
Prevents failure halfway into the release build due to missing or misconfigured NSIS.