### PR TITLE
Windows (crash handler): resolve incorrect character types used

### DIFF
--- a/src/archutils/Win32/Crash.cpp
+++ b/src/archutils/Win32/Crash.cpp
@@ -232,7 +232,7 @@ void RunChild() {
   WriteToChild(hToStdin, &g_CrashInfo, sizeof(g_CrashInfo));
 
   // 2. Write info.
-  const TCHAR* p = RageLog::GetInfo();
+  const char* p = RageLog::GetInfo();
   int iSize = static_cast<int>(strlen(p));
   WriteToChild(hToStdin, &iSize, sizeof(iSize));
   WriteToChild(hToStdin, p, iSize);
@@ -245,7 +245,7 @@ void RunChild() {
 
   // 4. Write RecentLogs.
   int cnt = 0;
-  const TCHAR* ps[1024];
+  const char* ps[1024];
   while (cnt < 1024 && (ps[cnt] = RageLog::GetRecentLog(cnt)) != nullptr) {
     ++cnt;
   }
@@ -258,7 +258,7 @@ void RunChild() {
   }
 
   // 5. Write CHECKPOINTs.
-  static TCHAR buf[1024 * 32];
+  static char buf[1024 * 32];
   Checkpoints::GetLogs(buf, sizeof(buf), "$$");
   iSize = static_cast<int>(strlen(buf)) + 1;
   WriteToChild(hToStdin, &iSize, sizeof(iSize));
@@ -282,7 +282,7 @@ void RunChild() {
       break;
     }
 
-    TCHAR szName[MAX_PATH];
+    char szName[MAX_PATH];
     if (!CrashGetModuleBaseName(hMod, szName)) {
       strcpy(szName, "???");
     }


### PR DESCRIPTION
# Preface

Resolves a myriad of type mismatch errors in `src\archutils\Win32\Crash.cpp`, mostly stemming from functions expecting a plain `char` but being given `TCHAR`.

# Description

Replaces the TCHAR type with char as TCHAR is no longer the correct type to use here. This was identified by the Visual Studio IDE, as this type mismatch did not generate any warnings/errors visible via the compiler. 

Fully resolves #1455 