### PR TITLE
Display series header for multi-item series only

### DIFF
--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -915,6 +915,7 @@ void MusicWheel::BuildWheelItemDatas(
             std::string lastSeries;
             std::string lastGroup;
             bool haveLast = false;
+            bool seriesHasMultipleGroups = false;
             for (unsigned i = 0; i < arraySongs.size(); ++i) {
               Song* pSong = arraySongs[i];
               Group* pGroup = SONGMAN->GetGroup(pSong);
@@ -935,23 +936,28 @@ void MusicWheel::BuildWheelItemDatas(
               if (!seriesName.empty() &&
                   (!haveLast || seriesName != lastSeries)) {
                 int seriesSongCount = 0;
+                std::set<Group*> seriesGroups;
                 for (unsigned j = i; j < arraySongs.size(); ++j) {
                   Group* pG = SONGMAN->GetGroup(arraySongs[j]);
                   if (pG != nullptr && pG->GetSeries() == seriesName) {
                     ++seriesSongCount;
+                    seriesGroups.insert(pG);
                   } else {
                     break;
                   }
                 }
-                RageColor seriesColor =
-                    SECTION_COLORS.GetValue(iSectionColorIndex);
-                iSectionColorIndex =
-                    (iSectionColorIndex + 1) % NUM_SECTION_COLORS;
-                MusicWheelItemData* pSeriesItem = new MusicWheelItemData(
-                    WheelItemDataType_ParentSection, nullptr, seriesName,
-                    nullptr, nullptr, seriesColor, seriesSongCount);
-                pSeriesItem->m_sLabel = seriesName;
-                arrayWheelItemDatas.push_back(pSeriesItem);
+                seriesHasMultipleGroups = seriesGroups.size() > 1;
+                if (seriesHasMultipleGroups) {
+                  RageColor seriesColor =
+                      SECTION_COLORS.GetValue(iSectionColorIndex);
+                  iSectionColorIndex =
+                      (iSectionColorIndex + 1) % NUM_SECTION_COLORS;
+                  MusicWheelItemData* pSeriesItem = new MusicWheelItemData(
+                      WheelItemDataType_ParentSection, nullptr, seriesName,
+                      nullptr, nullptr, seriesColor, seriesSongCount);
+                  pSeriesItem->m_sLabel = seriesName;
+                  arrayWheelItemDatas.push_back(pSeriesItem);
+                }
               }
 
               if (!haveLast || groupName != lastGroup) {
@@ -967,7 +973,9 @@ void MusicWheel::BuildWheelItemDatas(
                 arrayWheelItemDatas.push_back(new MusicWheelItemData(
                     WheelItemDataType_Section, nullptr, groupName, nullptr,
                     pGroup, SONGMAN->GetSongGroupColor(groupName),
-                    groupSongCount, seriesName));
+                    groupSongCount,
+                    seriesHasMultipleGroups && !seriesName.empty() ? seriesName
+                                                                   : ""));
               }
 
               arrayWheelItemDatas.push_back(new MusicWheelItemData(


### PR DESCRIPTION
In the current release (1.3.0) if a pack has a series defined, but only one pack exists for that series, the series is displayed separately, which has the potential to feel slightly awkward when accessing the only subfolder.

For an idea of how this looks, compare to screenshots from this commit:

With packs that have a series defined, but no accompanying pack in that series:
<img width="1282" height="752" alt="Screenshot 2026-09-08 161814" src="https://github.com/user-attachments/assets/a7f0ed27-78e1-4e59-a3e4-e17a14912521" />

With multiple packs in a given series:
<img width="1282" height="752" alt="Screenshot 2026-09-08 161924" src="https://github.com/user-attachments/assets/3a56b805-3a60-4c42-8d09-02d6ac31bab7" />

I recognize the behavior of a single-item series could be a personal preference thing, LMK if this should have a preference exposed.