### PR TITLE
Windows (crash handler):  increase crash pipe buffer size

### DIFF
--- a/src/archutils/Win32/Crash.cpp
+++ b/src/archutils/Win32/Crash.cpp
@@ -132,8 +132,8 @@ bool StartChild(HANDLE& hProcess, HANDLE& hToStdin, HANDLE& hFromStdout) {
     sa.bInheritHandle = true;
     sa.lpSecurityDescriptor = nullptr;
 
-    CreatePipe(&si.hStdInput, &hToStdin, &sa, 0);
-    CreatePipe(&hFromStdout, &si.hStdOutput, &sa, 0);
+    CreatePipe(&si.hStdInput, &hToStdin, &sa, 1024 * 64);
+    CreatePipe(&hFromStdout, &si.hStdOutput, &sa, 1024 * 64);
     SetHandleInformation(hToStdin, HANDLE_FLAG_INHERIT, 0);
     SetHandleInformation(hFromStdout, HANDLE_FLAG_INHERIT, 0);
   }


### PR DESCRIPTION
Instead of relying on whatever amount of space we are given by defining a size of 0, explicitly define a 64KB buffer for our stdin/stdio pipes. According to the function documentation, 0 provides the default value, but I don't see that size defined clearly anywhere. https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-createpipe