### PR TITLE
Fix memory card being wiped when switching between ITG and Casual mode

### DIFF
--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -1111,7 +1111,7 @@ void Profile::LoadCustomFunction(std::string sDir, PlayerNumber pn) {
   LUA->Release(L);
 }
 
-void Profile::HandleStatsPrefixChange(std::string dir, bool require_signature) {
+bool Profile::HandleStatsPrefixChange(std::string dir, bool require_signature) {
   // Temp variables to preserve stuff across the reload.
   // Some stuff intentionally left out because the original reason for the
   // stats prefix was to allow scores from different game types to coexist.
@@ -1168,8 +1168,10 @@ void Profile::HandleStatsPrefixChange(std::string dir, bool require_signature) {
   m_fTotalCaloriesBurned = total_calories_burned;
   m_UserTable = user_table;
   if (need_to_create_file) {
-    SaveAllToDir(dir, require_signature);
+    return SaveAllToDir(dir, require_signature);
   }
+
+  return true;
 }
 
 ProfileLoadResult Profile::LoadAllFromDir(

--- a/src/Profile.h
+++ b/src/Profile.h
@@ -439,7 +439,7 @@ class Profile {
   void swap(Profile& other);
 
   // Loading and saving
-  void HandleStatsPrefixChange(std::string dir, bool require_signature);
+  bool HandleStatsPrefixChange(std::string dir, bool require_signature);
   ProfileLoadResult LoadAllFromDir(std::string sDir, bool bRequireSignature);
   ProfileLoadResult LoadStatsFromDir(std::string dir, bool require_signature);
   void LoadSongsFromDir(

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -147,6 +147,7 @@ void ProfileManager::Init() {
     m_bLastLoadWasFromLastGood[p] = false;
     m_bNeedToBackUpLastLoad[p] = false;
     m_bNewProfile[p] = false;
+    m_bStatsPrefixChangeFailed[p] = false;
   }
 
   LoadMachineProfile();
@@ -191,6 +192,7 @@ ProfileLoadResult ProfileManager::LoadProfile(
   m_bWasLoadedFromMemoryCard[pn] = bIsMemCard;
   m_bLastLoadWasFromLastGood[pn] = false;
   m_bNeedToBackUpLastLoad[pn] = false;
+  m_bStatsPrefixChangeFailed[pn] = false;
 
   // Try to load the original, non-backup data.
   ProfileLoadResult lr = GetProfile(pn)->LoadAllFromDir(
@@ -259,6 +261,7 @@ bool ProfileManager::LoadLocalProfileFromMachine(PlayerNumber pn) {
   m_sProfileDir[pn] = LocalProfileIDToDir(sProfileID);
   m_bWasLoadedFromMemoryCard[pn] = false;
   m_bLastLoadWasFromLastGood[pn] = false;
+  m_bStatsPrefixChangeFailed[pn] = false;
 
   if (GetLocalProfile(sProfileID) == nullptr) {
     m_sProfileDir[pn] = "";
@@ -385,6 +388,9 @@ bool ProfileManager::SaveProfile(PlayerNumber pn) const {
   if (m_sProfileDir[pn].empty()) {
     return false;
   }
+  if (m_bStatsPrefixChangeFailed[pn]) {
+    return false;
+  }
 
   /*
    * If the profile we're writing was loaded from the primary (non-backup)
@@ -425,6 +431,7 @@ void ProfileManager::UnloadProfile(PlayerNumber pn) {
   m_bLastLoadWasTamperedOrCorrupt[pn] = false;
   m_bLastLoadWasFromLastGood[pn] = false;
   m_bNeedToBackUpLastLoad[pn] = false;
+  m_bStatsPrefixChangeFailed[pn] = false;
   m_pMemoryCardProfile[pn]->InitAll();
   SONGMAN->FreeAllLoadedFromProfile((ProfileSlot)pn);
 }
@@ -1374,10 +1381,18 @@ void ProfileManager::SetStatsPrefix(const std::string& prefix) {
   }
   FOREACH_PlayerNumber(pn) {
     if (ProfileWasLoadedFromMemoryCard(pn)) {
-      // This probably runs into a problem if the memory card has been removed.
-      // -Kyz
-      GetProfile(pn)->HandleStatsPrefixChange(
+      const bool was_mounted = MEMCARDMAN->IsMounted(pn);
+      if (!was_mounted && !MEMCARDMAN->MountCard(pn)) {
+        m_bStatsPrefixChangeFailed[pn] = true;
+        continue;
+      }
+
+      m_bStatsPrefixChangeFailed[pn] = !GetProfile(pn)->HandleStatsPrefixChange(
           m_sProfileDir[pn], PREFSMAN->m_bSignProfileData);
+
+      if (!was_mounted) {
+        MEMCARDMAN->UnmountCard(pn);
+      }
     }
   }
   m_pMachineProfile->HandleStatsPrefixChange(MACHINE_PROFILE_DIR, false);

--- a/src/ProfileManager.h
+++ b/src/ProfileManager.h
@@ -177,6 +177,8 @@ class ProfileManager {
   mutable bool m_bNeedToBackUpLastLoad[NUM_PLAYERS];  // if true, back up
                                                       // profile on next save
   bool m_bNewProfile[NUM_PLAYERS];
+  // prevent a bad save from overwriting Stats.xml after a prefix reload failed
+  bool m_bStatsPrefixChangeFailed[NUM_PLAYERS];
 
   Profile* m_pMemoryCardProfile[NUM_PLAYERS];  // holds Profile for the
                                                // currently inserted card


### PR DESCRIPTION
``SetStatsPrefix`` did not attempt to mount the memory card before reading the profile so on Linux it would fail and thus load an empty profile into memory which would be saved at the end of your session and wipe your stats.xml. 

The same would happen on Windows or Linux if loading the profile failed during mode switching for any reason.

This PR correctly mounts the card during the mode switch and prevents a failure from causing the stats to be wiped. 
