### PR TITLE
NSIS: fix a mis-written function

### DIFF
--- a/CMake/Modules/NSIS.template.in
+++ b/CMake/Modules/NSIS.template.in
@@ -819,7 +819,7 @@ Section -FinishComponents
 
   ; Strip off the last 13 characters, to see if we have AddRemove.exe
   StrLen $R1 $R0
-  IntOp $R1 $R0 - 13
+  IntOp $R1 $R1 - 13
   StrCpy $R2 $R0 13 $R1
   StrCmp $R2 "AddRemove.exe" addremove_installed
 


### PR DESCRIPTION
It seems like the author's intention was to compute the path length, subtract 13, and then evaluate the last 13 characters of the string  to compare with AddRemove.exe. It seems like we would operate on $R1 since we just got that value, but we operate on $R0 (the path string itself) instead, so we may not get the correct result.  We need to change it to $R1, which provides the path length.