### PR TITLE
Revert "Revert symbol changes to RageFileManager_ReadAhead"

### DIFF
--- a/src/RageFileManager_ReadAhead.cpp
+++ b/src/RageFileManager_ReadAhead.cpp
@@ -2,6 +2,7 @@
 
 #include <fcntl.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 #include <cerrno>
 #include <cstddef>
@@ -11,7 +12,7 @@
 #include <io.h>
 #endif
 
-#if defined(HAVE_POSIX_FADVISE)
+#if defined(__linux__)
 
 void RageFileManagerReadAhead::Init() {}
 void RageFileManagerReadAhead::Shutdown() {}
@@ -157,7 +158,7 @@ void RageFileManagerReadAhead::DiscardCache(
 #endif
 
 void RageFileManagerReadAhead::CacheHintStreaming(RageFileBasic* pFile) {
-#if defined(HAVE_POSIX_FADVISE)
+#if defined(__linux__)
   /* This guesses at the actual size of the file on disk, which may be smaller
    * if this file is compressed. Since this is usually used on music and video
    * files, it generally shouldn't be. */


### PR DESCRIPTION
This reverts commit edb45aec402189f5d1cd02a10cb92e3d6a3e3042.

Was missing an include.