### PR TITLE
Fix Stats.xml backup system for USBs

### DIFF
--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -2581,19 +2581,33 @@ XNode* Profile::SaveCoinDataCreateNode() const {
 }
 
 void Profile::MoveBackupToDir(std::string sFromDir, std::string sToDir) {
-  if (FILEMAN->IsAFile(sFromDir + STATS_XML) &&
-      FILEMAN->IsAFile(sFromDir + STATS_XML + SIGNATURE_APPEND)) {
-    FILEMAN->Move(sFromDir + STATS_XML, sToDir + STATS_XML);
-    FILEMAN->Move(
-        sFromDir + STATS_XML + SIGNATURE_APPEND,
-        sToDir + STATS_XML + SIGNATURE_APPEND);
-  } else if (
-      FILEMAN->IsAFile(sFromDir + STATS_XML_GZ) &&
-      FILEMAN->IsAFile(sFromDir + STATS_XML_GZ + SIGNATURE_APPEND)) {
-    FILEMAN->Move(sFromDir + STATS_XML_GZ, sToDir + STATS_XML);
-    FILEMAN->Move(
-        sFromDir + STATS_XML_GZ + SIGNATURE_APPEND,
-        sToDir + STATS_XML + SIGNATURE_APPEND);
+  std::string stats_file;
+  std::string old_stats_file;
+  if (FILEMAN->IsAFile(sFromDir + STATS_XML)) {
+    stats_file = STATS_XML;
+    old_stats_file = STATS_XML_GZ;
+  } else if (FILEMAN->IsAFile(sFromDir + STATS_XML_GZ)) {
+    stats_file = STATS_XML_GZ;
+    old_stats_file = STATS_XML;
+  }
+
+  if (!stats_file.empty()) {
+    bool backup_complete =
+        FILEMAN->Move(sFromDir + stats_file, sToDir + stats_file);
+    const std::string signature_file = stats_file + SIGNATURE_APPEND;
+    if (FILEMAN->IsAFile(sFromDir + signature_file)) {
+      const bool signature_moved =
+          FILEMAN->Move(sFromDir + signature_file, sToDir + signature_file);
+      backup_complete = backup_complete && signature_moved;
+    }
+
+    // We should not leave an outdated file in LastGood for an alternate format
+    // after the new backup succeeds.
+    // Otherwise the wrong backup file might be loaded if LastGood gets used.
+    if (backup_complete) {
+      FILEMAN->Remove(sToDir + old_stats_file);
+      FILEMAN->Remove(sToDir + old_stats_file + SIGNATURE_APPEND);
+    }
   }
 
   if (FILEMAN->IsAFile(sFromDir + EDITABLE_INI)) {

--- a/src/ProfileManager.cpp
+++ b/src/ProfileManager.cpp
@@ -209,22 +209,30 @@ ProfileLoadResult ProfileManager::LoadProfile(
   m_bLastLoadWasTamperedOrCorrupt[pn] = lr == ProfileLoadResult_FailedTampered;
 
   //
-  // Try to load from the backup if the original data fails to load
+  // Try to load from the backup if the original data is corrupt or missing.
   //
-  if (lr == ProfileLoadResult_FailedTampered) {
-    lr = GetProfile(pn)->LoadAllFromDir(
-        sBackupDir, PREFSMAN->m_bSignProfileData);
+  if (lr == ProfileLoadResult_FailedTampered ||
+      lr == ProfileLoadResult_FailedNoProfile) {
+    const ProfileLoadResult primary_lr = lr;
+
+    if (primary_lr == ProfileLoadResult_FailedNoProfile) {
+      // Validate LastGood separately so a missing or invalid backup does not
+      // overwrite useful non-stats data loaded from the primary directory.
+      Profile backup_profile;
+      lr = backup_profile.LoadStatsFromDir(
+          sBackupDir, PREFSMAN->m_bSignProfileData);
+    }
+    if (primary_lr == ProfileLoadResult_FailedTampered ||
+        lr == ProfileLoadResult_Success) {
+      lr = GetProfile(pn)->LoadAllFromDir(
+          sBackupDir, PREFSMAN->m_bSignProfileData);
+    }
     m_bLastLoadWasFromLastGood[pn] = lr == ProfileLoadResult_Success;
 
-    /* If the LastGood profile doesn't exist at all, and the actual profile was
-     * failed_tampered, then the error should be failed_tampered and not
-     * failed_no_profile. */
-    if (lr == ProfileLoadResult_FailedNoProfile) {
-      LOG->Trace(
-          "Profile was corrupt and LastGood for %s doesn't exist; error is "
-          "ProfileLoadResult_FailedTampered",
-          sProfileDir.c_str());
-      lr = ProfileLoadResult_FailedTampered;
+    // If the backup also fails, preserve the primary load result.
+    // (a new profile should remain FailedNoProfile)
+    if (!m_bLastLoadWasFromLastGood[pn]) {
+      lr = primary_lr;
     }
   }
 

--- a/src/ProfileManager.h
+++ b/src/ProfileManager.h
@@ -171,9 +171,8 @@ class ProfileManager {
       [NUM_PLAYERS];  // true if Stats.xml was present, but failed to load
                       // (probably because of a signature failure)
   bool m_bLastLoadWasFromLastGood
-      [NUM_PLAYERS];  // if true, then
-                      // m_bLastLoadWasTamperedOrCorrupt
-                      // is also true
+      [NUM_PLAYERS];  // true if the primary Stats file was corrupt or missing
+                      // and LastGood loaded successfully
   mutable bool m_bNeedToBackUpLastLoad[NUM_PLAYERS];  // if true, back up
                                                       // profile on next save
   bool m_bNewProfile[NUM_PLAYERS];


### PR DESCRIPTION
The game has had a USB profile backup system in the form of the LastGood folder since [2004](https://github.com/itgmania/itgmania/commit/ebb9e730a4a) but it was broken on accident in [2007](https://github.com/itgmania/itgmania/commit/572f0afdf306) to only work with signed profiles, and I guess no one noticed.

Currently the behavior for Editable.ini is functional but the Stats.xml file is never moved, so the backup is never able to be used. 

The intended behavior is that before saving your Stats.xml and Editable.ini file the game will move them to the LastGood directory. then it will write the new save. Then upon load if something is wrong with the Stats.xml it will attempt the one from LastGood, if the LastGood profile loads then it will have a (backup) note displayed in the name as shown in the screenshot. Then the next time your profile is saved again it will be from the backup file, in theory this note lets you decide to unplug it to investigate instead of letting it auto-fix.

The whole system including loading from the backup has worked this whole time for signed profiles, but no one uses those.

There are a few other things I fixed at the same time while turning this back on.

There's currently 4 configurations of Stats.xml. (Normal, Compressed, Signed, and Compressed+Signed), when switching between one of those configurations the previous backup now gets flushed so you won't have an outdated copy lying around which could cause problems if you switch back to the previous configuration.

Also it was possible that after moving your Stats.xml to LastGood but before writing any part of the new one something could fail or the drive could disconnect, and you'd only have the LastGood Stats.xml. Previously the game did not check if was an existing Stats.xml in LastGood before assuming that the lack of a primary Stats.xml meant that it's a new profile and gives you a blank profile. So now it checks for ``ProfileLoadResult_FailedTampered`` and also ``ProfileLoadResult_FailedNoProfile`` instead of only the first one. 

This PR does not make LastGood work with Casual-Stats.xml. 

<img width="528" height="244" alt="image" src="https://github.com/user-attachments/assets/993ea0c7-924b-4faf-8c87-46f3fe1dc4a1" />
