### PR TITLE
Discard outlier samples when autosync'ing the offset

### DIFF
--- a/src/AdjustSync.cpp
+++ b/src/AdjustSync.cpp
@@ -190,10 +190,23 @@ void AdjustSync::HandleSongEnd() {
 }
 
 void AdjustSync::AutosyncOffset() {
-  const float mean =
+  // Sort the offsets in descending order by their absolute difference
+  // from the mean. The first OFFSET_SAMPLE_OUTLIER_DISCARD_COUNT will
+  // be discarded when calculating the final mean and stddev below.
+  const float initialMean =
       calc_mean(s_fAutosyncOffset, s_fAutosyncOffset + OFFSET_SAMPLE_COUNT);
-  const float stddev =
-      calc_stddev(s_fAutosyncOffset, s_fAutosyncOffset + OFFSET_SAMPLE_COUNT);
+  std::sort(
+      s_fAutosyncOffset, s_fAutosyncOffset + OFFSET_SAMPLE_COUNT,
+      [initialMean](float a, float b) {
+        return std::abs(a - initialMean) > std::abs(b - initialMean);
+      });
+
+  const float mean = calc_mean(
+      s_fAutosyncOffset + OFFSET_SAMPLE_OUTLIER_DISCARD_COUNT,
+      s_fAutosyncOffset + OFFSET_SAMPLE_COUNT);
+  const float stddev = calc_stddev(
+      s_fAutosyncOffset + OFFSET_SAMPLE_OUTLIER_DISCARD_COUNT,
+      s_fAutosyncOffset + OFFSET_SAMPLE_COUNT);
 
   AutosyncType type = GAMESTATE->m_SongOptions.GetCurrent().m_AutosyncType;
 

--- a/src/AdjustSync.h
+++ b/src/AdjustSync.h
@@ -48,6 +48,12 @@ class AdjustSync {
   static int s_iAutosyncOffsetSample;
   static float s_fStandardDeviation;
 
+  // After collecting the OFFSET_SAMPLE_COUNT samples to adjust sync,
+  // throw away OFFSET_SAMPLE_OUTLIER_DISCARD_COUNT with the largest
+  // offsets prior to calculating mean and std_dev. This is to minimize
+  // the effects of having a bad step or two during the autosync.
+  static const int OFFSET_SAMPLE_OUTLIER_DISCARD_COUNT = 2;
+
   // Measured in seconds.  If the average error is too high, we
   // reject the recorded data for the Least Squares Regression.
   static const float ERROR_TOO_HIGH;


### PR DESCRIPTION
When using autosync to adjust the machine offset, a single outlier can skew the calculated mean and thus the new offset.  While there's already a check for stddev < .03f, this can still happen.

For me, this usually happens if I'm using autosync on a relatively easy song, and there's a single step during a quieter part of the song that I mess up.  Or sometimes a bad offset sample just happens if you get tripped up on something temporarily.

Instead of having a skewed offset calculation or possibly throwing the entire set of samples out, we can throw away the two worst offsets (relative to their initial mean), before calculating the mean and stddev as before.  This should make the calculations more consistent and robust to the occasional poor step for whatever reason.