### PR TITLE
NSIS: remove SMZIP registry keys

### DIFF
--- a/CMake/Modules/NSIS.template.in
+++ b/CMake/Modules/NSIS.template.in
@@ -716,12 +716,6 @@ Section "-Core installation"
   Push "@CPACK_NSIS_CONTACT@"
   Call ConditionalAddToRegisty
   
-  ; Associate SMZIP files. (Yes, we still use them it seems)
-  WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\smzipfile" "" "SMZIP package"
-  WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\smzipfile\DefaultIcon" "" "$INSTDIR\Program\ITGmania.exe,1"
-  WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\smzipfile\shell\open\command" "" '"$INSTDIR\Program\ITGmania.exe" "%1"'
-  WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\.smzip" "" "smzipfile"
-  
   !insertmacro MUI_INSTALLOPTIONS_READ $INSTALL_DESKTOP "NSIS.InstallOptions.ini" "Field 5" "State"
   !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
 


### PR DESCRIPTION
The installer writes registry keys for association with the SMZIP format, but if we don't support SMZIP anymore, we shouldn't make this association.