### PR TITLE
Fix memmove in get_readable_ranges()

### DIFF
--- a/src/archutils/Unix/Backtrace.cpp
+++ b/src/archutils/Unix/Backtrace.cpp
@@ -96,8 +96,8 @@ static int get_readable_ranges(
 
       char line[1024];
       strcpy(line, file);
-      memmove(file, p, file_used);
       file_used -= p - file;
+      memmove(file, p, file_used);
 
       /* Search for the hyphen. */
       char* hyphen = strchr(line, '-');


### PR DESCRIPTION
p is pointer to byte after newline in file, we need to copy the number of bytes from p to the end of file, not the entire file.