### PR TITLE
[Windows] Wasapi Shared Low-Latency Mode

### DIFF
--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -311,6 +311,8 @@ PrefsManager::PrefsManager()
       m_iSoundWriteAhead("SoundWriteAhead", 0),
       m_iSoundDevice("SoundDevice", ""),
       m_iSoundPreferredSampleRate("SoundPreferredSampleRate", 0),
+      m_sWASAPISubDriverOrder(
+          "WASAPISubDriverOrder", "SharedLL,Shared,Exclusive"),
       m_sLightsStepsDifficulty("LightsStepsDifficulty", "hard,medium"),
       m_bLightsSimplifyBass("LightsSimplifyBass", false),
       m_bLightsBassParallel("LightsBassParallel", false),

--- a/src/PrefsManager.h
+++ b/src/PrefsManager.h
@@ -332,6 +332,7 @@ class PrefsManager {
   Preference<int> m_iSoundWriteAhead;
   Preference<std::string> m_iSoundDevice;
   Preference<int> m_iSoundPreferredSampleRate;
+  Preference<std::string> m_sWASAPISubDriverOrder;
   Preference<std::string> m_sLightsStepsDifficulty;
   Preference<bool> m_bLightsSimplifyBass;
   Preference<bool> m_bLightsBassParallel;

--- a/src/arch/Sound/RageSoundDriver_WASAPI.cpp
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.cpp
@@ -23,7 +23,7 @@ HRESULT InitializeSharedLowLatencyStream(
   IAudioClient3* pAudioClient3 = nullptr;
   HRESULT hr = pAudioClient->QueryInterface(IID_PPV_ARGS(&pAudioClient3));
   if (FAILED(hr) || pAudioClient3 == nullptr) {
-    LOG->Info("WASAPI: IAudioClient3 not available; skipping shared low-latency pathway");
+    LOG->Info("WASAPI: Shared LowLatency - IAudioClient3 not available");
     return S_FALSE;
   }
 
@@ -36,9 +36,7 @@ HRESULT InitializeSharedLowLatencyStream(
       &iMinPeriodFrames, &iMaxPeriodFrames);
 
   if (FAILED(hr)) {
-    LOG->Warn(
-        "WASAPI: Shared LowLatency GetSharedModeEnginePeriod failed; "
-        "falling back to shared Initialize");
+    LOG->Warn("WASAPI: Shared LowLatency - GetSharedModeEnginePeriod failed");
     pAudioClient3->Release();
     return S_FALSE;
   }
@@ -74,15 +72,11 @@ HRESULT InitializeSharedLowLatencyStream(
   pAudioClient3->Release();
 
   if (FAILED(hr)) {
-    LOG->Warn("WASAPI: Shared LowLatency InitializeSharedAudioStream failed; "
-              "falling back to shared Initialize");
+    LOG->Warn("WASAPI: Shared LowLatency InitializeSharedAudioStream failed");
     return hr;
   }
 
-  LOG->Info(
-      "WASAPI: Shared LowLatency mode initialized successfully",
-      iPeriodFrames, iMinPeriodFrames, iDefaultPeriodFrames, iMaxPeriodFrames,
-      iFundamentalPeriodFrames);
+  LOG->Info("WASAPI: Shared LowLatency mode initialized successfully");
   return S_OK;
 #else
   LOG->Info(
@@ -280,8 +274,11 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
   }
 
   LOG->Info(
-      "WASAPI: Shared mode, %d channels, %d Hz, %s, buffer size %d frames",
-      iChannels, m_iSampleRate, m_bFloat ? "Float" : "Int16",
+      "WASAPI: %s mode, %d channels, %d Hz, %s, buffer size %d frames",
+      hrLowLatency == S_OK ? "Shared LowLatency" : "Shared",
+      iChannels,
+      m_iSampleRate,
+      m_bFloat ? "Float" : "Int16",
       m_iBufferSizeFrames);
 
   return true;

--- a/src/arch/Sound/RageSoundDriver_WASAPI.cpp
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.cpp
@@ -322,6 +322,8 @@ std::string RageSoundDriver_WASAPI::Init() {
 
   // Set decode buffer size.
   // We want it to be at least as big as the WASAPI buffer.
+  // Having a minimum decodeBufferSize does not impact latency,
+  // and helps with xrun with very small hardware buffers
   UINT32 decodeBufferSizeFrames = m_iBufferSizeFrames * 3 / 2;
   if (decodeBufferSizeFrames < 768) {
     decodeBufferSizeFrames = 768;

--- a/src/arch/Sound/RageSoundDriver_WASAPI.cpp
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.cpp
@@ -70,6 +70,10 @@ void RageSoundDriver_WASAPI::FreeWASAPI() {
 bool RageSoundDriver_WASAPI::TrySubDriver(
     std::unique_ptr<WasapiSubDriver> pCandidateSubDriver,
     const WasapiInitParams& params, HRESULT& hrInitialize) {
+
+  LOG->Info("WASAPI: Attempting to initialize `%s` mode",
+            pCandidateSubDriver->GetModeName());
+
   HRESULT hrSub = pCandidateSubDriver->InitializeStream(params);
   if (SUCCEEDED(hrSub)) {
     m_pSubDriver = std::move(pCandidateSubDriver);

--- a/src/arch/Sound/RageSoundDriver_WASAPI.cpp
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.cpp
@@ -17,14 +17,6 @@
 REGISTER_SOUND_DRIVER_CLASS2("WASAPI", WASAPI);
 
 namespace {
-REFERENCE_TIME FramesToHnsDuration(UINT32 iFrames, int iSampleRate) {
-  if (iFrames == 0 || iSampleRate <= 0) {
-    return 0;
-  }
-
-  return (REFERENCE_TIME)iFrames * 10000000ULL / iSampleRate;
-}
-
 HRESULT InitializeSharedLowLatencyStream(
     IAudioClient* pAudioClient, WAVEFORMATEX* pwfx, UINT32 iRequestedFrames) {
 #ifdef __IAudioClient3_INTERFACE_DEFINED
@@ -45,8 +37,8 @@ HRESULT InitializeSharedLowLatencyStream(
 
   if (FAILED(hr)) {
     LOG->Warn(
-        "WASAPI: GetSharedModeEnginePeriod failed; skipping shared "
-        "low-latency pathway");
+        "WASAPI: Shared LowLatency GetSharedModeEnginePeriod failed; "
+        "falling back to shared Initialize");
     pAudioClient3->Release();
     return S_FALSE;
   }
@@ -70,28 +62,31 @@ HRESULT InitializeSharedLowLatencyStream(
     }
   }
 
+  LOG->Info(
+      "WASAPI: Shared LowLatency attempting to initialize using parameters "
+      "(period=%u, min=%u, default=%u, max=%u, fundamental=%u)",
+      iPeriodFrames, iMinPeriodFrames, iDefaultPeriodFrames, iMaxPeriodFrames,
+      iFundamentalPeriodFrames);
+
   hr = pAudioClient3->InitializeSharedAudioStream(
       AUDCLNT_STREAMFLAGS_EVENTCALLBACK, iPeriodFrames, pwfx, nullptr);
 
   pAudioClient3->Release();
 
   if (FAILED(hr)) {
-    LOG->Warn(
-        hr_ssprintf(hr,
-                    "WASAPI: InitializeSharedAudioStream failed; falling back "
-                    "to shared Initialize")
-            .c_str());
+    LOG->Warn("WASAPI: Shared LowLatency InitializeSharedAudioStream failed; "
+              "falling back to shared Initialize");
     return hr;
   }
 
   LOG->Info(
-      "WASAPI: Shared low-latency mode enabled (period=%u frames, min=%u, default=%u, max=%u, fundamental=%u)",
+      "WASAPI: Shared LowLatency mode initialized successfully",
       iPeriodFrames, iMinPeriodFrames, iDefaultPeriodFrames, iMaxPeriodFrames,
       iFundamentalPeriodFrames);
   return S_OK;
 #else
   LOG->Info(
-      "WASAPI: IAudioClient3 headers unavailable in this SDK; skipping shared "
+      "WASAPI: Low-Latency IAudioClient3 headers unavailable in this SDK; skipping shared "
       "low-latency pathway");
   (void)pAudioClient;
   (void)pwfx;
@@ -206,7 +201,6 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
   }
 
   WAVEFORMATEXTENSIBLE* pEx = (WAVEFORMATEXTENSIBLE*)pwfx;
-
   if (pEx->SubFormat == KSDATAFORMAT_SUBTYPE_IEEE_FLOAT) {
     m_bFloat = true;
   } else if (
@@ -220,8 +214,12 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
     return false;
   }
 
-  REFERENCE_TIME hnsRequestedDuration =
-      FramesToHnsDuration(PREFSMAN->m_iSoundWriteAhead, m_iSampleRate);
+  REFERENCE_TIME hnsRequestedDuration = 0;
+  if (PREFSMAN->m_iSoundWriteAhead) {
+    // WriteAhead is in frames. Convert to 100-nanosecond units.
+    hnsRequestedDuration = (REFERENCE_TIME)PREFSMAN->m_iSoundWriteAhead *
+                           10000000ULL / m_iSampleRate;
+  }
 
   HRESULT hrLowLatency = InitializeSharedLowLatencyStream(
       m_pAudioClient, pwfx, PREFSMAN->m_iSoundWriteAhead);
@@ -285,7 +283,7 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
       "WASAPI: Shared mode, %d channels, %d Hz, %s, buffer size %d frames",
       iChannels, m_iSampleRate, m_bFloat ? "Float" : "Int16",
       m_iBufferSizeFrames);
-  
+
   return true;
 }
 

--- a/src/arch/Sound/RageSoundDriver_WASAPI.cpp
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.cpp
@@ -67,6 +67,23 @@ void RageSoundDriver_WASAPI::FreeWASAPI() {
   }
 }
 
+bool RageSoundDriver_WASAPI::TrySubDriver(
+    std::unique_ptr<WasapiSubDriver> pCandidateSubDriver,
+    const WasapiInitParams& params, HRESULT& hrInitialize) {
+  HRESULT hrSub = pCandidateSubDriver->InitializeStream(params);
+  if (SUCCEEDED(hrSub)) {
+    m_pSubDriver = std::move(pCandidateSubDriver);
+    hrInitialize = hrSub;
+    return true;
+  }
+
+  LOG->Warn(hr_ssprintf(
+                hrSub, "WASAPI: %s mode unsuccessful; trying fallback mode",
+                pCandidateSubDriver->GetModeName())
+                .c_str());
+  return false;
+}
+
 bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
   HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
   if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
@@ -119,30 +136,9 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
   };
   m_pSubDriver.reset();
 
-  auto TrySubDriver =
-      [&](std::unique_ptr<WasapiSubDriver> pCandidateSubDriver) -> bool {
-    HRESULT hrSub = pCandidateSubDriver->InitializeStream(params);
-    if (SUCCEEDED(hrSub)) {
-      m_pSubDriver = std::move(pCandidateSubDriver);
-      hr = hrSub;
-      return true;
-    }
-
-    if (hrSub == S_FALSE) {
-      LOG->Info("WASAPI: %s mode unavailable; trying fallback mode",
-                pCandidateSubDriver->GetModeName());
-    } else {
-      LOG->Warn(hr_ssprintf(hrSub,
-                            "WASAPI: %s mode init failed; trying fallback "
-                            "mode")
-                    .c_str());
-    }
-    return false;
-  };
-
-  if (!TrySubDriver(CreateWasapiExclusiveSubDriver()) &&
-      !TrySubDriver(CreateWasapiSharedLLSubDriver()) &&
-      !TrySubDriver(CreateWasapiSharedSubDriver())) {
+  if (!TrySubDriver(CreateWasapiSharedLLSubDriver(), params, hr) &&
+      !TrySubDriver(CreateWasapiSharedSubDriver(), params, hr) &&
+      !TrySubDriver(CreateWasapiExclusiveSubDriver(), params, hr)) {
     sError = "Failed to initialize WASAPI stream mode";
     CoTaskMemFree(pwfx);
     FreeWASAPI();
@@ -174,12 +170,6 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
   int iChannels = pwfx->nChannels;
 
   CoTaskMemFree(pwfx);
-
-  if (FAILED(hr)) {
-    sError = hr_ssprintf(hr, "Initialize(IAudioClient) failed");
-    FreeWASAPI();
-    return false;
-  }
 
   m_hAudioEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
   if (m_hAudioEvent == NULL) {
@@ -243,8 +233,8 @@ std::string RageSoundDriver_WASAPI::Init() {
   // Set decode buffer size.
   // We want it to be at least as big as the WASAPI buffer.
   UINT32 decodeBufferSizeFrames = m_iBufferSizeFrames * 3 / 2;
-  if (decodeBufferSizeFrames < 512) {
-    decodeBufferSizeFrames = 512;
+  if (decodeBufferSizeFrames < 768) {
+    decodeBufferSizeFrames = 768;
   }
 
   SetDecodeBufferSize(decodeBufferSizeFrames);

--- a/src/arch/Sound/RageSoundDriver_WASAPI.cpp
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.cpp
@@ -120,7 +120,39 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
     return false;
   }
 
+  
+  hr = m_pAudioClient->IsFormatSupported(
+      AUDCLNT_SHAREMODE_EXCLUSIVE, pwfx, nullptr);
+  
+  // cast pwfx to a modifiable WAVEFORMATEXTENSIBLE
+  // to change it to 16-bit PCM in-place
   WAVEFORMATEXTENSIBLE* pEx = (WAVEFORMATEXTENSIBLE*)pwfx;
+
+  if (FAILED(hr)) {
+    
+    
+    pEx->SubFormat = KSDATAFORMAT_SUBTYPE_PCM;
+    pEx->Format.wBitsPerSample = 16;
+    pEx->Samples.wValidBitsPerSample = 16;
+    pEx->Format.nBlockAlign =
+        pEx->Format.nChannels * pEx->Format.wBitsPerSample / 8;
+    pEx->Format.nAvgBytesPerSec =
+        pEx->Format.nSamplesPerSec * pEx->Format.nBlockAlign;
+
+    hr = m_pAudioClient->IsFormatSupported(
+        AUDCLNT_SHAREMODE_EXCLUSIVE, pwfx, nullptr);
+    if (SUCCEEDED(hr)) {
+      LOG->Info("WASAPI: Fell back to int16 format");
+    } else {
+      sError = hr_ssprintf(
+          hr, "Exclusive mode does not support float or 16-bit PCM at this "
+              "device rate/channel layout");
+      CoTaskMemFree(pwfx);
+      FreeWASAPI();
+      return false;
+    }
+  }
+
   if (pEx->SubFormat == KSDATAFORMAT_SUBTYPE_IEEE_FLOAT) {
     m_bFloat = true;
   } else if (
@@ -141,9 +173,22 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
                            10000000ULL / m_iSampleRate;
   }
 
+  if (hnsRequestedDuration == 0) {
+    REFERENCE_TIME hnsDefaultPeriod = 0;
+    REFERENCE_TIME hnsMinimumPeriod = 0;
+    hr = m_pAudioClient->GetDevicePeriod(&hnsDefaultPeriod, &hnsMinimumPeriod);
+    if (FAILED(hr)) {
+      sError = hr_ssprintf(hr, "GetDevicePeriod failed");
+      CoTaskMemFree(pwfx);
+      FreeWASAPI();
+      return false;
+    }
+    hnsRequestedDuration = hnsMinimumPeriod ? hnsMinimumPeriod : hnsDefaultPeriod;
+  }
+
   hr = m_pAudioClient->Initialize(
-      AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
-      hnsRequestedDuration, 0, pwfx, nullptr);
+      AUDCLNT_SHAREMODE_EXCLUSIVE, AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
+      hnsRequestedDuration, hnsRequestedDuration, pwfx, nullptr);
 
   CoTaskMemFree(pwfx);
 
@@ -195,11 +240,14 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
     return false;
   }
 
+  float latency = GetPlayLatency();  // just to log it
+  LOG->Info("WASAPI: Reported latency %f", latency);
+
   LOG->Info(
-      "WASAPI: Shared mode, %d channels, %d Hz, %s, buffer size %d frames",
+      "WASAPI: Exclusive mode, %d channels, %d Hz, %s, buffer size %d frames",
       iChannels, m_iSampleRate, m_bFloat ? "Float" : "Int16",
       m_iBufferSizeFrames);
-
+  
   return true;
 }
 
@@ -211,7 +259,8 @@ std::string RageSoundDriver_WASAPI::Init() {
 
   // Set decode buffer size.
   // We want it to be at least as big as the WASAPI buffer.
-  SetDecodeBufferSize(m_iBufferSizeFrames * 3 / 2);
+  //  SetDecodeBufferSize(m_iBufferSizeFrames * 3 / 2);
+  SetDecodeBufferSize(512);
   StartDecodeThread();
 
   m_MixingThread.SetName("WASAPI Mixer Thread");
@@ -235,13 +284,36 @@ void RageSoundDriver_WASAPI::MixerThread() {
     }
   }
 
+  int64_t iHardwareFrame = 0;  // Total frames played/mixed so far
+
+  {
+    BYTE* pData = nullptr;
+    HRESULT hr = m_pRenderClient->GetBuffer(m_iBufferSizeFrames, &pData);
+    if (FAILED(hr)) {
+      LOG->Warn(hr_ssprintf(hr, "GetBuffer (initial fill) failed").c_str());
+      return;
+    }
+
+    if (m_bFloat) {
+      this->Mix((float*)pData, m_iBufferSizeFrames, iHardwareFrame, 0);
+    } else {
+      this->Mix((int16_t*)pData, m_iBufferSizeFrames, iHardwareFrame, 0);
+    }
+
+    hr = m_pRenderClient->ReleaseBuffer(m_iBufferSizeFrames, 0);
+    if (FAILED(hr)) {
+      LOG->Warn(hr_ssprintf(hr, "ReleaseBuffer (initial fill) failed").c_str());
+      return;
+    }
+
+    iHardwareFrame += m_iBufferSizeFrames;
+  }
+
   HRESULT hr = m_pAudioClient->Start();
   if (FAILED(hr)) {
     LOG->Warn(hr_ssprintf(hr, "Failed to start IAudioClient").c_str());
     return;
   }
-
-  int64_t iHardwareFrame = 0;  // Total frames played/mixed so far
 
   while (!m_bShutdownMixerThread) {
     DWORD waitResult =
@@ -257,17 +329,7 @@ void RageSoundDriver_WASAPI::MixerThread() {
       break;
     }
 
-    UINT32 padding = 0;
-    hr = m_pAudioClient->GetCurrentPadding(&padding);
-    if (FAILED(hr)) {
-      LOG->Warn(hr_ssprintf(hr, "GetCurrentPadding failed").c_str());
-      continue;
-    }
-
-    UINT32 framesAvailable = m_iBufferSizeFrames - padding;
-    if (framesAvailable == 0) {
-      continue;
-    }
+    UINT32 framesAvailable = m_iBufferSizeFrames;
 
     BYTE* pData = nullptr;
     hr = m_pRenderClient->GetBuffer(framesAvailable, &pData);

--- a/src/arch/Sound/RageSoundDriver_WASAPI.cpp
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.cpp
@@ -1,4 +1,5 @@
 #include "RageSoundDriver_WASAPI.h"
+#include "RageSoundDriver_WASAPI_SubDriver.h"
 
 // clang-format off
 #include <windows.h>
@@ -15,80 +16,6 @@
 #include "global.h"
 
 REGISTER_SOUND_DRIVER_CLASS2("WASAPI", WASAPI);
-
-namespace {
-HRESULT InitializeSharedLowLatencyStream(
-    IAudioClient* pAudioClient, WAVEFORMATEX* pwfx, UINT32 iRequestedFrames) {
-#ifdef __IAudioClient3_INTERFACE_DEFINED
-  IAudioClient3* pAudioClient3 = nullptr;
-  HRESULT hr = pAudioClient->QueryInterface(IID_PPV_ARGS(&pAudioClient3));
-  if (FAILED(hr) || pAudioClient3 == nullptr) {
-    LOG->Info("WASAPI: Shared LowLatency - IAudioClient3 not available");
-    return S_FALSE;
-  }
-
-  UINT32 iDefaultPeriodFrames = 0;
-  UINT32 iFundamentalPeriodFrames = 0;
-  UINT32 iMinPeriodFrames = 0;
-  UINT32 iMaxPeriodFrames = 0;
-  hr = pAudioClient3->GetSharedModeEnginePeriod(
-      pwfx, &iDefaultPeriodFrames, &iFundamentalPeriodFrames,
-      &iMinPeriodFrames, &iMaxPeriodFrames);
-
-  if (FAILED(hr)) {
-    LOG->Warn("WASAPI: Shared LowLatency - GetSharedModeEnginePeriod failed");
-    pAudioClient3->Release();
-    return S_FALSE;
-  }
-
-  UINT32 iPeriodFrames =
-      iRequestedFrames > 0 ? iRequestedFrames : iMinPeriodFrames;
-  if (iPeriodFrames < iMinPeriodFrames) {
-    iPeriodFrames = iMinPeriodFrames;
-  }
-  if (iPeriodFrames > iMaxPeriodFrames) {
-    iPeriodFrames = iMaxPeriodFrames;
-  }
-
-  if (iFundamentalPeriodFrames > 0) {
-    UINT32 iRemainder = iPeriodFrames % iFundamentalPeriodFrames;
-    if (iRemainder != 0) {
-      iPeriodFrames += iFundamentalPeriodFrames - iRemainder;
-      if (iPeriodFrames > iMaxPeriodFrames) {
-        iPeriodFrames = iMaxPeriodFrames;
-      }
-    }
-  }
-
-  LOG->Info(
-      "WASAPI: Shared LowLatency attempting to initialize using parameters "
-      "(period=%u, min=%u, default=%u, max=%u, fundamental=%u)",
-      iPeriodFrames, iMinPeriodFrames, iDefaultPeriodFrames, iMaxPeriodFrames,
-      iFundamentalPeriodFrames);
-
-  hr = pAudioClient3->InitializeSharedAudioStream(
-      AUDCLNT_STREAMFLAGS_EVENTCALLBACK, iPeriodFrames, pwfx, nullptr);
-
-  pAudioClient3->Release();
-
-  if (FAILED(hr)) {
-    LOG->Warn("WASAPI: Shared LowLatency InitializeSharedAudioStream failed");
-    return hr;
-  }
-
-  LOG->Info("WASAPI: Shared LowLatency mode initialized successfully");
-  return S_OK;
-#else
-  LOG->Info(
-      "WASAPI: Low-Latency IAudioClient3 headers unavailable in this SDK; skipping shared "
-      "low-latency pathway");
-  (void)pAudioClient;
-  (void)pwfx;
-  (void)iRequestedFrames;
-  return S_FALSE;
-#endif
-}
-}  // namespace
 
 RageSoundDriver_WASAPI::RageSoundDriver_WASAPI()
     : m_iSampleRate(0),
@@ -184,8 +111,43 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
     return false;
   }
 
-  m_iSampleRate = pwfx->nSamplesPerSec;
-  int iChannels = pwfx->nChannels;
+  WasapiInitParams params = {
+      m_pAudioClient,
+      pwfx,
+      (int)pwfx->nSamplesPerSec,
+      PREFSMAN->m_iSoundWriteAhead,
+  };
+  m_pSubDriver.reset();
+
+  auto TrySubDriver =
+      [&](std::unique_ptr<WasapiSubDriver> pCandidateSubDriver) -> bool {
+    HRESULT hrSub = pCandidateSubDriver->InitializeStream(params);
+    if (SUCCEEDED(hrSub)) {
+      m_pSubDriver = std::move(pCandidateSubDriver);
+      hr = hrSub;
+      return true;
+    }
+
+    if (hrSub == S_FALSE) {
+      LOG->Info("WASAPI: %s mode unavailable; trying fallback mode",
+                pCandidateSubDriver->GetModeName());
+    } else {
+      LOG->Warn(hr_ssprintf(hrSub,
+                            "WASAPI: %s mode init failed; trying fallback "
+                            "mode")
+                    .c_str());
+    }
+    return false;
+  };
+
+  if (!TrySubDriver(CreateWasapiExclusiveSubDriver()) &&
+      !TrySubDriver(CreateWasapiSharedLLSubDriver()) &&
+      !TrySubDriver(CreateWasapiSharedSubDriver())) {
+    sError = "Failed to initialize WASAPI stream mode";
+    CoTaskMemFree(pwfx);
+    FreeWASAPI();
+    return false;
+  }
 
   if (pwfx->wFormatTag != WAVE_FORMAT_EXTENSIBLE) {
     sError = ssprintf("Unsupported format tag: %d", pwfx->wFormatTag);
@@ -208,20 +170,8 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
     return false;
   }
 
-  REFERENCE_TIME hnsRequestedDuration = 0;
-  if (PREFSMAN->m_iSoundWriteAhead) {
-    // WriteAhead is in frames. Convert to 100-nanosecond units.
-    hnsRequestedDuration = (REFERENCE_TIME)PREFSMAN->m_iSoundWriteAhead *
-                           10000000ULL / m_iSampleRate;
-  }
-
-  HRESULT hrLowLatency = InitializeSharedLowLatencyStream(
-      m_pAudioClient, pwfx, PREFSMAN->m_iSoundWriteAhead);
-  if (hrLowLatency != S_OK) {
-    hr = m_pAudioClient->Initialize(
-        AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
-        hnsRequestedDuration, 0, pwfx, nullptr);
-  }
+  m_iSampleRate = pwfx->nSamplesPerSec;
+  int iChannels = pwfx->nChannels;
 
   CoTaskMemFree(pwfx);
 
@@ -273,12 +223,12 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
     return false;
   }
 
+  float reportedPlayLatency = GetPlayLatency();
+  LOG->Info("WASAPI: Reported audio play latency: %f", reportedPlayLatency);
   LOG->Info(
       "WASAPI: %s mode, %d channels, %d Hz, %s, buffer size %d frames",
-      hrLowLatency == S_OK ? "Shared LowLatency" : "Shared",
-      iChannels,
-      m_iSampleRate,
-      m_bFloat ? "Float" : "Int16",
+      m_pSubDriver ? m_pSubDriver->GetModeName() : "Unknown",
+      iChannels, m_iSampleRate, m_bFloat ? "Float" : "Int16",
       m_iBufferSizeFrames);
 
   return true;
@@ -292,7 +242,12 @@ std::string RageSoundDriver_WASAPI::Init() {
 
   // Set decode buffer size.
   // We want it to be at least as big as the WASAPI buffer.
-  SetDecodeBufferSize(m_iBufferSizeFrames * 3 / 2);
+  UINT32 decodeBufferSizeFrames = m_iBufferSizeFrames * 3 / 2;
+  if (decodeBufferSizeFrames < 512) {
+    decodeBufferSizeFrames = 512;
+  }
+
+  SetDecodeBufferSize(decodeBufferSizeFrames);
   StartDecodeThread();
 
   m_MixingThread.SetName("WASAPI Mixer Thread");
@@ -306,6 +261,32 @@ int RageSoundDriver_WASAPI::MixerThread_start(void* p) {
   return 0;
 }
 
+bool RageSoundDriver_WASAPI::WriteFrames(
+    UINT32 iFrames, int64_t iHardwareFrame, int64_t iCurrentFrame,
+    const char* sPhase) {
+  HRESULT hr = S_OK;
+  BYTE* pData = nullptr;
+  hr = m_pRenderClient->GetBuffer(iFrames, &pData);
+  if (FAILED(hr)) {
+    LOG->Warn(hr_ssprintf(hr, "GetBuffer (%s) failed", sPhase).c_str());
+    return false;
+  }
+
+  if (m_bFloat) {
+    this->Mix((float*)pData, iFrames, iHardwareFrame, iCurrentFrame);
+  } else {
+    this->Mix((int16_t*)pData, iFrames, iHardwareFrame, iCurrentFrame);
+  }
+
+  hr = m_pRenderClient->ReleaseBuffer(iFrames, 0);
+  if (FAILED(hr)) {
+    LOG->Warn(hr_ssprintf(hr, "ReleaseBuffer (%s) failed", sPhase).c_str());
+    return false;
+  }
+
+  return true;
+}
+
 void RageSoundDriver_WASAPI::MixerThread() {
   if (!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL)) {
     if (!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL)) {
@@ -316,13 +297,21 @@ void RageSoundDriver_WASAPI::MixerThread() {
     }
   }
 
-  HRESULT hr = m_pAudioClient->Start();
+  HRESULT hr = S_OK;
+  int64_t iHardwareFrame = 0;  // Total frames played/mixed so far
+
+  if (m_pSubDriver && m_pSubDriver->RequiresInitialFill()) {
+    if (!WriteFrames(m_iBufferSizeFrames, iHardwareFrame, 0, "initial fill")) {
+      return;
+    }
+    iHardwareFrame += m_iBufferSizeFrames;
+  }
+
+  hr = m_pAudioClient->Start();
   if (FAILED(hr)) {
     LOG->Warn(hr_ssprintf(hr, "Failed to start IAudioClient").c_str());
     return;
   }
-
-  int64_t iHardwareFrame = 0;  // Total frames played/mixed so far
 
   while (!m_bShutdownMixerThread) {
     DWORD waitResult =
@@ -338,39 +327,26 @@ void RageSoundDriver_WASAPI::MixerThread() {
       break;
     }
 
-    UINT32 padding = 0;
-    hr = m_pAudioClient->GetCurrentPadding(&padding);
-    if (FAILED(hr)) {
-      LOG->Warn(hr_ssprintf(hr, "GetCurrentPadding failed").c_str());
-      continue;
+    UINT32 framesAvailable = m_iBufferSizeFrames;
+    if (!m_pSubDriver || m_pSubDriver->UsesPaddingFrames()) {
+      UINT32 padding = 0;
+      hr = m_pAudioClient->GetCurrentPadding(&padding);
+      if (FAILED(hr)) {
+        LOG->Warn(hr_ssprintf(hr, "GetCurrentPadding failed").c_str());
+        continue;
+      }
+
+      framesAvailable = m_iBufferSizeFrames - padding;
     }
 
-    UINT32 framesAvailable = m_iBufferSizeFrames - padding;
     if (framesAvailable == 0) {
       continue;
     }
 
-    BYTE* pData = nullptr;
-    hr = m_pRenderClient->GetBuffer(framesAvailable, &pData);
-    if (FAILED(hr)) {
-      LOG->Warn(hr_ssprintf(hr, "GetBuffer failed").c_str());
+    int64_t iCurrentFrame = GetPosition();
+    if (!WriteFrames(framesAvailable, iHardwareFrame, iCurrentFrame, "streaming")) {
       continue;
     }
-
-    int64_t iCurrentFrame = GetPosition();
-
-    if (m_bFloat) {
-      this->Mix((float*)pData, framesAvailable, iHardwareFrame, iCurrentFrame);
-    } else {
-      this->Mix(
-          (int16_t*)pData, framesAvailable, iHardwareFrame, iCurrentFrame);
-    }
-
-    hr = m_pRenderClient->ReleaseBuffer(framesAvailable, 0);
-    if (FAILED(hr)) {
-      LOG->Warn(hr_ssprintf(hr, "ReleaseBuffer failed").c_str());
-    }
-
     iHardwareFrame += framesAvailable;
   }
 
@@ -390,7 +366,8 @@ float RageSoundDriver_WASAPI::GetPlayLatency() const {
   if (FAILED(m_pAudioClient->GetStreamLatency(&latency))) {
     return 0.0f;
   }
-  return (float)latency / 10000000.0f;
+  float result = latency / 10000000.0f;
+  return result;
 }
 
 int RageSoundDriver_WASAPI::GetSampleRate() const { return m_iSampleRate; }

--- a/src/arch/Sound/RageSoundDriver_WASAPI.cpp
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.cpp
@@ -66,6 +66,62 @@ void RageSoundDriver_WASAPI::FreeWASAPI() {
   }
 }
 
+bool RageSoundDriver_WASAPI::TryInitializeSharedLowLatencyStream(
+    WAVEFORMATEX* pwfx) {
+  IAudioClient3* pAudioClient3 = nullptr;
+  HRESULT hr = m_pAudioClient->QueryInterface(IID_PPV_ARGS(&pAudioClient3));
+  if (FAILED(hr) || pAudioClient3 == nullptr) {
+    return false;
+  }
+
+  UINT32 defaultPeriodInFrames = 0;
+  UINT32 fundamentalPeriodInFrames = 0;
+  UINT32 minPeriodInFrames = 0;
+  UINT32 maxPeriodInFrames = 0;
+  hr = pAudioClient3->GetSharedModeEnginePeriod(
+      pwfx, &defaultPeriodInFrames, &fundamentalPeriodInFrames,
+      &minPeriodInFrames, &maxPeriodInFrames);
+  if (FAILED(hr)) {
+    pAudioClient3->Release();
+    return false;
+  }
+
+  UINT32 periodInFrames = defaultPeriodInFrames;
+  if (PREFSMAN->m_iSoundWriteAhead > 0) {
+    periodInFrames = PREFSMAN->m_iSoundWriteAhead;
+    if (periodInFrames < minPeriodInFrames) {
+      periodInFrames = minPeriodInFrames;
+    }
+    if (periodInFrames > maxPeriodInFrames) {
+      periodInFrames = maxPeriodInFrames;
+    }
+  } else {
+    periodInFrames = minPeriodInFrames;
+  }
+
+  if (fundamentalPeriodInFrames > 0) {
+    UINT32 periodRemainder = periodInFrames % fundamentalPeriodInFrames;
+    if (periodRemainder != 0) {
+      periodInFrames += fundamentalPeriodInFrames - periodRemainder;
+      if (periodInFrames > maxPeriodInFrames) {
+        periodInFrames = maxPeriodInFrames;
+      }
+    }
+  }
+
+  hr = pAudioClient3->InitializeSharedAudioStream(
+      AUDCLNT_STREAMFLAGS_EVENTCALLBACK, periodInFrames, pwfx, nullptr);
+  if (SUCCEEDED(hr)) {
+    LOG->Info(
+        "WASAPI: Shared low-latency mode enabled (period=%u frames, min=%u, default=%u, max=%u, fundamental=%u)",
+        periodInFrames, minPeriodInFrames, defaultPeriodInFrames,
+        maxPeriodInFrames, fundamentalPeriodInFrames);
+  }
+
+  pAudioClient3->Release();
+  return SUCCEEDED(hr);
+}
+
 bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
   HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
   if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
@@ -120,38 +176,9 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
     return false;
   }
 
-  
-  hr = m_pAudioClient->IsFormatSupported(
-      AUDCLNT_SHAREMODE_EXCLUSIVE, pwfx, nullptr);
-  
   // cast pwfx to a modifiable WAVEFORMATEXTENSIBLE
-  // to change it to 16-bit PCM in-place
+  // to grab properties
   WAVEFORMATEXTENSIBLE* pEx = (WAVEFORMATEXTENSIBLE*)pwfx;
-
-  if (FAILED(hr)) {
-    
-    
-    pEx->SubFormat = KSDATAFORMAT_SUBTYPE_PCM;
-    pEx->Format.wBitsPerSample = 16;
-    pEx->Samples.wValidBitsPerSample = 16;
-    pEx->Format.nBlockAlign =
-        pEx->Format.nChannels * pEx->Format.wBitsPerSample / 8;
-    pEx->Format.nAvgBytesPerSec =
-        pEx->Format.nSamplesPerSec * pEx->Format.nBlockAlign;
-
-    hr = m_pAudioClient->IsFormatSupported(
-        AUDCLNT_SHAREMODE_EXCLUSIVE, pwfx, nullptr);
-    if (SUCCEEDED(hr)) {
-      LOG->Info("WASAPI: Fell back to int16 format");
-    } else {
-      sError = hr_ssprintf(
-          hr, "Exclusive mode does not support float or 16-bit PCM at this "
-              "device rate/channel layout");
-      CoTaskMemFree(pwfx);
-      FreeWASAPI();
-      return false;
-    }
-  }
 
   if (pEx->SubFormat == KSDATAFORMAT_SUBTYPE_IEEE_FLOAT) {
     m_bFloat = true;
@@ -166,29 +193,19 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
     return false;
   }
 
-  REFERENCE_TIME hnsRequestedDuration = 0;
-  if (PREFSMAN->m_iSoundWriteAhead) {
-    // WriteAhead is in frames. Convert to 100-nanosecond units.
-    hnsRequestedDuration = (REFERENCE_TIME)PREFSMAN->m_iSoundWriteAhead *
-                           10000000ULL / m_iSampleRate;
-  }
 
-  if (hnsRequestedDuration == 0) {
-    REFERENCE_TIME hnsDefaultPeriod = 0;
-    REFERENCE_TIME hnsMinimumPeriod = 0;
-    hr = m_pAudioClient->GetDevicePeriod(&hnsDefaultPeriod, &hnsMinimumPeriod);
-    if (FAILED(hr)) {
-      sError = hr_ssprintf(hr, "GetDevicePeriod failed");
-      CoTaskMemFree(pwfx);
-      FreeWASAPI();
-      return false;
+  if (!TryInitializeSharedLowLatencyStream(pwfx)) {
+    REFERENCE_TIME hnsRequestedDuration = 0;
+    if (PREFSMAN->m_iSoundWriteAhead) {
+      // WriteAhead is in frames. Convert to 100-nanosecond units.
+      hnsRequestedDuration = (REFERENCE_TIME)PREFSMAN->m_iSoundWriteAhead *
+                             10000000ULL / m_iSampleRate;
     }
-    hnsRequestedDuration = hnsMinimumPeriod ? hnsMinimumPeriod : hnsDefaultPeriod;
-  }
 
-  hr = m_pAudioClient->Initialize(
-      AUDCLNT_SHAREMODE_EXCLUSIVE, AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
-      hnsRequestedDuration, hnsRequestedDuration, pwfx, nullptr);
+    hr = m_pAudioClient->Initialize(
+        AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
+        hnsRequestedDuration, 0, pwfx, nullptr);
+  }
 
   CoTaskMemFree(pwfx);
 
@@ -244,7 +261,7 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
   LOG->Info("WASAPI: Reported latency %f", latency);
 
   LOG->Info(
-      "WASAPI: Exclusive mode, %d channels, %d Hz, %s, buffer size %d frames",
+      "WASAPI: Shared mode, %d channels, %d Hz, %s, buffer size %d frames",
       iChannels, m_iSampleRate, m_bFloat ? "Float" : "Int16",
       m_iBufferSizeFrames);
   
@@ -259,8 +276,7 @@ std::string RageSoundDriver_WASAPI::Init() {
 
   // Set decode buffer size.
   // We want it to be at least as big as the WASAPI buffer.
-  //  SetDecodeBufferSize(m_iBufferSizeFrames * 3 / 2);
-  SetDecodeBufferSize(512);
+  SetDecodeBufferSize(m_iBufferSizeFrames * 3 / 2);
   StartDecodeThread();
 
   m_MixingThread.SetName("WASAPI Mixer Thread");
@@ -284,36 +300,13 @@ void RageSoundDriver_WASAPI::MixerThread() {
     }
   }
 
-  int64_t iHardwareFrame = 0;  // Total frames played/mixed so far
-
-  {
-    BYTE* pData = nullptr;
-    HRESULT hr = m_pRenderClient->GetBuffer(m_iBufferSizeFrames, &pData);
-    if (FAILED(hr)) {
-      LOG->Warn(hr_ssprintf(hr, "GetBuffer (initial fill) failed").c_str());
-      return;
-    }
-
-    if (m_bFloat) {
-      this->Mix((float*)pData, m_iBufferSizeFrames, iHardwareFrame, 0);
-    } else {
-      this->Mix((int16_t*)pData, m_iBufferSizeFrames, iHardwareFrame, 0);
-    }
-
-    hr = m_pRenderClient->ReleaseBuffer(m_iBufferSizeFrames, 0);
-    if (FAILED(hr)) {
-      LOG->Warn(hr_ssprintf(hr, "ReleaseBuffer (initial fill) failed").c_str());
-      return;
-    }
-
-    iHardwareFrame += m_iBufferSizeFrames;
-  }
-
   HRESULT hr = m_pAudioClient->Start();
   if (FAILED(hr)) {
     LOG->Warn(hr_ssprintf(hr, "Failed to start IAudioClient").c_str());
     return;
   }
+
+  int64_t iHardwareFrame = 0;  // Total frames played/mixed so far
 
   while (!m_bShutdownMixerThread) {
     DWORD waitResult =
@@ -329,7 +322,17 @@ void RageSoundDriver_WASAPI::MixerThread() {
       break;
     }
 
-    UINT32 framesAvailable = m_iBufferSizeFrames;
+    UINT32 padding = 0;
+    hr = m_pAudioClient->GetCurrentPadding(&padding);
+    if (FAILED(hr)) {
+      LOG->Warn(hr_ssprintf(hr, "GetCurrentPadding failed").c_str());
+      continue;
+    }
+
+    UINT32 framesAvailable = m_iBufferSizeFrames - padding;
+    if (framesAvailable == 0) {
+      continue;
+    }
 
     BYTE* pData = nullptr;
     hr = m_pRenderClient->GetBuffer(framesAvailable, &pData);

--- a/src/arch/Sound/RageSoundDriver_WASAPI.cpp
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.cpp
@@ -11,11 +11,29 @@
 #include "PrefsManager.h"
 #include "RageLog.h"
 #include "RageUtil.h"
+#include "StdString.h"
 #include "archutils/Win32/DirectXHelpers.h"
 #include "archutils/Win32/ErrorStrings.h"
 #include "global.h"
 
 REGISTER_SOUND_DRIVER_CLASS2("WASAPI", WASAPI);
+
+namespace {
+const std::string* MatchCanonicalName(
+    const std::string& sSource,
+    const std::vector<std::string>& asCanonicalNames) {
+  std::string sTrimmed = sSource;
+  Trim(sTrimmed);
+
+  for (const std::string& sCanonicalName : asCanonicalNames) {
+    if (EqualsNoCase(sTrimmed, sCanonicalName)) {
+      return &sCanonicalName;
+    }
+  }
+
+  return nullptr;
+}
+}  // namespace
 
 RageSoundDriver_WASAPI::RageSoundDriver_WASAPI()
     : m_iSampleRate(0),
@@ -68,8 +86,14 @@ void RageSoundDriver_WASAPI::FreeWASAPI() {
 }
 
 bool RageSoundDriver_WASAPI::TrySubDriver(
-    std::unique_ptr<WasapiSubDriver> pCandidateSubDriver,
-    const WasapiInitParams& params, HRESULT& hrInitialize) {
+    const std::string& sSubDriverName, const WasapiInitParams& params,
+    HRESULT& hrInitialize) {
+  std::unique_ptr<WasapiSubDriver> pCandidateSubDriver =
+      CreateWasapiSubDriverByName(sSubDriverName);
+  if (!pCandidateSubDriver) {
+    LOG->Warn("WASAPI: Unknown subdriver '%s'; skipping", sSubDriverName.c_str());
+    return false;
+  }
 
   LOG->Info("WASAPI: Attempting to initialize `%s` mode",
             pCandidateSubDriver->GetModeName());
@@ -81,11 +105,64 @@ bool RageSoundDriver_WASAPI::TrySubDriver(
     return true;
   }
 
-  LOG->Warn(hr_ssprintf(
-                hrSub, "WASAPI: %s mode unsuccessful; trying fallback mode",
-                pCandidateSubDriver->GetModeName())
-                .c_str());
+  if (hrSub == S_FALSE) {
+    LOG->Info("WASAPI: %s mode unavailable; trying fallback mode",
+              pCandidateSubDriver->GetModeName());
+  } else {
+    LOG->Warn(hr_ssprintf(hrSub,
+                          "WASAPI: %s mode unsuccessful; trying fallback mode",
+                          pCandidateSubDriver->GetModeName())
+                  .c_str());
+  }
+
   return false;
+}
+
+bool RageSoundDriver_WASAPI::HasSubDriverName(
+    const std::vector<std::string>& asSubDriverNames,
+    const std::string& sSubDriverName) const {
+  for (const std::string& sExistingName : asSubDriverNames) {
+    if (sExistingName == sSubDriverName) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void RageSoundDriver_WASAPI::BuildSubDriverTryOrder(
+    std::vector<std::string>& asSubDriverNames) const {
+  asSubDriverNames.clear();
+
+  std::vector<std::string> asDefaultOrder;
+  split(GetWasapiSubDriverValidNames(), ",", asDefaultOrder, true);
+
+  std::vector<std::string> asPreferredNames;
+  split(PREFSMAN->m_sWASAPISubDriverOrder.Get(), ",", asPreferredNames, true);
+
+  for (const std::string& sPreferredName : asPreferredNames) {
+    const std::string* psCanonicalName =
+        MatchCanonicalName(sPreferredName, asDefaultOrder);
+    if (psCanonicalName == nullptr) {
+      LOG->Warn(
+          "WASAPI: Invalid WASAPISubDriverOrder entry '%s'; ignoring",
+          sPreferredName.c_str());
+      continue;
+    }
+
+    if (!HasSubDriverName(asSubDriverNames, *psCanonicalName)) {
+      asSubDriverNames.push_back(*psCanonicalName);
+    }
+  }
+
+  for (const std::string& sDefaultName : asDefaultOrder) {
+    if (!HasSubDriverName(asSubDriverNames, sDefaultName)) {
+      asSubDriverNames.push_back(sDefaultName);
+    }
+  }
+
+  LOG->Info("WASAPI: Resolved WASAPISubDriverOrder: %s",
+            join(",", asSubDriverNames).c_str());
 }
 
 bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
@@ -140,9 +217,18 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
   };
   m_pSubDriver.reset();
 
-  if (!TrySubDriver(CreateWasapiSharedLLSubDriver(), params, hr) &&
-      !TrySubDriver(CreateWasapiSharedSubDriver(), params, hr) &&
-      !TrySubDriver(CreateWasapiExclusiveSubDriver(), params, hr)) {
+  std::vector<std::string> asSubDriverNames;
+  BuildSubDriverTryOrder(asSubDriverNames);
+
+  bool bInitialized = false;
+  for (const std::string& sSubDriverName : asSubDriverNames) {
+    if (TrySubDriver(sSubDriverName, params, hr)) {
+      bInitialized = true;
+      break;
+    }
+  }
+
+  if (!bInitialized) {
     sError = "Failed to initialize WASAPI stream mode";
     CoTaskMemFree(pwfx);
     FreeWASAPI();

--- a/src/arch/Sound/RageSoundDriver_WASAPI.cpp
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.cpp
@@ -16,6 +16,91 @@
 
 REGISTER_SOUND_DRIVER_CLASS2("WASAPI", WASAPI);
 
+namespace {
+REFERENCE_TIME FramesToHnsDuration(UINT32 iFrames, int iSampleRate) {
+  if (iFrames == 0 || iSampleRate <= 0) {
+    return 0;
+  }
+
+  return (REFERENCE_TIME)iFrames * 10000000ULL / iSampleRate;
+}
+
+HRESULT InitializeSharedLowLatencyStream(
+    IAudioClient* pAudioClient, WAVEFORMATEX* pwfx, UINT32 iRequestedFrames) {
+#ifdef __IAudioClient3_INTERFACE_DEFINED
+  IAudioClient3* pAudioClient3 = nullptr;
+  HRESULT hr = pAudioClient->QueryInterface(IID_PPV_ARGS(&pAudioClient3));
+  if (FAILED(hr) || pAudioClient3 == nullptr) {
+    LOG->Info("WASAPI: IAudioClient3 not available; skipping shared low-latency pathway");
+    return S_FALSE;
+  }
+
+  UINT32 iDefaultPeriodFrames = 0;
+  UINT32 iFundamentalPeriodFrames = 0;
+  UINT32 iMinPeriodFrames = 0;
+  UINT32 iMaxPeriodFrames = 0;
+  hr = pAudioClient3->GetSharedModeEnginePeriod(
+      pwfx, &iDefaultPeriodFrames, &iFundamentalPeriodFrames,
+      &iMinPeriodFrames, &iMaxPeriodFrames);
+
+  if (FAILED(hr)) {
+    LOG->Warn(
+        "WASAPI: GetSharedModeEnginePeriod failed; skipping shared "
+        "low-latency pathway");
+    pAudioClient3->Release();
+    return S_FALSE;
+  }
+
+  UINT32 iPeriodFrames =
+      iRequestedFrames > 0 ? iRequestedFrames : iMinPeriodFrames;
+  if (iPeriodFrames < iMinPeriodFrames) {
+    iPeriodFrames = iMinPeriodFrames;
+  }
+  if (iPeriodFrames > iMaxPeriodFrames) {
+    iPeriodFrames = iMaxPeriodFrames;
+  }
+
+  if (iFundamentalPeriodFrames > 0) {
+    UINT32 iRemainder = iPeriodFrames % iFundamentalPeriodFrames;
+    if (iRemainder != 0) {
+      iPeriodFrames += iFundamentalPeriodFrames - iRemainder;
+      if (iPeriodFrames > iMaxPeriodFrames) {
+        iPeriodFrames = iMaxPeriodFrames;
+      }
+    }
+  }
+
+  hr = pAudioClient3->InitializeSharedAudioStream(
+      AUDCLNT_STREAMFLAGS_EVENTCALLBACK, iPeriodFrames, pwfx, nullptr);
+
+  pAudioClient3->Release();
+
+  if (FAILED(hr)) {
+    LOG->Warn(
+        hr_ssprintf(hr,
+                    "WASAPI: InitializeSharedAudioStream failed; falling back "
+                    "to shared Initialize")
+            .c_str());
+    return hr;
+  }
+
+  LOG->Info(
+      "WASAPI: Shared low-latency mode enabled (period=%u frames, min=%u, default=%u, max=%u, fundamental=%u)",
+      iPeriodFrames, iMinPeriodFrames, iDefaultPeriodFrames, iMaxPeriodFrames,
+      iFundamentalPeriodFrames);
+  return S_OK;
+#else
+  LOG->Info(
+      "WASAPI: IAudioClient3 headers unavailable in this SDK; skipping shared "
+      "low-latency pathway");
+  (void)pAudioClient;
+  (void)pwfx;
+  (void)iRequestedFrames;
+  return S_FALSE;
+#endif
+}
+}  // namespace
+
 RageSoundDriver_WASAPI::RageSoundDriver_WASAPI()
     : m_iSampleRate(0),
       m_iBufferSizeFrames(0),
@@ -64,62 +149,6 @@ void RageSoundDriver_WASAPI::FreeWASAPI() {
     CoUninitialize();
     m_bOwnsComInit = false;
   }
-}
-
-bool RageSoundDriver_WASAPI::TryInitializeSharedLowLatencyStream(
-    WAVEFORMATEX* pwfx) {
-  IAudioClient3* pAudioClient3 = nullptr;
-  HRESULT hr = m_pAudioClient->QueryInterface(IID_PPV_ARGS(&pAudioClient3));
-  if (FAILED(hr) || pAudioClient3 == nullptr) {
-    return false;
-  }
-
-  UINT32 defaultPeriodInFrames = 0;
-  UINT32 fundamentalPeriodInFrames = 0;
-  UINT32 minPeriodInFrames = 0;
-  UINT32 maxPeriodInFrames = 0;
-  hr = pAudioClient3->GetSharedModeEnginePeriod(
-      pwfx, &defaultPeriodInFrames, &fundamentalPeriodInFrames,
-      &minPeriodInFrames, &maxPeriodInFrames);
-  if (FAILED(hr)) {
-    pAudioClient3->Release();
-    return false;
-  }
-
-  UINT32 periodInFrames = defaultPeriodInFrames;
-  if (PREFSMAN->m_iSoundWriteAhead > 0) {
-    periodInFrames = PREFSMAN->m_iSoundWriteAhead;
-    if (periodInFrames < minPeriodInFrames) {
-      periodInFrames = minPeriodInFrames;
-    }
-    if (periodInFrames > maxPeriodInFrames) {
-      periodInFrames = maxPeriodInFrames;
-    }
-  } else {
-    periodInFrames = minPeriodInFrames;
-  }
-
-  if (fundamentalPeriodInFrames > 0) {
-    UINT32 periodRemainder = periodInFrames % fundamentalPeriodInFrames;
-    if (periodRemainder != 0) {
-      periodInFrames += fundamentalPeriodInFrames - periodRemainder;
-      if (periodInFrames > maxPeriodInFrames) {
-        periodInFrames = maxPeriodInFrames;
-      }
-    }
-  }
-
-  hr = pAudioClient3->InitializeSharedAudioStream(
-      AUDCLNT_STREAMFLAGS_EVENTCALLBACK, periodInFrames, pwfx, nullptr);
-  if (SUCCEEDED(hr)) {
-    LOG->Info(
-        "WASAPI: Shared low-latency mode enabled (period=%u frames, min=%u, default=%u, max=%u, fundamental=%u)",
-        periodInFrames, minPeriodInFrames, defaultPeriodInFrames,
-        maxPeriodInFrames, fundamentalPeriodInFrames);
-  }
-
-  pAudioClient3->Release();
-  return SUCCEEDED(hr);
 }
 
 bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
@@ -176,8 +205,6 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
     return false;
   }
 
-  // cast pwfx to a modifiable WAVEFORMATEXTENSIBLE
-  // to grab properties
   WAVEFORMATEXTENSIBLE* pEx = (WAVEFORMATEXTENSIBLE*)pwfx;
 
   if (pEx->SubFormat == KSDATAFORMAT_SUBTYPE_IEEE_FLOAT) {
@@ -193,15 +220,12 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
     return false;
   }
 
+  REFERENCE_TIME hnsRequestedDuration =
+      FramesToHnsDuration(PREFSMAN->m_iSoundWriteAhead, m_iSampleRate);
 
-  if (!TryInitializeSharedLowLatencyStream(pwfx)) {
-    REFERENCE_TIME hnsRequestedDuration = 0;
-    if (PREFSMAN->m_iSoundWriteAhead) {
-      // WriteAhead is in frames. Convert to 100-nanosecond units.
-      hnsRequestedDuration = (REFERENCE_TIME)PREFSMAN->m_iSoundWriteAhead *
-                             10000000ULL / m_iSampleRate;
-    }
-
+  HRESULT hrLowLatency = InitializeSharedLowLatencyStream(
+      m_pAudioClient, pwfx, PREFSMAN->m_iSoundWriteAhead);
+  if (hrLowLatency != S_OK) {
     hr = m_pAudioClient->Initialize(
         AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
         hnsRequestedDuration, 0, pwfx, nullptr);
@@ -256,9 +280,6 @@ bool RageSoundDriver_WASAPI::InitWASAPI(std::string& sError) {
     FreeWASAPI();
     return false;
   }
-
-  float latency = GetPlayLatency();  // just to log it
-  LOG->Info("WASAPI: Reported latency %f", latency);
 
   LOG->Info(
       "WASAPI: Shared mode, %d channels, %d Hz, %s, buffer size %d frames",

--- a/src/arch/Sound/RageSoundDriver_WASAPI.h
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.h
@@ -15,6 +15,7 @@ struct IAudioClient;
 struct IAudioRenderClient;
 struct IAudioClock;
 class WasapiSubDriver;
+struct WasapiInitParams;
 
 class RageSoundDriver_WASAPI : public RageSoundDriver {
  public:
@@ -46,6 +47,9 @@ class RageSoundDriver_WASAPI : public RageSoundDriver {
   std::unique_ptr<WasapiSubDriver> m_pSubDriver;
 
   static int MixerThread_start(void* p);
+  bool TrySubDriver(std::unique_ptr<WasapiSubDriver> pCandidateSubDriver,
+                    const WasapiInitParams& params,
+                    HRESULT& hrInitialize);
   bool WriteFrames(UINT32 iFrames, int64_t iHardwareFrame, int64_t iCurrentFrame,
                    const char* sPhase);
   void MixerThread();

--- a/src/arch/Sound/RageSoundDriver_WASAPI.h
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.h
@@ -6,6 +6,7 @@
 // clang-format on
 
 #include <atomic>
+#include <memory>
 
 #include "RageSoundDriver.h"
 #include "RageThreads.h"
@@ -13,6 +14,7 @@
 struct IAudioClient;
 struct IAudioRenderClient;
 struct IAudioClock;
+class WasapiSubDriver;
 
 class RageSoundDriver_WASAPI : public RageSoundDriver {
  public:
@@ -41,8 +43,11 @@ class RageSoundDriver_WASAPI : public RageSoundDriver {
 
   std::atomic<bool> m_bShutdownMixerThread;
   bool m_bOwnsComInit;
+  std::unique_ptr<WasapiSubDriver> m_pSubDriver;
 
   static int MixerThread_start(void* p);
+  bool WriteFrames(UINT32 iFrames, int64_t iHardwareFrame, int64_t iCurrentFrame,
+                   const char* sPhase);
   void MixerThread();
   RageThread m_MixingThread;
 

--- a/src/arch/Sound/RageSoundDriver_WASAPI.h
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.h
@@ -13,8 +13,6 @@
 struct IAudioClient;
 struct IAudioRenderClient;
 struct IAudioClock;
-struct tWAVEFORMATEX;
-typedef struct tWAVEFORMATEX WAVEFORMATEX;
 
 class RageSoundDriver_WASAPI : public RageSoundDriver {
  public:
@@ -48,7 +46,6 @@ class RageSoundDriver_WASAPI : public RageSoundDriver {
   void MixerThread();
   RageThread m_MixingThread;
 
-  bool TryInitializeSharedLowLatencyStream(WAVEFORMATEX* pwfx);
   bool InitWASAPI(std::string& sError);
   void FreeWASAPI();
 };

--- a/src/arch/Sound/RageSoundDriver_WASAPI.h
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.h
@@ -13,6 +13,8 @@
 struct IAudioClient;
 struct IAudioRenderClient;
 struct IAudioClock;
+struct tWAVEFORMATEX;
+typedef struct tWAVEFORMATEX WAVEFORMATEX;
 
 class RageSoundDriver_WASAPI : public RageSoundDriver {
  public:
@@ -46,6 +48,7 @@ class RageSoundDriver_WASAPI : public RageSoundDriver {
   void MixerThread();
   RageThread m_MixingThread;
 
+  bool TryInitializeSharedLowLatencyStream(WAVEFORMATEX* pwfx);
   bool InitWASAPI(std::string& sError);
   void FreeWASAPI();
 };

--- a/src/arch/Sound/RageSoundDriver_WASAPI.h
+++ b/src/arch/Sound/RageSoundDriver_WASAPI.h
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <memory>
+#include <vector>
 
 #include "RageSoundDriver.h"
 #include "RageThreads.h"
@@ -47,9 +48,12 @@ class RageSoundDriver_WASAPI : public RageSoundDriver {
   std::unique_ptr<WasapiSubDriver> m_pSubDriver;
 
   static int MixerThread_start(void* p);
-  bool TrySubDriver(std::unique_ptr<WasapiSubDriver> pCandidateSubDriver,
+  bool TrySubDriver(const std::string& sSubDriverName,
                     const WasapiInitParams& params,
                     HRESULT& hrInitialize);
+  bool HasSubDriverName(const std::vector<std::string>& asSubDriverNames,
+                        const std::string& sSubDriverName) const;
+  void BuildSubDriverTryOrder(std::vector<std::string>& asSubDriverNames) const;
   bool WriteFrames(UINT32 iFrames, int64_t iHardwareFrame, int64_t iCurrentFrame,
                    const char* sPhase);
   void MixerThread();

--- a/src/arch/Sound/RageSoundDriver_WASAPI_Exclusive.cpp
+++ b/src/arch/Sound/RageSoundDriver_WASAPI_Exclusive.cpp
@@ -4,6 +4,8 @@
 #include <ksmedia.h>
 // clang-format on
 
+#include "RageLog.h"
+
 namespace {
 REFERENCE_TIME FramesToHnsDuration(UINT32 iFrames, int iSampleRate) {
   if (iFrames == 0 || iSampleRate <= 0) {
@@ -59,6 +61,9 @@ class WasapiExclusiveSubDriver : public WasapiSubDriver {
       }
       hnsRequestedDuration =
           hnsMinimumPeriod ? hnsMinimumPeriod : hnsDefaultPeriod;
+      LOG->Info(
+          "WASAPI: Exclusive hnsDuration: (Requested:%lld), (Min:%lld), (Default:%lld)",
+          hnsRequestedDuration, hnsMinimumPeriod, hnsDefaultPeriod);
     }
 
     hr = params.pAudioClient->Initialize(

--- a/src/arch/Sound/RageSoundDriver_WASAPI_Exclusive.cpp
+++ b/src/arch/Sound/RageSoundDriver_WASAPI_Exclusive.cpp
@@ -1,0 +1,84 @@
+#include "RageSoundDriver_WASAPI_SubDriver.h"
+
+// clang-format off
+#include <ksmedia.h>
+// clang-format on
+
+namespace {
+REFERENCE_TIME FramesToHnsDuration(UINT32 iFrames, int iSampleRate) {
+  if (iFrames == 0 || iSampleRate <= 0) {
+    return 0;
+  }
+
+  return (REFERENCE_TIME)iFrames * 10000000ULL / iSampleRate;
+}
+
+class WasapiExclusiveSubDriver : public WasapiSubDriver {
+ public:
+  const char* GetModeName() const override { return "Exclusive"; }
+
+  HRESULT InitializeStream(const WasapiInitParams& params) override {
+    if (params.pWaveFormat->wFormatTag != WAVE_FORMAT_EXTENSIBLE) {
+      return AUDCLNT_E_UNSUPPORTED_FORMAT;
+    }
+
+    // create a copy of the original format to modify if needed
+    const WAVEFORMATEXTENSIBLE* pOriginalFormat =
+        reinterpret_cast<const WAVEFORMATEXTENSIBLE*>(params.pWaveFormat);
+    WAVEFORMATEXTENSIBLE selectedFormat = *pOriginalFormat;
+    WAVEFORMATEX* pSelectedFormat = (WAVEFORMATEX*)&selectedFormat;
+
+    HRESULT hr = params.pAudioClient->IsFormatSupported(
+        AUDCLNT_SHAREMODE_EXCLUSIVE, pSelectedFormat, nullptr);
+    if (FAILED(hr)) {
+      selectedFormat.SubFormat = KSDATAFORMAT_SUBTYPE_PCM;
+      selectedFormat.Format.wBitsPerSample = 16;
+      selectedFormat.Samples.wValidBitsPerSample = 16;
+      selectedFormat.Format.nBlockAlign =
+          selectedFormat.Format.nChannels *
+          selectedFormat.Format.wBitsPerSample / 8;
+      selectedFormat.Format.nAvgBytesPerSec =
+          selectedFormat.Format.nSamplesPerSec * selectedFormat.Format.nBlockAlign;
+
+      hr = params.pAudioClient->IsFormatSupported(
+          AUDCLNT_SHAREMODE_EXCLUSIVE, pSelectedFormat, nullptr);
+      if (FAILED(hr)) {
+        return hr;
+      }
+    }
+
+    REFERENCE_TIME hnsRequestedDuration =
+        FramesToHnsDuration(params.iWriteAheadFrames, params.iSampleRate);
+    if (hnsRequestedDuration == 0) {
+      REFERENCE_TIME hnsDefaultPeriod = 0;
+      REFERENCE_TIME hnsMinimumPeriod = 0;
+      hr = params.pAudioClient->GetDevicePeriod(
+          &hnsDefaultPeriod, &hnsMinimumPeriod);
+      if (FAILED(hr)) {
+        return hr;
+      }
+      hnsRequestedDuration =
+          hnsMinimumPeriod ? hnsMinimumPeriod : hnsDefaultPeriod;
+    }
+
+    hr = params.pAudioClient->Initialize(
+        AUDCLNT_SHAREMODE_EXCLUSIVE, AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
+        hnsRequestedDuration, hnsRequestedDuration, pSelectedFormat, nullptr);
+    if (FAILED(hr)) {
+      return hr;
+    }
+
+    // set params.pWaveFormat to the actual format we are using, since we succeeded.
+    *reinterpret_cast<WAVEFORMATEXTENSIBLE*>(params.pWaveFormat) =
+        selectedFormat;
+    return S_OK;
+  }
+
+  bool UsesPaddingFrames() const override { return false; }
+  bool RequiresInitialFill() const override { return true; }
+};
+}  // namespace
+
+std::unique_ptr<WasapiSubDriver> CreateWasapiExclusiveSubDriver() {
+  return std::make_unique<WasapiExclusiveSubDriver>();
+}

--- a/src/arch/Sound/RageSoundDriver_WASAPI_Shared.cpp
+++ b/src/arch/Sound/RageSoundDriver_WASAPI_Shared.cpp
@@ -1,0 +1,34 @@
+#include "RageSoundDriver_WASAPI_SubDriver.h"
+
+#include "PrefsManager.h"
+
+namespace {
+REFERENCE_TIME FramesToHnsDuration(UINT32 iFrames, int iSampleRate) {
+  if (iFrames == 0 || iSampleRate <= 0) {
+    return 0;
+  }
+
+  return (REFERENCE_TIME)iFrames * 10000000ULL / iSampleRate;
+}
+
+class WasapiSharedSubDriver : public WasapiSubDriver {
+ public:
+  const char* GetModeName() const override { return "Shared"; }
+
+  HRESULT InitializeStream(const WasapiInitParams& params) override {
+    REFERENCE_TIME hnsRequestedDuration =
+        FramesToHnsDuration(params.iWriteAheadFrames, params.iSampleRate);
+
+    return params.pAudioClient->Initialize(
+        AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
+        hnsRequestedDuration, 0, params.pWaveFormat, nullptr);
+  }
+
+  bool UsesPaddingFrames() const override { return true; }
+  bool RequiresInitialFill() const override { return false; }
+};
+}  // namespace
+
+std::unique_ptr<WasapiSubDriver> CreateWasapiSharedSubDriver() {
+  return std::make_unique<WasapiSharedSubDriver>();
+}

--- a/src/arch/Sound/RageSoundDriver_WASAPI_Shared_LL.cpp
+++ b/src/arch/Sound/RageSoundDriver_WASAPI_Shared_LL.cpp
@@ -1,0 +1,87 @@
+#include "RageSoundDriver_WASAPI_SubDriver.h"
+
+#include "RageLog.h"
+
+namespace {
+class WasapiSharedLLSubDriver : public WasapiSubDriver {
+ public:
+  const char* GetModeName() const override { return "Shared LowLatency"; }
+
+  HRESULT InitializeStream(const WasapiInitParams& params) override {
+#ifdef __IAudioClient3_INTERFACE_DEFINED__
+    IAudioClient3* pAudioClient3 = nullptr;
+    HRESULT hr =
+        params.pAudioClient->QueryInterface(IID_PPV_ARGS(&pAudioClient3));
+    if (FAILED(hr) || pAudioClient3 == nullptr) {
+      LOG->Info("WASAPI: Shared LowLatency - IAudioClient3 not available");
+      return S_FALSE;
+    }
+
+    UINT32 iDefaultPeriodFrames = 0;
+    UINT32 iFundamentalPeriodFrames = 0;
+    UINT32 iMinPeriodFrames = 0;
+    UINT32 iMaxPeriodFrames = 0;
+    hr = pAudioClient3->GetSharedModeEnginePeriod(
+        params.pWaveFormat, &iDefaultPeriodFrames, &iFundamentalPeriodFrames,
+        &iMinPeriodFrames, &iMaxPeriodFrames);
+    if (FAILED(hr)) {
+      LOG->Warn(
+          "WASAPI: Shared LowLatency - GetSharedModeEnginePeriod failed");
+      pAudioClient3->Release();
+      return S_FALSE;
+    }
+
+    UINT32 iPeriodFrames = params.iWriteAheadFrames;
+    if (iPeriodFrames < iMinPeriodFrames) {
+      iPeriodFrames = iMinPeriodFrames;
+    }
+    if (iPeriodFrames > iMaxPeriodFrames) {
+      iPeriodFrames = iMaxPeriodFrames;
+    }
+
+    if (iFundamentalPeriodFrames > 0) {
+      UINT32 iRemainder = iPeriodFrames % iFundamentalPeriodFrames;
+      if (iRemainder != 0) {
+        iPeriodFrames += iFundamentalPeriodFrames - iRemainder;
+        if (iPeriodFrames > iMaxPeriodFrames) {
+          iPeriodFrames = iMaxPeriodFrames;
+        }
+      }
+    }
+
+    LOG->Info(
+        "WASAPI: Shared LowLatency attempting to initialize using parameters "
+        "(period=%u, min=%u, default=%u, max=%u, fundamental=%u)",
+        iPeriodFrames, iMinPeriodFrames, iDefaultPeriodFrames,
+        iMaxPeriodFrames, iFundamentalPeriodFrames);
+
+    hr = pAudioClient3->InitializeSharedAudioStream(
+        AUDCLNT_STREAMFLAGS_EVENTCALLBACK, iPeriodFrames, params.pWaveFormat,
+        nullptr);
+
+    pAudioClient3->Release();
+
+    if (FAILED(hr)) {
+      LOG->Warn("WASAPI: Shared LowLatency InitializeSharedAudioStream failed");
+      return hr;
+    }
+
+    LOG->Info("WASAPI: Shared LowLatency mode initialized successfully");
+    return S_OK;
+#else
+    LOG->Info(
+        "WASAPI: Low-Latency IAudioClient3 headers unavailable in this SDK; "
+        "skipping shared low-latency pathway");
+    (void)params;
+    return S_FALSE;
+#endif
+  }
+
+  bool UsesPaddingFrames() const override { return true; }
+  bool RequiresInitialFill() const override { return false; }
+};
+}  // namespace
+
+std::unique_ptr<WasapiSubDriver> CreateWasapiSharedLLSubDriver() {
+  return std::make_unique<WasapiSharedLLSubDriver>();
+}

--- a/src/arch/Sound/RageSoundDriver_WASAPI_SubDriver.cpp
+++ b/src/arch/Sound/RageSoundDriver_WASAPI_SubDriver.cpp
@@ -1,0 +1,34 @@
+#include "RageSoundDriver_WASAPI_SubDriver.h"
+
+#include "RageUtil.h"
+#include "StdString.h"
+
+namespace {
+const char* const kWasapiSubDriverSharedLL = "SharedLL";
+const char* const kWasapiSubDriverShared = "Shared";
+const char* const kWasapiSubDriverExclusive = "Exclusive";
+}  // namespace
+
+std::unique_ptr<WasapiSubDriver> CreateWasapiSubDriverByName(
+    const std::string& sName) {
+  std::string sCanonicalName = sName;
+  Trim(sCanonicalName);
+
+  if (EqualsNoCase(sCanonicalName, kWasapiSubDriverSharedLL)) {
+    return CreateWasapiSharedLLSubDriver();
+  }
+
+  if (EqualsNoCase(sCanonicalName, kWasapiSubDriverShared)) {
+    return CreateWasapiSharedSubDriver();
+  }
+
+  if (EqualsNoCase(sCanonicalName, kWasapiSubDriverExclusive)) {
+    return CreateWasapiExclusiveSubDriver();
+  }
+
+  return nullptr;
+}
+
+const char* GetWasapiSubDriverValidNames() {
+  return "SharedLL,Shared,Exclusive";
+}

--- a/src/arch/Sound/RageSoundDriver_WASAPI_SubDriver.h
+++ b/src/arch/Sound/RageSoundDriver_WASAPI_SubDriver.h
@@ -29,5 +29,8 @@ class WasapiSubDriver {
 std::unique_ptr<WasapiSubDriver> CreateWasapiSharedSubDriver();
 std::unique_ptr<WasapiSubDriver> CreateWasapiSharedLLSubDriver();
 std::unique_ptr<WasapiSubDriver> CreateWasapiExclusiveSubDriver();
+std::unique_ptr<WasapiSubDriver> CreateWasapiSubDriverByName(
+    const std::string& sName);
+const char* GetWasapiSubDriverValidNames();
 
 #endif

--- a/src/arch/Sound/RageSoundDriver_WASAPI_SubDriver.h
+++ b/src/arch/Sound/RageSoundDriver_WASAPI_SubDriver.h
@@ -1,0 +1,33 @@
+#ifndef RAGE_SOUND_WASAPI_SUB_DRIVER_H
+#define RAGE_SOUND_WASAPI_SUB_DRIVER_H
+
+// clang-format off
+#include <windows.h>
+#include <audioclient.h>
+// clang-format on
+
+#include <memory>
+#include <string>
+
+struct WasapiInitParams {
+  IAudioClient* pAudioClient;
+  WAVEFORMATEX* pWaveFormat;
+  int iSampleRate;
+  int iWriteAheadFrames;
+};
+
+class WasapiSubDriver {
+ public:
+  virtual ~WasapiSubDriver() = default;
+
+  virtual const char* GetModeName() const = 0;
+  virtual HRESULT InitializeStream(const WasapiInitParams& params) = 0;
+  virtual bool UsesPaddingFrames() const = 0;
+  virtual bool RequiresInitialFill() const = 0;
+};
+
+std::unique_ptr<WasapiSubDriver> CreateWasapiSharedSubDriver();
+std::unique_ptr<WasapiSubDriver> CreateWasapiSharedLLSubDriver();
+std::unique_ptr<WasapiSubDriver> CreateWasapiExclusiveSubDriver();
+
+#endif


### PR DESCRIPTION
This mode breaks the "WASAPI shared" 10ms buffer limit imposed by windows.

Note that Synced Global Offset is me just playing a song by hand and using machine auto sync, and is prone to human errors. If someone has a better way of testing, i would love to use that instead :( Honestly i think my margin of error is +-10ms, so i'm not certain that i can actually tell a difference between shared and shared LL, but sharedLL is what microsoft themselves recommend.

For some reason my `exclusive` gives me "higher" latency despite the literature stating the opposite.
Either way, this exposes all three for people with better tools to test/tweak.

All tested on 44100hz

## Realtek 887
|Audio Mode                | GetStreamLatency() | Reported Buffer size | Synced Global Offset|
|--------------------------|--------------------|------------|-------------|
|WASAPI shared             |0ms                 | 984 frames |~11 ms       | 
|WASAPI shared low latency |0ms                 | 984 frames |~6 ms        | 
|WASAPI exclusive          |~6 ms               | 256 frames | 60 ms (!!?) |

## Apple dongle USBC -> 3.5mm
|Audio Mode                | GetStreamLatency() | Reported Buffer size | Synced Global Offset|
|--------------------------|--------------------|------------|--------|
|WASAPI shared             |0ms                 | 970 frames | 2-6 ms  | 
|WASAPI shared low latency |0ms                 | 678 frames | -1 to 4 ms   | 
|WASAPI exclusive          |~3 ms               | 132 frames | 6-11 ms  | 

I've changed WASAPI shared Low Latency to the default - i'm not sure if this is the "best thing", but it is changable in a single line if we want to keep WASAPI Shared as the de-facto until further testing is done.