### PR TITLE
Use `unordered_map` for ImageCache

### DIFF
--- a/src/ImageCache.cpp
+++ b/src/ImageCache.cpp
@@ -4,8 +4,8 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "CommonMetrics.h"
@@ -75,7 +75,7 @@ static const int IMAGE_CACHE_VERSION = 1;
 
 ImageCache* IMAGECACHE;  // global and accessible from anywhere in our program
 
-static std::map<std::string, RageSurface*> g_ImagePathToImage;
+static std::unordered_map<std::string, RageSurface*> g_ImagePathToImage;
 static int g_iDemandRefcount = 0;
 
 /* Synchronizes access to g_ImagePathToImage and ImageCache::ImageData. */


### PR DESCRIPTION
Using an unordered_map here rather than a standard map incurs a cost of 0.46x-0.6x compared to the existing implementation in my testing. The standard map had a maximum recorded access time of 26 microseconds, with a 1300 song library, compared to unordered_map which never exceeds 4 microseconds.

I assume this was only not already using unordered_map due to being written for an older C++ standard, since map really hurts on larger song libraries for this purpose.