### PR TITLE
Rewrite a comparison using mismatched data types

### DIFF
--- a/src/arch/Threads/Threads_Win32.cpp
+++ b/src/arch/Threads/Threads_Win32.cpp
@@ -1,6 +1,6 @@
 #include "Threads_Win32.h"
 
-#include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -296,9 +296,8 @@ bool EventImpl_Win32::Wait(RageTimer* pTimeout) {
 
   unsigned iMilliseconds = INFINITE;
   if (pTimeout != nullptr) {
-    float fSecondsInFuture = -pTimeout->Ago();
-    iMilliseconds = static_cast<unsigned>(
-        std::max(0, static_cast<int>(fSecondsInFuture * 1000)));
+    const int iMsecInFuture = std::ceil(-pTimeout->Ago() * 1000.f);
+    iMsecInFuture > 0 ? iMilliseconds = iMsecInFuture : iMilliseconds = 0;
   }
 
   // Unlock the mutex and wait for a signal.


### PR DESCRIPTION
The main reason for this PR to exist is that I noticed mismatched types being used in the std::max call, so I have rewritten it to be a type-agnostic comparison.

I have pulled in `<cmath>` instead to use ceil. In this context, it's preferable to round up (if the decimal is being truncated, we would prefer to be one millisecond late than one millisecond early).

Sorry for using Hungarian notation, I felt it would be weird to not to given the surrounding style though.