### PR TITLE
Windows (threading): update threading code to utilize the native condition variable

### DIFF
--- a/src/arch/Threads/Threads_Win32.cpp
+++ b/src/arch/Threads/Threads_Win32.cpp
@@ -194,11 +194,15 @@ ThreadImpl* MakeThread(
 }
 
 MutexImpl_Win32::MutexImpl_Win32(RageMutex* pParent) : MutexImpl(pParent) {
-  mutex = CreateMutex(nullptr, false, nullptr);
-  ASSERT_M(mutex != nullptr, werr_ssprintf(GetLastError(), "CreateMutex"));
+  if (!InitializeCriticalSectionAndSpinCount(&mutex, kSpinCount)) {
+    FAIL_M(werr_ssprintf(
+        GetLastError(),
+        "Unexpected failure in InitializeCriticalSectionAndSpinCount which "
+        "should have been impossible!"));
+  }
 }
 
-MutexImpl_Win32::~MutexImpl_Win32() { CloseHandle(mutex); }
+MutexImpl_Win32::~MutexImpl_Win32() { DeleteCriticalSection(&mutex); }
 
 /* NOTE(sukibaby):  the function name here is a bit misleading.
  * It provides additional error handling and assertions which
@@ -231,35 +235,13 @@ static bool SimpleWaitForSingleObject(HANDLE h, DWORD ms) {
 }
 
 bool MutexImpl_Win32::Lock() {
-  DWORD dwWaitResult = WaitForSingleObject(mutex, INFINITE);
-  switch (dwWaitResult) {
-    case WAIT_OBJECT_0:
-      return true;
-
-    case WAIT_TIMEOUT:
-      return false;
-
-    case WAIT_ABANDONED:
-      return false;
-
-    default:
-      FAIL_M(
-          "WaitForSingleObject failed in a way that shouldn't have been "
-          "possible");
-  }
+  EnterCriticalSection(&mutex);  // This is guaranteed to succeed, no need to
+                                 // check anything at this point.
+  return true;
 }
 
-bool MutexImpl_Win32::TryLock() { return SimpleWaitForSingleObject(mutex, 0); }
-
-void MutexImpl_Win32::Unlock() {
-  const bool ret = !!ReleaseMutex(mutex);
-
-  /* We can't ASSERT here, since this is called from checkpoints,
-   * which is called from ASSERT. */
-  if (!ret) {
-    sm_crash(werr_ssprintf(GetLastError(), "ReleaseMutex failed"));
-  }
-}
+bool MutexImpl_Win32::TryLock() { return TryEnterCriticalSection(&mutex) != 0; }
+void MutexImpl_Win32::Unlock() { LeaveCriticalSection(&mutex); }
 
 uint64_t GetThisThreadId() { return GetCurrentThreadId(); }
 
@@ -271,98 +253,38 @@ MutexImpl* MakeMutex(RageMutex* pParent) {
 
 EventImpl_Win32::EventImpl_Win32(MutexImpl_Win32* pParent) {
   m_pParent = pParent;
-  m_iNumWaiting = 0;
-  m_WakeupSema = CreateSemaphore(nullptr, 0, 0x7fffffff, nullptr);
-  InitializeCriticalSection(&m_iNumWaitingLock);
-  m_WaitersDone = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+  InitializeConditionVariable(&m_ThreadConditionVariable);
 }
 
 EventImpl_Win32::~EventImpl_Win32() {
-  ASSERT_M(
-      m_iNumWaiting == 0,
-      ssprintf("event destroyed while still in use (%i)", m_iNumWaiting));
-
   // We don't own m_pParent; don't free it.
-  CloseHandle(m_WakeupSema);
-  DeleteCriticalSection(&m_iNumWaitingLock);
-  CloseHandle(m_WaitersDone);
 }
 
-// Event logic from http://www.cs.wustl.edu/~schmidt/win32-cv-1.html.
 bool EventImpl_Win32::Wait(RageTimer* pTimeout) {
-  EnterCriticalSection(&m_iNumWaitingLock);
-  ++m_iNumWaiting;
-  LeaveCriticalSection(&m_iNumWaitingLock);
-
-  unsigned iMilliseconds = INFINITE;
+  DWORD iMilliseconds = INFINITE;
   if (pTimeout != nullptr) {
     float fSecondsInFuture = -pTimeout->Ago();
-    iMilliseconds = static_cast<unsigned>(
+    iMilliseconds = static_cast<DWORD>(
         std::max(0, static_cast<int>(fSecondsInFuture * 1000)));
   }
 
   // Unlock the mutex and wait for a signal.
   bool bSuccess =
-      (SignalObjectAndWait(
-           m_pParent->mutex, m_WakeupSema, iMilliseconds, FALSE) ==
-       WAIT_OBJECT_0);
+      SleepConditionVariableCS(
+          &m_ThreadConditionVariable, &m_pParent->mutex, iMilliseconds) != 0;
 
-  EnterCriticalSection(&m_iNumWaitingLock);
   if (!bSuccess) {
-    /* Avoid a race condition: someone may have signalled the object
-     * between SignalObjectAndWait and EnterCriticalSection.
-     * While we hold m_iNumWaitingLock, poll (with a zero timeout) the
-     * object one last time. */
-    if (WaitForSingleObject(m_WakeupSema, 0) == WAIT_OBJECT_0) {
-      bSuccess = true;
-    }
-  }
-  --m_iNumWaiting;
-  bool bLastWaiting = (m_iNumWaiting == 0);
-  LeaveCriticalSection(&m_iNumWaitingLock);
-
-  /* If we're the last waiter to wake up, and we were actually woken by
-   * another thread (not by timeout), wake up the signaller. */
-  if (bLastWaiting && bSuccess) {
-    SignalObjectAndWait(m_WaitersDone, m_pParent->mutex, INFINITE, FALSE);
-  } else {
-    WaitForSingleObject(m_pParent->mutex, INFINITE);
   }
 
   return bSuccess;
 }
 
 void EventImpl_Win32::Signal() {
-  EnterCriticalSection(&m_iNumWaitingLock);
-
-  if (m_iNumWaiting == 0) {
-    LeaveCriticalSection(&m_iNumWaitingLock);
-    return;
-  }
-
-  ReleaseSemaphore(m_WakeupSema, 1, 0);
-
-  LeaveCriticalSection(&m_iNumWaitingLock);
-
-  // The waiter will touch m_WaitersDone.
-  WaitForSingleObject(m_WaitersDone, INFINITE);
+  WakeConditionVariable(&m_ThreadConditionVariable);
 }
 
 void EventImpl_Win32::Broadcast() {
-  EnterCriticalSection(&m_iNumWaitingLock);
-
-  if (m_iNumWaiting == 0) {
-    LeaveCriticalSection(&m_iNumWaitingLock);
-    return;
-  }
-
-  ReleaseSemaphore(m_WakeupSema, m_iNumWaiting, 0);
-
-  LeaveCriticalSection(&m_iNumWaitingLock);
-
-  /* The last waiter will touch m_WaitersDone, so we wait for all waiters
-   * to wake up and start waiting for the mutex before returning. */
-  WaitForSingleObject(m_WaitersDone, INFINITE);
+  WakeAllConditionVariable(&m_ThreadConditionVariable);
 }
 
 EventImpl* MakeEvent(MutexImpl* pMutex) {
@@ -384,23 +306,16 @@ void SemaImpl_Win32::Post() {
 }
 
 bool SemaImpl_Win32::Wait() {
-  int len = 15000;
-  int tries = 5;
+  DWORD result = WaitForSingleObject(sem, INFINITE);
 
-  while (tries--) {
-    /* Wait for 15 seconds. If it takes longer than that, we're
-     * probably deadlocked. */
-    if (SimpleWaitForSingleObject(sem, len)) {
-      --m_iCounter;
+  switch (result) {
+    case WAIT_OBJECT_0:
       return true;
-    }
-
-    /* Timed out; probably deadlocked. Try again a few more times,
-     * with a smaller timeout, just in case we're debugging and
-     * happened to stop while waiting on the mutex. */
-    len = 1000;
+    case WAIT_FAILED:
+      FAIL_M(werr_ssprintf(GetLastError(), "WaitForSingleObject"));
+    default:
+      FAIL_M("Unexpected WaitForSingleObject return");
   }
-
   return false;
 }
 

--- a/src/arch/Threads/Threads_Win32.cpp
+++ b/src/arch/Threads/Threads_Win32.cpp
@@ -274,6 +274,13 @@ bool EventImpl_Win32::Wait(RageTimer* pTimeout) {
           &m_ThreadConditionVariable, &m_pParent->mutex, iMilliseconds) != 0;
 
   if (!bSuccess) {
+    ASSERT_M(
+        GetLastError() == ERROR_TIMEOUT,
+        ssprintf(
+            "%s", werr_ssprintf(
+                      GetLastError(),
+                      "Waited as instructed, but received a timeout signal!")
+                      .c_str()));
   }
 
   return bSuccess;

--- a/src/arch/Threads/Threads_Win32.h
+++ b/src/arch/Threads/Threads_Win32.h
@@ -38,7 +38,11 @@ class MutexImpl_Win32 : public MutexImpl {
   void Unlock();
 
  private:
-  HANDLE mutex;
+  static constexpr DWORD kSpinCount =
+      4000;  // Windows heap manager default. According to MSDN, the default is
+             // "about 4000". Thanks for the clear answer, Microsoft.
+             // https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-setcriticalsectionspincount
+  CRITICAL_SECTION mutex;
 };
 
 class EventImpl_Win32 : public EventImpl {
@@ -53,11 +57,7 @@ class EventImpl_Win32 : public EventImpl {
 
  private:
   MutexImpl_Win32* m_pParent;
-
-  int m_iNumWaiting;
-  CRITICAL_SECTION m_iNumWaitingLock;
-  HANDLE m_WakeupSema;
-  HANDLE m_WaitersDone;
+  CONDITION_VARIABLE m_ThreadConditionVariable;
 };
 
 class SemaImpl_Win32 : public SemaImpl {

--- a/src/archutils/Win32/Crash.cpp
+++ b/src/archutils/Win32/Crash.cpp
@@ -226,6 +226,7 @@ void RunChild() {
         FALSE, DUPLICATE_SAME_ACCESS);
 
     WriteToChild(hToStdin, &hTargetHandle, sizeof(hTargetHandle));
+    CloseHandle(hTargetHandle);
   }
 
   // 1. Write the CrashData.
@@ -290,6 +291,16 @@ void RunChild() {
     WriteToChild(hToStdin, &iSize, sizeof(iSize));
     WriteToChild(hToStdin, szName, iSize);
   }
+
+  WaitForSingleObject(
+      hProcess, INFINITE);  // We won't actually wait for infinite time here,
+                            // we're just letting the crash handler child
+                            // process do its thing before we wrap up here, to
+                            // avoid leaking or detaching the child process.
+
+  CloseHandle(hProcess);
+  CloseHandle(hToStdin);
+  CloseHandle(hFromStdout);
 }
 
 static DWORD WINAPI MainExceptionHandler(LPVOID lpParameter) {


### PR DESCRIPTION
# Summary

The existing code hasn't been meaningfully updated since 0.9.0 where some Windows 9x specific code was removed to stop crashes that were happening, but the actual design of the code which avoided use of a Windows native condition variable for pre-Vista compatibility needed to be changed.

# Explanation

Windows didn't have condition variables until Vista. SM5 supported XP so it would have had to use the existing approach.

The problem is that it does not seem to scale up well. When Windows crashes attributed to RageLog threaded changes were reported, I traced the problem to the Windows threading code itself. I verified Linux wasn't affected, so macOS should also never have been affected (Linux and macOS both use Pthreads).

Since the failing code was part of the manual semaphore management, I implemented the native condition variable to be able to replace that broken code.

# Key Changes

**EventImpl_Win32 directly implements Windows' native condition variable type**. This allows us to eliminate the fragile custom semaphore & waiter count completely. As a result, several variables used for manual tracking can be removed from the header file.

**MutexImpl_Win32 now uses CriticalSection directly** both to provide the same primitive the condition variable expects and to also simplify the code.

**SemaImpl_Win32::Wait is simplified to a single WaitForSingleObject call** with proper error handling. In other words it is no longer a condition variable substitute, and now only handles explicit semaphore semantics.

Windows' Crash Handler code is also updated to ensure that proper cleanup of all child processes takes place as expected with the above restructuring. This specifically also makes significant progress to resolve issue #1444 .

# Conclusion

This is intended to be merged alongside #1454 #1457 #1458 and #1459 since this code was all tested together but broken out to individual PR's. Please consider it to be the individual parts of one larger PR.