### PR TITLE
add fallback stdout LoadingWindow impl for Unix builds

### DIFF
--- a/src/CMakeData-arch.cmake
+++ b/src/CMakeData-arch.cmake
@@ -170,6 +170,10 @@ else()
                 "arch/LoadingWindow/LoadingWindow_MacOSX.h")
   elseif(LINUX)
     include(CMakeData-gtk.cmake)
+    list(APPEND SMDATA_ARCH_LOADING_SRC
+          "arch/LoadingWindow/LoadingWindow_stdio.cpp")
+    list(APPEND SMDATA_ARCH_LOADING_HPP
+          "arch/LoadingWindow/LoadingWindow_stdio.h")
   endif()
 endif()
 

--- a/src/arch/LoadingWindow/LoadingWindow.cpp
+++ b/src/arch/LoadingWindow/LoadingWindow.cpp
@@ -8,6 +8,11 @@
 #include "RageUtil.h"
 #include "StdString.h"
 #include "arch/LoadingWindow/LoadingWindow_Null.h"
+
+#if defined(UNIX)
+#include "arch/LoadingWindow/LoadingWindow_stdio.h"
+#endif
+
 #include "arch/arch_default.h"
 #include "global.h"
 
@@ -19,7 +24,7 @@ LoadingWindow* LoadingWindow::Create() {
     return new LoadingWindow_Null;
   }
 #if defined(UNIX) && !defined(HAVE_GTK)
-  return new LoadingWindow_Null;
+  return new LoadingWindow_stdio;
 #endif
   // Don't load nullptr by default.
   const std::string drivers = "win32,macosx,gtk";

--- a/src/arch/LoadingWindow/LoadingWindow_stdio.cpp
+++ b/src/arch/LoadingWindow/LoadingWindow_stdio.cpp
@@ -1,0 +1,28 @@
+#include "LoadingWindow_stdio.h"
+
+#include <iostream>
+#include <string>
+
+std::string LoadingWindow_stdio::Init() {
+  std::cout << "[Loading Songs] Progress: 0%" << std::endl;
+  return "";
+}
+
+void LoadingWindow_stdio::SetText(std::string str) {}
+
+void LoadingWindow_stdio::SetProgress(const int progress) {
+  LoadingWindow::SetProgress(progress);
+
+  if (m_totalWork > 0) {
+    int pct = static_cast<int>((m_progress * 100.0) / m_totalWork);
+    std::cout << "[Loading Songs] Progress: " << pct << "%" << std::endl;
+  }
+}
+
+void LoadingWindow_stdio::SetTotalWork(const int totalWork) {
+  LoadingWindow::SetTotalWork(totalWork);
+}
+
+void LoadingWindow_stdio::SetIndeterminate(bool indeterminate) {
+  LoadingWindow::SetIndeterminate(indeterminate);
+}

--- a/src/arch/LoadingWindow/LoadingWindow_stdio.h
+++ b/src/arch/LoadingWindow/LoadingWindow_stdio.h
@@ -1,0 +1,30 @@
+// Writes the song loading progress to standard output.
+
+#ifndef LOADING_WINDOW_STDIO_H
+#define LOADING_WINDOW_STDIO_H
+
+#include <iostream>
+#include <string>
+
+#include "LoadingWindow.h"
+#include "RageSurface.h"
+
+class LoadingWindow_stdio : public LoadingWindow {
+ public:
+  LoadingWindow_stdio() {}
+  ~LoadingWindow_stdio() override {}
+
+  std::string Init() override;
+  void SetText(std::string str) override;
+
+  void SetProgress(const int progress) override;
+  void SetTotalWork(const int totalWork) override;
+  void SetIndeterminate(bool indeterminate) override;
+
+  // Unused, but necessary.
+  void SetIcon(const RageSurface* pIcon) override {}
+  void SetSplash(const RageSurface* pSplash) override {}
+};
+
+#define USE_LOADING_WINDOW_STDIO
+#endif


### PR DESCRIPTION
The purpose of this is to replace LoadingWindow_Null as a fallback for Unix builds with something that can provide usable info. I have added a fake LoadingWindow which has no GUI and simply redirects the progress status to stdout via iostream. It will occasionally write out the status as percentages. Requires building with `-DWITH_GTK3=OFF` to enable this code path.

Only lists the percentage to avoid excess console spam. I experimented pushing occasional song name or status indeterminate updates but thought it looked awkward in the stdout log,
