### PR TITLE
Added premium free implementation

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -936,6 +936,7 @@
 			<Function name='GetPreferredSong'/>
 			<Function name='GetPreferredSongGroup'/>
 			<Function name='GetPremium'/>
+			<Function name='GetPremiumFreeSecondsLeft'/>
 			<Function name='GetSmallestNumStagesLeftForAnyHumanPlayer'/>
 			<Function name='GetSongBPS'/>
 			<Function name='GetSongBeat'/>
@@ -969,6 +970,8 @@
 			<Function name='IsGoalComplete'/>
 			<Function name='IsHumanPlayer'/>
 			<Function name='IsPlayerEnabled'/>
+			<Function name='IsPremiumFreeActive'/>
+			<Function name='IsPremiumFreeExpired'/>
 			<Function name='IsSideJoined'/>
 			<Function name='IsWinner'/>
 			<Function name='JoinInput'/>
@@ -1127,6 +1130,7 @@
 			<Function name='ChangeSort'/>
 			<Function name='GetCurrentSections'/>
 			<Function name='GetSelectedSection'/>
+			<Function name='HasSongs'/>
 			<Function name='IsRouletting'/>
 			<Function name='Move'/>
 			<Function name='SelectCourse'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -3184,6 +3184,12 @@ end
 	<Function name='GetPremium' return='Premium' arguments=''>
 		Returns the current Premium.
 	</Function>
+	<Function name='GetPremiumFreeSecondsLeft' return='float' arguments='' since='ITGmania 1.4.0'>
+		Returns the number of seconds left in the current premium free session, or <code>0</code> if
+		<Link function='IsPremiumFreeActive'>premium free</Link> is not active.  The countdown only starts when
+		ScreenSelectMusic begins, so until then the full duration set by the <code>PremiumFreeMinutes</code>
+		preference is returned.
+	</Function>
 	<Function name='GetSmallestNumStagesLeftForAnyHumanPlayer' return='int' arguments=''>
 		<!-- Kind of does what it says on the tin. -->
 		Returns the smallest number of stages left for any human player.
@@ -3295,6 +3301,16 @@ end
 	</Function>
 	<Function name='IsPlayerEnabled' return='bool' arguments='PlayerNumber pn'>
 		Returns <code>true</code> if player <code>pn</code> is enabled.
+	</Function>
+	<Function name='IsPremiumFreeActive' return='bool' arguments='' since='ITGmania 1.4.0'>
+		Returns <code>true</code> if premium free is active.  While it is active, players are not charged stage
+		tokens, <Link function='GetSmallestNumStagesLeftForAnyHumanPlayer' /> reports an unlimited number of
+		stages and no extra stage can be earned.  Premium free is turned on by the <code>premiumfree</code>
+		GameCommand and is cleared by <Link function='Reset' />.
+	</Function>
+	<Function name='IsPremiumFreeExpired' return='bool' arguments='' since='ITGmania 1.4.0'>
+		Returns <code>true</code> if premium free is active and its timer has run out.  Returns <code>false</code>
+		while premium free is inactive or while its timer has not started yet.
 	</Function>
 	<Function name='IsSideJoined' return='bool' arguments='PlayerNumber pn'>
 		Returns <code>true</code> if player <code>pn</code> has joined the game.
@@ -3683,6 +3699,9 @@ end
 	</Function>
 	<Function name='GetSelectedSection' return='string' arguments=''>
 		Returns the name of the currently selected section.
+	</Function>
+	<Function name='HasSongs' return='bool' arguments='' since='ITGmania 1.4.0'>
+		Returns <code>true</code> if the wheel currently holds at least one song.
 	</Function>
 	<Function name='IsRouletting' return='bool' arguments=''>
 		Returns <code>true</code> if the MusicWheel is currently handling Roulette selection.

--- a/src/GameCommand.cpp
+++ b/src/GameCommand.cpp
@@ -80,6 +80,7 @@ void GameCommand::Init() {
   m_bClearCredits = false;
   m_bStopMusic = false;
   m_bApplyDefaultOptions = false;
+  m_bActivatePremiumFree = false;
   m_bFadeMusic = false;
   m_fMusicFadeOutVolume = -1.0f;
   m_fMusicFadeOutSeconds = -1.0f;
@@ -434,6 +435,10 @@ void GameCommand::LoadOne(const Command& cmd) {
 
   else if (sName == "applydefaultoptions") {
     m_bApplyDefaultOptions = true;
+  }
+
+  else if (sName == "premiumfree") {
+    m_bActivatePremiumFree = true;
   }
 
   // sm-ssc additions begin:
@@ -873,6 +878,10 @@ void GameCommand::ApplySelf(const std::vector<PlayerNumber>& vpns) const {
     GAMESTATE->GetDefaultSongOptions(so);
     GAMESTATE->m_SongOptions.Assign(ModsLevel_Stage, so);
   }
+
+  if (m_bActivatePremiumFree) {
+    GAMESTATE->ActivatePremiumFree();
+  }
   // HACK: Set life type to BATTERY just once here so it happens once and
   // we don't override the user's changes if they back out.
   FOREACH_PlayerNumber(pn) {
@@ -896,7 +905,7 @@ bool GameCommand::IsZero() const {
       m_CourseDifficulty != Difficulty_Invalid || !m_sSongGroup.empty() ||
       m_SortOrder != SortOrder_Invalid || m_iWeightPounds != -1 ||
       m_iGoalCalories != -1 || m_GoalType != GoalType_Invalid ||
-      !m_sProfileID.empty()) {
+      !m_sProfileID.empty() || m_bActivatePremiumFree) {
     return false;
   }
 

--- a/src/GameCommand.h
+++ b/src/GameCommand.h
@@ -64,6 +64,7 @@ class GameCommand {
         m_bClearCredits(false),
         m_bStopMusic(false),
         m_bApplyDefaultOptions(false),
+        m_bActivatePremiumFree(false),
         m_bFadeMusic(false),
         m_fMusicFadeOutVolume(-1),
         m_fMusicFadeOutSeconds(-1),
@@ -137,6 +138,7 @@ class GameCommand {
   bool m_bClearCredits;
   bool m_bStopMusic;
   bool m_bApplyDefaultOptions;
+  bool m_bActivatePremiumFree;
   // sm-ssc also adds:
   bool m_bFadeMusic;
   float m_fMusicFadeOutVolume;

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -129,6 +129,9 @@ static ThemeMetric<bool> ARE_STAGE_SONG_MODS_FORCED(
     "GameState", "AreStageSongModsForced");
 
 static Preference<Premium> g_Premium("Premium", Premium_DoubleFor1Credit);
+static Preference<int> g_iPremiumFreeMinutes("PremiumFreeMinutes", 10);
+static Preference<float> g_fPremiumFreeSongGraceSeconds(
+    "PremiumFreeSongGraceSeconds", 150.0f);
 Preference<bool> GameState::m_bAutoJoin("AutoJoin", false);
 
 GameState::GameState()
@@ -147,6 +150,8 @@ GameState::GameState()
       m_pCurSteps(Message_CurrentStepsP1Changed),
       m_pCurCourse(Message_CurrentCourseChanged),
       m_pCurTrail(Message_CurrentTrailP1Changed),
+      m_bPremiumFreeActive(false),
+      m_iPremiumFreeMinutes(0),
       m_bGameplayLeadIn(Message_GameplayLeadInChanged),
       m_bDidModeChangeNoteSkin(false),
       m_bIsUsingStepTiming(true),
@@ -331,6 +336,9 @@ void GameState::Reset() {
   m_pPreferredSong = nullptr;
   m_pCurCourse.Set(nullptr);
   m_pPreferredCourse = nullptr;
+  m_bPremiumFreeActive = false;
+  m_iPremiumFreeMinutes = 0;
+  m_PremiumFreeStartTime.SetZero();
 
   FOREACH_MultiPlayer(p) m_pMultiPlayerState[p]->Reset();
 
@@ -750,7 +758,7 @@ void GameState::BeginStage() {
   FOREACH_EnabledPlayer(p) {
     // only do this check with human players, assume CPU players (Rave)
     // always have tokens. -aj (this could probably be moved below, even.)
-    if (!IsEventMode() && !IsCpuPlayer(p)) {
+    if (!IsEventMode() && !m_bPremiumFreeActive && !IsCpuPlayer(p)) {
       if (m_iPlayerStageTokens[p] < m_iNumStagesOfThisSong) {
         LuaHelpers::ReportScriptErrorFmt(
             "Player %d only has %d stage tokens, but needs %d.", p,
@@ -1291,7 +1299,7 @@ int GameState::GetNumStagesLeft(PlayerNumber pn) const {
 }
 
 int GameState::GetSmallestNumStagesLeftForAnyHumanPlayer() const {
-  if (IsEventMode()) {
+  if (IsEventMode() || m_bPremiumFreeActive) {
     return 999;
   }
   int iSmallest = INT_MAX;
@@ -1424,6 +1432,63 @@ int GameState::GetLoadingCourseSongIndex() const {
     ++iIndex;
   }
   return iIndex;
+}
+
+void GameState::ActivatePremiumFree() {
+  if (m_bPremiumFreeActive) {
+    return;
+  }
+
+  m_bPremiumFreeActive = true;
+  m_iPremiumFreeMinutes = g_iPremiumFreeMinutes.Get();
+  m_PremiumFreeStartTime.SetZero();
+}
+
+void GameState::StartPremiumFreeTimer() {
+  if (!m_PremiumFreeStartTime.IsZero()) {
+    return;
+  }
+
+  m_PremiumFreeStartTime.Touch();
+}
+
+float GameState::GetPremiumFreeSecondsLeft() const {
+  if (!m_bPremiumFreeActive) {
+    return 0.0f;
+  }
+
+  const float seconds = GetPremiumFreeSeconds();
+  if (m_PremiumFreeStartTime.IsZero()) {
+    return seconds;
+  }
+
+  return std::max(0.0f, seconds - m_PremiumFreeStartTime.Ago());
+}
+
+float GameState::GetPremiumFreeSeconds() const {
+  return std::clamp(
+      static_cast<float>(m_iPremiumFreeMinutes) * 60.0f, 0.0f, 3600.0f);
+}
+
+float GameState::GetPremiumFreeSongGraceSeconds() const {
+  return std::clamp(g_fPremiumFreeSongGraceSeconds.Get(), 60.0f, 240.0f);
+}
+
+bool GameState::IsPremiumFreeExpired() const {
+  return m_bPremiumFreeActive && !m_PremiumFreeStartTime.IsZero() &&
+         GetPremiumFreeSecondsLeft() <= 0.0f;
+}
+
+bool GameState::IsSongAllowedByPremiumFree(const Song* song) const {
+  if (!m_bPremiumFreeActive) {
+    return true;
+  }
+  if (song == nullptr) {
+    return false;
+  }
+
+  return song->m_fMusicLengthSeconds <=
+         GetPremiumFreeSecondsLeft() + GetPremiumFreeSongGraceSeconds();
 }
 
 static const char* prepare_song_failures[] = {
@@ -1716,7 +1781,7 @@ bool GameState::IsBattleMode() const {
 }
 
 EarnedExtraStage GameState::CalculateEarnedExtraStage() const {
-  if (IsEventMode()) {
+  if (IsEventMode() || m_bPremiumFreeActive) {
     return EarnedExtraStage_No;
   }
 
@@ -2870,6 +2935,9 @@ class LunaGameState : public Luna<GameState> {
       PlayerIsUsingModifier(Enum::Check<PlayerNumber>(L, 1), SArg(2)))
   DEFINE_METHOD(GetCourseSongIndex, GetCourseSongIndex())
   DEFINE_METHOD(GetLoadingCourseSongIndex, GetLoadingCourseSongIndex())
+  DEFINE_METHOD(IsPremiumFreeActive, IsPremiumFreeActive())
+  DEFINE_METHOD(GetPremiumFreeSecondsLeft, GetPremiumFreeSecondsLeft())
+  DEFINE_METHOD(IsPremiumFreeExpired, IsPremiumFreeExpired())
   DEFINE_METHOD(
       GetSmallestNumStagesLeftForAnyHumanPlayer,
       GetSmallestNumStagesLeftForAnyHumanPlayer())
@@ -3392,6 +3460,9 @@ class LunaGameState : public Luna<GameState> {
     ADD_METHOD(PlayerIsUsingModifier);
     ADD_METHOD(GetCourseSongIndex);
     ADD_METHOD(GetLoadingCourseSongIndex);
+    ADD_METHOD(IsPremiumFreeActive);
+    ADD_METHOD(GetPremiumFreeSecondsLeft);
+    ADD_METHOD(IsPremiumFreeExpired);
     ADD_METHOD(GetSmallestNumStagesLeftForAnyHumanPlayer);
     ADD_METHOD(IsAnExtraStage);
     ADD_METHOD(IsExtraStage);

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -260,6 +260,13 @@ class GameState {
   int GetCourseSongIndex() const;
   std::string GetPlayerDisplayName(PlayerNumber pn) const;
 
+  void ActivatePremiumFree();
+  bool IsPremiumFreeActive() const { return m_bPremiumFreeActive; }
+  void StartPremiumFreeTimer();
+  float GetPremiumFreeSecondsLeft() const;
+  bool IsPremiumFreeExpired() const;
+  bool IsSongAllowedByPremiumFree(const Song* song) const;
+
   bool m_bLoadingNextSong;
   int GetLoadingCourseSongIndex() const;
 
@@ -282,6 +289,10 @@ class GameState {
   BroadcastOnChangePtr1D<Trail, NUM_PLAYERS> m_pCurTrail;
 
   bool m_bBackedOutOfFinalStage;
+
+  bool m_bPremiumFreeActive;
+  int m_iPremiumFreeMinutes;
+  RageTimer m_PremiumFreeStartTime;
 
   // Music statistics:
   SongPosition m_Position;
@@ -463,6 +474,8 @@ class GameState {
 
   // Keep extra stage logic internal to GameState.
  private:
+  float GetPremiumFreeSeconds() const;
+  float GetPremiumFreeSongGraceSeconds() const;
   EarnedExtraStage CalculateEarnedExtraStage() const;
   int m_iAwardedExtraStages[NUM_PLAYERS];
   bool m_bEarnedExtraStage;

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -345,6 +345,17 @@ bool MusicWheel::SelectSection(const std::string& SectionName) {
   return false;
 }
 
+bool MusicWheel::HasSongs() {
+  std::vector<MusicWheelItemData*>& wheelItems =
+      getWheelItemsData(GAMESTATE->m_SortOrder);
+  for (MusicWheelItemData* item : wheelItems) {
+    if (item->m_Type == WheelItemDataType_Song) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool MusicWheel::SelectSong(const Song* p) {
   if (p == nullptr) {
     return false;
@@ -1378,6 +1389,11 @@ void MusicWheel::FilterWheelItemDatas(
         aiRemove[i] = true;
         continue;
       }
+
+      if (!GAMESTATE->IsSongAllowedByPremiumFree(pSong)) {
+        aiRemove[i] = true;
+        continue;
+      }
     }
 
     if (WID.m_Type == WheelItemDataType_Course) {
@@ -2245,6 +2261,10 @@ class LunaMusicWheel : public Luna<MusicWheel> {
     lua_pushboolean(L, p->WheelIsLocked());
     return 1;
   }
+  static int HasSongs(T* p, lua_State* L) {
+    lua_pushboolean(L, p->HasSongs());
+    return 1;
+  }
   static int SelectSong(T* p, lua_State* L) {
     if (lua_isnil(L, 1)) {
       lua_pushboolean(L, false);
@@ -2278,6 +2298,7 @@ class LunaMusicWheel : public Luna<MusicWheel> {
     ADD_METHOD(GetSelectedSection);
     ADD_METHOD(IsRouletting);
     ADD_METHOD(IsLocked);
+    ADD_METHOD(HasSongs);
     ADD_METHOD(SelectSong);
     ADD_METHOD(SelectCourse);
     ADD_METHOD(Move);

--- a/src/MusicWheel.h
+++ b/src/MusicWheel.h
@@ -52,6 +52,7 @@ class MusicWheel : public WheelBase {
 
   bool SelectSong(const Song* p);
   bool SelectCourse(const Course* p);
+  bool HasSongs();
   bool SelectSection(const std::string& SectionName);
   bool CloseOpenSectionOneLevel();
   void SetOpenSection(std::string group);

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -167,6 +167,28 @@ static void MoveNop(int& iSel, bool bToSel, const ConfOption* pConfOption) {
   }
 }
 
+static constexpr int PREMIUM_FREE_MIN_MINUTES = 5;
+static constexpr int PREMIUM_FREE_MAX_MINUTES = 60;
+static constexpr int NUM_PREMIUM_FREE_MINUTE_VALUES =
+    PREMIUM_FREE_MAX_MINUTES - PREMIUM_FREE_MIN_MINUTES + 1;
+
+static void PremiumFreeMinuteChoices(std::vector<std::string>& out) {
+  for (int minutes = PREMIUM_FREE_MIN_MINUTES;
+       minutes <= PREMIUM_FREE_MAX_MINUTES; ++minutes) {
+    out.push_back(ToString(minutes));
+  }
+}
+
+static void PremiumFreeMinutes(
+    int& sel, bool toSel, const ConfOption* pConfOption) {
+  int mapping[NUM_PREMIUM_FREE_MINUTE_VALUES];
+  for (int i = 0; i < NUM_PREMIUM_FREE_MINUTE_VALUES; ++i) {
+    mapping[i] = PREMIUM_FREE_MIN_MINUTES + i;
+  }
+
+  MoveMap(sel, pConfOption, toSel, mapping, ARRAYLEN(mapping));
+}
+
 // TODO: Write GenerateValueList() function that can use ints and floats. -aj
 
 static void GameChoices(std::vector<std::string>& out) {
@@ -936,6 +958,9 @@ static void InitializeConfOptions() {
   ADD(ConfOption(
       "Premium", MovePref<Premium>, "Off", "Double for 1 Credit",
       "2 Players for 1 Credit"));
+  ADD(ConfOption(
+      "PremiumFreeMinutes", PremiumFreeMinutes, PremiumFreeMinuteChoices));
+  g_ConfOptions.back().m_sPrefName = "PremiumFreeMinutes";
   ADD(ConfOption(
       "JointPremium", JointPremium, "Off", "2 Players for 1 Credit"));
   g_ConfOptions.back().m_sPrefName = "Premium";

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -317,6 +317,9 @@ void ScreenSelectMusic::BeginScreen() {
 
   OPTIONS_MENU_AVAILABLE.Load(m_sName, "OptionsMenuAvailable");
   PlayCommand("Mods");
+  if (GAMESTATE->IsPremiumFreeActive()) {
+    GAMESTATE->StartPremiumFreeTimer();
+  }
   m_MusicWheel.BeginScreen();
 
   m_SelectionState = SelectionState_SelectingSong;


### PR DESCRIPTION
Premium free allows to play a set limited by time instead of songs per play.

the feature can be enabled through Arcade options and the user can set the maximum time per set.
Via metrics the PremiumFreeSongGraceSeconds can be set as well. This parameters tells a threshold to allow to play one last song when the timer is lower that any songs in the game. it is set to 150 seconds by default.

The feature has been added in engine to filter out songs while reloading song wheel when songs exceeds the time limit. 

Any suggestion is welcome. 

I tested myself the feature, but i'd like someone else to test it otu before merging.

Refer to PR for theme changes: https://github.com/Simply-Love/Simply-Love-SM5/pull/770
