### PR TITLE
Allow USB profiles to be loaded over an empty guest profile (supersedes #1477)

### DIFF
--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -172,8 +172,11 @@ GameState::GameState()
 
   m_PlayMode.Set(
       PlayMode_Invalid);  // used by IsPlayerEnabled before the first screen
-  FOREACH_PlayerNumber(p) m_bSideIsJoined[p] =
-      false;  // used by GetNumSidesJoined before the first screen
+  FOREACH_PlayerNumber(p) {
+    // used by GetNumSidesJoined before the first screen
+    m_bSideIsJoined[p] = false;
+    m_bPlayerHasCommittedGameplay[p] = false;
+  }
 
   FOREACH_PlayerNumber(p) {
     m_pPlayerState[p] = new PlayerState;
@@ -281,6 +284,7 @@ void GameState::ResetPlayer(PlayerNumber pn) {
   m_pCurTrail[pn].Set(nullptr);
   m_pPlayerState[pn]->Reset();
   PROFILEMAN->UnloadProfile(pn);
+  m_bPlayerHasCommittedGameplay[pn] = false;
   ResetPlayerOptions(pn);
 }
 
@@ -594,6 +598,38 @@ void GameState::BeginGame() {
   FOREACH_PlayerNumber(pn) MEMCARDMAN->UnlockCard(pn);
 }
 
+bool GameState::CanAcceptProfile(PlayerNumber pn) const {
+  return IsHumanPlayer(pn) && !PROFILEMAN->IsPersistentProfile(pn) &&
+         !m_bPlayerHasCommittedGameplay[pn];
+}
+
+bool GameState::LoadProfileOverGuest(PlayerNumber pn, bool bLoadEdits) {
+  if (!CanAcceptProfile(pn)) {
+    return false;
+  }
+
+  MEMCARDMAN->MountCard(pn);
+  const bool bSuccess = PROFILEMAN->LoadFirstAvailableProfile(
+      pn, bLoadEdits);  // load full profile
+  MEMCARDMAN->UnmountCard(pn);
+
+  if (!bSuccess) {
+    return false;
+  }
+
+  // Lock the card on successful load, so we won't allow it to be changed.
+  MEMCARDMAN->LockCard(pn);
+
+  LoadCurrentSettingsFromProfile(pn);
+
+  Profile* pPlayerProfile = PROFILEMAN->GetProfile(pn);
+  if (pPlayerProfile) {
+    pPlayerProfile->m_iTotalSessions++;
+  }
+
+  return true;
+}
+
 void GameState::LoadProfiles(bool bLoadEdits) {
   // Unlock any cards that we might want to load.
   FOREACH_HumanPlayer(pn) if (!PROFILEMAN->IsPersistentProfile(pn))
@@ -601,31 +637,7 @@ void GameState::LoadProfiles(bool bLoadEdits) {
 
   MEMCARDMAN->WaitForCheckingToComplete();
 
-  FOREACH_HumanPlayer(pn) {
-    // If a profile is already loaded, this was already called.
-    if (PROFILEMAN->IsPersistentProfile(pn)) {
-      continue;
-    }
-
-    MEMCARDMAN->MountCard(pn);
-    bool bSuccess = PROFILEMAN->LoadFirstAvailableProfile(
-        pn, bLoadEdits);  // load full profile
-    MEMCARDMAN->UnmountCard(pn);
-
-    if (!bSuccess) {
-      continue;
-    }
-
-    // Lock the card on successful load, so we won't allow it to be changed.
-    MEMCARDMAN->LockCard(pn);
-
-    LoadCurrentSettingsFromProfile(pn);
-
-    Profile* pPlayerProfile = PROFILEMAN->GetProfile(pn);
-    if (pPlayerProfile) {
-      pPlayerProfile->m_iTotalSessions++;
-    }
-  }
+  FOREACH_HumanPlayer(pn) { LoadProfileOverGuest(pn, bLoadEdits); }
 }
 
 void GameState::SavePlayerProfiles() {
@@ -654,22 +666,17 @@ void GameState::SavePlayerProfile(PlayerNumber pn) {
   }
 }
 
-bool GameState::HaveProfileToLoad() {
-  FOREACH_HumanPlayer(pn) {
-    // We won't load this profile if it's already loaded.
-    if (PROFILEMAN->IsPersistentProfile(pn)) {
-      continue;
-    }
-
-    // If a memory card is inserted, we'l try to load it.
-    if (MEMCARDMAN->CardInserted(pn)) {
-      return true;
-    }
-    if (!PROFILEMAN->m_sDefaultLocalProfileID[pn].Get().empty()) {
-      return true;
-    }
+bool GameState::HaveProfileToLoad(PlayerNumber pn) const {
+  if (!CanAcceptProfile(pn)) {
+    return false;
   }
 
+  return MEMCARDMAN->CardInserted(pn) ||
+         !PROFILEMAN->m_sDefaultLocalProfileID[pn].Get().empty();
+}
+
+bool GameState::HaveProfileToLoad() {
+  FOREACH_HumanPlayer(pn) if (HaveProfileToLoad(pn)) return true;
   return false;
 }
 
@@ -788,6 +795,7 @@ void GameState::CommitStageStats() {
   }
 
   STATSMAN->CommitStatsToProfiles(&STATSMAN->m_CurStageStats);
+  FOREACH_HumanPlayer(p) m_bPlayerHasCommittedGameplay[p] = true;
 
   // Update TotalPlaySeconds.
   int iPlaySeconds = std::max(0, (int)m_timeGameStarted.GetDeltaTime());

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -44,6 +44,9 @@ class GameState {
   PlayerNumber masterPlayerNumber;
   /** @brief The TimingData that is used for processing certain functions. */
   TimingData* processedTiming;
+  /** @brief Whether the player has score data on their profile from playing
+   * a song this game. */
+  bool m_bPlayerHasCommittedGameplay[NUM_PLAYERS];
 
  public:
   /** @brief Set up the GameState with initial values. */
@@ -62,9 +65,12 @@ class GameState {
   void UnjoinPlayer(PlayerNumber pn);
   bool JoinInput(PlayerNumber pn);
   bool JoinPlayers();
+  bool CanAcceptProfile(PlayerNumber pn) const;
+  bool LoadProfileOverGuest(PlayerNumber pn, bool bLoadEdits = true);
   void LoadProfiles(bool bLoadEdits = true);
   void SavePlayerProfiles();
   void SavePlayerProfile(PlayerNumber pn);
+  bool HaveProfileToLoad(PlayerNumber pn) const;
   bool HaveProfileToLoad();
   bool HaveProfileToSave();
   void SaveLocalData();

--- a/src/MemoryCardManager.cpp
+++ b/src/MemoryCardManager.cpp
@@ -499,6 +499,7 @@ void MemoryCardManager::CheckStateChanges() {
       }
 
       m_State[p] = state;
+      m_StateChangedAt[p].Touch();
       m_sError[p] = sError;
     }
   }

--- a/src/MemoryCardManager.h
+++ b/src/MemoryCardManager.h
@@ -8,6 +8,7 @@
 #include "PlayerNumber.h"
 #include "Preference.h"
 #include "RageSound.h"
+#include "RageTimer.h"
 #include "arch/MemoryCard/MemoryCardDriver.h"
 
 extern const std::string MEM_CARD_MOUNT_POINT[NUM_PLAYERS];
@@ -20,6 +21,9 @@ class MemoryCardManager {
   void Update();
 
   MemoryCardState GetCardState(PlayerNumber pn) const { return m_State[pn]; }
+  float GetCardStateAge(PlayerNumber pn) const {
+    return m_StateChangedAt[pn].Ago();
+  }
   std::string GetCardError(PlayerNumber pn) const { return m_sError[pn]; }
 
   void WaitForCheckingToComplete();
@@ -75,6 +79,7 @@ class MemoryCardManager {
                                    // finalized, blank if none
 
   MemoryCardState m_State[NUM_PLAYERS];
+  RageTimer m_StateChangedAt[NUM_PLAYERS];
   std::string m_sError[NUM_PLAYERS];  // if MemoryCardState_Error
 
   RageSound m_soundReady;

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -24,6 +24,7 @@
 #include "InputMapper.h"
 #include "LocalizedString.h"
 #include "LuaManager.h"
+#include "MemoryCardManager.h"
 #include "MenuTimer.h"
 #include "MessageManager.h"
 #include "ModsGroup.h"
@@ -66,6 +67,8 @@ XToString(SelectionState);
 
 /** @brief The maximum number of digits for the ScoreDisplay. */
 const int NUM_SCORE_DIGITS = 9;
+/** @brief Period to block leaving ScreenSelectMusic while late joining. */
+const float CARD_LATE_JOIN_BLOCK_SECONDS = 5.0f;
 
 #define SHOW_OPTIONS_MESSAGE_SECONDS \
   THEME->GetMetricF(m_sName, "ShowOptionsMessageSeconds")
@@ -184,6 +187,7 @@ void ScreenSelectMusic::Init() {
 
   this->SubscribeToMessage(Message_PlayerJoined);
   this->SubscribeToMessage(Message_PlayerProfileSet);
+  this->SubscribeToMessage(Message_StorageDevicesChanged);
 
   // Cache these values
   // Marking for change -- Midiman (why? -aj)
@@ -562,12 +566,22 @@ bool ScreenSelectMusic::Input(const InputEventPlus& input) {
   }
 
   // Handle late joining
-  // If the other player is allowed to join on the extra stage, then the
-  // summary screen will crash on invalid stage stats. -Kyz
-  if (m_SelectionState != SelectionState_Finalized &&
-      input.MenuI == GAME_BUTTON_START && input.type == IET_FIRST_PRESS &&
-      !GAMESTATE->IsAnExtraStage() && GAMESTATE->JoinInput(input.pn)) {
-    return true;  // don't handle this press again below
+  if (input.MenuI == GAME_BUTTON_START && input.type == IET_FIRST_PRESS &&
+      m_SelectionState != SelectionState_Finalized) {
+    // If the other player is allowed to join on the extra stage, then the
+    // summary screen will crash on invalid stage stats. -Kyz
+    if (!GAMESTATE->IsAnExtraStage() && GAMESTATE->JoinInput(input.pn)) {
+      return true;
+    }
+
+    // Give eligible memory cards time to finish if they are still checking.
+    // Also load any late ready cards that got past the
+    // Message_StorageDevicesChanged handler load.
+    if (GAMESTATE->IsHumanPlayer(input.pn) &&
+        GetNextSelectionState() == SelectionState_Finalized &&
+        (LoadReadyMemoryCards() || ShouldWaitForMemoryCard())) {
+      return true;
+    }
   }
 
   if (!GAMESTATE->IsHumanPlayer(input.pn)) {
@@ -1107,6 +1121,22 @@ void ScreenSelectMusic::ChangeSteps(PlayerNumber pn, int dir) {
 
 void ScreenSelectMusic::HandleMessage(const Message& msg) {
   if (m_bRunning && msg == Message_PlayerJoined) {
+    PlayerNumber pn;
+    bool b = msg.GetParam("Player", pn);
+    ASSERT(b);
+
+    if (GAMESTATE->CanAcceptProfile(pn)) {
+      MEMCARDMAN->UnlockCard(pn);
+    }
+
+    // A checking card will be loaded asynchronously when it becomes ready.
+    // Continue loading local profiles immediately when there is no card.
+    bool bProfileLoaded = false;
+    if (MEMCARDMAN->GetCardState(pn) != MemoryCardState_Checking &&
+        GAMESTATE->HaveProfileToLoad(pn)) {
+      bProfileLoaded = LoadPlayerProfile(pn);
+    }
+
     PlayerNumber master_pn = GAMESTATE->GetMasterPlayerNumber();
     // The current steps may no longer be playable. If one player has double
     // steps selected, they are no longer playable now that P2 has joined.
@@ -1125,14 +1155,7 @@ void ScreenSelectMusic::HandleMessage(const Message& msg) {
     AfterMusicChange();
 
     int iSel = 0;
-    PlayerNumber pn;
-    bool b = msg.GetParam("Player", pn);
-    ASSERT(b);
-
-    // load player profiles
-    if (GAMESTATE->HaveProfileToLoad()) {
-      GAMESTATE->LoadProfiles(
-          true);  // I guess you could always load edits here...
+    if (bProfileLoaded) {
       SCREENMAN
           ->ZeroNextUpdate();  // be kind, don't skip frames if you can avoid it
     }
@@ -1152,9 +1175,52 @@ void ScreenSelectMusic::HandleMessage(const Message& msg) {
 
       GAMESTATE->m_pCurSteps[pn].Set(pSteps);
     }
+  } else if (
+      m_bRunning && msg == Message_StorageDevicesChanged &&
+      m_SelectionState != SelectionState_Finalized && !IsTransitioning() &&
+      SCREENMAN->GetTopScreen() == this) {
+    LoadReadyMemoryCards();
   }
 
   ScreenWithMenuElements::HandleMessage(msg);
+}
+
+bool ScreenSelectMusic::LoadPlayerProfile(PlayerNumber pn) {
+  if (!GAMESTATE->LoadProfileOverGuest(pn, true)) {
+    return false;
+  }
+
+  Message msg(MessageIDToString(Message_PlayerProfileSet));
+  msg.SetParam("Player", pn);
+  MESSAGEMAN->Broadcast(msg);
+  return true;
+}
+
+bool ScreenSelectMusic::LoadReadyMemoryCards() {
+  bool bProfileLoaded = false;
+  FOREACH_HumanPlayer(pn) {
+    if (MEMCARDMAN->GetCardState(pn) == MemoryCardState_Ready) {
+      bProfileLoaded |= LoadPlayerProfile(pn);
+    }
+  }
+
+  if (bProfileLoaded) {
+    m_MusicWheel.ReloadSongList();
+    SCREENMAN->ZeroNextUpdate();
+  }
+
+  return bProfileLoaded;
+}
+
+bool ScreenSelectMusic::ShouldWaitForMemoryCard() const {
+  FOREACH_HumanPlayer(pn) {
+    if (GAMESTATE->CanAcceptProfile(pn) &&
+        MEMCARDMAN->GetCardState(pn) == MemoryCardState_Checking &&
+        MEMCARDMAN->GetCardStateAge(pn) < CARD_LATE_JOIN_BLOCK_SECONDS) {
+      return true;
+    }
+  }
+  return false;
 }
 
 void ScreenSelectMusic::HandleScreenMessage(const ScreenMessage SM) {

--- a/src/ScreenSelectMusic.h
+++ b/src/ScreenSelectMusic.h
@@ -84,6 +84,9 @@ class ScreenSelectMusic : public ScreenWithMenuElements {
 
   void CheckBackgroundRequests(bool bForce);
   bool DetectCodes(const InputEventPlus& input);
+  bool LoadPlayerProfile(PlayerNumber pn);
+  bool LoadReadyMemoryCards();
+  bool ShouldWaitForMemoryCard() const;
 
   std::vector<Steps*> m_vpSteps;
   std::vector<Trail*> m_vpTrails;


### PR DESCRIPTION
The current behavior is quite misleading. 

If you join as a guest (either from the start menu or as a late join guest) the game will display "INSERT CARD" in that player name, if you then insert a USB it will load your username and make the USB loaded sound, but your profile will never load and your scores will not save. 

This PR makes it so if you plug in a USB for a guest profile with no scores played yet it will just load your USB profile as expected.

supersedes #1477

There remains a visual issue where if the guest profile has a score played and then you insert a USB afterwards it will still display your name without loading your profile. Ideally it should say "TOO LATE" but currently that message is reserved for a profile which has already been locked, but that doesn't really fit into the current system with guest profiles, so I'd rather fix that in a separate refactor. 