### PR TITLE
Allow @MenuDown+MenuUp to close current folder

### DIFF
--- a/Themes/_fallback/Scripts/03 Gameplay.lua
+++ b/Themes/_fallback/Scripts/03 Gameplay.lua
@@ -344,8 +344,8 @@ local CodeDetectorCodes = {
 	},
 	CloseCurrentFolder = {
 		default = "MenuUp-MenuDown",
-		dance = "Up-Down",
-		pump = "@UpLeft-@UpRight-Center",
+		dance = "Up-Down|@MenuUp-MenuDown",
+		pump = "@UpLeft-@UpRight-Center|@MenuUp-MenuDown",
 	},
 	-- OptionsList
 	PrevOptionsList = {

--- a/Themes/_fallback/Scripts/03 Gameplay.lua
+++ b/Themes/_fallback/Scripts/03 Gameplay.lua
@@ -344,8 +344,8 @@ local CodeDetectorCodes = {
 	},
 	CloseCurrentFolder = {
 		default = "MenuUp-MenuDown",
-		dance = "Up-Down|@MenuUp-MenuDown",
-		pump = "@UpLeft-@UpRight-Center|@MenuUp-MenuDown",
+		dance = "Up-Down|@MenuDown-MenuUp",
+		pump = "@UpLeft-@UpRight-Center|@MenuDown-MenuUp",
 	},
 	-- OptionsList
 	PrevOptionsList = {

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -937,6 +937,8 @@ bool ScreenSelectMusic::Input(const InputEventPlus& input) {
 }
 
 bool ScreenSelectMusic::DetectCodes(const InputEventPlus& input) {
+  // We have a fallback close folder command that's a prefix of the prev/next
+  // steps command, so make sure to handle close folder command first.
   if (CodeDetector::EnteredCloseFolder(input.GameI.controller)) {
     if (GAMESTATE->IsAnExtraStageAndSelectionLocked() ||
         m_MusicWheel.WheelIsLocked() || m_MusicWheel.IsRouletting()) {
@@ -945,7 +947,8 @@ bool ScreenSelectMusic::DetectCodes(const InputEventPlus& input) {
       m_MusicWheel.CloseOpenSectionOneLevel();
       AfterMusicChange();
     }
-  } else if (CodeDetector::EnteredPrevSteps(input.GameI.controller) &&
+  } else if (
+      CodeDetector::EnteredPrevSteps(input.GameI.controller) &&
       !CHANGE_STEPS_WITH_GAME_BUTTONS) {
     if (GAMESTATE->IsAnExtraStageAndSelectionLocked()) {
       m_soundLocked.Play(true);

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -937,7 +937,15 @@ bool ScreenSelectMusic::Input(const InputEventPlus& input) {
 }
 
 bool ScreenSelectMusic::DetectCodes(const InputEventPlus& input) {
-  if (CodeDetector::EnteredPrevSteps(input.GameI.controller) &&
+  if (CodeDetector::EnteredCloseFolder(input.GameI.controller)) {
+    if (GAMESTATE->IsAnExtraStageAndSelectionLocked() ||
+        m_MusicWheel.WheelIsLocked() || m_MusicWheel.IsRouletting()) {
+      m_soundLocked.Play(true);
+    } else {
+      m_MusicWheel.CloseOpenSectionOneLevel();
+      AfterMusicChange();
+    }
+  } else if (CodeDetector::EnteredPrevSteps(input.GameI.controller) &&
       !CHANGE_STEPS_WITH_GAME_BUTTONS) {
     if (GAMESTATE->IsAnExtraStageAndSelectionLocked()) {
       m_soundLocked.Play(true);
@@ -1001,14 +1009,6 @@ bool ScreenSelectMusic::DetectCodes(const InputEventPlus& input) {
       m_MusicWheel.SelectSection(sNewGroup);
       m_MusicWheel.SetOpenSection(sNewGroup);
       MESSAGEMAN->Broadcast("PreviousGroup");
-      AfterMusicChange();
-    }
-  } else if (CodeDetector::EnteredCloseFolder(input.GameI.controller)) {
-    if (GAMESTATE->IsAnExtraStageAndSelectionLocked() ||
-        m_MusicWheel.WheelIsLocked() || m_MusicWheel.IsRouletting()) {
-      m_soundLocked.Play(true);
-    } else {
-      m_MusicWheel.CloseOpenSectionOneLevel();
       AfterMusicChange();
     }
   } else {


### PR DESCRIPTION
(press MenuUp while holding MenuDown)

So there's an easy way to close current folder while navigating song select.

Requires handling CloseFolder before Prev/NextSteps since Prev/NextSteps command is a prefix of CloseFolder command.