### PR TITLE
Support "show one in row" option in toggle options menu

### DIFF
--- a/src/OptionRow.cpp
+++ b/src/OptionRow.cpp
@@ -320,7 +320,17 @@ void OptionRow::InitText(RowType type) {
 
   // load m_textItems
   switch (m_pHand->m_Def.m_layoutType) {
-    case LAYOUT_SHOW_ONE_IN_ROW:
+    case LAYOUT_SHOW_ONE_IN_ROW: {
+      if (IsShowOneValueWithGoDown()) {
+        // Show a persistent ▼.
+        BitmapText* pArrow = new BitmapText(m_pParentType->m_textItem);
+        m_textItems.push_back(pArrow);
+        pArrow->PlayCommand("On");
+        pArrow->SetText(GetThemedItemText(0));
+        pArrow->SetX(
+            m_pParentType->ITEMS_START_X + pArrow->GetZoomedWidth() / 2);
+      }
+
       // init text
       FOREACH_PlayerNumber(p) {
         BitmapText* pText = new BitmapText(m_pParentType->m_textItem);
@@ -352,6 +362,7 @@ void OptionRow::InitText(RowType type) {
         }
       }
       break;
+    }
 
     case LAYOUT_SHOW_ALL_IN_ROW: {
       float fX = m_pParentType->ITEMS_START_X;
@@ -413,7 +424,8 @@ void OptionRow::AfterImportOptions(PlayerNumber pn) {
    * will be joined when we're displayed. Hide items for inactive players. */
   if (m_pHand->m_Def.m_layoutType == LAYOUT_SHOW_ONE_IN_ROW &&
       !m_pHand->m_Def.m_bOneChoiceForAllPlayers) {
-    m_textItems[pn]->SetVisible(GAMESTATE->IsHumanPlayer(pn));
+    unsigned item_no = pn + (IsShowOneValueWithGoDown() ? 1 : 0);
+    m_textItems[item_no]->SetVisible(GAMESTATE->IsHumanPlayer(pn));
   }
 
   // Hide underlines for disabled players or disabled options.
@@ -471,6 +483,11 @@ void OptionRow::PositionUnderlines(PlayerNumber pn) {
             ? GetChoiceInRowWithFocus(pn)
             : i;
 
+    if (IsShowOneValueWithGoDown() && iChoiceWithFocus == 0) {
+      int iSelected = GetOneSelection(pn, true);
+      iChoiceWithFocus = (iSelected >= 1) ? iSelected : 1;
+    }
+
     float fAlpha = 1.0f;
     if (m_pHand->m_Def.m_layoutType == LAYOUT_SHOW_ONE_IN_ROW) {
       bool bRowEnabled = m_pHand->m_Def.m_vEnabledForPlayers.find(pn) !=
@@ -522,26 +539,34 @@ void OptionRow::PositionIcons(PlayerNumber pn) {
 
 // This is called when the focus changes, to update "long row" text.
 void OptionRow::UpdateText(PlayerNumber p) {
-  switch (m_pHand->m_Def.m_layoutType) {
-    case LAYOUT_SHOW_ONE_IN_ROW: {
-      unsigned pn = m_pHand->m_Def.m_bOneChoiceForAllPlayers ? 0 : p;
-      int iChoiceWithFocus = m_iChoiceInRowWithFocus[pn];
-      if (iChoiceWithFocus == -1) {
-        break;
-      }
-
-      std::string sText = GetThemedItemText(iChoiceWithFocus);
-
-      // If player_no is 2 and there is no player 1:
-      int index = std::min(
-          static_cast<int>(pn), static_cast<int>(m_textItems.size()) - 1);
-
-      // TODO: Always have one textItem for each player
-
-      m_textItems[index]->SetText(sText);
+  if (m_pHand->m_Def.m_layoutType == LAYOUT_SHOW_ONE_IN_ROW) {
+    unsigned pn = m_pHand->m_Def.m_bOneChoiceForAllPlayers ? 0 : p;
+    int iChoiceWithFocus = m_iChoiceInRowWithFocus[pn];
+    if (iChoiceWithFocus == -1) {
+      return;
     }
-    default:
-      break;
+
+    bool bValueArrow = IsShowOneValueWithGoDown();
+    int iDisplayChoice = iChoiceWithFocus;
+
+    if (bValueArrow) {
+      // Always display the ▼.
+      m_textItems[0]->SetText(GetThemedItemText(0));
+
+      if (iChoiceWithFocus == 0) {
+        // Focus is on the ▼; show the actively-selected value instead.
+        int iSelected = GetOneSelection(p, true);
+        iDisplayChoice = (iSelected >= 1) ? iSelected : 1;
+      }
+    }
+
+    std::string sText = GetThemedItemText(iDisplayChoice);
+
+    int index = std::min(
+        static_cast<int>(pn) + (bValueArrow ? 1 : 0),
+        static_cast<int>(m_textItems.size()) - 1);
+
+    m_textItems[index]->SetText(sText);
   }
 }
 
@@ -621,13 +646,28 @@ void OptionRow::UpdateEnabledDisabled() {
       }
 
       break;
-    case LAYOUT_SHOW_ONE_IN_ROW:
+    case LAYOUT_SHOW_ONE_IN_ROW: {
+      bool bValueArrow = IsShowOneValueWithGoDown();
+
+      if (bValueArrow) {
+        // Color the ▼ with the row-level color.
+        BitmapText& arrow = *m_textItems[0];
+        if (arrow.DestTweenState().diffuse[0] != color) {
+          arrow.StopTweening();
+          arrow.BeginTweening(m_pParentType->TWEEN_SECONDS);
+          arrow.SetDiffuse(color);
+        }
+      }
+
       FOREACH_HumanPlayer(pn) {
         bRowEnabled = m_pHand->m_Def.m_vEnabledForPlayers.find(pn) !=
                       m_pHand->m_Def.m_vEnabledForPlayers.end();
 
         if (!m_pHand->m_Def.m_bOneChoiceForAllPlayers) {
-          if (m_bRowHasFocus[pn]) {
+          bool bValueFocused =
+              m_bRowHasFocus[pn] &&
+              (!bValueArrow || GetChoiceInRowWithFocus(pn) >= 1);
+          if (bValueFocused) {
             color = m_pParentType->COLOR_SELECTED;
           } else if (bRowEnabled) {
             color = m_pParentType->COLOR_NOT_SELECTED;
@@ -637,6 +677,9 @@ void OptionRow::UpdateEnabledDisabled() {
         }
 
         unsigned item_no = m_pHand->m_Def.m_bOneChoiceForAllPlayers ? 0 : pn;
+        if (bValueArrow) {
+          item_no += 1;
+        }
 
         // If player_no is 2 and there is no player 1:
         item_no = std::min<unsigned int>(item_no, m_textItems.size() - 1);
@@ -650,6 +693,7 @@ void OptionRow::UpdateEnabledDisabled() {
         }
       }
       break;
+    }
     default:
       FAIL_M(ssprintf(
           "Invalid option row layout: %i", m_pHand->m_Def.m_layoutType));
@@ -674,10 +718,17 @@ const BitmapText& OptionRow::GetTextItemForRow(
   int index = -1;
   switch (m_pHand->m_Def.m_layoutType) {
     case LAYOUT_SHOW_ONE_IN_ROW:
-      index = bOneChoice ? 0 : pn;
-      // If only P2 is enabled, his selections will be in index 0.
-      if (m_textItems.size() == 1) {
-        index = 0;
+      if (IsShowOneValueWithGoDown()) {
+        if (iChoiceOnRow == 0) {
+          index = 0;
+        } else {
+          index = bOneChoice ? 1 : pn + 1;
+        }
+      } else {
+        index = bOneChoice ? 0 : pn;
+        if (m_textItems.size() == 1) {
+          index = 0;
+        }
       }
       break;
     case LAYOUT_SHOW_ALL_IN_ROW:
@@ -821,6 +872,12 @@ bool OptionRow::NotifyHandlerOfSelection(PlayerNumber pn, int choice) {
     UpdateEnabledDisabled();
   }
   return changed;
+}
+
+bool OptionRow::IsShowOneValueWithGoDown() const {
+  return m_bFirstItemGoesDown &&
+         m_pHand->m_Def.m_layoutType == LAYOUT_SHOW_ONE_IN_ROW &&
+         m_pHand->m_Def.m_selectType == SELECT_ONE;
 }
 
 bool OptionRow::GoToFirstOnStart() { return m_pHand->GoToFirstOnStart(); }

--- a/src/OptionRow.h
+++ b/src/OptionRow.h
@@ -118,6 +118,7 @@ class OptionRow : public ActorFrame {
   // that same TweenState.
   unsigned GetTextItemsSize() const { return m_textItems.size(); }
   bool GetFirstItemGoesDown() const { return m_bFirstItemGoesDown; }
+  bool IsShowOneValueWithGoDown() const;
   bool GoToFirstOnStart();
 
   std::string GetThemedItemText(int iChoice) const;

--- a/src/ScreenOptions.cpp
+++ b/src/ScreenOptions.cpp
@@ -1006,9 +1006,8 @@ void ScreenOptions::ProcessMenuStart(const InputEventPlus& input) {
 
     if (row.GetFirstItemGoesDown() && row.GoToFirstOnStart()) {
       // move to the first choice in the row
-      ChangeValueInRowRelative(
-          m_iCurrentRow[pn], pn, -row.GetChoiceInRowWithFocus(pn),
-          input.type != IET_FIRST_PRESS);
+      ChangeValueInRowAbsolute(
+          m_iCurrentRow[pn], pn, 0, input.type != IET_FIRST_PRESS);
     }
   } else  // data.selectType != SELECT_MULTIPLE
   {
@@ -1036,9 +1035,8 @@ void ScreenOptions::ProcessMenuStart(const InputEventPlus& input) {
         }
 
         if (row.GetFirstItemGoesDown()) {
-          ChangeValueInRowRelative(
-              m_iCurrentRow[pn], pn, -row.GetChoiceInRowWithFocus(pn),
-              input.type != IET_FIRST_PRESS);  // move to the first choice
+          ChangeValueInRowAbsolute(
+              m_iCurrentRow[pn], pn, 0, input.type != IET_FIRST_PRESS);
         } else {
           ChangeValueInRowRelative(
               m_iCurrentRow[pn], pn, 0, input.type != IET_FIRST_PRESS);
@@ -1124,15 +1122,76 @@ void ScreenOptions::ChangeValueInRowAbsolute(
   const int iNumChoices = row.GetRowDef().m_vsChoices.size();
   ASSERT(iNumChoices >= 0 && iChoiceIndex < iNumChoices);
 
+  if (bRepeat && !ALLOW_REPEATING_CHANGE_VALUE_INPUT) {
+    return;
+  }
+
   int iCurrentChoiceWithFocus = row.GetChoiceInRowWithFocus(pn);
-  int iDelta = iChoiceIndex - iCurrentChoiceWithFocus;
+  bool bOneChanged = (iCurrentChoiceWithFocus != iChoiceIndex);
 
   Message msg("ChangeValue");
   msg.SetParam("PlayerNumber", pn);
   msg.SetParam("RowIndex", iRow);
   MESSAGEMAN->Broadcast(msg);
 
-  ChangeValueInRowRelative(iRow, pn, iDelta, bRepeat);
+  row.SetChoiceInRowWithFocus(pn, iChoiceIndex);
+  StoreFocus(pn);
+
+  if (row.GetRowDef().m_bOneChoiceForAllPlayers) {
+    /* If this row is bOneChoiceForAllPlayers, then lock the cursors together
+     * for this row. Don't do this in toggle modes, since the current selection
+     * and the current focus are detached. */
+    bool bForceFocusedChoiceTogether = false;
+    if (m_OptionsNavigation != NAV_TOGGLE_THREE_KEY &&
+        m_OptionsNavigation != NAV_TOGGLE_FIVE_KEY &&
+        row.GetRowDef().m_bOneChoiceForAllPlayers) {
+      bForceFocusedChoiceTogether = true;
+    }
+
+    // Also lock focus if the screen is explicitly set to share cursors.
+    if (m_InputMode == INPUTMODE_SHARE_CURSOR) {
+      bForceFocusedChoiceTogether = true;
+    }
+
+    if (bForceFocusedChoiceTogether) {
+      // lock focus together
+      FOREACH_HumanPlayer(p) {
+        row.SetChoiceInRowWithFocus(p, iChoiceIndex);
+        StoreFocus(p);
+      }
+    }
+  }
+
+  FOREACH_PlayerNumber(p) {
+    if (!row.GetRowDef().m_bOneChoiceForAllPlayers && p != pn) {
+      continue;
+    }
+
+    // Don't auto-select the ▼ on value-arrow rows.
+    if (iChoiceIndex == 0 && row.IsShowOneValueWithGoDown()) {
+      continue;
+    }
+
+    // Value-arrow rows auto-select on Left/Right even in toggle mode.
+    bool bAutoSelect = m_OptionsNavigation != NAV_TOGGLE_THREE_KEY ||
+                       row.IsShowOneValueWithGoDown();
+
+    if (row.GetRowDef().m_selectType == SELECT_ONE && bAutoSelect) {
+      row.SetOneSelection(p, iChoiceIndex);
+    }
+  }
+
+  if (bOneChanged) {
+    m_SoundChangeCol.Play(true);
+  }
+
+  if (row.GetRowDef().m_bExportOnChange) {
+    std::vector<PlayerNumber> vpns;
+    FOREACH_HumanPlayer(p) vpns.push_back(p);
+    ExportOptions(iRow, vpns);
+  }
+
+  this->AfterChangeValueInRow(iRow, pn);
 }
 
 void ScreenOptions::ChangeValueInRowRelative(
@@ -1167,74 +1226,37 @@ void ScreenOptions::ChangeValueInRowRelative(
     return;
   }
 
-  if (bRepeat && !ALLOW_REPEATING_CHANGE_VALUE_INPUT) {
-    return;
-  }
-
-  bool bOneChanged = false;
-
   int iCurrentChoiceWithFocus = row.GetChoiceInRowWithFocus(pn);
-  int iNewChoiceWithFocus = iCurrentChoiceWithFocus + iDelta;
-  if (!bRepeat && WRAP_VALUE_IN_ROW.GetValue()) {
-    wrap(iNewChoiceWithFocus, iNumChoices);
+
+  // Value-arrow rows confine Left/Right to value choices [1, N-1]; the ▼
+  // (choice 0) is reached only via the Start key.
+  bool bConfineToValues = row.IsShowOneValueWithGoDown();
+
+  int iNewChoiceWithFocus;
+  if (bConfineToValues && iCurrentChoiceWithFocus == 0) {
+    // Leaving the ▼; hover the current value without changing it.
+    int iSelected = row.GetOneSelection(pn, true);
+    iNewChoiceWithFocus = (iSelected >= 1) ? iSelected : 1;
   } else {
-    rage_clamp(iNewChoiceWithFocus, 0, iNumChoices - 1);
-  }
-
-  if (iCurrentChoiceWithFocus != iNewChoiceWithFocus) {
-    bOneChanged = true;
-  }
-
-  row.SetChoiceInRowWithFocus(pn, iNewChoiceWithFocus);
-  StoreFocus(pn);
-
-  if (row.GetRowDef().m_bOneChoiceForAllPlayers) {
-    /* If this row is bOneChoiceForAllPlayers, then lock the cursors together
-     * for this row. Don't do this in toggle modes, since the current selection
-     * and the current focus are detached. */
-    bool bForceFocusedChoiceTogether = false;
-    if (m_OptionsNavigation != NAV_TOGGLE_THREE_KEY &&
-        m_OptionsNavigation != NAV_TOGGLE_FIVE_KEY &&
-        row.GetRowDef().m_bOneChoiceForAllPlayers) {
-      bForceFocusedChoiceTogether = true;
-    }
-
-    // Also lock focus if the screen is explicitly set to share cursors.
-    if (m_InputMode == INPUTMODE_SHARE_CURSOR) {
-      bForceFocusedChoiceTogether = true;
-    }
-
-    if (bForceFocusedChoiceTogether) {
-      // lock focus together
-      FOREACH_HumanPlayer(p) {
-        row.SetChoiceInRowWithFocus(p, iNewChoiceWithFocus);
-        StoreFocus(p);
+    int lo = bConfineToValues ? 1 : 0;
+    int hi = iNumChoices - 1;
+    iNewChoiceWithFocus = iCurrentChoiceWithFocus + iDelta;
+    if (!bRepeat && WRAP_VALUE_IN_ROW.GetValue()) {
+      if (bConfineToValues) {
+        if (iNewChoiceWithFocus < lo) {
+          iNewChoiceWithFocus = hi;
+        } else if (iNewChoiceWithFocus > hi) {
+          iNewChoiceWithFocus = lo;
+        }
+      } else {
+        wrap(iNewChoiceWithFocus, iNumChoices);
       }
+    } else {
+      rage_clamp(iNewChoiceWithFocus, lo, hi);
     }
   }
 
-  FOREACH_PlayerNumber(p) {
-    if (!row.GetRowDef().m_bOneChoiceForAllPlayers && p != pn) {
-      continue;
-    }
-
-    if (row.GetRowDef().m_selectType == SELECT_ONE &&
-        m_OptionsNavigation != NAV_TOGGLE_THREE_KEY) {
-      row.SetOneSelection(p, iNewChoiceWithFocus);
-    }
-  }
-
-  if (bOneChanged) {
-    m_SoundChangeCol.Play(true);
-  }
-
-  if (row.GetRowDef().m_bExportOnChange) {
-    std::vector<PlayerNumber> vpns;
-    FOREACH_HumanPlayer(p) vpns.push_back(p);
-    ExportOptions(iRow, vpns);
-  }
-
-  this->AfterChangeValueInRow(iRow, pn);
+  ChangeValueInRowAbsolute(iRow, pn, iNewChoiceWithFocus, bRepeat);
 }
 
 void ScreenOptions::AfterChangeValueInRow(int iRow, PlayerNumber pn) {


### PR DESCRIPTION
So that we can e.g. move "Notefield X offset" into advanced options.

For stepmania style navigation this is the same as the normal menu (e.g. main options).

For arcade style navigation we have the down arrow on the left like the other rows, but when you hit left/right on that, you get moved to the values, and left/right keeps changing the value, can't get back to the down arrow by hitting left/right. Hitting start will get you back to the down arrow.

Move most of the selection logic from ChangeValueInRowRelative() into ChangeValueInRowAbsolute() (which was previously unused) to make it cleaner to go to the first entry.