### PR TITLE
Add deflate arguments for network handler, to allow for compressed websocket connections.

### DIFF
--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -385,6 +385,13 @@ WebSocketHandlePtr NetworkManager::WebSocket(const WebSocketArgs& args) {
 
   handle->webSocket.setUrl(args.url);
   handle->webSocket.setTLSOptions(this->tlsOptions);
+
+  if (args.enableDeflate) {
+    handle->webSocket.enablePerMessageDeflate();
+  } else {
+    handle->webSocket.disablePerMessageDeflate();
+  }
+
   handle->webSocket.setOnMessageCallback(
       [onMessage = args.onMessage](const ix::WebSocketMessagePtr& msg) {
         if (onMessage) {
@@ -828,6 +835,17 @@ class LunaNetworkManager : public Luna<NetworkManager> {
         args.automaticReconnect = lua_toboolean(L, -1);
       } else {
         luaL_error(L, "automaticReconnect must be a boolean");
+      }
+    }
+    lua_pop(L, 1);
+
+    args.enableDeflate = true;
+    lua_getfield(L, 1, "enableDeflate");
+    if (!lua_isnil(L, -1)) {
+      if (lua_isboolean(L, -1)) {
+        args.enableDeflate = lua_toboolean(L, -1);
+      } else {
+        luaL_error(L, "enableDeflate must be a boolean");
       }
     }
     lua_pop(L, 1);

--- a/src/NetworkManager.h
+++ b/src/NetworkManager.h
@@ -104,6 +104,7 @@ struct WebSocketArgs {
   int handshakeTimeout = -1;
   int pingInterval = -1;
   bool automaticReconnect = true;
+  bool enableDeflate = true;
   std::function<void(const ix::WebSocketMessage& response)> onMessage;
   std::function<void()> onClose;
 };


### PR DESCRIPTION
Assuming I understand how the online lobbies and the underlying networking code works, this should be backward compatible. This will try a compressed websocket connection first, and if it's not supported, falls back to the uncompressed way.

https://github.com/machinezone/IXWebSocket/blob/2efe037c9cc96fd536774f17bdb5215161ee5087/ixwebsocket/IXWebSocketHandshake.cpp#L236-L240

Alternatively I could just broadly enable it, rather than making it toggleable, since it's the same behavior either way. Or default it to false if preferred.

I want to add this functionality for potential integration with Archipelago, which prefers compressed Websocket connections (https://github.com/bwaggone/ITGMania-Archipelago-Module).