### PR TITLE
add debug sensor state to InputFilter for supported devices

### DIFF
--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -1075,6 +1075,7 @@
 			<Function name='GetMouseWheel'/>
 			<Function name='GetMouseX'/>
 			<Function name='GetMouseY'/>
+			<Function name='GetFullSensorState'/>
 		</Class>
 		<Class base='BitmapText' name='InputList'>
 		</Class>
@@ -1633,6 +1634,8 @@
 		</Class>
 		<Class name='RageInput'>
 			<Function name='GetDescriptions'/>
+			<Function name='StartSensorTest'/>
+			<Function name='StopSensorTest'/>
 		</Class>
 		<Class name='RageQuadratic'>
 			<Function name='evaluate'/>

--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -2708,18 +2708,14 @@
 			<EnumValue name='&apos;PadPanel_DownRight&apos;' value='8'/>
 		</Enum>
 		<Enum name='PadSensor'>
-			<EnumValue name='&apos;PadSensor_Top&apos;' value='0'/>
-			<EnumValue name='&apos;PadSensor_Right&apos;' value='1'/>
-			<EnumValue name='&apos;PadSensor_Bottom&apos;' value='2'/>
-			<EnumValue name='&apos;PadSensor_Left&apos;' value='3'/>
-			<EnumValue name='&apos;PadSensor_TopCenter&apos;' value='4'/>
-			<EnumValue name='&apos;PadSensor_TopLeft&apos;' value='5'/>
-			<EnumValue name='&apos;PadSensor_TopRight&apos;' value='6'/>
-			<EnumValue name='&apos;PadSensor_RightCenter&apos;' value='7'/>
-			<EnumValue name='&apos;PadSensor_BottomCenter&apos;' value='8'/>
-			<EnumValue name='&apos;PadSensor_BottomLeft&apos;' value='9'/>
-			<EnumValue name='&apos;PadSensor_BottomRight&apos;' value='10'/>
-			<EnumValue name='&apos;PadSensor_LeftCenter&apos;' value='11'/>
+			<EnumValue name='&apos;PadSensor_TopCenter&apos;' value='0'/>
+			<EnumValue name='&apos;PadSensor_TopLeft&apos;' value='1'/>
+			<EnumValue name='&apos;PadSensor_TopRight&apos;' value='2'/>
+			<EnumValue name='&apos;PadSensor_RightCenter&apos;' value='3'/>
+			<EnumValue name='&apos;PadSensor_BottomCenter&apos;' value='4'/>
+			<EnumValue name='&apos;PadSensor_BottomLeft&apos;' value='5'/>
+			<EnumValue name='&apos;PadSensor_BottomRight&apos;' value='6'/>
+			<EnumValue name='&apos;PadSensor_LeftCenter&apos;' value='7'/>
 		</Enum>
 		<Enum name='PaneCategory'>
 			<EnumValue name='&apos;PaneCategory_NumSteps&apos;' value='0'/>

--- a/Docs/Luadoc/Lua.xml
+++ b/Docs/Luadoc/Lua.xml
@@ -2696,6 +2696,31 @@
 			<EnumValue name='&apos;OptEffect_ApplySong&apos;' value='5'/>
 			<EnumValue name='&apos;OptEffect_ApplyAspectRatio&apos;' value='6'/>
 		</Enum>
+		<Enum name='PadPanel'>
+			<EnumValue name='&apos;PadPanel_UpLeft&apos;' value='0'/>
+			<EnumValue name='&apos;PadPanel_Up&apos;' value='1'/>
+			<EnumValue name='&apos;PadPanel_UpRight&apos;' value='2'/>
+			<EnumValue name='&apos;PadPanel_Left&apos;' value='3'/>
+			<EnumValue name='&apos;PadPanel_Center&apos;' value='4'/>
+			<EnumValue name='&apos;PadPanel_Right&apos;' value='5'/>
+			<EnumValue name='&apos;PadPanel_DownLeft&apos;' value='6'/>
+			<EnumValue name='&apos;PadPanel_Down&apos;' value='7'/>
+			<EnumValue name='&apos;PadPanel_DownRight&apos;' value='8'/>
+		</Enum>
+		<Enum name='PadSensor'>
+			<EnumValue name='&apos;PadSensor_Top&apos;' value='0'/>
+			<EnumValue name='&apos;PadSensor_Right&apos;' value='1'/>
+			<EnumValue name='&apos;PadSensor_Bottom&apos;' value='2'/>
+			<EnumValue name='&apos;PadSensor_Left&apos;' value='3'/>
+			<EnumValue name='&apos;PadSensor_TopCenter&apos;' value='4'/>
+			<EnumValue name='&apos;PadSensor_TopLeft&apos;' value='5'/>
+			<EnumValue name='&apos;PadSensor_TopRight&apos;' value='6'/>
+			<EnumValue name='&apos;PadSensor_RightCenter&apos;' value='7'/>
+			<EnumValue name='&apos;PadSensor_BottomCenter&apos;' value='8'/>
+			<EnumValue name='&apos;PadSensor_BottomLeft&apos;' value='9'/>
+			<EnumValue name='&apos;PadSensor_BottomRight&apos;' value='10'/>
+			<EnumValue name='&apos;PadSensor_LeftCenter&apos;' value='11'/>
+		</Enum>
 		<Enum name='PaneCategory'>
 			<EnumValue name='&apos;PaneCategory_NumSteps&apos;' value='0'/>
 			<EnumValue name='&apos;PaneCategory_Jumps&apos;' value='1'/>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -3549,7 +3549,7 @@ end
 	<Function name='GetMouseY' return='float' arguments=''>
 		Returns the Y position of the mouse.
 	</Function>
-	<Function name='GetFullSensorState' return='table' arguments=''>
+	<Function name='GetFullSensorState' return='table' arguments='' since='ITGmania 1.4.0'>
 		Returns a table of <code>NUM_PLAYERS</code> with <code>NUM_PadPanel</code> panels, each with a float of the <code>NUM_PadSensor</code> the individual sensors and their per sensor, sub button, state. Be sure that <code>INPUTMAN:StartSensorTest()</code> and <code>INPUTMAN:StopSensorTest()</code> are correctly turned on/off otherwise the data in this table may be stale.
 	</Function>
 </Class>
@@ -5114,10 +5114,10 @@ prev_note_name, succeeded = options:NoteSkin("cel")
 	<Function name='GetDescriptions' return='{string}' arguments=''>
 		Returns an array of connected input device descriptions.
 	</Function>
-	<Function name='StartSensorTest' return='' arguments=''>
+	<Function name='StartSensorTest' return='' arguments='' since='ITGmania 1.4.0'>
 		Begins additional polling for information about the individual sensors if available. To be called before the data is to be shown to the user. Data can be requested via <code>INPUTFILTER:GetFullSensorState()</code>
 	</Function>
-	<Function name='StopSensorTest' return='' arguments=''>
+	<Function name='StopSensorTest' return='' arguments='' since='ITGmania 1.4.0'>
 		Stops additional polling for information about the individual sensors. To be called when the information is no longer to be sent to the user.
 	</Function>
 </Class>

--- a/Docs/Luadoc/LuaDocumentation.xml
+++ b/Docs/Luadoc/LuaDocumentation.xml
@@ -3549,6 +3549,9 @@ end
 	<Function name='GetMouseY' return='float' arguments=''>
 		Returns the Y position of the mouse.
 	</Function>
+	<Function name='GetFullSensorState' return='table' arguments=''>
+		Returns a table of <code>NUM_PLAYERS</code> with <code>NUM_PadPanel</code> panels, each with a float of the <code>NUM_PadSensor</code> the individual sensors and their per sensor, sub button, state. Be sure that <code>INPUTMAN:StartSensorTest()</code> and <code>INPUTMAN:StopSensorTest()</code> are correctly turned on/off otherwise the data in this table may be stale.
+	</Function>
 </Class>
 <Class name='InputList' grouping='Actor'>
 	<Description>
@@ -5110,6 +5113,12 @@ prev_note_name, succeeded = options:NoteSkin("cel")
 	</Description>
 	<Function name='GetDescriptions' return='{string}' arguments=''>
 		Returns an array of connected input device descriptions.
+	</Function>
+	<Function name='StartSensorTest' return='' arguments=''>
+		Begins additional polling for information about the individual sensors if available. To be called before the data is to be shown to the user. Data can be requested via <code>INPUTFILTER:GetFullSensorState()</code>
+	</Function>
+	<Function name='StopSensorTest' return='' arguments=''>
+		Stops additional polling for information about the individual sensors. To be called when the information is no longer to be sent to the user.
 	</Function>
 </Class>
 <Class name='RageQuadratic'>

--- a/src/InputFilter.cpp
+++ b/src/InputFilter.cpp
@@ -33,6 +33,7 @@ static const char* PadPanelNames[] = {"UpLeft",   "Up",     "UpRight",
                                       "DownLeft", "Down",   "DownRight"};
 XToString(PadPanel);
 StringToX(PadPanel);
+LuaXType(PadPanel);
 
 static const char* PadSensorNames[] = {
     "Top",          "Right",      "Bottom",      "Left",
@@ -41,6 +42,7 @@ static const char* PadSensorNames[] = {
 };
 XToString(PadSensor);
 StringToX(PadSensor);
+LuaXType(PadSensor);
 
 struct ButtonState {
   ButtonState();

--- a/src/InputFilter.cpp
+++ b/src/InputFilter.cpp
@@ -1,24 +1,25 @@
 #include "InputFilter.h"
 
+#include <cstddef>
+#include <map>  // for mouse stuff: -aj
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "EnumHelper.h"
 #include "GameInput.h"
 #include "InputMapper.h"
 #include "LuaManager.h"
+#include "PlayerNumber.h"
 #include "Preference.h"
+#include "PrefsManager.h"
 #include "RageInput.h"
 #include "RageInputDevice.h"
 #include "RageLog.h"
 #include "RageThreads.h"
 #include "RageTimer.h"
 #include "RageUtil.h"
-// for mouse stuff: -aj
-#include <map>
-#include <set>
-#include <string>
-#include <utility>
-#include <vector>
-
-#include "PrefsManager.h"
 #include "ScreenDimensions.h"
 
 static const char* InputEventTypeNames[] = {"FirstPress", "Repeat", "Release"};
@@ -26,6 +27,18 @@ static const char* InputEventTypeNames[] = {"FirstPress", "Repeat", "Release"};
 XToString(InputEventType);
 XToLocalizedString(InputEventType);
 LuaXType(InputEventType);
+
+static const char* PadPanelNames[] = {"UpLeft",   "Up",     "UpRight",
+                                      "Left",     "Center", "Right",
+                                      "DownLeft", "Down",   "DownRight"};
+XToString(PadPanel);
+StringToX(PadPanel);
+
+static const char* PadSensorNames[] = {
+    "Top", "Right", "Bottom", "Left", "Center",
+};
+XToString(PadSensor);
+StringToX(PadSensor);
 
 struct ButtonState {
   ButtonState();
@@ -465,6 +478,15 @@ void InputFilter::UpdateCursorLocation(float _fX, float _fY) {
 
 void InputFilter::UpdateMouseWheel(float _fZ) { m_MouseCoords.fZ = _fZ; }
 
+bool InputFilter::setFullSensorState(
+    PlayerNumber pn, PadPanel panel, PadSensor sensor, float intensity) {
+  if (pn < NUM_PlayerNumber && panel < NUM_PadPanel && sensor < NUM_PadSensor) {
+    m_Sensors[pn].Set(panel, sensor, intensity);
+    return true;
+  }
+  return false;
+}
+
 // lua start
 #include "LuaBinding.h"
 
@@ -495,10 +517,37 @@ class LunaInputFilter : public Luna<InputFilter> {
     return 1;
   }
 
+  static int GetFullSensorState(T* p, lua_State* L) {
+    lua_createtable(L, NUM_PLAYERS, 0);
+
+    for (size_t player = 0; player < NUM_PLAYERS; ++player) {
+      lua_createtable(L, 0, NUM_PadPanel);
+
+      for (size_t panel = 0; panel < NUM_PadPanel; ++panel) {
+        lua_createtable(L, 0, NUM_PadSensor);
+
+        for (size_t sensor = 0; sensor < NUM_PadSensor; ++sensor) {
+          lua_pushnumber(
+              L, p->getFullSensorState((PlayerNumber)player)
+                     ->intensity[panel][sensor]);
+
+          lua_setfield(L, -2, PadSensorNames[sensor]);
+        }
+
+        lua_setfield(L, -2, PadPanelNames[panel]);
+      }
+
+      lua_setfield(L, -2, PlayerNumberToString((PlayerNumber)player).c_str());
+    }
+
+    return 1;
+  }
+
   LunaInputFilter() {
     ADD_METHOD(GetMouseX);
     ADD_METHOD(GetMouseY);
     ADD_METHOD(GetMouseWheel);
+    ADD_METHOD(GetFullSensorState);
   }
 };
 

--- a/src/InputFilter.cpp
+++ b/src/InputFilter.cpp
@@ -35,9 +35,9 @@ XToString(PadPanel);
 StringToX(PadPanel);
 
 static const char* PadSensorNames[] = {
-    "Top",        "Right",       "Bottom",     "Left",        "Center",
-    "TopCenter",  "TopLeft",     "TopRight",   "RightCenter", "BottomCenter",
-    "BottomLeft", "BottomRight", "LeftCenter",
+    "Top",          "Right",      "Bottom",      "Left",
+    "TopCenter",    "TopLeft",    "TopRight",    "RightCenter",
+    "BottomCenter", "BottomLeft", "BottomRight", "LeftCenter",
 };
 XToString(PadSensor);
 StringToX(PadSensor);
@@ -481,9 +481,26 @@ void InputFilter::UpdateCursorLocation(float _fX, float _fY) {
 void InputFilter::UpdateMouseWheel(float _fZ) { m_MouseCoords.fZ = _fZ; }
 
 bool InputFilter::setFullSensorState(
-    PlayerNumber pn, PadPanel panel, PadSensor sensor, float intensity) {
+    PlayerNumber pn, PadPanel panel, PadSensor sensor, unsigned int intensity) {
   if (pn < NUM_PlayerNumber && panel < NUM_PadPanel && sensor < NUM_PadSensor) {
     m_Sensors[pn].Set(panel, sensor, intensity);
+    return true;
+  }
+  return false;
+}
+
+bool InputFilter::setFullSensorStateBinary(
+    PlayerNumber pn, PadPanel panel, PadSensor sensor, bool isPressed) {
+  if (pn < NUM_PlayerNumber && panel < NUM_PadPanel && sensor < NUM_PadSensor) {
+    m_Sensors[pn].SetBinary(panel, sensor, isPressed);
+    return true;
+  }
+  return false;
+}
+
+bool InputFilter::setFullSensorStateMax(PlayerNumber pn, unsigned int max) {
+  if (pn < NUM_PlayerNumber) {
+    m_Sensors[pn].SetMax(max);
     return true;
   }
   return false;
@@ -531,7 +548,7 @@ class LunaInputFilter : public Luna<InputFilter> {
         for (size_t sensor = 0; sensor < NUM_PadSensor; ++sensor) {
           lua_pushnumber(
               L, p->getFullSensorState((PlayerNumber)player)
-                     ->intensity[panel][sensor]);
+                     ->GetIntensity((PadPanel)panel, (PadSensor)sensor));
 
           lua_setfield(L, -2, PadSensorNames[sensor]);
         }

--- a/src/InputFilter.cpp
+++ b/src/InputFilter.cpp
@@ -35,7 +35,9 @@ XToString(PadPanel);
 StringToX(PadPanel);
 
 static const char* PadSensorNames[] = {
-    "Top", "Right", "Bottom", "Left", "Center",
+    "Top",        "Right",       "Bottom",     "Left",        "Center",
+    "TopCenter",  "TopLeft",     "TopRight",   "RightCenter", "BottomCenter",
+    "BottomLeft", "BottomRight", "LeftCenter",
 };
 XToString(PadSensor);
 StringToX(PadSensor);

--- a/src/InputFilter.cpp
+++ b/src/InputFilter.cpp
@@ -36,7 +36,6 @@ StringToX(PadPanel);
 LuaXType(PadPanel);
 
 static const char* PadSensorNames[] = {
-    "Top",          "Right",      "Bottom",      "Left",
     "TopCenter",    "TopLeft",    "TopRight",    "RightCenter",
     "BottomCenter", "BottomLeft", "BottomRight", "LeftCenter",
 };

--- a/src/InputFilter.h
+++ b/src/InputFilter.h
@@ -70,7 +70,6 @@ enum PadSensor {
   PadSensor_Right,
   PadSensor_Bottom,
   PadSensor_Left,
-  PadSensor_Center,
   PadSensor_TopCenter,
   PadSensor_TopLeft,
   PadSensor_TopRight,
@@ -85,18 +84,54 @@ enum PadSensor {
 };
 
 struct PadSensorState {
-  float intensity[NUM_PadPanel][NUM_PadSensor] = {};
+ private:
+  unsigned int currentValue[NUM_PadPanel][NUM_PadSensor] = {};
+  unsigned int threshold[NUM_PadPanel][NUM_PadSensor] = {};
+  unsigned int min = 0;
+  unsigned int max = 100;
 
-  const float& Get(PadPanel panel, PadSensor sensor) const {
-    return intensity[static_cast<int>(panel)][static_cast<int>(sensor)];
+ public:
+  float GetIntensity(PadPanel panel, PadSensor sensor) const {
+    return static_cast<float>(
+               currentValue[static_cast<int>(panel)][static_cast<int>(sensor)] -
+               min) /
+           static_cast<float>(max - min);
   }
 
-  void Set(PadPanel panel, PadSensor sensor, float value) {
-    value = std::clamp(value, 0.0f, 1.0f);
-    this->intensity[static_cast<int>(panel)][static_cast<int>(sensor)] = value;
+  void Set(PadPanel panel, PadSensor sensor, unsigned int value) {
+    value = std::clamp(value, min, max);
+    this->currentValue[static_cast<int>(panel)][static_cast<int>(sensor)] =
+        value;
   }
 
-  void Clear() { std::memset(intensity, 0, sizeof(intensity)); }
+  void SetBinary(PadPanel panel, PadSensor sensor, bool isPressed) {
+    Set(panel, sensor, isPressed ? max : min);
+  }
+
+  void SetMin(unsigned int value) { min = std::min(value, max); }
+  void SetMax(unsigned int value) { max = std::max(value, min); }
+
+  void SetMinMax(unsigned int newMin, unsigned int newMax) {
+    min = std::min(newMin, newMax);
+    max = std::max(newMin, newMax);
+  }
+
+  unsigned int GetMax() { return max; }
+  unsigned int GetMin() { return min; }
+
+  void SetThreshold(size_t panel, size_t sensor, unsigned int value) {
+    threshold[panel][sensor] = std::clamp(value, min, max);
+  }
+
+  unsigned int GetThreshold(size_t panel, size_t sensor) const {
+    return threshold[panel][sensor];
+  }
+
+  bool isAboveThreshold(size_t panel, size_t sensor) const {
+    return currentValue[panel][sensor] >= threshold[panel][sensor];
+  }
+
+  void Clear() { std::memset(currentValue, 0, sizeof(currentValue)); }
 };
 
 class RageMutex;
@@ -148,8 +183,14 @@ class InputFilter {
     return nullptr;
   }
 
+  bool setFullSensorStateMax(PlayerNumber pn, unsigned int max);
+
   bool setFullSensorState(
-      PlayerNumber pn, PadPanel panel, PadSensor sensor, float intensity);
+      PlayerNumber pn, PadPanel panel, PadSensor sensor,
+      unsigned int intensity);
+
+  bool setFullSensorStateBinary(
+      PlayerNumber pn, PadPanel panel, PadSensor sensor, bool isPressed);
 
   // Lua
   void PushSelf(lua_State* L);

--- a/src/InputFilter.h
+++ b/src/InputFilter.h
@@ -66,11 +66,7 @@ enum PadPanel {
 };
 
 enum PadSensor {
-  PadSensor_Top = 0,
-  PadSensor_Right,
-  PadSensor_Bottom,
-  PadSensor_Left,
-  PadSensor_TopCenter,
+  PadSensor_TopCenter = 0,
   PadSensor_TopLeft,
   PadSensor_TopRight,
   PadSensor_RightCenter,

--- a/src/InputFilter.h
+++ b/src/InputFilter.h
@@ -4,10 +4,12 @@
 #ifndef INPUT_FILTER_H
 #define INPUT_FILTER_H
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
 #include "EnumHelper.h"
+#include "PlayerNumber.h"
 #include "RageInputDevice.h"
 #include "RageTimer.h"
 
@@ -45,6 +47,49 @@ struct MouseCoordinates {
   float fX;
   float fY;
   float fZ;
+};
+
+// describes each of the panels of a single player dance pad
+enum PadPanel {
+  PadPanel_UpLeft = 0,
+  PadPanel_Up,
+  PadPanel_UpRight,
+  PadPanel_Left,
+  PadPanel_Center,
+  PadPanel_Right,
+  PadPanel_DownLeft,
+  PadPanel_Down,
+  PadPanel_DownRight,
+
+  NUM_PadPanel,
+  PadPanel_Invalid
+};
+
+enum PadSensor {
+  PadSensor_Top = 0,
+  PadSensor_Right,
+  PadSensor_Bottom,
+  PadSensor_Left,
+  PadSensor_Center,
+
+  NUM_PadSensor,
+  PadSensor_Invalid
+};
+
+struct PadSensorState {
+  float intensity[NUM_PadPanel][NUM_PadSensor] = {};
+
+  const float& Get(PadPanel panel, PadSensor sensor) const {
+    return intensity[static_cast<int>(panel)][static_cast<int>(sensor)];
+  }
+
+  void Set(PadPanel panel, PadSensor sensor, float intensity) {
+    intensity = std::clamp(intensity, 0.0f, 1.0f);
+    this->intensity[static_cast<int>(panel)][static_cast<int>(sensor)] =
+        intensity;
+  }
+
+  void Clear() { std::memset(intensity, 0, sizeof(intensity)); }
 };
 
 class RageMutex;
@@ -89,6 +134,16 @@ class InputFilter {
   float GetCursorY() { return m_MouseCoords.fY; }
   float GetMouseWheel() { return m_MouseCoords.fZ; }
 
+  PadSensorState* getFullSensorState(PlayerNumber pn) {
+    if (pn < NUM_PLAYERS) {
+      return &m_Sensors[pn];
+    }
+    return nullptr;
+  }
+
+  bool setFullSensorState(
+      PlayerNumber pn, PadPanel panel, PadSensor sensor, float intensity);
+
   // Lua
   void PushSelf(lua_State* L);
 
@@ -100,6 +155,9 @@ class InputFilter {
   std::vector<InputEvent> queue;
   RageMutex* queuemutex;
   MouseCoordinates m_MouseCoords;
+
+  // debug sensors.
+  PadSensorState m_Sensors[NUM_PLAYERS];
 
   InputFilter(const InputFilter& rhs);
   InputFilter& operator=(const InputFilter& rhs);

--- a/src/InputFilter.h
+++ b/src/InputFilter.h
@@ -71,6 +71,14 @@ enum PadSensor {
   PadSensor_Bottom,
   PadSensor_Left,
   PadSensor_Center,
+  PadSensor_TopCenter,
+  PadSensor_TopLeft,
+  PadSensor_TopRight,
+  PadSensor_RightCenter,
+  PadSensor_BottomCenter,
+  PadSensor_BottomLeft,
+  PadSensor_BottomRight,
+  PadSensor_LeftCenter,
 
   NUM_PadSensor,
   PadSensor_Invalid

--- a/src/InputFilter.h
+++ b/src/InputFilter.h
@@ -83,10 +83,9 @@ struct PadSensorState {
     return intensity[static_cast<int>(panel)][static_cast<int>(sensor)];
   }
 
-  void Set(PadPanel panel, PadSensor sensor, float intensity) {
-    intensity = std::clamp(intensity, 0.0f, 1.0f);
-    this->intensity[static_cast<int>(panel)][static_cast<int>(sensor)] =
-        intensity;
+  void Set(PadPanel panel, PadSensor sensor, float value) {
+    value = std::clamp(value, 0.0f, 1.0f);
+    this->intensity[static_cast<int>(panel)][static_cast<int>(sensor)] = value;
   }
 
   void Clear() { std::memset(intensity, 0, sizeof(intensity)); }

--- a/src/RageInput.cpp
+++ b/src/RageInput.cpp
@@ -202,6 +202,17 @@ std::string RageInput::GetDisplayDevicesString() const {
   return join("\n", vs);
 }
 
+void RageInput::StartSensorTest() {
+  for (unsigned i = 0; i < m_InputHandlers.size(); ++i) {
+    m_InputHandlers[i].m_pDevice->StartSensorDebugging();
+  }
+}
+void RageInput::StopSensorTest() {
+  for (unsigned i = 0; i < m_InputHandlers.size(); ++i) {
+    m_InputHandlers[i].m_pDevice->StopSensorDebugging();
+  }
+}
+
 // lua start
 #include "LuaBinding.h"
 
@@ -219,7 +230,21 @@ class LunaRageInput : public Luna<RageInput> {
     return 1;
   }
 
-  LunaRageInput() { ADD_METHOD(GetDescriptions); }
+  static int StartSensorTest(T* p, lua_State* L) {
+    p->StartSensorTest();
+    COMMON_RETURN_SELF;
+  }
+
+  static int StopSensorTest(T* p, lua_State* L) {
+    p->StopSensorTest();
+    COMMON_RETURN_SELF;
+  }
+
+  LunaRageInput() {
+    ADD_METHOD(GetDescriptions);
+    ADD_METHOD(StartSensorTest);
+    ADD_METHOD(StopSensorTest);
+  }
 };
 
 LUA_REGISTER_CLASS(RageInput)

--- a/src/RageInput.h
+++ b/src/RageInput.h
@@ -30,6 +30,9 @@ class RageInput {
   InputDeviceState GetInputDeviceState(InputDevice id);
   std::string GetDisplayDevicesString() const;
 
+  void StartSensorTest();
+  void StopSensorTest();
+
   // Lua
   void PushSelf(lua_State* L);
 };

--- a/src/ScreenTestInput.cpp
+++ b/src/ScreenTestInput.cpp
@@ -126,6 +126,16 @@ bool ScreenTestInput::Input(const InputEventPlus& input) {
   return Screen::Input(input) || bHandled;  // default handler
 }
 
+void ScreenTestInput::BeginScreen() {
+  INPUTMAN->StartSensorTest();
+  ScreenWithMenuElements::BeginScreen();
+}
+
+void ScreenTestInput::EndScreen() {
+  INPUTMAN->StopSensorTest();
+  ScreenWithMenuElements::EndScreen();
+}
+
 bool ScreenTestInput::MenuStart(const InputEventPlus& input) {
   return MenuBack(input);
 }

--- a/src/ScreenTestInput.h
+++ b/src/ScreenTestInput.h
@@ -10,6 +10,9 @@ class ScreenTestInput : public ScreenWithMenuElements {
  public:
   virtual bool Input(const InputEventPlus& input);
 
+  virtual void BeginScreen();
+  virtual void EndScreen();
+
   virtual bool MenuStart(const InputEventPlus& input);
   virtual bool MenuBack(const InputEventPlus& input);
 };

--- a/src/arch/InputHandler/InputHandler.h
+++ b/src/arch/InputHandler/InputHandler.h
@@ -54,6 +54,11 @@ class InputHandler : public RageDriver {
    * window. Override this if you need to do that. */
   virtual void WindowReset() {}
 
+  // Certain devices/input handlers have extra overhead to acquire the sensor
+  // state so we need to tell the InputHandler when we want this data.
+  virtual void StartSensorDebugging() {}
+  virtual void StopSensorDebugging() {}
+
  protected:
   /* Convenience function: Call this to queue a received event.
    * This may be called in a thread.

--- a/src/arch/InputHandler/InputHandler_PumpHID.cpp
+++ b/src/arch/InputHandler/InputHandler_PumpHID.cpp
@@ -12,6 +12,7 @@
 #include "Game.h"
 #include "GameInput.h"
 #include "GameState.h"
+#include "InputFilter.h"
 #include "InputMapper.h"
 #include "LightsManager.h"
 #include "PrefsManager.h"
@@ -77,12 +78,66 @@ int InputHandler_PumpHID::InputThread_Start(void* p) {
   return 0;
 }
 
+void InputHandler_PumpHID::BroadcastFullSensorStateHelper(
+    PlayerNumber pn, uint8_t sensor_index, pumphid_player_byte_t state) {
+  PadSensor currSensor = PadSensor_Top;
+
+  switch (sensor_index) {
+    case 0:
+      currSensor = PadSensor_Right;
+      break;
+    case 1:
+      currSensor = PadSensor_Left;
+      break;
+    case 2:
+      currSensor = PadSensor_Bottom;
+      break;
+    case 3:
+      currSensor = PadSensor_Top;
+      break;
+    default:
+      LOG->Warn("Invalid sensor position %d", sensor_index);
+      break;
+  }
+
+  // check to see which game we are running as it can change during gameplay.
+  const InputScheme* pInput = &GAMESTATE->GetCurrentGame()->m_InputScheme;
+  std::string sInputName = pInput->m_szName;
+
+  // all buttons here are active low, so set to zero when "true"
+  if (EqualsNoCase(sInputName, "dance")) {
+    INPUTFILTER->setFullSensorState(
+        pn, PadPanel_Up, currSensor, (state.btn_UL_U) ? 0.0f : 1.0f);
+    INPUTFILTER->setFullSensorState(
+        pn, PadPanel_Down, currSensor, (state.btn_UR_D) ? 0.0f : 1.0f);
+    INPUTFILTER->setFullSensorState(
+        pn, PadPanel_Left, currSensor, (state.btn_CN_L) ? 0.0f : 1.0f);
+    INPUTFILTER->setFullSensorState(
+        pn, PadPanel_Right, currSensor, (state.btn_LL_R) ? 0.0f : 1.0f);
+
+  } else if (EqualsNoCase(sInputName, "pump")) {
+    INPUTFILTER->setFullSensorState(
+        pn, PadPanel_UpLeft, currSensor, (state.btn_UL_U) ? 0.0f : 1.0f);
+    INPUTFILTER->setFullSensorState(
+        pn, PadPanel_UpRight, currSensor, (state.btn_UR_D) ? 0.0f : 1.0f);
+    INPUTFILTER->setFullSensorState(
+        pn, PadPanel_Center, currSensor, (state.btn_CN_L) ? 0.0f : 1.0f);
+    INPUTFILTER->setFullSensorState(
+        pn, PadPanel_DownLeft, currSensor, (state.btn_LL_R) ? 0.0f : 1.0f);
+    INPUTFILTER->setFullSensorState(
+        pn, PadPanel_DownRight, currSensor, (state.btn_LR_START) ? 0.0f : 1.0f);
+  }
+}
+
 void InputHandler_PumpHID::InputThreadMain() {
   uint32_t newInput = 0;
-  LightsState newLS;
+  LightsState newLS = {};
 
   uint32_t prevInput = 0;
   LightsState prevLS = {};
+
+  pumphid_player_byte_t prev_p1_sensor[PUMP_HID_NUMOFSENSORS] = {};
+  pumphid_player_byte_t prev_p2_sensor[PUMP_HID_NUMOFSENSORS] = {};
 
   while (!m_bShutdown) {
     newLS = LightsDriver_Export::GetState();
@@ -92,6 +147,7 @@ void InputHandler_PumpHID::InputThreadMain() {
     // know it hasn't changed.
     if (prevLS != newLS) {
       CreateLightingMessage(newLS);
+      prevLS = newLS;
     }
 
     // hidapi always wants a report id for the device
@@ -122,13 +178,25 @@ void InputHandler_PumpHID::InputThreadMain() {
     // don't flood the engine with states that are not different.
     if (prevInput != newInput) {
       PushInputStateToEngine(newInput);
-
-      // debugging pay no attention
-      // LOG->Info("%d | %08x", readRtn, newInput);
+      prevInput = newInput;
     }
 
-    prevLS = newLS;
-    prevInput = newInput;
+    // we have to separately compare the sensor states in the event the whole
+    // panel is being pressed, but the sensors in them have swapped.
+    // we can't rely on PumpHIDToLocalState changes to fire off this event since
+    // that decimates the sensor information into a button state.
+    for (int i = 0; i < PUMP_HID_NUMOFSENSORS; i++) {
+      if (msg_from_device.p1_sensor[i].raw != prev_p1_sensor[i].raw) {
+        BroadcastFullSensorStateHelper(
+            PLAYER_1, i, msg_from_device.p1_sensor[i]);
+        prev_p1_sensor[i] = msg_from_device.p1_sensor[i];
+      }
+      if (msg_from_device.p2_sensor[i].raw != prev_p2_sensor[i].raw) {
+        BroadcastFullSensorStateHelper(
+            PLAYER_2, i, msg_from_device.p2_sensor[i]);
+        prev_p2_sensor[i] = msg_from_device.p2_sensor[i];
+      }
+    }
   }
 }
 
@@ -221,14 +289,11 @@ uint32_t InputHandler_PumpHID::PumpHIDToLocalState(
     from_dev.raw_buff[i] = ~from_dev.raw_buff[i];
   }
 
-  // TODO: expose the raw individual sensor values to lua to allow someone to
-  // write a nice test input screen for debugging. See ITG3's theme and oITG for
-  // inspiration.
-  uint8_t p1 = from_dev.p1_sensor0.raw | from_dev.p1_sensor1.raw |
-               from_dev.p1_sensor2.raw | from_dev.p1_sensor3.raw;
+  uint8_t p1 = from_dev.p1_sensor[0].raw | from_dev.p1_sensor[1].raw |
+               from_dev.p1_sensor[2].raw | from_dev.p1_sensor[3].raw;
 
-  uint8_t p2 = from_dev.p2_sensor0.raw | from_dev.p2_sensor1.raw |
-               from_dev.p2_sensor2.raw | from_dev.p2_sensor3.raw;
+  uint8_t p2 = from_dev.p2_sensor[0].raw | from_dev.p2_sensor[1].raw |
+               from_dev.p2_sensor[2].raw | from_dev.p2_sensor[3].raw;
 
   // newer firmwares of the pump hid are WEIRD about this, so just pull out the
   // bits we want test, coin, service, and clear from p1, and just coin from p2.

--- a/src/arch/InputHandler/InputHandler_PumpHID.cpp
+++ b/src/arch/InputHandler/InputHandler_PumpHID.cpp
@@ -106,26 +106,26 @@ void InputHandler_PumpHID::BroadcastFullSensorStateHelper(
 
   // all buttons here are active low, so set to zero when "true"
   if (EqualsNoCase(sInputName, "dance")) {
-    INPUTFILTER->setFullSensorState(
-        pn, PadPanel_Up, currSensor, (state.btn_UL_U) ? 0.0f : 1.0f);
-    INPUTFILTER->setFullSensorState(
-        pn, PadPanel_Down, currSensor, (state.btn_UR_D) ? 0.0f : 1.0f);
-    INPUTFILTER->setFullSensorState(
-        pn, PadPanel_Left, currSensor, (state.btn_CN_L) ? 0.0f : 1.0f);
-    INPUTFILTER->setFullSensorState(
-        pn, PadPanel_Right, currSensor, (state.btn_LL_R) ? 0.0f : 1.0f);
+    INPUTFILTER->setFullSensorStateBinary(
+        pn, PadPanel_Up, currSensor, !(state.btn_UL_U));
+    INPUTFILTER->setFullSensorStateBinary(
+        pn, PadPanel_Down, currSensor, !(state.btn_UR_D));
+    INPUTFILTER->setFullSensorStateBinary(
+        pn, PadPanel_Left, currSensor, !(state.btn_CN_L));
+    INPUTFILTER->setFullSensorStateBinary(
+        pn, PadPanel_Right, currSensor, !(state.btn_LL_R));
 
   } else if (EqualsNoCase(sInputName, "pump")) {
-    INPUTFILTER->setFullSensorState(
-        pn, PadPanel_UpLeft, currSensor, (state.btn_UL_U) ? 0.0f : 1.0f);
-    INPUTFILTER->setFullSensorState(
-        pn, PadPanel_UpRight, currSensor, (state.btn_UR_D) ? 0.0f : 1.0f);
-    INPUTFILTER->setFullSensorState(
-        pn, PadPanel_Center, currSensor, (state.btn_CN_L) ? 0.0f : 1.0f);
-    INPUTFILTER->setFullSensorState(
-        pn, PadPanel_DownLeft, currSensor, (state.btn_LL_R) ? 0.0f : 1.0f);
-    INPUTFILTER->setFullSensorState(
-        pn, PadPanel_DownRight, currSensor, (state.btn_LR_START) ? 0.0f : 1.0f);
+    INPUTFILTER->setFullSensorStateBinary(
+        pn, PadPanel_UpLeft, currSensor, !(state.btn_UL_U));
+    INPUTFILTER->setFullSensorStateBinary(
+        pn, PadPanel_UpRight, currSensor, !(state.btn_UR_D));
+    INPUTFILTER->setFullSensorStateBinary(
+        pn, PadPanel_Center, currSensor, !(state.btn_CN_L));
+    INPUTFILTER->setFullSensorStateBinary(
+        pn, PadPanel_DownLeft, currSensor, !(state.btn_LL_R));
+    INPUTFILTER->setFullSensorStateBinary(
+        pn, PadPanel_DownRight, currSensor, !(state.btn_LR_START));
   }
 }
 

--- a/src/arch/InputHandler/InputHandler_PumpHID.cpp
+++ b/src/arch/InputHandler/InputHandler_PumpHID.cpp
@@ -80,20 +80,20 @@ int InputHandler_PumpHID::InputThread_Start(void* p) {
 
 void InputHandler_PumpHID::BroadcastFullSensorStateHelper(
     PlayerNumber pn, uint8_t sensor_index, pumphid_player_byte_t state) {
-  PadSensor currSensor = PadSensor_Top;
+  PadSensor currSensor = PadSensor_TopCenter;
 
   switch (sensor_index) {
     case 0:
-      currSensor = PadSensor_Right;
+      currSensor = PadSensor_RightCenter;
       break;
     case 1:
-      currSensor = PadSensor_Left;
+      currSensor = PadSensor_LeftCenter;
       break;
     case 2:
-      currSensor = PadSensor_Bottom;
+      currSensor = PadSensor_BottomCenter;
       break;
     case 3:
-      currSensor = PadSensor_Top;
+      currSensor = PadSensor_TopCenter;
       break;
     default:
       LOG->Warn("Invalid sensor position %d", sensor_index);

--- a/src/arch/InputHandler/InputHandler_PumpHID.h
+++ b/src/arch/InputHandler/InputHandler_PumpHID.h
@@ -27,6 +27,7 @@
 
 #include "InputHandler.h"
 #include "LightsManager.h"
+#include "PlayerNumber.h"
 #include "RageInputDevice.h"
 #include "RageThreads.h"
 #include "archutils/Common/HidDevice.h"
@@ -47,6 +48,8 @@
 #define PUMPHID_PID_V2 0x1040
 
 #define PUMPHID_INTERFACE_NUM 0
+
+#define PUMP_HID_NUMOFSENSORS 4
 
 #pragma pack(push, 1)
 
@@ -94,15 +97,8 @@ typedef union {
 
 typedef union {
   struct {
-    pumphid_player_byte_t p1_sensor0;
-    pumphid_player_byte_t p1_sensor1;
-    pumphid_player_byte_t p1_sensor2;
-    pumphid_player_byte_t p1_sensor3;
-
-    pumphid_player_byte_t p2_sensor0;
-    pumphid_player_byte_t p2_sensor1;
-    pumphid_player_byte_t p2_sensor2;
-    pumphid_player_byte_t p2_sensor3;
+    pumphid_player_byte_t p1_sensor[PUMP_HID_NUMOFSENSORS];
+    pumphid_player_byte_t p2_sensor[PUMP_HID_NUMOFSENSORS];
 
     pumphid_cabinet_byte_t cab0;
     pumphid_cabinet_byte_t cab1;
@@ -249,6 +245,9 @@ class InputHandler_PumpHID : public InputHandler {
 
   bool m_bShutdown;
   RageThread InputThread;
+
+  void BroadcastFullSensorStateHelper(
+      PlayerNumber pn, uint8_t sensor_index, pumphid_player_byte_t state);
 
   uint32_t PumpHIDToLocalState(pumphid_output_state_t from_dev);
 


### PR DESCRIPTION
Preforms the following changes:
- Adds a new enums for individual sensor states, assuming a 9 panel dance pad with internals of L/R/U/D/C sensors. Can be expanded on in the future.
- Adds a new struct for `PadSensorState` which keeps track of the state of each of these sensors as a 0.0f to 1.0f.
- Allows setting of these states via other parts of the code like the input filter using `setFullSensorState` for each state.
- Exports this information via lua hook `GetFullSensorState`, which generates a full table of NUM_PLAYERS, NUM_PadPanel, NUM_PadSensor for the theme to draw however it pleases.
- Adds new functions to `RageInput`: `StartSensorTest` and `StopSensorTest` due to some InputDrivers requiring advance knowledge of when these inputs are needed (as during the input test screen) as some hardware requires additional overhead and polling to get the full switch state up to the engine.
- Exports these new RageInput functions so they can be called by the theme (so that the theme can show a test input screen during a time of its choosing).
- Adds these start/stop calls to `ScreenTestInput` so they are always aware.
- Adds this new functionality to the existing InputHandler, PumpHID as this information was already in engine, just lacked a way to be shown to the user.

This requires accompanying theme changes to request this information from the engine, which can be found here: 
https://github.com/Simply-Love/Simply-Love-SM5/pull/777

Visual examples:
<img width="823" height="547" alt="image" src="https://github.com/user-attachments/assets/ee3c29e4-d870-47ff-ba71-e5d8bbca6c6c" />
<img width="384" height="389" alt="image" src="https://github.com/user-attachments/assets/58902e71-de87-407f-a6dd-5d9b41710a6b" />
<img width="467" height="396" alt="image" src="https://github.com/user-attachments/assets/a87beccb-9f00-44b1-9fd6-63e48c2d892b" />


Sample video showing use with Snek board (to be merged once this has been accepted/deliberated on):
https://bsky.app/profile/din.icedragon.io/post/3mtpk5li7622a
