### PR TITLE
Couple and routine per-player tech counts and column cues

### DIFF
--- a/src/ColumnCues.cpp
+++ b/src/ColumnCues.cpp
@@ -2,11 +2,14 @@
 
 #include <vector>
 
+#include "GameConstantsAndTypes.h"
 #include "GameState.h"
 #include "NoteData.h"
+#include "NoteDataUtil.h"
 #include "NoteTypes.h"
 
-void ColumnCue::CalculateColumnCues(
+namespace {
+void CalculateColumnCuesOnePlayer(
     const NoteData& in, TimingData* timing, std::vector<ColumnCue>& out,
     float minDuration) {
   NoteData::all_tracks_const_iterator curr_note =
@@ -14,7 +17,7 @@ void ColumnCue::CalculateColumnCues(
   int curr_row = -1;
 
   std::vector<ColumnCue> allColumnCues;
-  ColumnCue currentCue = ColumnCue();
+  ColumnCue currentCue;
 
   while (!curr_note.IsAtEnd()) {
     if (curr_note.Row() != curr_row) {
@@ -31,8 +34,7 @@ void ColumnCue::CalculateColumnCues(
         curr_note->type == TapNoteType_HoldHead ||
         curr_note->type == TapNoteType_Mine ||
         curr_note->type == TapNoteType_Lift) {
-      currentCue.columns.push_back(
-          ColumnCueColumn(curr_note.Track() + 1, curr_note->type));
+      currentCue.columns.emplace_back(curr_note.Track() + 1, curr_note->type);
     }
 
     ++curr_note;
@@ -44,16 +46,25 @@ void ColumnCue::CalculateColumnCues(
   }
 
   float previousCueTime = 0;
-  std::vector<ColumnCue> columnCues;
+  out.clear();
   for (ColumnCue columnCue : allColumnCues) {
     float duration = columnCue.startTime - previousCueTime;
     if (duration > minDuration || previousCueTime == 0) {
-      columnCues.push_back(
-          ColumnCue(previousCueTime, duration, columnCue.columns));
+      out.emplace_back(previousCueTime, duration, columnCue.columns);
     }
     previousCueTime = columnCue.startTime;
   }
+}
+}  // namespace
 
-  out.clear();
-  out.assign(columnCues.begin(), columnCues.end());
+void ColumnCue::CalculateColumnCues(
+    const NoteData& in, TimingData* timing, std::vector<ColumnCue>& out,
+    PlayerNumber pn, float minDuration, StepsType stepsType) {
+  std::vector<NoteData> splitNoteData;
+  if (NoteDataUtil::SplitCompositeOrStackedNoteData(
+          in, splitNoteData, stepsType)) {
+    CalculateColumnCuesOnePlayer(splitNoteData[pn], timing, out, minDuration);
+  } else {
+    CalculateColumnCuesOnePlayer(in, timing, out, minDuration);
+  }
 }

--- a/src/ColumnCues.h
+++ b/src/ColumnCues.h
@@ -5,6 +5,7 @@
 
 #include "NoteData.h"
 #include "NoteTypes.h"
+#include "PlayerNumber.h"
 #include "TimingData.h"
 
 /* ColumnCues are used to indicate to the player which column the next note will
@@ -45,7 +46,7 @@ struct ColumnCue {
    */
   static void CalculateColumnCues(
       const NoteData& in, TimingData* timing, std::vector<ColumnCue>& out,
-      float minDuration);
+      PlayerNumber pn, float minDuration, StepsType stepsType);
 };
 
 #endif

--- a/src/NoteDataUtil.cpp
+++ b/src/NoteDataUtil.cpp
@@ -14,6 +14,7 @@
 #include "Attack.h"
 #include "EnumHelper.h"
 #include "GameConstantsAndTypes.h"
+#include "GameManager.h"
 #include "GameState.h"
 #include "NoteData.h"
 #include "NoteTypes.h"
@@ -484,6 +485,28 @@ void NoteDataUtil::GetSMNoteDataString(
         sRet.append(1, '\n');
       }
     }
+  }
+}
+
+bool NoteDataUtil::SplitCompositeOrStackedNoteData(
+    const NoteData& in, std::vector<NoteData>& out, StepsType stepsType) {
+  if (in.IsComposite()) {
+    SplitCompositeNoteData(in, out);
+    return true;
+  } else if (
+      GAMEMAN->GetStepsTypeInfo(stepsType).m_StepsTypeCategory ==
+      StepsTypeCategory::StepsTypeCategory_Couple) {
+    // XXX: Assumption that couple will always have an even number of notes.
+    const int tracks = in.GetNumTracks() / 2;
+    out.resize(2);
+    out[PLAYER_1] = in;
+    out[PLAYER_1].SetNumTracks(tracks);
+    out[PLAYER_2] = in;
+    NoteDataUtil::ShiftTracks(out[PLAYER_2], tracks);
+    out[PLAYER_2].SetNumTracks(tracks);
+    return true;
+  } else {
+    return false;
   }
 }
 

--- a/src/NoteDataUtil.h
+++ b/src/NoteDataUtil.h
@@ -35,6 +35,14 @@ void LoadFromSMNoteDataString(
 void GetSMNoteDataString(
     const NoteData& in, std::string& notes_out, bool bIncludeMeasureComments);
 void SplitCompositeNoteData(const NoteData& in, std::vector<NoteData>& out);
+/**
+ * @brief Similar to SplitCompositeNoteData, but will also separate couple note
+ * data.
+ *
+ * @return true if the NoteData was split, otherwise false.
+ */
+bool SplitCompositeOrStackedNoteData(
+    const NoteData& in, std::vector<NoteData>& out, StepsType stepsType);
 void CombineCompositeNoteData(NoteData& out, const std::vector<NoteData>& in);
 /**
  * @brief Autogenerate notes from one type to another.

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -933,15 +933,14 @@ std::string Steps::GenerateChartKey(NoteData& nd, TimingData* td) {
   return o;
 }
 
-std::vector<ColumnCue> Steps::GetColumnCues(float minDuration) {
-  // TODO: Should we worry about getting the right steps per player?
-  // It seems like this is only necessary when dealing with Couples charts
-
+std::vector<ColumnCue> Steps::GetColumnCues(
+    PlayerNumber pn, float minDuration) {
   std::vector<ColumnCue> cues;
   NoteData noteData;
   this->GetNoteData(noteData);
   TimingData* timing = this->GetTimingData();
-  ColumnCue::CalculateColumnCues(noteData, timing, cues, minDuration);
+  ColumnCue::CalculateColumnCues(
+      noteData, timing, cues, pn, minDuration, m_StepsType);
   return cues;
 }
 
@@ -1163,7 +1162,11 @@ class LunaSteps : public Luna<Steps> {
     if (lua_isnumber(L, 1)) {
       minDuration = lua_tonumber(L, 1);
     }
-    std::vector<ColumnCue> cues = p->GetColumnCues(minDuration);
+    PlayerNumber pn = PLAYER_1;
+    if (!lua_isnoneornil(L, 2)) {
+      pn = Enum::Check<PlayerNumber>(L, 2);
+    }
+    std::vector<ColumnCue> cues = p->GetColumnCues(pn, minDuration);
     lua_createtable(L, cues.size(), 0);
 
     for (unsigned i = 0; i < cues.size(); i++) {

--- a/src/Steps.cpp
+++ b/src/Steps.cpp
@@ -68,6 +68,17 @@ std::optional<StepParity::StageLayout> getLayout(StepsType ty) {
           },
           {2}, {1}, {0, 3});
 
+    case StepsType_dance_couple:
+      return StepParity::StageLayout(
+          StepsType_dance_couple,
+          {
+              {0, 1},  // Left
+              {1, 0},  // Down
+              {1, 2},  // Up
+              {2, 1}   // Right
+          },
+          {2}, {1}, {0, 3});
+
     case StepsType_dance_double:
       return StepParity::StageLayout(
           StepsType_dance_double,
@@ -83,6 +94,23 @@ std::optional<StepParity::StageLayout> getLayout(StepsType ty) {
               {5, 1}   // P2 Right
           },
           {2, 6}, {1, 5}, {0, 3, 4, 7});
+
+    case StepsType_dance_routine:
+      return StepParity::StageLayout(
+          StepsType_dance_routine,
+          {
+              {0, 1},  // P1 Left
+              {1, 0},  // P1 Down
+              {1, 2},  // P1 Up
+              {2, 1},  // P1 Right
+
+              {3, 1},  // P2 Left
+              {4, 0},  // P2 Down
+              {4, 2},  // P2 Up
+              {5, 1}   // P2 Right
+          },
+          {2, 6}, {1, 5}, {0, 3, 4, 7});
+
     default:
       return std::nullopt;
   }
@@ -349,29 +377,14 @@ void Steps::CalculateRadarValues(
   FOREACH_PlayerNumber(pn) m_RadarValues[pn].Zero();
 
   TimingData* timing = this->GetTimingData();
-  if (tempNoteData.IsComposite()) {
-    std::vector<NoteData> vParts;
 
-    NoteDataUtil::SplitCompositeNoteData(tempNoteData, vParts);
-    for (size_t pn = 0; pn < std::min(vParts.size(), size_t(NUM_PLAYERS));
-         ++pn) {
+  std::vector<NoteData> splitNoteData;
+  if (NoteDataUtil::SplitCompositeOrStackedNoteData(
+          tempNoteData, splitNoteData, m_StepsType)) {
+    FOREACH_PlayerNumber(pn) {
       NoteDataUtil::CalculateRadarValues(
-          vParts[pn], fMusicLengthSeconds, timing, m_RadarValues[pn]);
+          splitNoteData[pn], fMusicLengthSeconds, timing, m_RadarValues[pn]);
     }
-  } else if (
-      GAMEMAN->GetStepsTypeInfo(this->m_StepsType).m_StepsTypeCategory ==
-      StepsTypeCategory_Couple) {
-    NoteData p1 = tempNoteData;
-    // XXX: Assumption that couple will always have an even number of notes.
-    const int tracks = tempNoteData.GetNumTracks() / 2;
-    p1.SetNumTracks(tracks);
-    NoteDataUtil::CalculateRadarValues(
-        p1, fMusicLengthSeconds, timing, m_RadarValues[PLAYER_1]);
-    NoteData p2 = tempNoteData;
-    NoteDataUtil::ShiftTracks(p2, tracks);
-    p2.SetNumTracks(tracks);
-    NoteDataUtil::CalculateRadarValues(
-        p2, fMusicLengthSeconds, timing, m_RadarValues[PLAYER_2]);
   } else {
     NoteDataUtil::CalculateRadarValues(
         tempNoteData, fMusicLengthSeconds, timing, m_RadarValues[0]);
@@ -394,19 +407,37 @@ void Steps::CalculateTechCounts(const NoteData& tempNoteData) {
     return;
   }
   TimingData* timing = this->GetTimingData();
-  StepParity::StepParityGenerator gen =
-      StepParity::StepParityGenerator(&*layout, timing);
-  gen.analyzeNoteData(tempNoteData);
 
-  std::vector<NoteAnnotation> tempNoteAnnotations;
-  TechCounts::CalculateTechCountsFromRows(
-      gen.rows, &*layout, m_TechCounts[0], tempNoteAnnotations);
-  std::fill_n(m_TechCounts + 1, NUM_PLAYERS - 1, m_TechCounts[0]);
+  std::vector<NoteData> splitNoteData;
+  if (NoteDataUtil::SplitCompositeOrStackedNoteData(
+          tempNoteData, splitNoteData, m_StepsType)) {
+    FOREACH_PlayerNumber(pn) {
+      StepParity::StepParityGenerator gen{&*layout, timing};
+      gen.analyzeNoteData(splitNoteData[pn]);
 
-  NoteAnnotationCache cachedAnnotations;
-  cachedAnnotations.decompressed = tempNoteAnnotations;
-  cachedAnnotations.Compress();
-  m_NoteAnnotations.push_back(cachedAnnotations);
+      std::vector<NoteAnnotation> tempNoteAnnotations;
+      TechCounts::CalculateTechCountsFromRows(
+          gen.rows, &*layout, m_TechCounts[pn], tempNoteAnnotations);
+
+      NoteAnnotationCache cachedAnnotations;
+      cachedAnnotations.decompressed = tempNoteAnnotations;
+      cachedAnnotations.Compress();
+      m_NoteAnnotations.push_back(cachedAnnotations);
+    }
+  } else {
+    StepParity::StepParityGenerator gen{&*layout, timing};
+    gen.analyzeNoteData(tempNoteData);
+
+    std::vector<NoteAnnotation> tempNoteAnnotations;
+    TechCounts::CalculateTechCountsFromRows(
+        gen.rows, &*layout, m_TechCounts[0], tempNoteAnnotations);
+    std::fill_n(m_TechCounts + 1, NUM_PLAYERS - 1, m_TechCounts[0]);
+
+    NoteAnnotationCache cachedAnnotations;
+    cachedAnnotations.decompressed = tempNoteAnnotations;
+    cachedAnnotations.Compress();
+    m_NoteAnnotations.push_back(cachedAnnotations);
+  }
 }
 
 void Steps::CalculateMeasureInfo(const NoteData& tempNoteData) {
@@ -417,30 +448,15 @@ void Steps::CalculateMeasureInfo(const NoteData& tempNoteData) {
   std::vector<MeasureInfo> measureInfoPerPlayer;
 
   TimingData* timing = this->GetTimingData();
-  if (tempNoteData.IsComposite()) {
+
+  std::vector<NoteData> splitNoteData;
+  if (NoteDataUtil::SplitCompositeOrStackedNoteData(
+          tempNoteData, splitNoteData, m_StepsType)) {
     measureInfoPerPlayer.resize(NUM_PLAYERS);
-    std::vector<NoteData> vParts;
-    NoteDataUtil::SplitCompositeNoteData(tempNoteData, vParts);
-    for (std::size_t pn = 0;
-         pn < std::min(vParts.size(), std::size_t(NUM_PLAYERS)); ++pn) {
+    FOREACH_PlayerNumber(pn) {
       MeasureInfo::CalculateMeasureInfo(
-          vParts[pn], timing, measureInfoPerPlayer[pn]);
+          splitNoteData[pn], timing, measureInfoPerPlayer[pn]);
     }
-  } else if (
-      GAMEMAN->GetStepsTypeInfo(this->m_StepsType).m_StepsTypeCategory ==
-      StepsTypeCategory_Couple) {
-    measureInfoPerPlayer.resize(NUM_PLAYERS);
-    NoteData p1 = tempNoteData;
-    // XXX: Assumption that couple will always have an even number of notes.
-    const int tracks = tempNoteData.GetNumTracks() / 2;
-    p1.SetNumTracks(tracks);
-    MeasureInfo::CalculateMeasureInfo(
-        tempNoteData, timing, measureInfoPerPlayer[PLAYER_1]);
-    NoteData p2 = tempNoteData;
-    NoteDataUtil::ShiftTracks(p2, tracks);
-    p2.SetNumTracks(tracks);
-    MeasureInfo::CalculateMeasureInfo(
-        p2, timing, measureInfoPerPlayer[PLAYER_2]);
   } else {
     measureInfoPerPlayer.resize(1);
     MeasureInfo::CalculateMeasureInfo(
@@ -962,9 +978,8 @@ const std::vector<int>& Steps::GetNotesPerMeasure(PlayerNumber pn) const {
 
 const std::vector<NoteAnnotation>& Steps::GetNoteAnnotations(
     PlayerNumber pn) const {
-  // m_NoteAnnotations doesn't actually support couples/routine charts
-  // yet, but in the event we ever get around to implementing that, this
-  // functions the same as GetNotesPerMeasure and GetNpsPerMeasure
+  // For couples/routine charts, this functions the same as GetNotesPerMeasure
+  // and GetNpsPerMeasure.
 
   static const std::vector<NoteAnnotation> EMPTY_VECTOR;
   if (Real()->m_NoteAnnotations.size() == 0) {
@@ -1184,7 +1199,11 @@ class LunaSteps : public Luna<Steps> {
   }
 
   static int GetNoteAnnotations(T* p, lua_State* L) {
-    const std::vector<NoteAnnotation> rows = p->GetNoteAnnotations(PLAYER_1);
+    PlayerNumber pn = PLAYER_1;
+    if (!lua_isnoneornil(L, 1)) {
+      pn = Enum::Check<PlayerNumber>(L, 1);
+    }
+    const std::vector<NoteAnnotation> rows = p->GetNoteAnnotations(pn);
 
     lua_createtable(L, static_cast<int>(rows.size()), 0);
 

--- a/src/Steps.h
+++ b/src/Steps.h
@@ -287,7 +287,7 @@ class Steps {
     return join(":", this->m_sAttackString);
   }
 
-  std::vector<ColumnCue> GetColumnCues(float minDuration);
+  std::vector<ColumnCue> GetColumnCues(PlayerNumber pn, float minDuration);
 
  private:
   inline const Steps* Real() const { return parent ? parent : this; }


### PR DESCRIPTION
Column cue support will need [some theme changes](https://github.com/Simply-Love/Simply-Love-SM5/pull/761) to use the correct player number. Otherwise, P1's column cues will be shown for both players.

Before this, dance-routine had column cues only when neither player had steps. For dance-couple, the theme column cue code ran into errors because the P2's cues had column numbers 5-8 instead of 1-4.

The routine/couple notedata splitting code was duplicated in a few places. This adds the `NoteDataUtil::SplitCompositeOrStackedNoteData` function for that.