### PR TITLE
Move unistd.h include into #ifdef __linux__

### DIFF
--- a/src/RageFileManager_ReadAhead.cpp
+++ b/src/RageFileManager_ReadAhead.cpp
@@ -2,7 +2,6 @@
 
 #include <fcntl.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 #include <cerrno>
 #include <cstddef>
@@ -13,6 +12,8 @@
 #endif
 
 #if defined(__linux__)
+
+#include <unistd.h>
 
 void RageFileManagerReadAhead::Init() {}
 void RageFileManagerReadAhead::Shutdown() {}


### PR DESCRIPTION
Fixes #1425 breaking the windows build.