### PR TITLE
add snekconfig for sensor debugging

### DIFF
--- a/src/CMakeData-arch.cmake
+++ b/src/CMakeData-arch.cmake
@@ -254,9 +254,11 @@ source_group("Arch Specific\\\\Lights"
 
 list(APPEND SMDATA_ARCH_INPUT_SRC "arch/InputHandler/InputHandler.cpp"
             "arch/InputHandler/InputHandler_PumpHID.cpp"
+            "arch/InputHandler/InputHandler_SnekConfig.cpp"
             "arch/InputHandler/InputHandler_MonkeyKeyboard.cpp")
 list(APPEND SMDATA_ARCH_INPUT_HPP "arch/InputHandler/InputHandler.h"
             "arch/InputHandler/InputHandler_PumpHID.h"
+            "arch/InputHandler/InputHandler_SnekConfig.h"
             "arch/InputHandler/InputHandler_MonkeyKeyboard.h")
 
 if(WIN32)

--- a/src/arch/InputHandler/InputHandler_PumpHID.cpp
+++ b/src/arch/InputHandler/InputHandler_PumpHID.cpp
@@ -24,10 +24,6 @@
 #include "arch/Lights/LightsDriver_Export.h"
 #include "archutils/Common/HidDevice.h"
 
-// all of the known device pid's that use this communication protocol.
-const std::vector<int> InputHandler_PumpHID::devPIDS = {
-    PUMPHID_PID_V1, PUMPHID_PID_V2};
-
 REGISTER_INPUT_HANDLER_CLASS(PumpHID);
 
 InputHandler_PumpHID::InputHandler_PumpHID() {
@@ -37,11 +33,6 @@ InputHandler_PumpHID::InputHandler_PumpHID() {
   memset(msg_from_device.raw_buff, PUMPHID_DEF_INPUT, sizeof(msg_from_device));
 
   m_bShutdown = false;
-
-  // ensure auto reconnect and blocking reads (since the device wants write/read
-  // cycles properly.)
-  dev = std::make_unique<HidDevice>(
-      PUMPHID_VID, devPIDS, PUMPHID_INTERFACE_NUM, true, false);
 
   if (IsConnected() && PREFSMAN->m_bThreadedInput) {
     InputThread.SetName("PumpHID thread");
@@ -59,7 +50,7 @@ InputHandler_PumpHID::~InputHandler_PumpHID() {
 
     // turn off all of the lights manually.
     memset(msg_to_device.raw_buff, PUMPHID_DEF_LIGHTS, sizeof(msg_to_device));
-    dev->Write(msg_to_device.raw_buff, PUMPHID_PAYLOADSIZE_TODEV);
+    dev.Write(msg_to_device.raw_buff, PUMPHID_PAYLOADSIZE_TODEV);
   }
 }
 
@@ -157,7 +148,7 @@ void InputHandler_PumpHID::InputThreadMain() {
 
     // push lighting state
     HidResults writeRtn =
-        dev->Write(msg_to_device.raw_buff, PUMPHID_PAYLOADSIZE_TODEV);
+        dev.Write(msg_to_device.raw_buff, PUMPHID_PAYLOADSIZE_TODEV);
 
     if (writeRtn != HidResults::Success) {
       LOG->Warn("PumpHID write fail %d", writeRtn);
@@ -166,7 +157,7 @@ void InputHandler_PumpHID::InputThreadMain() {
 
     // pull input state
     int readRtn =
-        dev->Read(msg_from_device.raw_buff, PUMPHID_PAYLOADSIZE_FROMDEV);
+        dev.Read(msg_from_device.raw_buff, PUMPHID_PAYLOADSIZE_FROMDEV);
 
     if (readRtn != PUMPHID_PAYLOADSIZE_FROMDEV) {
       LOG->Warn("PumpHID read fail %d", readRtn);

--- a/src/arch/InputHandler/InputHandler_PumpHID.cpp
+++ b/src/arch/InputHandler/InputHandler_PumpHID.cpp
@@ -40,7 +40,8 @@ InputHandler_PumpHID::InputHandler_PumpHID() {
 
   // ensure auto reconnect and blocking reads (since the device wants write/read
   // cycles properly.)
-  dev = new HidDevice(PUMPHID_VID, devPIDS, PUMPHID_INTERFACE_NUM, true, false);
+  dev = std::make_unique<HidDevice>(
+      PUMPHID_VID, devPIDS, PUMPHID_INTERFACE_NUM, true, false);
 
   if (IsConnected() && PREFSMAN->m_bThreadedInput) {
     InputThread.SetName("PumpHID thread");

--- a/src/arch/InputHandler/InputHandler_PumpHID.h
+++ b/src/arch/InputHandler/InputHandler_PumpHID.h
@@ -234,11 +234,17 @@ class InputHandler_PumpHID : public InputHandler {
   std::string GetDeviceSpecificInputString(const DeviceInput& di);
   void GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut);
 
-  bool IsConnected() { return dev != nullptr && dev->IsConnected(); }
+  bool IsConnected() { return dev.IsConnected(); }
 
  private:
-  std::unique_ptr<HidDevice> dev;
-  static const std::vector<int> devPIDS;
+  // all of the known device pid's that use this communication protocol.
+  inline static const std::vector<int> devPIDS = {
+      PUMPHID_PID_V1, PUMPHID_PID_V2};
+
+  // ensure auto reconnect and blocking reads (since the device wants write/read
+  // cycles properly.)
+  HidDevice dev =
+      HidDevice(PUMPHID_VID, devPIDS, PUMPHID_INTERFACE_NUM, true, false);
 
   pumphid_output_state_t msg_from_device;
   pumphid_input_state_t msg_to_device;

--- a/src/arch/InputHandler/InputHandler_PumpHID.h
+++ b/src/arch/InputHandler/InputHandler_PumpHID.h
@@ -237,7 +237,7 @@ class InputHandler_PumpHID : public InputHandler {
   bool IsConnected() { return dev != nullptr && dev->IsConnected(); }
 
  private:
-  HidDevice* dev;
+  std::unique_ptr<HidDevice> dev;
   static const std::vector<int> devPIDS;
 
   pumphid_output_state_t msg_from_device;

--- a/src/arch/InputHandler/InputHandler_SnekConfig.cpp
+++ b/src/arch/InputHandler/InputHandler_SnekConfig.cpp
@@ -43,7 +43,7 @@ InputHandler_SnekConfig::InputHandler_SnekConfig() {
 
   // ensure auto reconnect and blocking reads (we need to ask it a question then
   // get an answer)
-  dev = new HidDevice(
+  dev = std::make_unique<HidDevice>(
       SNEK_CONFIG_VID, SNEK_CONFIG_PID, SNEK_CONFIG_INTERFACE_NUM, true, false);
 
   if (IsConnected()) {
@@ -145,7 +145,11 @@ void InputHandler_SnekConfig::InputThreadMain() {
 
   while (!m_bShutdown) {
     // extio sensor cmds are 1,2,3,4, so add one to zero index.
-    SendCommand(SNEK_CONFIG_OPCODE_SET_EXTIO_SENSOR, (sensorNumber + 1), res);
+    if (!SendCommand(
+            SNEK_CONFIG_OPCODE_SET_EXTIO_SENSOR, (sensorNumber + 1), res)) {
+      // bad response, try again
+      continue;
+    }
 
     uint32_t newState = 0;
     std::memcpy(&newState, &res[2], sizeof(newState));

--- a/src/arch/InputHandler/InputHandler_SnekConfig.cpp
+++ b/src/arch/InputHandler/InputHandler_SnekConfig.cpp
@@ -1,0 +1,239 @@
+#include "InputHandler_SnekConfig.h"
+
+#include <fcntl.h>
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "EnumHelper.h"
+#include "Game.h"
+#include "GameInput.h"
+#include "GameState.h"
+#include "InputFilter.h"
+#include "InputMapper.h"
+#include "LightsManager.h"
+#include "PrefsManager.h"
+#include "RageInputDevice.h"
+#include "RageLog.h"
+#include "RageUtil.h"
+#include "StdString.h"
+#include "arch/ArchHooks/ArchHooks.h"
+#include "arch/InputHandler/InputHandler.h"
+#include "arch/Lights/LightsDriver_Export.h"
+#include "archutils/Common/HidDevice.h"
+
+REGISTER_INPUT_HANDLER_CLASS(SnekConfig);
+
+// this is the bit position of the response, mapped to the panel number it
+// matches to.
+static constexpr SnekBitMapping sensorBitMappingDance[] = {
+    {14, PLAYER_2, PadPanel_Up},    {15, PLAYER_1, PadPanel_Up},
+    {16, PLAYER_1, PadPanel_Left},  {17, PLAYER_2, PadPanel_Left},
+    {18, PLAYER_1, PadPanel_Down},  {19, PLAYER_2, PadPanel_Down},
+    {20, PLAYER_2, PadPanel_Right}, {21, PLAYER_1, PadPanel_Right},
+};
+
+InputHandler_SnekConfig::InputHandler_SnekConfig() {
+  // do not start the thread when initialized.
+  m_bShutdown = true;
+
+  // ensure auto reconnect and blocking reads (we need to ask it a question then
+  // get an answer)
+  dev = new HidDevice(
+      SNEK_CONFIG_VID, SNEK_CONFIG_PID, SNEK_CONFIG_INTERFACE_NUM, true, false);
+
+  if (IsConnected()) {
+    std::array<uint8_t, SNEK_CONFIG_PACKETSIZE> res;
+
+    // get firmware information and check connection
+    if (SendCommand(SNEK_CONFIG_OPCODE_GETINFO, 0, res)) {
+      LOG->Info(
+          "Found snek version: %s", reinterpret_cast<const char*>(&res[2]));
+    } else {
+      LOG->Warn("Failed to open snek config end point");
+      return;
+    }
+  } else {
+    LOG->Warn("SnekConfig enabled, but could not connect to snek.");
+  }
+}
+
+InputHandler_SnekConfig::~InputHandler_SnekConfig() {
+  // disconnect cleanup etc
+  StopSensorDebugging();
+  SendSafeDisconnect();
+}
+
+void InputHandler_SnekConfig::SendSafeDisconnect() {
+  if (IsConnected()) {
+    std::array<uint8_t, SNEK_CONFIG_PACKETSIZE> res;
+    SendCommand(SNEK_CONFIG_OPCODE_SET_EXTIO_SENSOR, 0, res);
+    SendCommand(SNEK_CONFIG_OPCODE_DISCONNECT, 0, res);
+  }
+}
+
+std::string InputHandler_SnekConfig::GetDeviceSpecificInputString(
+    const DeviceInput& di) {
+  return InputHandler::GetDeviceSpecificInputString(di);
+}
+
+void InputHandler_SnekConfig::GetDevicesAndDescriptions(
+    std::vector<InputDeviceInfo>& vDevicesOut) {
+  // input data is not used in this class, it is routed through the system.
+}
+
+int InputHandler_SnekConfig::InputThread_Start(void* p) {
+  ((InputHandler_SnekConfig*)p)->InputThreadMain();
+  return 0;
+}
+
+void InputHandler_SnekConfig::BroadcastFullSensorStateHelper(
+    SnekBitMapping mapping, uint8_t sensor_index, bool isPressed) {
+  PadSensor currSensor = PadSensor_TopCenter;
+
+  switch (sensor_index) {
+    case 0:
+      currSensor = PadSensor_TopCenter;
+      break;
+    case 1:
+      currSensor = PadSensor_BottomCenter;
+      break;
+    case 2:
+      currSensor = PadSensor_LeftCenter;
+      break;
+    case 3:
+      currSensor = PadSensor_RightCenter;
+      break;
+    default:
+      LOG->Warn("Invalid sensor position %d", sensor_index);
+      break;
+  }
+
+  INPUTFILTER->setFullSensorStateBinary(
+      mapping.pn, mapping.panel, currSensor, isPressed);
+}
+
+void InputHandler_SnekConfig::StartSensorDebugging() {
+  if (!IsConnected() || DebugThread != nullptr) {
+    return;
+  }
+
+  m_bShutdown = false;
+
+  DebugThread = new RageThread();
+  DebugThread->SetName("SnekConfig debug thread");
+  DebugThread->Create(InputThread_Start, this);
+}
+
+void InputHandler_SnekConfig::StopSensorDebugging() {
+  if (DebugThread != nullptr && !m_bShutdown) {
+    m_bShutdown = true;
+    DebugThread->Wait();
+
+    delete DebugThread;
+    DebugThread = nullptr;
+  }
+}
+
+void InputHandler_SnekConfig::InputThreadMain() {
+  std::array<uint8_t, SNEK_CONFIG_PACKETSIZE> res;
+  uint8_t sensorNumber = 0;
+
+  while (!m_bShutdown) {
+    // extio sensor cmds are 1,2,3,4, so add one to zero index.
+    SendCommand(SNEK_CONFIG_OPCODE_SET_EXTIO_SENSOR, (sensorNumber + 1), res);
+
+    uint32_t newState = 0;
+    std::memcpy(&newState, &res[2], sizeof(newState));
+
+    if (newState != sensorState[sensorNumber]) {
+      // use xor to fire events only on the bits that have changed.
+      uint32_t changed = newState ^ sensorState[sensorNumber];
+
+      // walk through only the bits are are interested in (via the sensor
+      // mapping)
+      for (const auto& mapping : sensorBitMappingDance) {
+        const uint32_t mask = 1u << mapping.bitPosition;
+
+        if ((changed & mask) == 0) {
+          // This sensor didn't change.
+          continue;
+        }
+
+        const bool pressed = (newState & mask) != 0;
+
+        // Only send an event for this changed sensor.
+        BroadcastFullSensorStateHelper(mapping, sensorNumber, pressed);
+      }
+
+      // inform listeners of a new state, as during this debug state the snek
+      // will not fire events over the gamepad endpoint
+      // as the response is sent via the config end point.
+      MESSAGEMAN->Broadcast("TestSensorRedrawEvent");
+
+      sensorState[sensorNumber] = newState;
+    }
+
+    sensorNumber++;
+    if (sensorNumber >= SNEK_CONFIG_NUM_SENSORS) {
+      sensorNumber = 0;
+    }
+  }
+
+  SendSafeDisconnect();
+}
+
+bool InputHandler_SnekConfig::SendCommand(
+    uint8_t opcode, uint8_t payload,
+    std::array<uint8_t, SNEK_CONFIG_PACKETSIZE>& response) {
+  std::array<uint8_t, SNEK_CONFIG_PACKETSIZE> cmd{};
+
+  cmd[0] = SNEK_CONFIG_HID_OUTPUT;
+  cmd[1] = opcode;
+  cmd[2] = payload;
+
+  // Compute CRC over bytes 0-62
+  uint8_t crc = 0;
+  for (size_t i = 0; i < SNEK_CONFIG_PACKETSIZE - 1; ++i) {
+    crc = static_cast<uint8_t>(crc + cmd[i]);
+  }
+
+  // last byte is the crc.
+  cmd[(SNEK_CONFIG_PACKETSIZE - 1)] = crc;
+
+  // Send command
+  if (dev->Write(cmd.data(), cmd.size()) != HidResults::Success) {
+    LOG->Warn("snek could not send");
+    return false;
+  }
+
+  int rtnSize = dev->Read(response.data(), response.size());
+
+  // Read response, always a full payload size.
+  if (rtnSize != SNEK_CONFIG_PACKETSIZE) {
+    LOG->Warn("could not read snek command back");
+    return false;
+  }
+
+  if (response[0] != SNEK_CONFIG_HID_INPUT) {
+    LOG->Warn("snek invalid hid report: %02x", response[0]);
+    return false;
+  }
+
+  uint8_t opencodeRtn = response[1];
+
+  if (opencodeRtn == SNEK_CONFIG_ERROR) {
+    LOG->Warn("snek invalid opcode: %02x", opcode);
+    return false;
+  } else if (opencodeRtn != opcode) {
+    LOG->Warn(
+        "snek recv mismatching opcode: %02x != %02x", opencodeRtn, opcode);
+    return false;
+  }
+
+  return true;
+}

--- a/src/arch/InputHandler/InputHandler_SnekConfig.cpp
+++ b/src/arch/InputHandler/InputHandler_SnekConfig.cpp
@@ -41,11 +41,6 @@ InputHandler_SnekConfig::InputHandler_SnekConfig() {
   // do not start the thread when initialized.
   m_bShutdown = true;
 
-  // ensure auto reconnect and blocking reads (we need to ask it a question then
-  // get an answer)
-  dev = std::make_unique<HidDevice>(
-      SNEK_CONFIG_VID, SNEK_CONFIG_PID, SNEK_CONFIG_INTERFACE_NUM, true, false);
-
   if (IsConnected()) {
     std::array<uint8_t, SNEK_CONFIG_PACKETSIZE> res;
 
@@ -210,12 +205,12 @@ bool InputHandler_SnekConfig::SendCommand(
   cmd[(SNEK_CONFIG_PACKETSIZE - 1)] = crc;
 
   // Send command
-  if (dev->Write(cmd.data(), cmd.size()) != HidResults::Success) {
+  if (dev.Write(cmd.data(), cmd.size()) != HidResults::Success) {
     LOG->Warn("snek could not send");
     return false;
   }
 
-  int rtnSize = dev->Read(response.data(), response.size());
+  int rtnSize = dev.Read(response.data(), response.size());
 
   // Read response, always a full payload size.
   if (rtnSize != SNEK_CONFIG_PACKETSIZE) {

--- a/src/arch/InputHandler/InputHandler_SnekConfig.h
+++ b/src/arch/InputHandler/InputHandler_SnekConfig.h
@@ -69,13 +69,16 @@ class InputHandler_SnekConfig : public InputHandler {
   std::string GetDeviceSpecificInputString(const DeviceInput& di);
   void GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut);
 
-  bool IsConnected() { return dev != nullptr && dev->IsConnected(); }
+  bool IsConnected() { return dev.IsConnected(); }
 
   void StartSensorDebugging();
   void StopSensorDebugging();
 
  private:
-  std::unique_ptr<HidDevice> dev;
+  // ensure auto reconnect and blocking reads (we need to ask it a question then
+  // get an answer)
+  HidDevice dev = HidDevice(
+      SNEK_CONFIG_VID, SNEK_CONFIG_PID, SNEK_CONFIG_INTERFACE_NUM, true, false);
 
   std::atomic<bool> m_bShutdown;
   RageThread* DebugThread = nullptr;

--- a/src/arch/InputHandler/InputHandler_SnekConfig.h
+++ b/src/arch/InputHandler/InputHandler_SnekConfig.h
@@ -56,7 +56,7 @@
 #define SNEK_CONFIG_NUM_SENSORS 4
 
 struct SnekBitMapping {
-  uint bitPosition;
+  uint32_t bitPosition;
   PlayerNumber pn;
   PadPanel panel;
 };

--- a/src/arch/InputHandler/InputHandler_SnekConfig.h
+++ b/src/arch/InputHandler/InputHandler_SnekConfig.h
@@ -1,0 +1,122 @@
+#ifndef INPUT_HANDLER_SNEK_CONFIG
+#define INPUT_HANDLER_SNEK_CONFIG
+
+/*
+ * -------------------------- NOTE --------------------------
+ *
+ * This driver needs user read/write access the device.
+ * This can be achieved by using a udev rule like this:
+ *
+ * SUBSYSTEMS=="usb", ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="10a8",
+ * OWNER="dance", GROUP="dance", MODE="0660"
+ *
+ * or
+ *
+ * KERNEL=="hidraw*", ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="10a8",
+ * OWNER="dance", GROUP="dance", MODE="0660"
+ *
+ * Refer to your distribution's documentation on how to properly apply a udev
+ * rule.
+ *
+ * -------------------------- NOTE --------------------------
+ */
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "InputFilter.h"
+#include "InputHandler.h"
+#include "LightsManager.h"
+#include "PlayerNumber.h"
+#include "RageInputDevice.h"
+#include "RageThreads.h"
+#include "archutils/Common/HidDevice.h"
+
+#define SNEK_CONFIG_PACKETSIZE 64
+
+#define SNEK_CONFIG_VID 0x2E8A
+#define SNEK_CONFIG_PID 0x10a8
+
+// the config interface is number 1
+#define SNEK_CONFIG_INTERFACE_NUM 1
+
+// hid report number is this
+#define SNEK_CONFIG_HID_OUTPUT 0x77
+
+// hid report response starts with this.
+#define SNEK_CONFIG_HID_INPUT 0x78
+
+// these are all opcodes.
+#define SNEK_CONFIG_OPCODE_GETINFO 0x01
+#define SNEK_CONFIG_OPCODE_SET_EXTIO_SENSOR 0x08
+#define SNEK_CONFIG_OPCODE_DISCONNECT 0x0A
+#define SNEK_CONFIG_ERROR 0xFF
+
+#define SNEK_CONFIG_NUM_SENSORS 4
+
+struct SnekBitMapping {
+  uint bitPosition;
+  PlayerNumber pn;
+  PadPanel panel;
+};
+
+class InputHandler_SnekConfig : public InputHandler {
+ public:
+  InputHandler_SnekConfig();
+  ~InputHandler_SnekConfig();
+
+  std::string GetDeviceSpecificInputString(const DeviceInput& di);
+  void GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut);
+
+  bool IsConnected() { return dev != nullptr && dev->IsConnected(); }
+
+  void StartSensorDebugging();
+  void StopSensorDebugging();
+
+ private:
+  HidDevice* dev;
+
+  bool m_bShutdown;
+  RageThread* DebugThread = nullptr;
+
+  uint32_t sensorState[SNEK_CONFIG_NUM_SENSORS] = {};
+
+  static int InputThread_Start(void* p);
+  void InputThreadMain();
+
+  void BroadcastFullSensorStateHelper(
+      SnekBitMapping mapping, uint8_t sensor_index, bool isPressed);
+  void SendSafeDisconnect();
+
+  bool SendCommand(
+      uint8_t opcode, uint8_t payload,
+      std::array<uint8_t, SNEK_CONFIG_PACKETSIZE>& response);
+};
+
+#endif
+
+/*
+ * (c) 2026 din
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, provided that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the Software and that both the above copyright notice(s) and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+ * THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+ * INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */

--- a/src/arch/InputHandler/InputHandler_SnekConfig.h
+++ b/src/arch/InputHandler/InputHandler_SnekConfig.h
@@ -75,9 +75,9 @@ class InputHandler_SnekConfig : public InputHandler {
   void StopSensorDebugging();
 
  private:
-  HidDevice* dev;
+  std::unique_ptr<HidDevice> dev;
 
-  bool m_bShutdown;
+  std::atomic<bool> m_bShutdown;
   RageThread* DebugThread = nullptr;
 
   uint32_t sensorState[SNEK_CONFIG_NUM_SENSORS] = {};


### PR DESCRIPTION
Provides the ability to poll the snek board for the sensor states during a debugging session.

Sample video: https://bsky.app/profile/din.icedragon.io/post/3mtpk5li7622a

Remains dormant until `StartSensorDebugging` is called, then the polling begins and sends data off using the new InputFilter method.

Once `StopSensorDebugging` is called, the thread quits and correctly tells the device to go back into game mode and set the pad pcb's in the correct state. 

Things I need critique on:
- The way I am handling the temporary polling thread. I chose a pointer and boolean `m_bShutdown` to continue running. It works on my machine :tm: on linux, but is this the "correct" way we want to handle this?
- On the thread shutdown do I need to delete the pointer and set it to `nullptr`? Or am I just doing extra work there.