### PR TITLE
Remove WITH_LOGGING_TIMING_DATA option

### DIFF
--- a/CMake/DefineOptions.cmake
+++ b/CMake/DefineOptions.cmake
@@ -39,10 +39,6 @@ option(
   "Build without the ROLC assembly instructions for tomcrypt."
   OFF)
 
-# Turn this option on to log every segment added or removed.
-option(WITH_LOGGING_TIMING_DATA
-       "Build with logging all Add and Erase Segment calls." OFF)
-
 if(MSVC)
   # Turn this option on to enable using the Texture Font Generator.
   option(

--- a/src/TimingData.cpp
+++ b/src/TimingData.cpp
@@ -459,11 +459,6 @@ TimingSegment* TimingData::GetSegmentAtRow(
 
 static void EraseSegment(
     std::vector<TimingSegment*>& vSegs, int index, TimingSegment* cur) {
-#ifdef WITH_LOGGING_TIMING_DATA
-  LOG->Trace("EraseSegment(%d, %p)", index, cur);
-  cur->DebugPrint();
-#endif
-
   vSegs.erase(vSegs.begin() + index);
   RageUtil::SafeDelete(cur);
 }
@@ -471,11 +466,6 @@ static void EraseSegment(
 // NOTE: the pointer we're passed is a reference to a temporary,
 // so we must deep-copy it (with ::Copy) for new allocations.
 void TimingData::AddSegment(const TimingSegment* seg) {
-#ifdef WITH_LOGGING_TIMING_DATA
-  LOG->Trace(
-      "AddSegment( %s )", TimingSegmentTypeToString(seg->GetType()).c_str());
-  seg->DebugPrint();
-#endif
   InvalidateLookups();
 
   TimingSegmentType tst = seg->GetType();
@@ -573,9 +563,6 @@ void TimingData::AddSegment(const TimingSegment* seg) {
 
   // the segment at or before this row is equal to the new one; ignore it
   if (bOnSameRow && (*cur) == (*seg)) {
-#ifdef WITH_LOGGING_TIMING_DATA
-    LOG->Trace("equals previous segment, ignoring");
-#endif
     return;
   }
 

--- a/src/config.hpp.in
+++ b/src/config.hpp.in
@@ -3,9 +3,6 @@
 
 /* Auto-generated config.h file powered by cmake. */
 
-/* Defined to 1 if logging timing segment additions and removals. */
-#cmakedefine WITH_LOGGING_TIMING_DATA 1
-
 
 /* Ensure we have a function that acts like a size limited sprintf. */
 #if defined(_WIN32)


### PR DESCRIPTION
Added in 166e4c8287537fddba25fedfdeada2924db77c92 in 2015, I really doubt anyone is using this.