### PR TITLE
Behavior change: Automatically scale lifebar for Beginner charts

### DIFF
--- a/src/LifeMeterBar.cpp
+++ b/src/LifeMeterBar.cpp
@@ -11,6 +11,7 @@
 #include "GameState.h"
 #include "LifeMeter.h"
 #include "LuaReference.h"
+#include "MeasureInfo.h"
 #include "MessageManager.h"
 #include "PlayerNumber.h"
 #include "PlayerOptions.h"
@@ -104,12 +105,31 @@ void LifeMeterBar::Load(
       FAIL_M(ssprintf("Invalid DrainType: %i", dtype));
   }
 
-  // Change life difficulty to really easy if merciful beginner on
-  m_bMercifulBeginnerInEffect =
-      GAMESTATE->m_PlayMode == PLAY_MODE_REGULAR &&
-      GAMESTATE->IsPlayerEnabled(pPlayerState) &&
-      GAMESTATE->m_pCurSteps[pn]->GetDifficulty() == Difficulty_Beginner &&
-      PREFSMAN->m_bMercifulBeginner;
+  const Steps* pSteps = GAMESTATE->m_pCurSteps[pn];
+  bool bIsBeginner = pSteps && pSteps->GetDifficulty() == Difficulty_Beginner;
+
+  float fPeakNps = 0.0f;
+  if (bIsBeginner) {
+    // This is a beginner chart, now figure out if the NPS value matches what we
+    // think a beginner chart is. If it's low enough, automatically enable
+    // Merciful lifebar behavior for that player. It's common for WIP charts to
+    // be in the Beginner slot, so we don't want to unintentionally apply
+    // Merciful lifebar to those charts. We also don't want people to manipulate
+    // the lifebar by moving the chart to the Beginner slot, so this also
+    // provides basic protection in that regard.
+    NoteData nd;
+    pSteps->GetNoteData(nd);
+    MeasureInfo measureInfo;
+    MeasureInfo::CalculateMeasureInfo(
+        nd, const_cast<TimingData*>(pSteps->GetTimingData()), measureInfo);
+    fPeakNps = measureInfo.peakNps;
+  }
+
+  m_bMercifulBeginnerInEffect = GAMESTATE->m_PlayMode == PLAY_MODE_REGULAR &&
+                                GAMESTATE->IsPlayerEnabled(pPlayerState) &&
+                                bIsBeginner &&
+                                (PREFSMAN->m_bMercifulBeginner ||
+                                 fPeakNps <= MERCIFUL_BEGINNER_MAX_PEAK_NPS);
 
   AfterLifeChanged();
 }

--- a/src/MeasureInfo.h
+++ b/src/MeasureInfo.h
@@ -28,4 +28,6 @@ struct MeasureInfo {
       const NoteData& in, TimingData* timing, MeasureInfo& out);
 };
 
+const float MERCIFUL_BEGINNER_MAX_PEAK_NPS = 2.5f;
+
 #endif

--- a/src/PlayerStageStats.cpp
+++ b/src/PlayerStageStats.cpp
@@ -58,6 +58,7 @@ void PlayerStageStats::InternalInit() {
 
   m_bPlayerCanAchieveFullCombo = true;
   m_bJoined = false;
+  m_bMercifulBeginnerInEffect = false;
   m_vpPossibleSteps.clear();
   m_iStepsPlayed = 0;
   m_fAliveSeconds = 0;
@@ -212,16 +213,16 @@ Grade PlayerStageStats::GetGrade() const {
   }
 
   FOREACH_ENUM(TapNoteScore, tns) {
-    int iTapScoreValue =
-        ScoreKeeperNormal::TapNoteScoreToGradePoints(tns, bIsBeginner);
+    int iTapScoreValue = ScoreKeeperNormal::TapNoteScoreToGradePoints(
+        tns, bIsBeginner, m_bMercifulBeginnerInEffect);
     fActual += m_iTapNoteScores[tns] * iTapScoreValue;
     // LOG->Trace( "GetGrade actual: %i * %i", m_iTapNoteScores[tns],
     // iTapScoreValue );
   }
 
   FOREACH_ENUM(HoldNoteScore, hns) {
-    int iHoldScoreValue =
-        ScoreKeeperNormal::HoldNoteScoreToGradePoints(hns, bIsBeginner);
+    int iHoldScoreValue = ScoreKeeperNormal::HoldNoteScoreToGradePoints(
+        hns, bIsBeginner, m_bMercifulBeginnerInEffect);
     fActual += m_iHoldNoteScores[hns] * iHoldScoreValue;
     // LOG->Trace( "GetGrade actual: %i * %i", m_iHoldNoteScores[hns],
     // iHoldScoreValue );

--- a/src/PlayerStageStats.h
+++ b/src/PlayerStageStats.h
@@ -64,6 +64,8 @@ class PlayerStageStats {
    * this is only set if both players were failing at the same time. */
   bool m_bFailed;
 
+  bool m_bMercifulBeginnerInEffect;
+
   int m_iPossibleDancePoints;
   int m_iCurPossibleDancePoints;
   int m_iActualDancePoints;

--- a/src/ScoreKeeperNormal.cpp
+++ b/src/ScoreKeeperNormal.cpp
@@ -14,6 +14,7 @@
 #include "GamePreferences.h"
 #include "GameState.h"
 #include "LuaManager.h"
+#include "MeasureInfo.h"
 #include "MessageManager.h"
 #include "NoteData.h"
 #include "NoteDataUtil.h"
@@ -213,8 +214,8 @@ void ScoreKeeperNormal::OnNextSong(
   ASSERT(m_iMaxPossiblePoints >= 0);
   m_iMaxScoreSoFar += m_iMaxPossiblePoints;
 
-  GAMESTATE->SetProcessedTimingData(
-      const_cast<TimingData*>(pSteps->GetTimingData()));
+  TimingData* pTimingData = const_cast<TimingData*>(pSteps->GetTimingData());
+  GAMESTATE->SetProcessedTimingData(pTimingData);
 
   m_iNumTapsAndHolds = pNoteData->GetNumRowsWithTapOrHoldHead() +
                        pNoteData->GetNumHoldNotes() + pNoteData->GetNumRolls();
@@ -226,6 +227,20 @@ void ScoreKeeperNormal::OnNextSong(
    * song is in a course, since that makes PlayerStageStats::GetGrade hard. */
   m_bIsBeginner = pSteps->GetDifficulty() == Difficulty_Beginner &&
                   !GAMESTATE->IsCourseMode();
+
+  // Merciful Beginner behavior is automatically enabled for very slow beginner
+  // charts, regardless of the preference. See the comment in LifeMeterBar::Load
+  float fPeakNps = 0.0f;
+  if (m_bIsBeginner) {
+    MeasureInfo measureInfo;
+    MeasureInfo::CalculateMeasureInfo(*pNoteData, pTimingData, measureInfo);
+    fPeakNps = measureInfo.peakNps;
+  }
+  m_bMercifulBeginnerInEffect =
+      m_bIsBeginner && (PREFSMAN->m_bMercifulBeginner ||
+                        fPeakNps <= MERCIFUL_BEGINNER_MAX_PEAK_NPS);
+  m_pPlayerStageStats->m_bMercifulBeginnerInEffect =
+      m_bMercifulBeginnerInEffect;
 
   ASSERT(m_iPointBonus >= 0);
 
@@ -666,15 +681,15 @@ int ScoreKeeperNormal::GetPossibleDancePoints(
   int ret = 0;
 
   ret += int(radars[RadarCategory_TapsAndHolds]) *
-         TapNoteScoreToDancePoints(TNS_W1, false);
+         TapNoteScoreToDancePoints(TNS_W1, false, false);
   if (TICK_HOLDS) {
     ret += NoteDataUtil::GetTotalHoldTicks(nd, td) *
            g_iPercentScoreWeight.GetValue(SE_CheckpointHit);
   }
   ret += int(radars[RadarCategory_Holds]) *
-         HoldNoteScoreToDancePoints(HNS_Held, false);
+         HoldNoteScoreToDancePoints(HNS_Held, false, false);
   ret += int(radars[RadarCategory_Rolls]) *
-         HoldNoteScoreToDancePoints(HNS_Held, false);
+         HoldNoteScoreToDancePoints(HNS_Held, false, false);
 
   return ret;
 }
@@ -701,15 +716,15 @@ int ScoreKeeperNormal::GetPossibleGradePoints(
   int ret = 0;
 
   ret += int(radars[RadarCategory_TapsAndHolds]) *
-         TapNoteScoreToGradePoints(TNS_W1, false);
+         TapNoteScoreToGradePoints(TNS_W1, false, false);
   if (TICK_HOLDS) {
     ret += NoteDataUtil::GetTotalHoldTicks(nd, td) *
            g_iGradeWeight.GetValue(SE_CheckpointHit);
   }
   ret += int(radars[RadarCategory_Holds]) *
-         HoldNoteScoreToGradePoints(HNS_Held, false);
+         HoldNoteScoreToGradePoints(HNS_Held, false, false);
   ret += int(radars[RadarCategory_Rolls]) *
-         HoldNoteScoreToGradePoints(HNS_Held, false);
+         HoldNoteScoreToGradePoints(HNS_Held, false, false);
 
   return ret;
 }
@@ -726,22 +741,26 @@ int ScoreKeeperNormal::GetPossibleGradePoints(
 }
 
 int ScoreKeeperNormal::TapNoteScoreToDancePoints(TapNoteScore tns) const {
-  return TapNoteScoreToDancePoints(tns, m_bIsBeginner);
+  return TapNoteScoreToDancePoints(
+      tns, m_bIsBeginner, m_bMercifulBeginnerInEffect);
 }
 
 int ScoreKeeperNormal::HoldNoteScoreToDancePoints(HoldNoteScore hns) const {
-  return HoldNoteScoreToDancePoints(hns, m_bIsBeginner);
+  return HoldNoteScoreToDancePoints(
+      hns, m_bIsBeginner, m_bMercifulBeginnerInEffect);
 }
 
 int ScoreKeeperNormal::TapNoteScoreToGradePoints(TapNoteScore tns) const {
-  return TapNoteScoreToGradePoints(tns, m_bIsBeginner);
+  return TapNoteScoreToGradePoints(
+      tns, m_bIsBeginner, m_bMercifulBeginnerInEffect);
 }
 int ScoreKeeperNormal::HoldNoteScoreToGradePoints(HoldNoteScore hns) const {
-  return HoldNoteScoreToGradePoints(hns, m_bIsBeginner);
+  return HoldNoteScoreToGradePoints(
+      hns, m_bIsBeginner, m_bMercifulBeginnerInEffect);
 }
 
 int ScoreKeeperNormal::TapNoteScoreToDancePoints(
-    TapNoteScore tns, bool bBeginner) {
+    TapNoteScore tns, bool bBeginner, bool bMercifulBeginnerActive) {
   if (!GAMESTATE->ShowW1() && tns == TNS_W1) {
     tns = TNS_W2;
   }
@@ -782,14 +801,14 @@ int ScoreKeeperNormal::TapNoteScoreToDancePoints(
       iWeight = g_iPercentScoreWeight.GetValue(SE_CheckpointMiss);
       break;
   }
-  if (bBeginner && PREFSMAN->m_bMercifulBeginner) {
+  if (bBeginner && bMercifulBeginnerActive) {
     iWeight = std::max(0, iWeight);
   }
   return iWeight;
 }
 
 int ScoreKeeperNormal::HoldNoteScoreToDancePoints(
-    HoldNoteScore hns, bool bBeginner) {
+    HoldNoteScore hns, bool bBeginner, bool bMercifulBeginnerActive) {
   int iWeight = 0;
   switch (hns) {
     DEFAULT_FAIL(hns);
@@ -806,14 +825,14 @@ int ScoreKeeperNormal::HoldNoteScoreToDancePoints(
       iWeight = g_iPercentScoreWeight.GetValue(SE_Missed);
       break;
   }
-  if (bBeginner && PREFSMAN->m_bMercifulBeginner) {
+  if (bBeginner && bMercifulBeginnerActive) {
     iWeight = std::max(0, iWeight);
   }
   return iWeight;
 }
 
 int ScoreKeeperNormal::TapNoteScoreToGradePoints(
-    TapNoteScore tns, bool bBeginner) {
+    TapNoteScore tns, bool bBeginner, bool bMercifulBeginnerActive) {
   if (!GAMESTATE->ShowW1() && tns == TNS_W1) {
     tns = TNS_W2;
   }
@@ -857,14 +876,14 @@ int ScoreKeeperNormal::TapNoteScoreToGradePoints(
       iWeight = g_iGradeWeight.GetValue(SE_CheckpointMiss);
       break;
   }
-  if (bBeginner && PREFSMAN->m_bMercifulBeginner) {
+  if (bBeginner && bMercifulBeginnerActive) {
     iWeight = std::max(0, iWeight);
   }
   return iWeight;
 }
 
 int ScoreKeeperNormal::HoldNoteScoreToGradePoints(
-    HoldNoteScore hns, bool bBeginner) {
+    HoldNoteScore hns, bool bBeginner, bool bMercifulBeginnerActive) {
   int iWeight = 0;
   switch (hns) {
     DEFAULT_FAIL(hns);

--- a/src/ScoreKeeperNormal.h
+++ b/src/ScoreKeeperNormal.h
@@ -36,6 +36,7 @@ class ScoreKeeperNormal : public ScoreKeeper {
   int m_next_toasty_at;
   bool m_bIsLastSongInCourse;
   bool m_bIsBeginner;
+  bool m_bMercifulBeginnerInEffect;
 
   int m_iNumNotesHitThisRow;  // Used by Custom Scoring only
 
@@ -101,10 +102,14 @@ class ScoreKeeperNormal : public ScoreKeeper {
   int HoldNoteScoreToDancePoints(HoldNoteScore hns) const;
   int TapNoteScoreToGradePoints(TapNoteScore tns) const;
   int HoldNoteScoreToGradePoints(HoldNoteScore hns) const;
-  static int TapNoteScoreToDancePoints(TapNoteScore tns, bool bBeginner);
-  static int HoldNoteScoreToDancePoints(HoldNoteScore hns, bool bBeginner);
-  static int TapNoteScoreToGradePoints(TapNoteScore tns, bool bBeginner);
-  static int HoldNoteScoreToGradePoints(HoldNoteScore hns, bool bBeginner);
+  static int TapNoteScoreToDancePoints(
+      TapNoteScore tns, bool bBeginner, bool bMercifulBeginnerActive);
+  static int HoldNoteScoreToDancePoints(
+      HoldNoteScore hns, bool bBeginner, bool bMercifulBeginnerActive);
+  static int TapNoteScoreToGradePoints(
+      TapNoteScore tns, bool bBeginner, bool bMercifulBeginnerActive);
+  static int HoldNoteScoreToGradePoints(
+      HoldNoteScore hns, bool bBeginner, bool bMercifulBeginnerActive);
 
  private:
   /**

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -208,7 +208,8 @@ void ScreenEvaluation::Init() {
       ss.m_player[p].m_iTapNoteScores[TNS_W2] = RandomInt(3);
       ss.m_player[p].m_iTapNoteScores[TNS_W3] = RandomInt(3);
       ss.m_player[p].m_iPossibleGradePoints =
-          4 * ScoreKeeperNormal::TapNoteScoreToGradePoints(TNS_W1, false);
+          4 *
+          ScoreKeeperNormal::TapNoteScoreToGradePoints(TNS_W1, false, false);
       ss.m_player[p].m_fLifeRemainingSeconds = randomf(90, 580);
       ss.m_player[p].m_iScore = rand() % (900 * 1000 * 1000);
       ss.m_player[p].m_iPersonalHighScoreIndex = (rand() % 3) - 1;


### PR DESCRIPTION
Allows PlayerStageStats, ScoreKeeper and LifeMeterBar to make decisions about whether to scale the lifebar for beginners based on chart slot and peak NPS, while providing some basic protection against abuse of the Beginner slot.

Only the player playing the beginner chart is affected.  So if P1 is playing an Expert 15 and P2 is playing a Beginner 2  then P1 doesn't have their lifebar affected.

This defines the maximum as 2.5NPS, which fits the majority of ITG official Beginner charts. For ITG official Beginner charts, most seem to be somewhere between 0.5NPS and 2.0NPS, with very few exceptions above 2.0NPS. For ITG official Easy charts, most seem to start at about 2.0NPS and go up from there, so this should scale accurately.

LifeMeterBar and ScoreKeeperNormal both gain the ability to directly access a chart's peak NPS values to allow this behavior.