### PR TITLE
Build Texture Font Generator as part of Windows CI

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -89,6 +89,7 @@ runs:
     - name: Set CMake environment variables (Windows)
       if: runner.os == 'Windows'
       run: |
+        echo "CMAKE_FLAGS=-DWITH_TEXTURE_GENERATOR=ON" >> $GITHUB_ENV
         echo "CMAKE_BUILD_FLAGS=--parallel $env:NUMBER_OF_PROCESSORS" >> $env:GITHUB_ENV
         echo "ARTIFACT_PATH=build/ITGmania-*.exe" >> $env:GITHUB_ENV
       shell: pwsh


### PR DESCRIPTION
This is part of the Windows full release, but isn't built as any part of the Windows test or nightly builds, so build failures can go undetected as-is. This commit adds the flag to also build Texture Font Generator to the Windows CI so these failures get caught early.