### PR TITLE
Various NSIS formatting / typo fixes

### DIFF
--- a/CMake/Modules/NSIS.template.in
+++ b/CMake/Modules/NSIS.template.in
@@ -213,7 +213,7 @@ Function AddToPath
   Push $2
   Push $3
 
-  # don't add if the path doesn't exist
+  ; don't add if the path doesn't exist
   IfFileExists "$0\*.*" "" AddToPath_done
 
   ReadEnvStr $1 PATH
@@ -358,17 +358,17 @@ Function un.RemoveFromPath
     Pop $2 ; pos of our dir
     StrCmp $2 "" unRemoveFromPath_done
       ; else, it is in path
-      # $0 - path to add
-      # $1 - path var
+      ; $0 - path to add
+      ; $1 - path var
       StrLen $3 "$0;"
       StrLen $4 $2
-      StrCpy $5 $1 -$4 # $5 is now the part before the path to remove
-      StrCpy $6 $2 "" $3 # $6 is now the part after the path to remove
+      StrCpy $5 $1 -$4 ; $5 is now the part before the path to remove
+      StrCpy $6 $2 "" $3 ; $6 is now the part after the path to remove
       StrCpy $3 $5$6
 
-      StrCpy $5 $3 1 -1 # copy last char
-      StrCmp $5 ";" 0 +2 # if last char == ;
-        StrCpy $3 $3 -1 # remove last char
+      StrCpy $5 $3 1 -1 ; copy last char
+      StrCmp $5 ";" 0 +2 ; if last char == ;
+        StrCpy $3 $3 -1 ; remove last char
 
       StrCmp $ADD_TO_PATH_ALL_USERS "1" unWriteAllKey
         WriteRegExpandStr ${NT_current_env} "PATH" $3

--- a/CMake/Modules/NSIS.template.in
+++ b/CMake/Modules/NSIS.template.in
@@ -376,7 +376,7 @@ Function un.RemoveFromPath
       unWriteAllKey:
         WriteRegExpandStr ${NT_all_env} "PATH" $3
       unDoSend:
-      SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+        SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
 
   unRemoveFromPath_done:
     Pop $6

--- a/CMake/Modules/NSIS.template.in
+++ b/CMake/Modules/NSIS.template.in
@@ -389,7 +389,7 @@ Function un.RemoveFromPath
 FunctionEnd
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Uninstall sutff
+; Uninstall stuff
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ###########################################
@@ -493,15 +493,15 @@ Done:
 	Exch $R1
 FunctionEnd
 
-Function ConditionalAddToRegisty
+Function ConditionalAddToRegistry
   Pop $0
   Pop $1
-  StrCmp "$0" "" ConditionalAddToRegisty_EmptyString
+  StrCmp "$0" "" ConditionalAddToRegistry_EmptyString
     WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\@CPACK_PACKAGE_INSTALL_REGISTRY_KEY@" \
     "$1" "$0"
     ;MessageBox MB_OK "Set Registry: '$1' to '$0'"
     DetailPrint "Set install registry entry: '$1' to '$0'"
-  ConditionalAddToRegisty_EmptyString:
+  ConditionalAddToRegistry_EmptyString:
 FunctionEnd
 
 ;--------------------------------
@@ -677,44 +677,44 @@ Section "-Core installation"
   WriteUninstaller "$INSTDIR\@CPACK_NSIS_UNINSTALL_NAME@.exe"
   Push "DisplayName"
   Push "@CPACK_NSIS_DISPLAY_NAME@"
-  Call ConditionalAddToRegisty
+  Call ConditionalAddToRegistry
   Push "DisplayVersion"
   Push "@CPACK_PACKAGE_VERSION@"
-  Call ConditionalAddToRegisty
+  Call ConditionalAddToRegistry
   Push "Publisher"
   Push "@CPACK_PACKAGE_VENDOR@"
-  Call ConditionalAddToRegisty
+  Call ConditionalAddToRegistry
   Push "UninstallString"
   Push "$\"$INSTDIR\@CPACK_NSIS_UNINSTALL_NAME@.exe$\""
-  Call ConditionalAddToRegisty
+  Call ConditionalAddToRegistry
   Push "NoRepair"
   Push "1"
-  Call ConditionalAddToRegisty
+  Call ConditionalAddToRegistry
 
   !ifdef CPACK_NSIS_ADD_REMOVE
   ;Create add/remove functionality
   Push "ModifyPath"
   Push "$INSTDIR\AddRemove.exe"
-  Call ConditionalAddToRegisty
+  Call ConditionalAddToRegistry
   !else
   Push "NoModify"
   Push "1"
-  Call ConditionalAddToRegisty
+  Call ConditionalAddToRegistry
   !endif
 
   ; Optional registration
   Push "DisplayIcon"
   Push "$INSTDIR\@CPACK_NSIS_INSTALLED_ICON_NAME@"
-  Call ConditionalAddToRegisty
+  Call ConditionalAddToRegistry
   Push "HelpLink"
   Push "@CPACK_NSIS_HELP_LINK@"
-  Call ConditionalAddToRegisty
+  Call ConditionalAddToRegistry
   Push "URLInfoAbout"
   Push "@CPACK_NSIS_URL_INFO_ABOUT@"
-  Call ConditionalAddToRegisty
+  Call ConditionalAddToRegistry
   Push "Contact"
   Push "@CPACK_NSIS_CONTACT@"
-  Call ConditionalAddToRegisty
+  Call ConditionalAddToRegistry
   
   ; Associate SMZIP files. (Yes, we still use them it seems)
   WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\smzipfile" "" "SMZIP package"
@@ -739,19 +739,19 @@ Section "-Core installation"
   ; Write special uninstall registry entries
   Push "StartMenu"
   Push "$STARTMENU_FOLDER"
-  Call ConditionalAddToRegisty
+  Call ConditionalAddToRegistry
   Push "DoNotAddToPath"
   Push "$DO_NOT_ADD_TO_PATH"
-  Call ConditionalAddToRegisty
+  Call ConditionalAddToRegistry
   Push "AddToPathAllUsers"
   Push "$ADD_TO_PATH_ALL_USERS"
-  Call ConditionalAddToRegisty
+  Call ConditionalAddToRegistry
   Push "AddToPathCurrentUser"
   Push "$ADD_TO_PATH_CURRENT_USER"
-  Call ConditionalAddToRegisty
+  Call ConditionalAddToRegistry
   Push "InstallToDesktop"
   Push "$INSTALL_DESKTOP"
-  Call ConditionalAddToRegisty
+  Call ConditionalAddToRegistry
 
   !insertmacro MUI_STARTMENU_WRITE_END
 
@@ -899,7 +899,7 @@ Section "Uninstall"
     StrCmp "$MUI_TEMP" "$SMPROGRAMS" startMenuDeleteLoopDone startMenuDeleteLoop
   startMenuDeleteLoopDone:
 
-  ; If the user changed the shortcut, then untinstall may not work. This should
+  ; If the user changed the shortcut, then uninstall may not work. This should
   ; try to fix it.
   StrCpy $MUI_TEMP "$START_MENU"
   Delete "$SMPROGRAMS\$MUI_TEMP\Uninstall.lnk"
@@ -921,7 +921,7 @@ Section "Uninstall"
   DeleteRegKey /ifempty SHCTX "Software\@CPACK_PACKAGE_VENDOR@\@CPACK_PACKAGE_INSTALL_REGISTRY_KEY@"
 
   Push $INSTDIR\bin
-  StrCmp $DO_NOT_ADD_TO_PATH_ "1" doNotRemoveFromPath 0
+  StrCmp $DO_NOT_ADD_TO_PATH "1" doNotRemoveFromPath 0
     Call un.RemoveFromPath
   doNotRemoveFromPath:
 SectionEnd


### PR DESCRIPTION
The template uses a mix of `#` and `;` to indicate comments. We're supposed to use `;` in NSIS so be consistent with that.

Many mis-spelled words were corrected.

Some variable references containing an extra `_` had that extra underscore removed.

Lastly, fixed indentation on line 379.