### PR TITLE
Windows (threading): Prevent deadlock by moving mutex lock within ArchHooks::SetHasFocus

### DIFF
--- a/src/arch/ArchHooks/ArchHooks.cpp
+++ b/src/arch/ArchHooks/ArchHooks.cpp
@@ -31,13 +31,13 @@ void ArchHooks::SetToggleWindowed() {
 }
 
 void ArchHooks::SetHasFocus(bool bHasFocus) {
+  LockMut(g_Mutex);
   if (bHasFocus == m_bHasFocus) {
     return;
   }
   m_bHasFocus = bHasFocus;
 
   LOG->Trace("App %s focus", bHasFocus ? "has" : "doesn't have");
-  LockMut(g_Mutex);
   m_bFocusChanged = true;
 }
 


### PR DESCRIPTION
Revealed by Windows threading-related changes to be a potential source of deadlocks if focus is quickly lost and regained. It's most easily reproduced doing a quick alt tab in and out right upon a screen change.