### PR TITLE
NSIS (UX): simplify uninstall-before-updating prompt

### DIFF
--- a/CMake/Modules/NSIS.template.in
+++ b/CMake/Modules/NSIS.template.in
@@ -942,10 +942,12 @@ Function .onInit
   ReadRegStr $0 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\@CPACK_PACKAGE_INSTALL_REGISTRY_KEY@" "UninstallString"
   StrCmp $0 "" inst
 
-  MessageBox MB_YESNOCANCEL|MB_ICONEXCLAMATION \
-  "@CPACK_PACKAGE_NAME@ is already installed. $\n$\nDo you want to uninstall the existing version before installing this one?" \
-  /SD IDYES IDYES uninst IDNO inst
-  Abort
+  MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
+    "We found an existing @CPACK_PACKAGE_NAME@ installation. $\n$\nWould you like to continue with upgrading? $\n$\nYour user data and content will be safe through the upgrade process." \
+    /SD IDOK IDOK inst IDCANCEL cancel_install
+
+  cancel_install:
+    Abort
 
 ;Run the uninstaller
 uninst:


### PR DESCRIPTION
If someone runs the ITGmania Windows installer and already has the game installed, it asks them if they want to uninstall first, with "yes" / "no" / "cancel" as options.


However the "Yes" option in that uninstall prompt does not call up the same logic as `Uninstall.exe` and tends to fail.


Recommend simplifying this prompt and removing the failure point.


Resolves #1180 also.