### PR TITLE
Make WASAPI the default driver on windows

### DIFF
--- a/src/arch/arch_default.h
+++ b/src/arch/arch_default.h
@@ -24,7 +24,7 @@ inline const std::vector<std::string>& GetDefaultMovieDriverList() {
 
 inline const std::vector<std::string>& GetDefaultSoundDriverList() {
   static const std::vector<std::string> soundDriverList = {
-      "DirectSound-sw", "WASAPI", "WaveOut", "WDMKS", "Null"};
+      "WASAPI", "DirectSound-sw", "WaveOut", "WDMKS", "Null"};
   return soundDriverList;
 }
 


### PR DESCRIPTION
This should happen at some point, and if nobody is seriously testing this that'll never happen. If this does turn out to be an issue, after the next release we can revert this and create a new release, or people can override drivers.

The few people that have tried this haven't reported anything except improvements.