### PR TITLE
NSIS: remove DOS logic from installer template; update for 64-bit Windows

### DIFF
--- a/CMake/Modules/NSIS.template.in
+++ b/CMake/Modules/NSIS.template.in
@@ -263,7 +263,12 @@ Function un.RemoveFromPath
   Push $5
   Push $6
 
-  IntFmt $6 "%c" 26 # DOS EOF
+  StrCmp $ADD_TO_PATH_ALL_USERS "1" unReadAllKey
+    ReadRegStr $1 ${NT_current_env} "PATH"
+    Goto unDoTrim
+  unReadAllKey:
+    ReadRegStr $1 ${NT_all_env} "PATH"
+
   unDoTrim:
     StrCmp $1 "" unRemoveFromPath_done
       Push $1
@@ -543,9 +548,6 @@ FunctionEnd
   ReserveFile "NSIS.InstallOptions.ini"
   !insertmacro MUI_RESERVEFILE_INSTALLOPTIONS
 
-  ; for UserInfo::GetName and UserInfo::GetAccountType
-  ReserveFile /plugin 'UserInfo.dll'
-
 ;--------------------------------
 ; Installation types
 @CPACK_NSIS_INSTALLATION_TYPES@
@@ -670,28 +672,9 @@ Function InstallOptionsPage
 FunctionEnd
 
 ;--------------------------------
-; determine admin versus local install
+; uninstaller initialization
 Function un.onInit
-
-  ClearErrors
-  UserInfo::GetName
-  IfErrors noLM
-  Pop $0
-  UserInfo::GetAccountType
-  Pop $1
-  StrCmp $1 "Admin" 0 +3
-    SetShellVarContext all
-    ;MessageBox MB_OK 'User "$0" is in the Admin group'
-    Goto done
-  StrCmp $1 "Power" 0 +3
-    SetShellVarContext all
-    ;MessageBox MB_OK 'User "$0" is in the Power Users group'
-    Goto done
-
-  noLM:
-    ;Get installation folder from registry if available
-
-  done:
+  SetShellVarContext all
 
 FunctionEnd
 
@@ -822,15 +805,14 @@ SectionEnd
 
 ;--------------------------------
 ; determine admin versus local install
-; Is install for "AllUsers" or "JustMe"?
-; Default to "JustMe" - set to "AllUsers" if admin or on Win9x
 ; This function is used for the very first "custom page" of the installer.
 ; This custom page does not show up visibly, but it executes prior to the
 ; first visible page and sets up $INSTDIR properly...
-; Choose different default installation folder based on SV_ALLUSERS...
-; "Program Files" for AllUsers, "My Documents" for JustMe...
 
 Function .onInit
+  SetShellVarContext all
+  StrCpy $SV_ALLUSERS "AllUsers"
+
   StrCmp "@CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL@" "ON" 0 inst
 
   ReadRegStr $0 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\@CPACK_PACKAGE_INSTALL_REGISTRY_KEY@" "UninstallString"
@@ -859,46 +841,6 @@ uninst_failed:
 inst:
   ; Reads components status for registry
   !insertmacro SectionList "InitSection"
-
-  ; check to see if /D has been used to change
-  ; the install directory by comparing it to the
-  ; install directory that is expected to be the
-  ; default
-  StrCpy $IS_DEFAULT_INSTALLDIR 0
-  StrCmp "$INSTDIR" "@CPACK_NSIS_INSTALL_ROOT@\@CPACK_PACKAGE_INSTALL_DIRECTORY@" 0 +2
-    StrCpy $IS_DEFAULT_INSTALLDIR 1
-
-  StrCpy $SV_ALLUSERS "JustMe"
-  ; if default install dir then change the default
-  ; if it is installed for JustMe
-  StrCmp "$IS_DEFAULT_INSTALLDIR" "1" 0 +2
-    StrCpy $INSTDIR "$DOCUMENTS\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
-
-  ClearErrors
-  UserInfo::GetName
-  IfErrors noLM
-  Pop $0
-  UserInfo::GetAccountType
-  Pop $1
-  StrCmp $1 "Admin" 0 +4
-    SetShellVarContext all
-    ;MessageBox MB_OK 'User "$0" is in the Admin group'
-    StrCpy $SV_ALLUSERS "AllUsers"
-    Goto done
-  StrCmp $1 "Power" 0 +4
-    SetShellVarContext all
-    ;MessageBox MB_OK 'User "$0" is in the Power Users group'
-    StrCpy $SV_ALLUSERS "AllUsers"
-    Goto done
-
-  noLM:
-    StrCpy $SV_ALLUSERS "AllUsers"
-    ;Get installation folder from registry if available
-
-  done:
-  StrCmp $SV_ALLUSERS "AllUsers" 0 +3
-    StrCmp "$IS_DEFAULT_INSTALLDIR" "1" 0 +2
-      StrCpy $INSTDIR "@CPACK_NSIS_INSTALL_ROOT@\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
 
   StrCmp "@CPACK_NSIS_MODIFY_PATH@" "ON" 0 noOptionsPage
     !insertmacro MUI_INSTALLOPTIONS_EXTRACT "NSIS.InstallOptions.ini"

--- a/CMake/Modules/NSIS.template.in
+++ b/CMake/Modules/NSIS.template.in
@@ -267,7 +267,7 @@ Function un.RemoveFromPath
   unDoTrim:
     StrCmp $1 "" unRemoveFromPath_done
       Push $1
-      Call Trim
+      Call un.Trim
       Pop $1
 
     StrCpy $5 $1 1 -1 ; copy last char
@@ -364,23 +364,28 @@ FunctionEnd
 !insertmacro StrStr ""
 !insertmacro StrStr "un."
 
-Function Trim ; Added by Pelaca
-	Exch $R1
-	Push $R2
+!macro TrimImpl FuncName ; Added by Pelaca
+Function ${FuncName}
+  Exch $R1
+  Push $R2
 Loop:
-	StrCpy $R2 "$R1" 1 -1
-	StrCmp "$R2" " " RTrim
-	StrCmp "$R2" "$\n" RTrim
-	StrCmp "$R2" "$\r" RTrim
-	StrCmp "$R2" ";" RTrim
-	GoTo Done
+  StrCpy $R2 "$R1" 1 -1
+  StrCmp "$R2" " " RTrim
+  StrCmp "$R2" "$\n" RTrim
+  StrCmp "$R2" "$\r" RTrim
+  StrCmp "$R2" ";" RTrim
+  GoTo Done
 RTrim:
-	StrCpy $R1 "$R1" -1
-	Goto Loop
+  StrCpy $R1 "$R1" -1
+  Goto Loop
 Done:
-	Pop $R2
-	Exch $R1
+  Pop $R2
+  Exch $R1
 FunctionEnd
+!macroend
+
+!insertmacro TrimImpl Trim
+!insertmacro TrimImpl un.Trim
 
 Function ConditionalAddToRegisty
   Pop $0

--- a/CMake/Modules/NSIS.template.in
+++ b/CMake/Modules/NSIS.template.in
@@ -263,6 +263,8 @@ Function un.RemoveFromPath
   Push $5
   Push $6
 
+  SetRegView 64
+
   StrCmp $ADD_TO_PATH_ALL_USERS "1" unReadAllKey
     ReadRegStr $1 ${NT_current_env} "PATH"
     Goto unDoTrim
@@ -562,6 +564,7 @@ FunctionEnd
 Section "-Core installation"
   ;Use the entire tree produced by the INSTALL target.  Keep the
   ;list of directories here in sync with the RMDir commands below.
+  SetRegView 64
   SetOutPath "$INSTDIR"
   @CPACK_NSIS_EXTRA_PREINSTALL_COMMANDS@
   @CPACK_NSIS_FULL_INSTALL@
@@ -674,6 +677,7 @@ FunctionEnd
 ;--------------------------------
 ; uninstaller initialization
 Function un.onInit
+  SetRegView 64
   SetShellVarContext all
 
 FunctionEnd
@@ -687,6 +691,7 @@ FunctionEnd
 
 Section -FinishComponents
   ;Removes unselected components and writes component status to registry
+  SetRegView 64
   !insertmacro SectionList "FinishSection"
 
 !ifdef CPACK_NSIS_ADD_REMOVE
@@ -718,6 +723,7 @@ FunctionEnd
 ;Uninstaller Section
 
 Section "Uninstall"
+  SetRegView 64
   ReadRegStr $START_MENU SHCTX \
    "Software\Microsoft\Windows\CurrentVersion\Uninstall\@CPACK_PACKAGE_INSTALL_REGISTRY_KEY@" "StartMenu"
   ;MessageBox MB_OK "Start menu is in: $START_MENU"
@@ -810,6 +816,7 @@ SectionEnd
 ; first visible page and sets up $INSTDIR properly...
 
 Function .onInit
+  SetRegView 64
   SetShellVarContext all
   StrCpy $SV_ALLUSERS "AllUsers"
 

--- a/CMake/Modules/NSIS.template.in
+++ b/CMake/Modules/NSIS.template.in
@@ -171,41 +171,11 @@ Var AR_RegFlags
 !verbose 3
 !include "WinMessages.NSH"
 !verbose 4
-;====================================================
-; get_NT_environment
-;     Returns: the selected environment
-;     Output : head of the stack
-;====================================================
-!macro select_NT_profile UN
-Function ${UN}select_NT_profile
-   StrCmp $ADD_TO_PATH_ALL_USERS "1" 0 environment_single
-      DetailPrint "Selected environment for all users"
-      Push "all"
-      Return
-   environment_single:
-      DetailPrint "Selected environment for current user only."
-      Push "current"
-      Return
-FunctionEnd
-!macroend
-!insertmacro select_NT_profile ""
-!insertmacro select_NT_profile "un."
-;----------------------------------------------------
 !define NT_current_env 'HKCU "Environment"'
 !define NT_all_env     'HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"'
 
-!ifndef WriteEnvStr_RegKey
-  !ifdef ALL_USERS
-    !define WriteEnvStr_RegKey \
-       'HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"'
-  !else
-    !define WriteEnvStr_RegKey 'HKCU "Environment"'
-  !endif
-!endif
-
 ; AddToPath - Adds the given dir to the search path.
 ;        Input - head of the stack
-;        Note - Win9x systems requires reboot
 
 Function AddToPath
   Exch $0
@@ -216,72 +186,61 @@ Function AddToPath
   # don't add if the path doesn't exist
   IfFileExists "$0\*.*" "" AddToPath_done
 
-  ReadEnvStr $1 PATH
-  ; if the path is too long for a NSIS variable NSIS will return a 0
-  ; length string.  If we find that, then warn and skip any path
-  ; modification as it will trash the existing path.
-  StrLen $2 $1
-  IntCmp $2 0 CheckPathLength_ShowPathWarning CheckPathLength_Done CheckPathLength_Done
-    CheckPathLength_ShowPathWarning:
-    Messagebox MB_OK|MB_ICONEXCLAMATION "Warning! PATH too long installer unable to modify PATH!"
-    Goto AddToPath_done
-  CheckPathLength_Done:
-  Push "$1;"
-  Push "$0;"
-  Call StrStr
-  Pop $2
-  StrCmp $2 "" "" AddToPath_done
-  Push "$1;"
-  Push "$0\;"
-  Call StrStr
-  Pop $2
-  StrCmp $2 "" "" AddToPath_done
-  GetFullPathName /SHORT $3 $0
-  Push "$1;"
-  Push "$3;"
-  Call StrStr
-  Pop $2
-  StrCmp $2 "" "" AddToPath_done
-  Push "$1;"
-  Push "$3\;"
-  Call StrStr
-  Pop $2
-  StrCmp $2 "" "" AddToPath_done
+  SetRegView 64
 
-  Call IsNT
-  Pop $1
-  StrCmp $1 1 AddToPath_NT
-    ; Not on NT
-    StrCpy $1 $WINDIR 2
-    FileOpen $1 "$1\autoexec.bat" a
-    FileSeek $1 -1 END
-    FileReadByte $1 $2
-    IntCmp $2 26 0 +2 +2 # DOS EOF
-      FileSeek $1 -1 END # write over EOF
-    FileWrite $1 "$\r$\nSET PATH=%PATH%;$3$\r$\n"
-    FileClose $1
-    SetRebootFlag true
-    Goto AddToPath_done
+  StrCmp $ADD_TO_PATH_ALL_USERS "1" ReadAllKey
+    ReadRegStr $1 ${NT_current_env} "PATH"
+    Goto DoTrim
+  ReadAllKey:
+    ReadRegStr $1 ${NT_all_env} "PATH"
 
-  AddToPath_NT:
-    StrCmp $ADD_TO_PATH_ALL_USERS "1" ReadAllKey
-      ReadRegStr $1 ${NT_current_env} "PATH"
-      Goto DoTrim
-    ReadAllKey:
-      ReadRegStr $1 ${NT_all_env} "PATH"
-    DoTrim:
-    StrCmp $1 "" AddToPath_NTdoIt
+  DoTrim:
+    StrCmp $1 "" CheckDuplicates
       Push $1
       Call Trim
       Pop $1
+
+  CheckDuplicates:
+    StrCmp $1 "" AddToPath_Write
+    Push "$1;"
+    Push "$0;"
+    Call StrStr
+    Pop $2
+    StrCmp $2 "" +2
+      Goto AddToPath_done
+
+    Push "$1;"
+    Push "$0\;"
+    Call StrStr
+    Pop $2
+    StrCmp $2 "" +2
+      Goto AddToPath_done
+
+    GetFullPathName /SHORT $3 $0
+    Push "$1;"
+    Push "$3;"
+    Call StrStr
+    Pop $2
+    StrCmp $2 "" +2
+      Goto AddToPath_done
+
+    Push "$1;"
+    Push "$3\;"
+    Call StrStr
+    Pop $2
+    StrCmp $2 "" +2
+      Goto AddToPath_done
+
+  AddToPath_Write:
+    StrCmp $1 "" +2
       StrCpy $0 "$1;$0"
-    AddToPath_NTdoIt:
-      StrCmp $ADD_TO_PATH_ALL_USERS "1" WriteAllKey
-        WriteRegExpandStr ${NT_current_env} "PATH" $0
-        Goto DoSend
-      WriteAllKey:
-        WriteRegExpandStr ${NT_all_env} "PATH" $0
-      DoSend:
+
+    StrCmp $ADD_TO_PATH_ALL_USERS "1" WriteAllKey
+      WriteRegExpandStr ${NT_current_env} "PATH" $0
+      Goto DoSend
+    WriteAllKey:
+      WriteRegExpandStr ${NT_all_env} "PATH" $0
+    DoSend:
       SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
 
   AddToPath_done:
@@ -305,53 +264,16 @@ Function un.RemoveFromPath
   Push $6
 
   IntFmt $6 "%c" 26 # DOS EOF
+  unDoTrim:
+    StrCmp $1 "" unRemoveFromPath_done
+      Push $1
+      Call Trim
+      Pop $1
 
-  Call un.IsNT
-  Pop $1
-  StrCmp $1 1 unRemoveFromPath_NT
-    ; Not on NT
-    StrCpy $1 $WINDIR 2
-    FileOpen $1 "$1\autoexec.bat" r
-    GetTempFileName $4
-    FileOpen $2 $4 w
-    GetFullPathName /SHORT $0 $0
-    StrCpy $0 "SET PATH=%PATH%;$0"
-    Goto unRemoveFromPath_dosLoop
+    StrCpy $5 $1 1 -1 ; copy last char
+    StrCmp $5 ";" +2 ; if last char != ;
+      StrCpy $1 "$1;" ; append ;
 
-    unRemoveFromPath_dosLoop:
-      FileRead $1 $3
-      StrCpy $5 $3 1 -1 # read last char
-      StrCmp $5 $6 0 +2 # if DOS EOF
-        StrCpy $3 $3 -1 # remove DOS EOF so we can compare
-      StrCmp $3 "$0$\r$\n" unRemoveFromPath_dosLoopRemoveLine
-      StrCmp $3 "$0$\n" unRemoveFromPath_dosLoopRemoveLine
-      StrCmp $3 "$0" unRemoveFromPath_dosLoopRemoveLine
-      StrCmp $3 "" unRemoveFromPath_dosLoopEnd
-      FileWrite $2 $3
-      Goto unRemoveFromPath_dosLoop
-      unRemoveFromPath_dosLoopRemoveLine:
-        SetRebootFlag true
-        Goto unRemoveFromPath_dosLoop
-
-    unRemoveFromPath_dosLoopEnd:
-      FileClose $2
-      FileClose $1
-      StrCpy $1 $WINDIR 2
-      Delete "$1\autoexec.bat"
-      CopyFiles /SILENT $4 "$1\autoexec.bat"
-      Delete $4
-      Goto unRemoveFromPath_done
-
-  unRemoveFromPath_NT:
-    StrCmp $ADD_TO_PATH_ALL_USERS "1" unReadAllKey
-      ReadRegStr $1 ${NT_current_env} "PATH"
-      Goto unDoTrim
-    unReadAllKey:
-      ReadRegStr $1 ${NT_all_env} "PATH"
-    unDoTrim:
-    StrCpy $5 $1 1 -1 # copy last char
-    StrCmp $5 ";" +2 # if last char != ;
-      StrCpy $1 "$1;" # append ;
     Push $1
     Push "$0;"
     Call un.StrStr ; Find `$0;` in $1
@@ -395,39 +317,6 @@ FunctionEnd
 ###########################################
 #            Utility Functions            #
 ###########################################
-
-;====================================================
-; IsNT - Returns 1 if the current system is NT, 0
-;        otherwise.
-;     Output: head of the stack
-;====================================================
-; IsNT
-; no input
-; output, top of the stack = 1 if NT or 0 if not
-;
-; Usage:
-;   Call IsNT
-;   Pop $R0
-;  ($R0 at this point is 1 or 0)
-
-!macro IsNT un
-Function ${un}IsNT
-  Push $0
-  ReadRegStr $0 HKLM "SOFTWARE\Microsoft\Windows NT\CurrentVersion" CurrentVersion
-  StrCmp $0 "" 0 IsNT_yes
-  ; we are not NT.
-  Pop $0
-  Push 0
-  Return
-
-  IsNT_yes:
-    ; NT!!!
-    Pop $0
-    Push 1
-FunctionEnd
-!macroend
-!insertmacro IsNT ""
-!insertmacro IsNT "un."
 
 ; StrStr
 ; input, top of stack = string to search for


### PR DESCRIPTION
Removes everything which exists only for DOS/9x/early NT compatibility. This is all pre-Windows XP stuff that doesn't get called up anymore being removed. 

If there is a DOS method as well as an NT method, and we still use the NT method, it's kept and modernized as needed.

The following commits are folded in with this PR to not cause merge conflicts:


 - The migration of Trim from a function to a macro so it can be called with the uninstaller prefix exists to resolve #1404.
 - The commit **_NSIS: remove legacy user/admin detection_** exists to remove code paths which never execute because we will always generate an installer which requires Admin rights to launch. The methods used are no longer reliable in modern Windows regardless.
- The commit to use a 64-bit registry view is also here to ensure that we know which registry we're writing to; otherwise, there may be issues with registry values getting redirected/lost via WoW64.