### PR TITLE
Fix hard scores not displaying in ScreenRanking

### DIFF
--- a/src/ScreenHighScores.cpp
+++ b/src/ScreenHighScores.cpp
@@ -162,6 +162,7 @@ void ScoreScroller::ConfigureActor(Actor* pActor, int iItem) {
     // Because pSteps or pTrail can be nullptr, what we're creating in Lua is
     // not an array. It must be iterated using pairs(), not ipairs().
     lua_setfield(L, -2, ssprintf("%d", i + 1).c_str());
+    i++;
   }
   lua_pop(L, 1);
   LUA->Release(L);


### PR DESCRIPTION
This iteration was lost in 2019 in this commit

https://github.com/itgmania/itgmania/commit/7e3789b131#diff-b4a788e86ca254933fd5db1efce29719d25d464653dbc9e4d5b6a9977c15a720R130-R153