### PR TITLE
Fix USB custom song timeout and unmounted data overwrites

### DIFF
--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -645,8 +645,11 @@ void GameState::SavePlayerProfile(PlayerNumber pn) {
   }
 
   bool bWasMemoryCard = PROFILEMAN->ProfileWasLoadedFromMemoryCard(pn);
-  if (bWasMemoryCard) {
-    MEMCARDMAN->MountCard(pn);
+  if (bWasMemoryCard && !MEMCARDMAN->MountCard(pn)) {
+    LOG->Warn(
+        "Couldn't mount P%d memory card, profile '%s' won't be saved", pn + 1,
+        PROFILEMAN->GetPlayerName(pn).c_str());
+    return;
   }
   PROFILEMAN->SaveProfile(pn);
   if (bWasMemoryCard) {

--- a/src/MemoryCardManager.cpp
+++ b/src/MemoryCardManager.cpp
@@ -646,8 +646,14 @@ void MemoryCardManager::UnmountCard(PlayerNumber pn) {
     return;
   }
 
+  // Give unmounting a fresh timeout instead of inheriting time spent accessing
+  // the card.
+  this->RefreshCardAccessTimeout();
+
   // Leave our own filesystem drivers mounted.  Unmount the kernel mount.
-  g_pWorker->Unmount(&m_Device[pn]);
+  if (!g_pWorker->Unmount(&m_Device[pn])) {
+    LOG->Warn("MemoryCardManager::UnmountCard: unmount failed");
+  }
 
   // Flush mountpoints pointing to what we've unmounted.
   FILEMAN->FlushDirCache(MEM_CARD_MOUNT_POINT[pn]);
@@ -691,8 +697,15 @@ void MemoryCardManager::PauseMountingThread(int iTimeout) {
   g_pWorker->SetMountThreadState(ThreadedMemoryCardWorker::paused);
 
   // Start the timeout period.
-  g_pWorker->SetTimeout((float)iTimeout);
-  RageFileDriverTimeout::SetTimeout((float)iTimeout);
+  this->RefreshCardAccessTimeout((float)iTimeout);
+}
+
+// The timeout prevents a bad memory card from indefinitely stalling the game.
+// Possibly each successful file system operation could adjust the
+// timeout by some amount, but that requires a more thoughtful implementation.
+void MemoryCardManager::RefreshCardAccessTimeout(float fTimeout) {
+  g_pWorker->SetTimeout(fTimeout);
+  RageFileDriverTimeout::SetTimeout(fTimeout);
 }
 
 void MemoryCardManager::UnPauseMountingThread() {

--- a/src/MemoryCardManager.h
+++ b/src/MemoryCardManager.h
@@ -31,6 +31,7 @@ class MemoryCardManager {
   bool MountCard(PlayerNumber pn, const UsbStorageDevice& d, int iTimeout = 10);
   void UnmountCard(PlayerNumber pn);
 
+  void RefreshCardAccessTimeout(float fTimeout = 10.0f);
   bool IsMounted(PlayerNumber pn) const { return m_bMounted[pn]; }
 
   // When paused, no changes in memory card state will be noticed until

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -29,6 +29,7 @@
 #include "HighScore.h"
 #include "IniFile.h"
 #include "LuaManager.h"
+#include "MemoryCardManager.h"
 #include "PlayerNumber.h"
 #include "Preference.h"
 #include "PrefsManager.h"
@@ -1204,7 +1205,7 @@ void Profile::LoadSongsFromDir(
     return;
   }
   std::string songs_folder = dir + "Songs";
-  if (FILEMAN->DoesFileExist(songs_folder) && isMemoryCard) {
+  if (isMemoryCard && FILEMAN->DoesFileExist(songs_folder)) {
     LOG->Trace("Found songs folder in profile.");
     std::vector<std::string> song_folders;
     RageTimer song_load_start_time;
@@ -1225,6 +1226,9 @@ void Profile::LoadSongsFromDir(
          m_songs.size() < PREFSMAN->m_custom_songs_max_count;
          ++song_index) {
       std::string& song_dir_name = song_folders[song_index];
+      // Each song gets a fresh memory card timeout. song_load_start_time limits
+      // the total custom song loading time.
+      MEMCARDMAN->RefreshCardAccessTimeout();
       Song* new_song = new Song;
       if (!new_song->LoadFromSongDir(song_dir_name, false, prof_slot)) {
         // The song failed to load.
@@ -1247,6 +1251,9 @@ void Profile::LoadSongsFromDir(
       delete m_group;
       m_group = nullptr;
     }
+    // Don't make subsequent profile work inherit the time
+    // used by the last song.
+    MEMCARDMAN->RefreshCardAccessTimeout();
   } else {
     LOG->Trace("No songs folder in profile.");
   }

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -281,12 +281,14 @@ void ProfileManager::GetMemoryCardProfileDirectoriesToTry(
 
 bool ProfileManager::LoadProfileFromMemoryCard(
     PlayerNumber pn, bool bLoadEdits) {
-  UnloadProfile(pn);
-
-  // mount slot
-  if (MEMCARDMAN->GetCardState(pn) != MemoryCardState_Ready) {
+  // The card must be ready and mounted to determine if a profile already
+  // exists on the card.
+  if (MEMCARDMAN->GetCardState(pn) != MemoryCardState_Ready ||
+      !MEMCARDMAN->IsMounted(pn)) {
     return false;
   }
+
+  UnloadProfile(pn);
 
   std::vector<std::string> asDirsToTry;
   GetMemoryCardProfileDirectoriesToTry(asDirsToTry);

--- a/src/ScreenSelectProfile.cpp
+++ b/src/ScreenSelectProfile.cpp
@@ -224,10 +224,12 @@ bool ScreenSelectProfile::Finish() {
     if (m_iSelectedProfiles[p] == 0) {
       MEMCARDMAN->WaitForCheckingToComplete();
 
-      MEMCARDMAN->MountCard(p);
-      bool bSuccess =
-          PROFILEMAN->LoadProfileFromMemoryCard(p, true);  // load full profile
-      MEMCARDMAN->UnmountCard(p);
+      bool bSuccess = false;
+      if (MEMCARDMAN->MountCard(p)) {
+        bSuccess = PROFILEMAN->LoadProfileFromMemoryCard(
+            p, true);  // load full profile
+        MEMCARDMAN->UnmountCard(p);
+      }
 
       // Lock the card on successful load, so we won't allow it to be changed.
       if (bSuccess) {


### PR DESCRIPTION
Fixes #1105 

The issue had 3 bugs that are fixed by this PR. I was able to replicate it and confirm that these changes fix it, and I tested most USB features afterward to make sure they still work. 

First any custom song load timeout over 10 seconds would do nothing because there is a lower level memory card timeout for all memory card tasks of 10 seconds. The purpose of that timeout is to prevent the game from stalling indefinitely on a bad USB. I've kept that timeout but it now gets refreshed after each custom song. 

Secondly the timeout for the mount worker and the file system worker were started at the same time, so if the filesystem worker timed out after 10 seconds the unmount worker would functionally have ~0 seconds to unmount the USB. On windows this was fine but on linux the unmount takes a little bit of time which would cause a race condition when the P2 memory card tries to mount right after the P1 unmount, effectively blocking it from mounting. The timeout is now refreshed at the start of the unmount function so it gets 10 seconds. 

Lastly the game was not distinguishing between "new memory card with no data" and "memory card that failed to mount" so anytime a card failed to mount for any reason the game would overwrite the data with a blank profile. This was fixed by simply checking that the card actually mounted before assuming that it is blank.

This does not fix all bugs that can cause a profile to be overridden or corrupted, I found possibly 3-5 others while working on this but I will fix them in another PR.